### PR TITLE
Closes #123: InlineAutocompleteEditText constructor requires non-null…

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -61,7 +61,12 @@ typealias TextFormatter = (String) -> String
  * (see also {@link setOnTextChangeListener},
  * {@link setOnSelectionChangedListener}, {@link setOnWindowsFocusChangeListener}).
  */
-open class InlineAutocompleteEditText(val ctx: Context, attrs: AttributeSet) : AppCompatEditText(ctx, attrs) {
+open class InlineAutocompleteEditText @JvmOverloads constructor(
+    val ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.editTextStyle
+) : AppCompatEditText(ctx, attrs, defStyleAttr) {
+
     data class AutocompleteResult(
         val text: String,
         val source: String,

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -53,7 +53,7 @@ class InlineAutocompleteEditTextTest {
 
     @Test
     fun testGetNonAutocompleteText() {
-        val et = InlineAutocompleteEditText(context, attributes)
+        val et = InlineAutocompleteEditText(context)
         et.setText("Test")
         assertEquals("Test", et.nonAutocompleteText)
 
@@ -79,7 +79,7 @@ class InlineAutocompleteEditTextTest {
 
     @Test
     fun testOnFocusChange() {
-        val et = InlineAutocompleteEditText(context, attributes)
+        val et = InlineAutocompleteEditText(context, attributes, R.attr.editTextStyle)
         val searchStates = mutableListOf<Boolean>()
 
         et.setOnSearchStateChangeListener { b: Boolean -> searchStates.add(searchStates.size, b) }


### PR DESCRIPTION
Allows construction of InlineAutoCompleteEditText with and without an AttributeSet and defStyleAttr.

