### PR TITLE
Closes #81: Add ui.fonts component with roboto fonts.

### DIFF
--- a/components/ui/fonts/build.gradle
+++ b/components/ui/fonts/build.gradle
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    // None
+}
+
+archivesBaseName = "fonts"
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.photon',
+        'fonts',
+        'Convenience accessor for fonts used by Mozilla.')

--- a/components/ui/fonts/proguard-rules.pro
+++ b/components/ui/fonts/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/ui/fonts/src/main/AndroidManifest.xml
+++ b/components/ui/fonts/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.ui.fonts" />

--- a/components/ui/fonts/src/main/res/values/roboto_fonts.xml
+++ b/components/ui/fonts/src/main/res/values/roboto_fonts.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
+
+    <!-- Designers specify the Roboto fontFamily as "Roboto Medium" but they appear in Android as
+         "sans-serif-medium": this file aliases the Android definitions to those used by the designers.
+
+         This solution is adapted from SO: https://stackoverflow.com/a/26545517 and https://stackoverflow.com/a/42927799 -->
+    <string name="font_roboto_regular">sans-serif</string>
+    <string name="font_roboto_light">sans-serif-light</string>
+    <string name="font_roboto_condensed">sans-serif-condensed</string>
+    <string name="font_roboto_black">sans-serif-black</string>
+    <string name="font_roboto_thin">sans-serif-thin</string> <!-- API 17+ -->
+    <string name="font_roboto_medium">sans-serif-medium</string> <!-- API 21+ -->
+
+</resources>

--- a/settings.gradle
+++ b/settings.gradle
@@ -57,6 +57,9 @@ project(':ui-autocomplete').projectDir = new File(rootDir, 'components/ui/autoco
 include ':ui-colors'
 project(':ui-colors').projectDir = new File(rootDir, 'components/ui/colors')
 
+include ':ui-fonts'
+project(':ui-fonts').projectDir = new File('components/ui/fonts')
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Support components
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I tested this by importing the new fonts file into firefox-tv and
verifying that each string correctly displays a font with a different
appearance.

To create the new module, I cp -r ui-colors and imported the resulting
module. Notably, I didn't add a .iml file like colors has, but I think these
modules should be generated by the gradle configuration anyway so iml is
unnecessary.