### PR TITLE
Closes #100: Autocomplete.ResultCallback is hard to implement

### DIFF
--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
@@ -119,24 +119,20 @@ class DomainAutoCompleteProviderTest {
         completion: String,
         expectedUrl: String
     ) {
-        val resultCallback = { result: String, url: String, source: String, totalItems: Int ->
-            assertFalse(result.isEmpty())
+        val result = provider.autocomplete(text)
+        assertFalse(result.text.isEmpty())
 
-            assertEquals(completion, result)
-            assertEquals(domainSource, source)
-            assertEquals(expectedUrl, url)
-            assertEquals(sourceSize, totalItems)
-        }
-        provider.autocomplete(text, resultCallback)
+        assertEquals(completion, result.text)
+        assertEquals(domainSource, result.source)
+        assertEquals(expectedUrl, result.url)
+        assertEquals(sourceSize, result.size)
     }
 
     private fun assertNoCompletion(provider: DomainAutoCompleteProvider, text: String) {
-        val resultCallback = { result: String, url: String, source: String, totalItems: Int ->
-            assertTrue(result.isEmpty())
-            assertTrue(url.isEmpty())
-            assertTrue(source.isEmpty())
-            assertEquals(0, totalItems)
-        }
-        provider.autocomplete(text, resultCallback)
+        val result = provider.autocomplete(text)
+        assertTrue(result.text.isEmpty())
+        assertTrue(result.url.isEmpty())
+        assertTrue(result.source.isEmpty())
+        assertEquals(0, result.size)
     }
 }

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
@@ -18,6 +18,14 @@ class DomainsTest {
     fun testLoadDomains() = runBlocking {
         val domains = Domains.load(RuntimeEnvironment.application, setOf("us"))
         Assert.assertFalse(domains.isEmpty())
-        Assert.assertTrue(domains.contains("google.com"))
+        Assert.assertTrue(domains.contains("reddit.com"))
+    }
+
+    @Test
+    fun testLoadDomainsWithDefaultCountries() = runBlocking {
+        val domains = Domains.load(RuntimeEnvironment.application)
+        Assert.assertFalse(domains.isEmpty())
+        // From the global list
+        Assert.assertTrue(domains.contains("mozilla.org"))
     }
 }


### PR DESCRIPTION
This seems to clean it up nicely. Since Kotlin's data classes are boilerplate-free, it doesn't matter much that we have two different result types. It wouldn't be worth it to introduce a shared module with a shared result type, and this way we solve the problem mentioned in #100.

**For Focus**
```
autoCompleteProvider.autocomplete(searchText, { result, source, size ->
    view.onAutocomplete(AutocompleteResult(result, source, size))
})
```

**will become**

```
val result = autoCompleteProvider.autocomplete(searchText)
view.onAutocomplete(AutocompleteResult(result.text, result.source, result.size))
```

**or to fully address #57 (and use the full URL incl. protocol)**
```
view.onAutocomplete(AutocompleteResult(result.text, result.source, result.size, 
  { _ -> result.url }))
```
