### PR TITLE
 Issue #41: Add InlineAutocomplete UI component 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ _Generic UI components for building apps._
 
 * **Colors** - The standard set of [Photon](https://design.firefox.com/photon/) colors.
 
+* **Autocomplete** - A set of components to provide autocomplete functionality.
+
 ## Support
 
 _Supporting components with generic helper code._

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+    implementation "com.android.support:appcompat-v7:27.1.0"
+
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.robolectric:robolectric:3.7.1"
+    testImplementation "org.mockito:mockito-core:2.12.0"
+}
+
+archivesBaseName = "autocomplete"
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.components',
+        'autocomplete',
+        'A set of components to provide autocomplete functionality.')
+

--- a/components/ui/autocomplete/proguard-rules.pro
+++ b/components/ui/autocomplete/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/ui/autocomplete/src/main/AndroidManifest.xml
+++ b/components/ui/autocomplete/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.ui.autocomplete" />

--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -1,0 +1,621 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.ui.autocomplete
+
+import android.content.Context
+import android.graphics.Rect
+import android.os.Build
+import android.support.v7.widget.AppCompatEditText
+import android.text.Editable
+import android.text.NoCopySpan
+import android.text.Selection
+import android.text.Spanned
+import android.text.TextUtils
+import android.text.TextWatcher
+import android.text.style.BackgroundColorSpan
+import android.util.AttributeSet
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
+import android.view.inputmethod.InputConnectionWrapper
+import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
+
+import android.graphics.Color.parseColor
+
+typealias OnCommitListener = () -> Unit
+typealias OnFilterListener = (String, InlineAutocompleteEditText?) -> Unit
+typealias OnSearchStateChangeListener = (Boolean) -> Unit
+typealias OnTextChangeListener = (String, String) -> Unit
+typealias OnKeyPreImeListener = (View, Int, KeyEvent) -> Boolean
+typealias OnSelectionChangedListener = (Int, Int) -> Unit
+typealias OnWindowsFocusChangeListener = (Boolean) -> Unit
+
+/**
+ * An {@link EditText} component which supports inline autocompletion.
+ *
+ * The background color of autocomplete spans can be configured using
+ * the custom autocompleteBackgroundColor attribute e.g.
+ * app:autocompleteBackgroundColor="#ffffff".
+ *
+ * A filter listener (see {@link setOnFilterListener}) needs to be attached to
+ * provide autocomplete results. It will be invoked when the input
+ * text changes. The listener gets direct access to this component (via its view
+ * parameter), so it can call {@link onAutocomplete} in return.
+ *
+ * A commit listener (see {@link setOnCommitListener}) can be attached which is
+ * invoked when the user selected the result i.e. is done editing.
+ *
+ * Various other listeners can be attached to enhance default behaviour e.g.
+ * {@link setOnSelectionChangedListener} and
+ * {@link setOnWindowsFocusChangeListener} which will be invoked in response to
+ * {@link onSelectionChanged} and {@link onWindowFocusChanged} respectively
+ * (see also {@link setOnTextChangeListener},
+ * {@link setOnSelectionChangedListener}, {@link setOnWindowsFocusChangeListener}).
+ */
+open class InlineAutocompleteEditText(val ctx: Context, attrs: AttributeSet) : AppCompatEditText(ctx, attrs) {
+    data class AutocompleteResult(val text: String, val source: String, val totalItems: Int) {
+        val isEmpty: Boolean = this.text.isEmpty()
+        val length: Int = this.text.length
+
+        fun startsWith(text: String): Boolean = this.text.startsWith(text)
+
+        companion object {
+            fun emptyResult(): AutocompleteResult = AutocompleteResult("", "", 0)
+        }
+    }
+
+    private var commitListener: OnCommitListener? = null
+    fun setOnCommitListener(l: OnCommitListener) { commitListener = l }
+
+    private var filterListener: OnFilterListener? = null
+    fun setOnFilterListener(l: OnFilterListener) { filterListener = l }
+
+    private var searchStateChangeListener: OnSearchStateChangeListener? = null
+    fun setOnSearchStateChangeListener(l: OnSearchStateChangeListener) { searchStateChangeListener = l }
+
+    private var textChangeListener: OnTextChangeListener? = null
+    fun setOnTextChangeListener(l: OnTextChangeListener) { textChangeListener = l }
+
+    private var keyPreImeListener: OnKeyPreImeListener? = null
+    fun setOnKeyPreImeListener(l: OnKeyPreImeListener) { keyPreImeListener = l }
+
+    private var selectionChangedListener: OnSelectionChangedListener? = null
+    fun setOnSelectionChangedListener(l: OnSelectionChangedListener) { selectionChangedListener = l }
+
+    private var windowFocusChangeListener: OnWindowsFocusChangeListener? = null
+    fun setOnWindowsFocusChangeListener(l: OnWindowsFocusChangeListener) { windowFocusChangeListener = l }
+
+    // The previous autocomplete result returned to us
+    var autocompleteResult = AutocompleteResult.emptyResult()
+        private set
+
+    // Length of the user-typed portion of the result
+    private var autoCompletePrefixLength: Int = 0
+    // If text change is due to us setting autocomplete
+    private var settingAutoComplete: Boolean = false
+    // Spans used for marking the autocomplete text
+    private var autoCompleteSpans: Array<Any>? = null
+    // Do not process autocomplete result
+    private var discardAutoCompleteResult: Boolean = false
+
+    val nonAutocompleteText: String
+        get() = getNonAutocompleteText(text)
+
+    val originalText: String
+        get() = text.subSequence(0, autoCompletePrefixLength).toString()
+
+    private val autoCompleteBackgroundColor: Int = {
+        val a = context.obtainStyledAttributes(attrs, R.styleable.InlineAutocompleteEditText)
+        val color = a.getColor(R.styleable.InlineAutocompleteEditText_autocompleteBackgroundColor,
+                DEFAULT_AUTOCOMPLETE_BACKGROUND_COLOR)
+        a.recycle()
+        color
+    }()
+
+    private val onKeyPreIme = fun (_: View, keyCode: Int, event: KeyEvent): Boolean {
+        // We only want to process one event per tap
+        if (event.action != KeyEvent.ACTION_DOWN) {
+            return false
+        }
+
+        if (keyCode == KeyEvent.KEYCODE_ENTER) {
+            // If the edit text has a composition string, don't submit the text yet.
+            // ENTER is needed to commit the composition string.
+            val content = text
+            if (!hasCompositionString(content)) {
+                commitListener?.invoke()
+                return true
+            }
+        }
+
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            removeAutocomplete(text)
+            return false
+        }
+
+        return false
+    }
+
+    private val onKey = fun (_: View, keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_ENTER) {
+            if (event.action != KeyEvent.ACTION_DOWN) {
+                return true
+            }
+
+            commitListener?.invoke()
+            return true
+        }
+
+        // Delete autocomplete text when backspacing or forward deleting.
+        return ((keyCode == KeyEvent.KEYCODE_DEL ||
+                keyCode == KeyEvent.KEYCODE_FORWARD_DEL) &&
+                removeAutocomplete(text))
+    }
+
+    private val onSelectionChanged = fun (selStart: Int, selEnd: Int) {
+        // The user has repositioned the cursor somewhere. We need to adjust
+        // the autocomplete text depending on where the new cursor is.
+        val text = text
+        val start = text.getSpanStart(AUTOCOMPLETE_SPAN)
+
+        if (settingAutoComplete || start < 0 || start == selStart && start == selEnd) {
+            // Do not commit autocomplete text if there is no autocomplete text
+            // or if selection is still at start of autocomplete text
+            return
+        }
+
+        if (selStart <= start && selEnd <= start) {
+            // The cursor is in user-typed text; remove any autocomplete text.
+            removeAutocomplete(text)
+        } else {
+            // The cursor is in the autocomplete text; commit it so it becomes regular text.
+            commitAutocomplete(text)
+        }
+    }
+
+    public override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        this.keyPreImeListener = onKeyPreIme
+        this.selectionChangedListener = onSelectionChanged
+
+        setOnKeyListener(onKey)
+        addTextChangedListener(TextChangeListener())
+    }
+
+    public override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
+
+        // Make search icon inactive when edit toolbar search term isn't a user entered
+        // search term
+        val isActive = !TextUtils.isEmpty(text)
+
+        searchStateChangeListener?.invoke(isActive)
+
+        if (gainFocus) {
+            resetAutocompleteState()
+            return
+        }
+
+        removeAutocomplete(text)
+
+        val imm = ctx.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        try {
+            imm.restartInput(this)
+            imm.hideSoftInputFromWindow(windowToken, 0)
+        } catch (ignored: NullPointerException) {
+            // See bug 782096 for details
+        }
+    }
+
+    override fun setText(text: CharSequence?, type: TextView.BufferType) {
+        val textString = text?.toString() ?: ""
+        super.setText(textString, type)
+
+        // Any autocomplete text would have been overwritten, so reset our autocomplete states.
+        resetAutocompleteState()
+    }
+
+    override fun sendAccessibilityEventUnchecked(event: AccessibilityEvent) {
+        // We need to bypass the isShown() check in the default implementation
+        // for TYPE_VIEW_TEXT_SELECTION_CHANGED events so that accessibility
+        // services could detect a url change.
+        if (event.eventType == AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED &&
+                parent != null && !isShown) {
+            onInitializeAccessibilityEvent(event)
+            dispatchPopulateAccessibilityEvent(event)
+            parent.requestSendAccessibilityEvent(this, event)
+        } else {
+            super.sendAccessibilityEventUnchecked(event)
+        }
+    }
+
+    /**
+     * Mark the start of autocomplete changes so our text change
+     * listener does not react to changes in autocomplete text
+     */
+    private fun beginSettingAutocomplete() {
+        beginBatchEdit()
+        settingAutoComplete = true
+    }
+
+    /**
+     * Mark the end of autocomplete changes
+     */
+    private fun endSettingAutocomplete() {
+        settingAutoComplete = false
+        endBatchEdit()
+    }
+
+    /**
+     * Reset autocomplete states to their initial values
+     */
+    private fun resetAutocompleteState() {
+        autoCompleteSpans = arrayOf(AUTOCOMPLETE_SPAN, BackgroundColorSpan(autoCompleteBackgroundColor))
+        autocompleteResult = AutocompleteResult.emptyResult()
+        // Pretend we already autocompleted the existing text,
+        // so that actions like backspacing don't trigger autocompletion.
+        autoCompletePrefixLength = text.length
+        isCursorVisible = true
+    }
+
+    /**
+     * Remove any autocomplete text
+     *
+     * @param text Current text content that may include autocomplete text
+     */
+    private fun removeAutocomplete(text: Editable): Boolean {
+        val start = text.getSpanStart(AUTOCOMPLETE_SPAN)
+        if (start < 0) {
+            // No autocomplete text
+            return false
+        }
+
+        beginSettingAutocomplete()
+
+        // When we call delete() here, the autocomplete spans we set are removed as well.
+        text.delete(start, text.length)
+
+        // Keep autoCompletePrefixLength the same because the prefix has not changed.
+        // Clear mAutoCompleteResult to make sure we get fresh autocomplete text next time.
+        autocompleteResult = AutocompleteResult.emptyResult()
+
+        // Reshow the cursor.
+        isCursorVisible = true
+
+        endSettingAutocomplete()
+        return true
+    }
+
+    /**
+     * Convert any autocomplete text to regular text
+     *
+     * @param text Current text content that may include autocomplete text
+     */
+    private fun commitAutocomplete(text: Editable): Boolean {
+        val start = text.getSpanStart(AUTOCOMPLETE_SPAN)
+        if (start < 0) {
+            // No autocomplete text
+            return false
+        }
+
+        beginSettingAutocomplete()
+
+        // Remove all spans here to convert from autocomplete text to regular text
+        for (span in autoCompleteSpans!!) {
+            text.removeSpan(span)
+        }
+
+        // Keep mAutoCompleteResult the same because the result has not changed.
+        // Reset autoCompletePrefixLength because the prefix now includes the autocomplete text.
+        autoCompletePrefixLength = text.length
+
+        // Reshow the cursor.
+        isCursorVisible = true
+
+        endSettingAutocomplete()
+
+        // Filter on the new text
+        filterListener?.invoke(text.toString(), null)
+        return true
+    }
+
+    /**
+     * Add autocomplete text based on the result URI.
+     *
+     * @param result Result URI to be turned into autocomplete text
+     */
+    fun onAutocomplete(result: AutocompleteResult?) {
+        // If discardAutoCompleteResult is true, we temporarily disabled
+        // autocomplete (due to backspacing, etc.) and we should bail early.
+        if (discardAutoCompleteResult) {
+            return
+        }
+
+        if (!isEnabled || result == null || result.isEmpty) {
+            autocompleteResult = AutocompleteResult.emptyResult()
+            return
+        }
+
+        val text = text
+        val textLength = text.length
+        val resultLength = result.length
+        val autoCompleteStart = text.getSpanStart(AUTOCOMPLETE_SPAN)
+        autocompleteResult = result
+
+        if (autoCompleteStart > -1) {
+            // Autocomplete text already exists; we should replace existing autocomplete text.
+
+            // If the result and the current text don't have the same prefixes,
+            // the result is stale and we should wait for the another result to come in.
+            if (!TextUtils.regionMatches(result.text, 0, text, 0, autoCompleteStart)) {
+                return
+            }
+
+            beginSettingAutocomplete()
+
+            // Replace the existing autocomplete text with new one.
+            // replace() preserves the autocomplete spans that we set before.
+            text.replace(autoCompleteStart, textLength, result.text, autoCompleteStart, resultLength)
+
+            // Reshow the cursor if there is no longer any autocomplete text.
+            if (autoCompleteStart == resultLength) {
+                isCursorVisible = true
+            }
+
+            endSettingAutocomplete()
+        } else {
+            // No autocomplete text yet; we should add autocomplete text
+
+            // If the result prefix doesn't match the current text,
+            // the result is stale and we should wait for the another result to come in.
+            if (resultLength <= textLength || !TextUtils.regionMatches(result.text, 0, text, 0, textLength)) {
+                return
+            }
+
+            val spans = text.getSpans(textLength, textLength, Any::class.java)
+            val spanStarts = IntArray(spans.size)
+            val spanEnds = IntArray(spans.size)
+            val spanFlags = IntArray(spans.size)
+
+            // Save selection/composing span bounds so we can restore them later.
+            for (i in spans.indices) {
+                val span = spans[i]
+                val spanFlag = text.getSpanFlags(span)
+
+                // We don't care about spans that are not selection or composing spans.
+                // For those spans, spanFlag[i] will be 0 and we don't restore them.
+                if (spanFlag and Spanned.SPAN_COMPOSING == 0 &&
+                        span !== Selection.SELECTION_START &&
+                        span !== Selection.SELECTION_END) {
+                    continue
+                }
+
+                spanStarts[i] = text.getSpanStart(span)
+                spanEnds[i] = text.getSpanEnd(span)
+                spanFlags[i] = spanFlag
+            }
+
+            beginSettingAutocomplete()
+
+            // First add trailing text.
+            text.append(result.text, textLength, resultLength)
+
+            // Restore selection/composing spans.
+            for (i in spans.indices) {
+                val spanFlag = spanFlags[i]
+                if (spanFlag == 0) {
+                    // Skip if the span was ignored before.
+                    continue
+                }
+                text.setSpan(spans[i], spanStarts[i], spanEnds[i], spanFlag)
+            }
+
+            // Mark added text as autocomplete text.
+            for (span in autoCompleteSpans!!) {
+                text.setSpan(span, textLength, resultLength, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+
+            // Hide the cursor.
+            isCursorVisible = false
+
+            // Make sure the autocomplete text is visible. If the autocomplete text is too
+            // long, it would appear the cursor will be scrolled out of view. However, this
+            // is not the case in practice, because EditText still makes sure the cursor is
+            // still in view.
+            bringPointIntoView(resultLength)
+
+            endSettingAutocomplete()
+        }
+
+        announceForAccessibility(text.toString())
+    }
+
+    /**
+     * Code to handle deleting autocomplete first when backspacing.
+     * If there is no autocomplete text, both removeAutocomplete() and commitAutocomplete()
+     * are no-ops and return false. Therefore we can use them here without checking explicitly
+     * if we have autocomplete text or not.
+     *
+     * Also turns off text prediction for private mode tabs.
+     */
+    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
+        val ic = super.onCreateInputConnection(outAttrs) ?: return null
+
+        return object : InputConnectionWrapper(ic, false) {
+            override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+                if (removeAutocomplete(text)) {
+                    // If we have autocomplete text, the cursor is at the boundary between
+                    // regular and autocomplete text. So regardless of which direction we
+                    // are deleting, we should delete the autocomplete text first.
+                    // Make the IME aware that we interrupted the deleteSurroundingText call,
+                    // by restarting the IME.
+                    val imm = ctx.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                    imm.restartInput(this@InlineAutocompleteEditText)
+                    return false
+                }
+                return super.deleteSurroundingText(beforeLength, afterLength)
+            }
+
+            private fun removeAutocompleteOnComposing(text: CharSequence): Boolean {
+                val editable = getText()
+                val composingStart = BaseInputConnection.getComposingSpanStart(editable)
+                val composingEnd = BaseInputConnection.getComposingSpanEnd(editable)
+                // We only delete the autocomplete text when the user is backspacing,
+                // i.e. when the composing text is getting shorter.
+                if (composingStart >= 0 &&
+                        composingEnd >= 0 &&
+                        composingEnd - composingStart > text.length &&
+                        removeAutocomplete(editable)) {
+                    // Make the IME aware that we interrupted the setComposingText call,
+                    // by having finishComposingText() send change notifications to the IME.
+                    finishComposingText()
+                    setComposingRegion(composingStart, composingEnd)
+                    return true
+                }
+                return false
+            }
+
+            override fun commitText(text: CharSequence, newCursorPosition: Int): Boolean {
+                return if (removeAutocompleteOnComposing(text))
+                    false
+                else
+                    super.commitText(text, newCursorPosition)
+            }
+
+            override fun setComposingText(text: CharSequence, newCursorPosition: Int): Boolean {
+                return if (removeAutocompleteOnComposing(text))
+                    false
+                else
+                    super.setComposingText(text, newCursorPosition)
+            }
+        }
+    }
+
+    private inner class TextChangeListener : TextWatcher {
+        private var textLengthBeforeChange: Int = 0
+
+        override fun afterTextChanged(editable: Editable) {
+            if (!isEnabled || settingAutoComplete) {
+                return
+            }
+
+            val text = getNonAutocompleteText(editable)
+            val textLength = text.length
+            var doAutocomplete = true
+
+            // Check if search query
+            if (text.contains(" ")) {
+                doAutocomplete = false
+            } else if (textLength == textLengthBeforeChange - 1 || textLength == 0) {
+                // If you're hitting backspace (the string is getting smaller), don't autocomplete
+                doAutocomplete = false
+            }
+
+            autoCompletePrefixLength = textLength
+
+            // If we are not autocompleting, we set discardAutoCompleteResult to true
+            // to discard any autocomplete results that are in-flight, and vice versa.
+            discardAutoCompleteResult = !doAutocomplete
+
+            if (doAutocomplete && autocompleteResult.startsWith(text)) {
+                // If this text already matches our autocomplete text, autocomplete likely
+                // won't change. Just reuse the old autocomplete value.
+                onAutocomplete(autocompleteResult)
+                doAutocomplete = false
+            } else {
+                // Otherwise, remove the old autocomplete text
+                // until any new autocomplete text gets added.
+                removeAutocomplete(editable)
+            }
+
+            // Update search icon with an active state since user is typing
+            searchStateChangeListener?.invoke(textLength > 0)
+
+            filterListener?.invoke(text, if (doAutocomplete) this@InlineAutocompleteEditText else null)
+
+            textChangeListener?.invoke(text, getText().toString())
+        }
+
+        override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+            textLengthBeforeChange = s.length
+        }
+
+        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+            // do nothing
+        }
+    }
+
+    override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
+        return keyPreImeListener?.invoke(this, keyCode, event) ?: false
+    }
+
+    public override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+        selectionChangedListener?.invoke(selStart, selEnd)
+        super.onSelectionChanged(selStart, selEnd)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        windowFocusChangeListener?.invoke(hasFocus)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        return if (android.os.Build.VERSION.SDK_INT == Build.VERSION_CODES.M &&
+                event.actionMasked == MotionEvent.ACTION_UP) {
+            // Android 6 occasionally throws a NullPointerException inside Editor.onTouchEvent()
+            // for ACTION_UP when attempting to display (uninitialised) text handles. The Editor
+            // and TextView IME interactions are quite complex, so I don't know how to properly
+            // work around this issue, but we can at least catch the NPE to prevent crashing
+            // the whole app.
+            // (Editor tries to make both selection handles visible, but in certain cases they haven't
+            // been initialised yet, causing the NPE. It doesn't bother to check the selection handle
+            // state, and making some other calls to ensure the handles exist doesn't seem like a
+            // clean solution either since I don't understand most of the selection logic. This implementation
+            // only seems to exist in Android 6, both Android 5 and 7 have different implementations.)
+            try {
+                super.onTouchEvent(event)
+            } catch (ignored: NullPointerException) {
+                // Ignore this (see above) - since we're now in an unknown state let's clear all selection
+                // (which is still better than an arbitrary crash that we can't control):
+                clearFocus()
+                true
+            }
+        } else {
+            super.onTouchEvent(event)
+        }
+    }
+
+    companion object {
+        val AUTOCOMPLETE_SPAN = NoCopySpan.Concrete()
+        val DEFAULT_AUTOCOMPLETE_BACKGROUND_COLOR = parseColor("#ffb5007f")
+
+        /**
+         * Get the portion of text that is not marked as autocomplete text.
+         *
+         * @param text Current text content that may include autocomplete text
+         */
+        private fun getNonAutocompleteText(text: Editable): String {
+            val start = text.getSpanStart(AUTOCOMPLETE_SPAN)
+            return if (start < 0) {
+                // No autocomplete text; return the whole string.
+                text.toString()
+            } else {
+                // Only return the portion that's not autocomplete text
+                TextUtils.substring(text, 0, start)
+            }
+        }
+
+        private fun hasCompositionString(content: Editable): Boolean {
+            val spans = content.getSpans(0, content.length, Any::class.java)
+            return spans.any { span -> content.getSpanFlags(span) and Spanned.SPAN_COMPOSING != 0 }
+        }
+    }
+}

--- a/components/ui/autocomplete/src/main/res/values/attrs.xml
+++ b/components/ui/autocomplete/src/main/res/values/attrs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <declare-styleable name="InlineAutocompleteEditText">
+        <attr name="autocompleteBackgroundColor" format="color" />
+    </declare-styleable>
+</resources>

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -1,0 +1,326 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.ui.autocomplete
+
+import android.content.Context
+import android.text.Spanned
+import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+import android.util.AttributeSet
+import android.view.KeyEvent
+import android.view.ViewParent
+import android.view.accessibility.AccessibilityEvent
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.doReturn
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
+import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.Companion.AUTOCOMPLETE_SPAN
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class)
+class InlineAutocompleteEditTextTest {
+    private val context: Context = RuntimeEnvironment.application
+    private val attributes: AttributeSet = mock(AttributeSet::class.java)
+
+    @Test
+    fun testAutoCompleteResult() {
+        val empty = AutocompleteResult.emptyResult()
+        assertTrue(empty.isEmpty)
+        assertEquals(0, empty.length)
+        assertFalse(empty.startsWith("test"))
+
+        val nonEmpty = AutocompleteResult("testText", "testSource", 1)
+        assertFalse(nonEmpty.isEmpty)
+        assertEquals(8, nonEmpty.length)
+        assertTrue(nonEmpty.startsWith("test"))
+        assertEquals("testSource", nonEmpty.source)
+        assertEquals(1, nonEmpty.totalItems)
+    }
+
+    @Test
+    fun testGetNonAutocompleteText() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        et.setText("Test")
+        assertEquals("Test", et.nonAutocompleteText)
+
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 2, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        assertEquals("Te", et.nonAutocompleteText)
+
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 0, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        assertEquals("", et.nonAutocompleteText)
+    }
+
+    @Test
+    fun testGetOriginalText() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        et.setText("Test")
+        assertEquals("Test", et.originalText)
+
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 2, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        assertEquals("Test", et.originalText)
+
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 0, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        assertEquals("Test", et.originalText)
+    }
+
+    @Test
+    fun testOnFocusChange() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        val searchStates = mutableListOf<Boolean>()
+
+        et.setOnSearchStateChangeListener { b: Boolean -> searchStates.add(searchStates.size, b) }
+        et.onFocusChanged(false, 0, null)
+
+        et.setText("text")
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 0, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        et.onFocusChanged(false, 0, null)
+        assertTrue(et.text.isEmpty())
+
+        et.setText("text")
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 0, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        et.onFocusChanged(true, 0, null)
+        assertFalse(et.text.isEmpty())
+        assertEquals(listOf(false, true, true), searchStates)
+    }
+
+    @Test
+    fun testSendAccessibilityEventUnchecked() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        doReturn(false).`when`(et).isShown
+        doReturn(mock(ViewParent::class.java)).`when`(et).parent
+
+        val event = AccessibilityEvent.obtain()
+        event.eventType = AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED
+        et.sendAccessibilityEventUnchecked(event)
+
+        verify(et).onInitializeAccessibilityEvent(event)
+        verify(et).dispatchPopulateAccessibilityEvent(event)
+        verify(et.parent).requestSendAccessibilityEvent(et, event)
+    }
+
+    @Test
+    fun testOnAutocompleteSetsEmptyResult() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+
+        doReturn(false).`when`(et).isEnabled
+        et.onAutocomplete(AutocompleteResult("text", "source", 1))
+        assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
+
+        doReturn(true).`when`(et).isEnabled
+        et.onAutocomplete(null)
+        assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
+
+        et.onAutocomplete(AutocompleteResult.emptyResult())
+        assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
+    }
+
+    @Test
+    fun testOnAutocompleteDiscardsStaleResult() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        doReturn(true).`when`(et).isEnabled
+        et.setText("text")
+
+        et.onAutocomplete(AutocompleteResult("stale result", "source", 1))
+        assertEquals("text", et.text.toString())
+
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 1, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        et.onAutocomplete(AutocompleteResult("stale result", "source", 1))
+        assertEquals("text", et.text.toString())
+    }
+
+    @Test
+    fun testOnAutocompleteReplacesExistingAutocompleteText() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        doReturn(true).`when`(et).isEnabled
+
+        et.setText("text")
+        et.text.setSpan(AUTOCOMPLETE_SPAN, 1, 3, SPAN_EXCLUSIVE_EXCLUSIVE)
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+        assertEquals("text completed", et.text.toString())
+    }
+
+    @Test
+    fun testOnAutocompleteAppendsExistingText() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        doReturn(true).`when`(et).isEnabled
+
+        et.setText("text")
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+        assertEquals("text completed", et.text.toString())
+    }
+
+    @Test
+    fun testOnAutocompleteSetsSpan() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        doReturn(true).`when`(et).isEnabled
+
+        et.setText("text")
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+
+        assertEquals(4, et.text.getSpanStart(AUTOCOMPLETE_SPAN))
+        assertEquals(14, et.text.getSpanEnd(AUTOCOMPLETE_SPAN))
+        assertEquals(Spanned.SPAN_EXCLUSIVE_EXCLUSIVE, et.text.getSpanFlags(AUTOCOMPLETE_SPAN))
+    }
+
+    @Test
+    fun testOnKeyPreImeListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        var invokedWithParams: List<Any>? = null
+        et.setOnKeyPreImeListener { p1, p2, p3 ->
+            invokedWithParams = listOf(p1, p2, p3)
+            true
+        }
+        val event = mock(KeyEvent::class.java)
+        et.onKeyPreIme(1, event)
+        assertEquals(listOf(et, 1, event), invokedWithParams)
+    }
+
+    @Test
+    fun testOnSelectionChangedListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        var invokedWithParams: List<Any>? = null
+        et.setOnSelectionChangedListener { p1, p2 ->
+            invokedWithParams = listOf(p1, p2)
+        }
+        et.onSelectionChanged(0, 1)
+        assertEquals(listOf(0, 1), invokedWithParams)
+    }
+
+    @Test
+    fun testOnSelectionChangedCommitsResult() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        et.onAttachedToWindow()
+
+        et.setText("text")
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+        assertEquals(4, et.text.getSpanStart(AUTOCOMPLETE_SPAN))
+
+        et.onSelectionChanged(4, 14)
+        assertEquals(-1, et.text.getSpanStart(AUTOCOMPLETE_SPAN))
+    }
+
+    @Test
+    fun testOnWindowFocusChangedListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        var invokedWithParams: List<Any>? = null
+        et.setOnWindowsFocusChangeListener { p1 ->
+            invokedWithParams = listOf(p1)
+        }
+        et.onWindowFocusChanged(true)
+        assertEquals(listOf(true), invokedWithParams)
+    }
+
+    @Test
+    fun testOnCommitListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        var invoked: Boolean = false
+        et.setOnCommitListener { invoked = true }
+        et.onAttachedToWindow()
+
+        et.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+        assertTrue(invoked)
+    }
+
+    @Test
+    fun testOnTextChangeListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        var invokedWithParams: List<Any>? = null
+        et.setOnTextChangeListener { p1, p2 ->
+            invokedWithParams = listOf(p1, p2)
+        }
+        et.onAttachedToWindow()
+
+        et.setText("text")
+        assertEquals(listOf("text", "text"), invokedWithParams)
+    }
+
+    @Test
+    fun testOnSearchStateChangeListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        et.onAttachedToWindow()
+
+        var invokedWithParams: List<Any>? = null
+        et.setOnSearchStateChangeListener { p1 ->
+            invokedWithParams = listOf(p1)
+        }
+
+        et.setText("")
+        assertEquals(listOf(false), invokedWithParams)
+
+        et.setText("text")
+        assertEquals(listOf(true), invokedWithParams)
+    }
+
+    @Test
+    fun testOnFilterListenerInvocation() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        et.onAttachedToWindow()
+
+        var invokedWithParams: List<Any?>? = null
+        et.setOnFilterListener { p1, p2 ->
+            invokedWithParams = listOf(p1, p2)
+        }
+
+        // Text existing autocomplete result
+        et.onAutocomplete(AutocompleteResult("text", "source", 1))
+        et.setText("text")
+        assertEquals(listOf("text", null), invokedWithParams)
+
+        et.setText("text")
+        assertEquals(listOf("text", et), invokedWithParams)
+
+        // Test backspace
+        et.setText("tex")
+        assertEquals(listOf("tex", null), invokedWithParams)
+
+        et.setText("search term")
+        assertEquals(listOf("search term", null), invokedWithParams)
+
+        et.setText("")
+        assertEquals(listOf("", null), invokedWithParams)
+    }
+
+    @Test
+    fun testOnCreateInputConnection() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        val icw = et.onCreateInputConnection(mock(EditorInfo::class.java))
+        doReturn(true).`when`(et).isEnabled
+
+        et.setText("text")
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+        assertEquals("text completed", et.text.toString())
+
+        icw?.deleteSurroundingText(0, 1)
+        assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
+        assertEquals("text", et.text.toString())
+
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+        assertEquals("text completed", et.text.toString())
+
+        BaseInputConnection.setComposingSpans(et.text)
+        icw?.commitText("text", 4)
+        assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
+        assertEquals("text", et.text.toString())
+
+        et.onAutocomplete(AutocompleteResult("text completed", "source", 1))
+        assertEquals("text completed", et.text.toString())
+
+        BaseInputConnection.setComposingSpans(et.text)
+        icw?.setComposingText("text", 4)
+        assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
+        assertEquals("text", et.text.toString())
+    }
+}

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist timestamp="1521663963552"></Blacklist>
-  <Whitelist timestamp="1521663963552">
+  <Whitelist timestamp="1522100300281">
+    <ID>ComplexCondition:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$settingAutoComplete || start &lt; 0 || start == selStart &amp;&amp; start == selEnd</ID>
+    <ID>ComplexCondition:InlineAutocompleteEditText.kt$InlineAutocompleteEditText.&lt;no name provided&gt;$composingStart &gt;= 0 &amp;&amp; composingEnd &gt;= 0 &amp;&amp; composingEnd - composingStart &gt; text.length &amp;&amp; removeAutocomplete(editable)</ID>
     <ID>ComplexMethod:DownloadUtils.kt$DownloadUtils$ @JvmStatic fun guessFileName(contentDisposition: String?, url: String?, mimeType: String?): String</ID>
     <ID>ComplexMethod:ErrorPages.kt$ErrorPages$ fun mapWebViewErrorCodeToErrorType(errorCode: Int): ErrorType</ID>
+    <ID>ComplexMethod:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$ fun onAutocomplete(result: AutocompleteResult?)</ID>
+    <ID>ComplexMethod:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$ override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection?</ID>
     <ID>EmptyCatchBlock:DownloadUtils.kt$DownloadUtils${ }</ID>
+    <ID>LargeClass:InlineAutocompleteEditText.kt$InlineAutocompleteEditText : AppCompatEditText</ID>
     <ID>MagicNumber:Bitmap.kt$100</ID>
     <ID>MagicNumber:ColorUtils.kt$ColorUtils$0.114</ID>
     <ID>MagicNumber:ColorUtils.kt$ColorUtils$0.299</ID>
@@ -13,11 +18,12 @@
     <ID>MagicNumber:DownloadUtils.kt$DownloadUtils$16</ID>
     <ID>MagicNumber:DownloadUtils.kt$DownloadUtils$3</ID>
     <ID>MagicNumber:DownloadUtils.kt$DownloadUtils$4</ID>
-    <ID>MaxLineLength:ErrorPages.kt$.ErrorPages.kt</ID>
     <ID>MaxLineLength:SafeIntent.kt$mozilla.components.utils.SafeIntent.kt</ID>
     <ID>MaxLineLength:WebURLFinder.kt$mozilla.components.utils.WebURLFinder.kt</ID>
     <ID>NestedBlockDepth:DownloadUtils.kt$DownloadUtils$ @JvmStatic fun guessFileName(contentDisposition: String?, url: String?, mimeType: String?): String</ID>
     <ID>ReturnCount:DownloadUtils.kt$DownloadUtils$private fun parseContentDisposition(contentDisposition: String): String?</ID>
+    <ID>ReturnCount:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$ fun onAutocomplete(result: AutocompleteResult?)</ID>
+    <ID>ReturnCount:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$fun (_: View, keyCode: Int, event: KeyEvent): Boolean</ID>
     <ID>ReturnCount:SafeBundle.kt$SafeBundle$fun &lt;T : Parcelable&gt; getParcelable(name: String): T?</ID>
     <ID>ReturnCount:SafeBundle.kt$SafeBundle$fun getString(name: String): String?</ID>
     <ID>ReturnCount:SafeIntent.kt$SafeIntent$fun &lt;T : Parcelable&gt; getParcelableArrayListExtra(name: String): ArrayList&lt;T&gt;?</ID>
@@ -29,9 +35,12 @@
     <ID>ReturnCount:SafeIntent.kt$SafeIntent$fun getStringArrayListExtra(name: String): ArrayList&lt;String&gt;?</ID>
     <ID>ReturnCount:SafeIntent.kt$SafeIntent$fun getStringExtra(name: String): String?</ID>
     <ID>ReturnCount:SafeIntent.kt$SafeIntent$fun hasExtra(name: String): Boolean</ID>
+    <ID>TooGenericExceptionCaught:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$e: NullPointerException</ID>
+    <ID>TooGenericExceptionCaught:InlineAutocompleteEditText.kt$InlineAutocompleteEditText$ignored: NullPointerException</ID>
     <ID>TooGenericExceptionCaught:SafeBundle.kt$SafeBundle$e: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:SafeIntent.kt$SafeIntent$e: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:WebURLFinder.kt$WebURLFinder.Companion$e: Exception</ID>
+    <ID>TooManyFunctions:InlineAutocompleteEditText.kt$InlineAutocompleteEditText : AppCompatEditText</ID>
     <ID>TopLevelPropertyNaming:Char.kt$/** * A series of dots (typically three, such as "…") that usually indicates an intentional omission of * a word, sentence, or whole section from a text without altering its original meaning. */ val Char.Companion.ELLIPSIS: Char get() = '…'</ID>
   </Whitelist>
 </SmellBaseline>

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,9 @@ project(':browser-toolbar').projectDir = new File(rootDir, 'components/browser/t
 // UI components
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+include ':ui-autocomplete'
+project(':ui-autocomplete').projectDir = new File(rootDir, 'components/ui/autocomplete')
+
 include ':ui-colors'
 project(':ui-colors').projectDir = new File(rootDir, 'components/ui/colors')
 


### PR DESCRIPTION
This PR provides a Kotlin (kotlinized?) version of `InlineAutocompleteEditText`, plus unit tests. :)

It makes use of various Kotlin features i.e. data classes, safe call operators, lamdas and type aliases. I've kept existing behavior with one exception: Instead of having specific interfaces for each listener type, I've switched to accepting lambdas. This will require minor modifications to existing consumers i.e. in Focus we'd have to change `UrlInputFragment`. It would no longer need to implement `OnFilterListener` and `OnCommitListener` and instead of being a listener it can simply provide a lambda or method reference i.e. instead of  `urlView.setOnFilterListener(this)`, we can use `urlView.setOnFilterListener(this::onFilter)` or similar. I've verified that the component still works fine after making these changes in Focus.

For the unit tests, I've focused on testing behavior observable through the public API. This is looking pretty good, I think. We got 97% line coverage with these tests.
