### PR TITLE
Gradle: Centralize depedency version configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,35 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
-    ext.compileSdkVersion = 27
-    ext.targetSdkVersion = 27
-    ext.minSdkVersion = 21
+    // Synchronized version numbers for dependencies used by (some) modules
+    ext.dependencies = [
+        kotlin: '1.2.30',
+        supportLibraries: '27.1.0',
+        junit: '4.12',
+        robolectric: '3.7.1',
+        mockito: '2.12.0'
+    ]
 
-    ext.version = "0.2.2"
+    // Synchronized build configuration for all modules
+    ext.build = [
+        compileSdkVersion: 27,
+        targetSdkVersion: 27,
+        minSdkVersion: 21
+    ]
+
+    // Synchronized library configuration for all modules
+    ext.library = [
+        version: '0.3'
+    ]
 
     repositories {
         google()
         jcenter()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${project.ext.dependencies['kotlin']}"
 
         // Publish.
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
     }
 
     lintOptions {
@@ -29,7 +29,7 @@ android {
 dependencies {
     implementation project(':browser-engine')
 
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 }
 
 archivesBaseName = "engine-gecko"

--- a/components/browser/engine/build.gradle
+++ b/components/browser/engine/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
     }
 
     lintOptions {
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 }
 
 archivesBaseName = "engine"

--- a/components/browser/errorpages/build.gradle
+++ b/components/browser/errorpages/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -35,9 +35,9 @@ android {
 }
 
 dependencies {
-    compileOnly 'com.android.support:support-annotations:27.1.0'
+    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
 
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 }
 
 archivesBaseName = "errorpages"

--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
     }
 
     lintOptions {
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 }
 
 archivesBaseName = "session"

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
     }
 
     lintOptions {
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 }
 
 archivesBaseName = "toolbar"

--- a/components/support/ktx/build.gradle
+++ b/components/support/ktx/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -28,14 +28,13 @@ android {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 
-    compileOnly "com.android.support:support-compat:27.1.0"
+    implementation "com.android.support:support-compat:${rootProject.ext.dependencies['supportLibraries']}"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:3.7.1"
-    testImplementation 'org.mockito:mockito-core:2.12.0'
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
 }
 
 archivesBaseName = "ktx"

--- a/components/support/utils/build.gradle
+++ b/components/support/utils/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -30,14 +30,13 @@ android {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compileOnly "com.android.support:support-annotations:27.1.0"
-    compileOnly "com.android.support:support-compat:27.1.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation "com.android.support:support-compat:${rootProject.ext.dependencies['supportLibraries']}"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:3.7.1"
-    testImplementation 'org.mockito:mockito-core:2.12.0'
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
 }
 
 archivesBaseName = "utils"

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -6,11 +6,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -29,14 +30,13 @@ android {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 
-    implementation "com.android.support:appcompat-v7:27.1.0"
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.robolectric:robolectric:3.7.1"
-    testImplementation "org.mockito:mockito-core:2.12.0"
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
 }
 
 archivesBaseName = "autocomplete"

--- a/components/ui/colors/build.gradle
+++ b/components/ui/colors/build.gradle
@@ -5,11 +5,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
     }
 
     lintOptions {

--- a/publish.gradle
+++ b/publish.gradle
@@ -52,7 +52,7 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
 
     apply plugin: 'com.jfrog.bintray'
 
-    version = rootProject.ext.version
+    version = rootProject.ext.library['version']
 
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs


### PR DESCRIPTION
And use "implementation" instead of "compileOnly". Issue #37.

I'll wait until #27 is merged to update the configuration of the new module too.