### PR TITLE
Closes #102: Fix intermittent SearchEngineManagerTest failure

### DIFF
--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -8,6 +8,8 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.browser.search.provider.SearchEngineProvider
 import org.junit.Assert.assertEquals
@@ -134,6 +136,7 @@ class SearchEngineManagerTest {
             verify(provider, never()).loadSearchEngines(RuntimeEnvironment.application)
 
             shadow.sendBroadcast(Intent(Intent.ACTION_LOCALE_CHANGED))
+            launch(CommonPool) {}.join()
 
             verify(provider).loadSearchEngines(RuntimeEnvironment.application)
             verifyNoMoreInteractions(provider)


### PR DESCRIPTION
Problem here is that the broadcasted intent is processed on a different thread than the assert that verifies `loadSearchEngine` was called: https://github.com/mozilla-mobile/android-components/blob/master/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt#L138

The problem is easy to reproduce by running just this one test in AS (`locale update broadcast will trigger reload`). The assertion then runs before `loadSearchEngines`, and fails.

This fixes the problem by introducing a `CountDownLatch` to make sure `loadSearchEngines` is finished before asserting. Timeout is provided to not have our tests get stuck in case it ever fails.

