### PR TITLE
Issue #28: Generate jacoco coverage reports for all components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,50 @@ allprojects {
     }
 }
 
+subprojects {
+    apply plugin: 'jacoco'
+
+    afterEvaluate {
+        if (it.hasProperty('android')) {
+            tasks.withType(Test) {
+                jacoco.includeNoLocationClasses = true
+            }
+
+            task jacocoTestReport(type: JacocoReport, dependsOn: ['test']) {
+                reports {
+                    xml.enabled = true
+                    html.enabled = true
+                }
+
+                def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*',
+                                  '**/*Test*.*', 'android/**/*.*', '**/*$[0-9].*']
+                def debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
+                def mainSrc = "$project.projectDir/src/main/java"
+
+                sourceDirectories = files([mainSrc])
+                classDirectories = files([debugTree])
+                executionData = fileTree(dir: project.buildDir, includes: [
+                        'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+                ])
+            }
+
+            android {
+                buildTypes {
+                    coverage {
+                        initWith debug
+                        testCoverageEnabled true
+                    }
+                }
+                testOptions {
+                    unitTests {
+                        includeAndroidResources = true
+                    }
+                }
+            }
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -21,12 +21,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
-    testOptions {
-        unitTests {
-            includeAndroidResources = true
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This adds a central configuration to enable `jacoco` reports for all components. 

I couldn't use the `jacoco-android` plugin, as I wasn't able to configure it to capture both `src/androidTest` and `src/test` and had troubles making it work with our Kotlin components. So, this is a little more involved as we have to write a task, but with the advantage of having fewer dependencies.

To run: `gradle clean test jacocoTestReport`
Report will be in: `components/[ui|browser|support]/[component]/build/reports/jacoco/jacocoTestReport`

This is based on these two articles (the second one describing the Kotlin solution):
https://medium.com/@rafael_toledo/setting-up-an-unified-coverage-report-in-android-with-jacoco-robolectric-and-espresso-ffe239aaf3fa

https://proandroiddev.com/unified-code-coverage-for-android-revisited-44789c9b722f

