### PR TITLE
Issue #91: Make loading progress available/observable

### DIFF
--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -32,6 +32,11 @@ dependencies {
     api "org.mozilla:geckoview-nightly-armeabi-v7a:${rootProject.ext.gecko['version']}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
 }
 
 archivesBaseName = "engine-gecko"

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -8,6 +8,9 @@ import mozilla.components.concept.engine.EngineSession
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
 
+const val PROGRESS_START = 25
+const val PROGRESS_STOP = 100
+
 /**
  * Gecko-based EngineSession implementation.
  */
@@ -20,6 +23,7 @@ class GeckoEngineSession(
         geckoSession.open(runtime)
 
         geckoSession.navigationDelegate = createNavigationDelegate()
+        geckoSession.progressDelegate = createProgressDelegate()
     }
 
     /**
@@ -55,5 +59,27 @@ class GeckoEngineSession(
             uri: String?,
             response: GeckoSession.Response<GeckoSession>?
         ) {}
+    }
+
+    /**
+    * ProgressDelegate implementation for forwarding callbacks to observers of the session.
+    */
+    private fun createProgressDelegate() = object : GeckoSession.ProgressDelegate {
+        override fun onSecurityChange(
+            session: GeckoSession?,
+            securityInfo: GeckoSession.ProgressDelegate.SecurityInformation?
+        ) { }
+
+        override fun onPageStart(session: GeckoSession?, url: String?) {
+            notifyObservers { onProgress(PROGRESS_START) }
+            notifyObservers { onLoadingStateChange(true) }
+        }
+
+        override fun onPageStop(session: GeckoSession?, success: Boolean) {
+            if (success) {
+                notifyObservers { onProgress(PROGRESS_STOP) }
+                notifyObservers { onLoadingStateChange(false) }
+            }
+        }
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import mozilla.components.concept.engine.EngineSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mozilla.gecko.util.BundleEventListener
+import org.mozilla.gecko.util.EventCallback
+import org.mozilla.gecko.util.GeckoBundle
+import org.mozilla.geckoview.GeckoRuntime
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineSessionTest {
+
+    @Test
+    fun testEngineSessionInitialization() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val engineSession = GeckoEngineSession(runtime)
+
+        assertTrue(engineSession.geckoSession.isOpen)
+        assertNotNull(engineSession.geckoSession.navigationDelegate)
+        assertNotNull(engineSession.geckoSession.progressDelegate)
+    }
+
+    @Test
+    fun testProgressDelegateNotifiesObservers() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+
+        var observerdProgress = 0
+        var observerLoadingState = false
+        engineSession.register(object : EngineSession.Observer {
+            override fun onLoadingStateChange(loading: Boolean) { observerLoadingState = loading }
+            override fun onLocationChange(url: String) { }
+            override fun onProgress(progress: Int) { observerdProgress = progress }
+        })
+
+        engineSession.geckoSession.progressDelegate.onPageStart(null, "http://mozilla.org")
+        assertEquals(PROGRESS_START, observerdProgress)
+        assertEquals(true, observerLoadingState)
+
+        engineSession.geckoSession.progressDelegate.onPageStop(null, true)
+        assertEquals(PROGRESS_STOP, observerdProgress)
+        assertEquals(false, observerLoadingState)
+    }
+
+    @Test
+    fun testNavigationDelegateNotifiesObservers() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+
+        var observedUrl = ""
+        engineSession.register(object : EngineSession.Observer {
+            override fun onLoadingStateChange(loading: Boolean) {}
+            override fun onLocationChange(url: String) { observedUrl = url }
+            override fun onProgress(progress: Int) { }
+        })
+
+        engineSession.geckoSession.navigationDelegate.onLocationChange(null, "http://mozilla.org")
+        assertEquals("http://mozilla.org", observedUrl)
+    }
+
+    @Test
+    fun testLoadUrl() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        var loadUriReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(object : BundleEventListener {
+            override fun handleMessage(event: String?, message: GeckoBundle?, callback: EventCallback?) {
+                loadUriReceived = true
+            }
+        }, "GeckoView:LoadUri")
+
+        engineSession.loadUrl("http://mozilla.org")
+        assertTrue(loadUriReceived)
+    }
+}

--- a/components/browser/engine-gecko/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/browser/engine-gecko/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/components/browser/engine-system/build.gradle
+++ b/components/browser/engine-system/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     implementation project(':concept-engine')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
 }
 
 archivesBaseName = "engine-system"

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.system
+
+import mozilla.components.concept.engine.EngineSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SystemEngineViewTest {
+
+    @Test
+    fun testEngineViewInitialization() {
+        val engineView = SystemEngineView(RuntimeEnvironment.application)
+
+        assertNotNull(engineView.currentWebView.webChromeClient)
+        assertNotNull(engineView.currentWebView.webViewClient)
+        assertEquals(engineView.currentWebView, engineView.getChildAt(0))
+    }
+
+    @Test
+    fun testWebViewClientNotifiesObservers() {
+        val engineSession = SystemEngineSession()
+        val engineView = SystemEngineView(RuntimeEnvironment.application)
+        engineView.render(engineSession)
+
+        var observedUrl = ""
+        var observedLoadingState = false
+        engineSession.register(object : EngineSession.Observer {
+            override fun onLoadingStateChange(loading: Boolean) { observedLoadingState = loading }
+            override fun onLocationChange(url: String) { observedUrl = url }
+            override fun onProgress(progress: Int) { }
+        })
+
+        engineView.currentWebView.webViewClient.onPageStarted(null, "http://mozilla.org", null)
+        assertEquals(true, observedLoadingState)
+
+        engineView.currentWebView.webViewClient.onReceivedError(null, null, null)
+        assertEquals(false, observedLoadingState)
+
+        observedLoadingState = true
+        engineView.currentWebView.webViewClient.onReceivedHttpError(null, null, null)
+        assertEquals(false, observedLoadingState)
+
+        observedLoadingState = true
+        engineView.currentWebView.webViewClient.onPageFinished(null, "http://mozilla.org")
+        assertEquals("http://mozilla.org", observedUrl)
+        assertEquals(false, observedLoadingState)
+    }
+
+    @Test
+    fun testWebChromeClientNotifiesObservers() {
+        val engineSession = SystemEngineSession()
+        val engineView = SystemEngineView(RuntimeEnvironment.application)
+        engineView.render(engineSession)
+
+        var observedProgress = 0
+        engineSession.register(object : EngineSession.Observer {
+            override fun onLoadingStateChange(loading: Boolean) { }
+            override fun onLocationChange(url: String) { }
+            override fun onProgress(progress: Int) { observedProgress = progress }
+        })
+
+        engineView.currentWebView.webChromeClient.onProgressChanged(null, 100)
+        assertEquals(100, observedProgress)
+    }
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -15,6 +15,8 @@ class Session(
      */
     interface Observer {
         fun onUrlChanged()
+        fun onProgress()
+        fun onLoadingStateChanged()
     }
 
     private val observers = mutableListOf<Observer>()
@@ -26,6 +28,24 @@ class Session(
         set(value) {
             field = value
             notifyObservers { onUrlChanged() }
+        }
+
+    /**
+     * The progress loading the current URL.
+     */
+    var progress: Int = 0
+        set(value) {
+            field = value
+            notifyObservers { onProgress() }
+        }
+
+    /**
+     * True if this session's url is currently loading, otherwise false.
+     */
+    var loading: Boolean = false
+        set(value) {
+            field = value
+            notifyObservers { onLoadingStateChanged() }
         }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -56,7 +56,36 @@ class SessionTest {
 
         session.url = "http://www.firefox.com"
 
+        assertEquals("http://www.firefox.com", session.url)
         verify(observer).onUrlChanged()
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is notified when progress changes`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.progress = 75
+
+        assertEquals(75, session.progress)
+        verify(observer).onProgress()
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is notified when loading state changes`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.loading = true
+
+        assertEquals(true, session.loading)
+        verify(observer).onLoadingStateChanged()
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -13,10 +13,12 @@ import android.support.annotation.CallSuper
  */
 abstract class EngineSession {
     /**
-     * Interface to be implemented by classes that want to observer this engine session.
+     * Interface to be implemented by classes that want to observe this engine session.
      */
     interface Observer {
         fun onLocationChange(url: String)
+        fun onProgress(progress: Int)
+        fun onLoadingStateChange(loading: Boolean)
     }
 
     private val observers = mutableListOf<Observer>()

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -21,9 +21,15 @@ class EngineSessionTest {
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
+        session.notifyInternalObservers { onProgress(25) }
+        session.notifyInternalObservers { onProgress(100) }
+        session.notifyInternalObservers { onLoadingStateChange(true) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
+        verify(observer).onProgress(25)
+        verify(observer).onProgress(100)
+        verify(observer).onLoadingStateChange(true)
         verifyNoMoreInteractions(observer)
     }
 
@@ -35,13 +41,20 @@ class EngineSessionTest {
         session.register(observer)
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
+        session.notifyInternalObservers { onProgress(25) }
+        session.notifyInternalObservers { onLoadingStateChange(true) }
 
         session.unregister(observer)
 
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
+        session.notifyInternalObservers { onProgress(100) }
+        session.notifyInternalObservers { onLoadingStateChange(false) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
+        verify(observer).onProgress(25)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
+        verify(observer, never()).onProgress(100)
+        verify(observer).onLoadingStateChange(true)
         verifyNoMoreInteractions(observer)
     }
 
@@ -53,13 +66,20 @@ class EngineSessionTest {
         session.register(observer)
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
+        session.notifyInternalObservers { onProgress(25) }
+        session.notifyInternalObservers { onLoadingStateChange(true) }
 
         session.close()
 
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
+        session.notifyInternalObservers { onProgress(100) }
+        session.notifyInternalObservers { onLoadingStateChange(false) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
+        verify(observer).onProgress(25)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
+        verify(observer, never()).onProgress(100)
+        verify(observer).onLoadingStateChange(true)
         verifyNoMoreInteractions(observer)
     }
 }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -17,7 +17,7 @@ class SessionFeature(
     engineView: EngineView,
     sessionMapping: SessionMapping = SessionMapping()
 ) {
-    private val presenter = EngineViewPresenter(sessionManager, engine, engineView, sessionMapping)
+    internal val presenter = EngineViewPresenter(sessionManager, engine, engineView, sessionMapping)
 
     /**
      * Start feature: App is in the foreground.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
@@ -15,11 +15,20 @@ class SessionProxy(
     private val session: Session,
     engineSession: EngineSession
 ) : EngineSession.Observer {
+
     init {
         engineSession.register(this)
     }
 
     override fun onLocationChange(url: String) {
         session.url = url
+    }
+
+    override fun onProgress(progress: Int) {
+        session.progress = progress
+    }
+
+    override fun onLoadingStateChange(loading: Boolean) {
+        session.loading = loading
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/EngineViewPresenterTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/EngineViewPresenterTest.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineView
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class EngineViewPresenterTest {
+    private val sessionManager = mock(SessionManager::class.java)
+    private val engine = mock(Engine::class.java)
+    private val engineView = mock(EngineView::class.java)
+    private val sessionMapping = mock(SessionMapping::class.java)
+
+    @Test
+    fun testStartRegistersObserver() {
+        val engineViewPresenter = EngineViewPresenter(sessionManager, engine, engineView, sessionMapping)
+        engineViewPresenter.start()
+        verify(sessionManager).register(engineViewPresenter)
+    }
+
+    @Test
+    fun testStopUnregistersObserver() {
+        val engineViewPresenter = EngineViewPresenter(sessionManager, engine, engineView, sessionMapping)
+        engineViewPresenter.stop()
+        verify(sessionManager).unregister(engineViewPresenter)
+    }
+}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineView
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+
+class SessionFeatureTest {
+    private val sessionManager = Mockito.mock(SessionManager::class.java)
+    private val engine = Mockito.mock(Engine::class.java)
+    private val engineView = Mockito.mock(EngineView::class.java)
+    private val sessionMapping = Mockito.mock(SessionMapping::class.java)
+
+    @Test
+    fun testStartEngineViewPresenter() {
+        val feature = SessionFeature(sessionManager, engine, engineView, sessionMapping)
+        feature.start()
+        verify(sessionManager).register(feature.presenter)
+    }
+
+    @Test
+    fun testStopEngineViewPresenter() {
+        val feature = SessionFeature(sessionManager, engine, engineView, sessionMapping)
+        feature.stop()
+        verify(sessionManager).unregister(feature.presenter)
+    }
+}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProxyTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProxyTest.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.engine.EngineSession
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionProxyTest {
+
+    @Test
+    fun testSessionProxyObservesChanges() {
+        val session = Session("")
+        val engineSession = object : EngineSession() {
+            override fun loadUrl(url: String) {
+                notifyObservers { onLocationChange(url) }
+                notifyObservers { onProgress(100) }
+                notifyObservers { onLoadingStateChange(true) }
+            }
+        }
+
+        // SessionProxy registers as an engine session observer
+        SessionProxy(session, engineSession)
+
+        engineSession.loadUrl("http://mozilla.org")
+        assertEquals("http://mozilla.org", session.url)
+        assertEquals(100, session.progress)
+        assertEquals(true, session.loading)
+    }
+}

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -16,6 +16,7 @@ class ToolbarPresenter(
     private val sessionManager: SessionManager,
     private val toolbar: Toolbar
 ) : SessionManager.Observer, Session.Observer {
+
     var session: Session = sessionManager.selectedSession
 
     /**
@@ -57,4 +58,8 @@ class ToolbarPresenter(
     override fun onUrlChanged() {
         toolbar.displayUrl(session.url)
     }
+
+    override fun onProgress() { /* TODO display progress */ }
+
+    override fun onLoadingStateChanged() { /* TODO */ }
 }


### PR DESCRIPTION
This PR makes the loading progress observable from both engines and wires it up, +tests.

I am not using a LiveData object for now. I think the fewer dependencies the better and I didn't see any value in using it (so far).