### PR TITLE
Issue #93: Make navigation state (canGoBack/canGoForward) observable

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -50,9 +50,13 @@ class GeckoEngineSession(
             response.respond(false)
         }
 
-        override fun onCanGoForward(session: GeckoSession?, canGoForward: Boolean) {}
+        override fun onCanGoForward(session: GeckoSession?, canGoForward: Boolean) {
+            notifyObservers { onNavigationStateChange(canGoForward = canGoForward) }
+        }
 
-        override fun onCanGoBack(session: GeckoSession?, canGoBack: Boolean) {}
+        override fun onCanGoBack(session: GeckoSession?, canGoBack: Boolean) {
+            notifyObservers { onNavigationStateChange(canGoBack = canGoBack) }
+        }
 
         override fun onNewSession(
             session: GeckoSession?,
@@ -71,14 +75,18 @@ class GeckoEngineSession(
         ) { }
 
         override fun onPageStart(session: GeckoSession?, url: String?) {
-            notifyObservers { onProgress(PROGRESS_START) }
-            notifyObservers { onLoadingStateChange(true) }
+            notifyObservers {
+                onProgress(PROGRESS_START)
+                onLoadingStateChange(true)
+            }
         }
 
         override fun onPageStop(session: GeckoSession?, success: Boolean) {
             if (success) {
-                notifyObservers { onProgress(PROGRESS_STOP) }
-                notifyObservers { onLoadingStateChange(false) }
+                notifyObservers {
+                    onProgress(PROGRESS_STOP)
+                    onLoadingStateChange(false)
+                }
             }
         }
     }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -40,6 +40,7 @@ class GeckoEngineSessionTest {
             override fun onLoadingStateChange(loading: Boolean) { observerLoadingState = loading }
             override fun onLocationChange(url: String) { }
             override fun onProgress(progress: Int) { observerdProgress = progress }
+            override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) { }
         })
 
         engineSession.geckoSession.progressDelegate.onPageStart(null, "http://mozilla.org")
@@ -56,14 +57,26 @@ class GeckoEngineSessionTest {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
 
         var observedUrl = ""
+        var observedCanGoBack: Boolean = false
+        var observedCanGoForward: Boolean = false
         engineSession.register(object : EngineSession.Observer {
             override fun onLoadingStateChange(loading: Boolean) {}
             override fun onLocationChange(url: String) { observedUrl = url }
             override fun onProgress(progress: Int) { }
+            override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
+                canGoBack?.let { observedCanGoBack = canGoBack }
+                canGoForward?.let { observedCanGoForward = canGoForward }
+            }
         })
 
         engineSession.geckoSession.navigationDelegate.onLocationChange(null, "http://mozilla.org")
         assertEquals("http://mozilla.org", observedUrl)
+
+        engineSession.geckoSession.navigationDelegate.onCanGoBack(null, true)
+        assertEquals(true, observedCanGoBack)
+
+        engineSession.geckoSession.navigationDelegate.onCanGoForward(null, true)
+        assertEquals(true, observedCanGoForward)
     }
 
     @Test

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -8,9 +8,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
 import android.webkit.WebChromeClient
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
@@ -63,21 +60,12 @@ class SystemEngineView @JvmOverloads constructor(
 
             override fun onPageFinished(view: WebView?, url: String?) {
                 url?.let {
-                    session?.internalNotifyObservers { onLocationChange(it) }
-                    session?.internalNotifyObservers { onLoadingStateChange(false) }
+                    session?.internalNotifyObservers {
+                        onLocationChange(it)
+                        onLoadingStateChange(false)
+                        onNavigationStateChange(webView.canGoBack(), webView.canGoForward())
+                    }
                 }
-            }
-
-            override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
-                session?.internalNotifyObservers { onLoadingStateChange(false) }
-            }
-
-            override fun onReceivedHttpError(
-                view: WebView?,
-                request: WebResourceRequest?,
-                errorResponse: WebResourceResponse?
-            ) {
-                session?.internalNotifyObservers { onLoadingStateChange(false) }
             }
         }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -32,26 +32,27 @@ class SystemEngineViewTest {
 
         var observedUrl = ""
         var observedLoadingState = false
+        var observedCanGoBack = false
+        var observedCanGoForward = false
         engineSession.register(object : EngineSession.Observer {
             override fun onLoadingStateChange(loading: Boolean) { observedLoadingState = loading }
             override fun onLocationChange(url: String) { observedUrl = url }
             override fun onProgress(progress: Int) { }
+            override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
+                observedCanGoBack = true
+                observedCanGoForward = true
+            }
         })
 
         engineView.currentWebView.webViewClient.onPageStarted(null, "http://mozilla.org", null)
         assertEquals(true, observedLoadingState)
 
-        engineView.currentWebView.webViewClient.onReceivedError(null, null, null)
-        assertEquals(false, observedLoadingState)
-
-        observedLoadingState = true
-        engineView.currentWebView.webViewClient.onReceivedHttpError(null, null, null)
-        assertEquals(false, observedLoadingState)
-
         observedLoadingState = true
         engineView.currentWebView.webViewClient.onPageFinished(null, "http://mozilla.org")
         assertEquals("http://mozilla.org", observedUrl)
         assertEquals(false, observedLoadingState)
+        assertEquals(true, observedCanGoBack)
+        assertEquals(true, observedCanGoForward)
     }
 
     @Test
@@ -65,6 +66,7 @@ class SystemEngineViewTest {
             override fun onLoadingStateChange(loading: Boolean) { }
             override fun onLocationChange(url: String) { }
             override fun onProgress(progress: Int) { observedProgress = progress }
+            override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) { }
         })
 
         engineView.currentWebView.webChromeClient.onProgressChanged(null, 100)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
@@ -86,6 +87,38 @@ class SessionTest {
 
         assertEquals(true, session.loading)
         verify(observer).onLoadingStateChanged()
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is notified when navigation state changes`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.canGoBack = true
+        assertEquals(true, session.canGoBack)
+        verify(observer).onNavigationStateChanged()
+
+        session.canGoForward = true
+        assertEquals(true, session.canGoForward)
+        verify(observer, times(2)).onNavigationStateChanged()
+
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is not notified when property is set but hasn't changed`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.url = "https://www.mozilla.org"
+
+        assertEquals("https://www.mozilla.org", session.url)
+        verify(observer, never()).onUrlChanged()
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -19,6 +19,7 @@ abstract class EngineSession {
         fun onLocationChange(url: String)
         fun onProgress(progress: Int)
         fun onLoadingStateChange(loading: Boolean)
+        fun onNavigationStateChange(canGoBack: Boolean? = null, canGoForward: Boolean? = null)
     }
 
     private val observers = mutableListOf<Observer>()

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
@@ -31,4 +31,9 @@ class SessionProxy(
     override fun onLoadingStateChange(loading: Boolean) {
         session.loading = loading
     }
+
+    override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
+        canGoBack?.let { session.canGoBack = canGoBack }
+        canGoForward?.let { session.canGoForward = canGoForward }
+    }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProxyTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProxyTest.kt
@@ -19,6 +19,7 @@ class SessionProxyTest {
                 notifyObservers { onLocationChange(url) }
                 notifyObservers { onProgress(100) }
                 notifyObservers { onLoadingStateChange(true) }
+                notifyObservers { onNavigationStateChange(true, true) }
             }
         }
 
@@ -29,5 +30,7 @@ class SessionProxyTest {
         assertEquals("http://mozilla.org", session.url)
         assertEquals(100, session.progress)
         assertEquals(true, session.loading)
+        assertEquals(true, session.canGoForward)
+        assertEquals(true, session.canGoBack)
     }
 }

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -62,4 +62,6 @@ class ToolbarPresenter(
     override fun onProgress() { /* TODO display progress */ }
 
     override fun onLoadingStateChanged() { /* TODO */ }
+
+    override fun onNavigationStateChanged() { /* TODO */ }
 }


### PR DESCRIPTION
This PR makes the navigation states (`canGoBack` and `canGoForward`) observable and includes some refactorings:

- `BrowserSession` now *only* notifies observers when its properties actually changed. I think this is going to be an important optimization once more UI updates are triggered. Then we can simply skip updating the UI when the value is set to the same as before.

- `EngineSession` now has a way to notify observers of multiple events in one go. So, if multiple events should be sent, we don't need to iterate over observers separately. Varargs would've made this super easy, but there's a performance problem with the spread operator (https://github.com/arturbosch/detekt/issues/554). Until that's addressed, I've added some utility methods so we can have the same syntax on the call-site.

- As I've touched SystemEngineView in this commit, I've also removed some callback methods which I added in my previous commit. They are currently not needed, as `onPageFinished` is also called in case of errors. 