### PR TITLE
Issue #28: Add config for travis/codecov 🔃

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: android
+
+jdk:
+  - oraclejdk8
+
+android:
+  components:
+    - tools
+    - platform-tools
+    - build-tools-27.0.3
+    - android-27
+
+sudo: false
+
+before_install:
+  - touch local.properties
+  - yes | sdkmanager "platforms;android-27"
+
+script:
+  - ./gradlew --no-daemon clean test -Pcoverage
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Adds a basic config for travis and codecov. Since we want to add examples/demo here soon I've configured the Android tooling right away.

This will only work when merged after https://github.com/mozilla-mobile/android-components/pull/52.