### PR TITLE
Issue #110: Add support for incoming intents

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionIntentProcessor.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionIntentProcessor.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import android.content.Intent
+import android.text.TextUtils
+
+typealias IntentHandler = (Intent) -> Boolean
+
+/**
+ * Processor for intents which should trigger session-related actions.
+ */
+class SessionIntentProcessor(
+    private val sessionUseCases: SessionUseCases,
+    useDefaultHandlers: Boolean = true
+) {
+    private val defaultActionViewHandler = { intent: Intent ->
+        val url = intent.dataString
+        if (TextUtils.isEmpty(url)) {
+            false
+        }
+
+        // TODO switch to loadUrlInNewTab, once available
+        sessionUseCases.loadUrl.invoke(url)
+        true
+    }
+
+    private val defaultHandlers: MutableMap<String, IntentHandler> by lazy {
+        mutableMapOf(Intent.ACTION_VIEW to defaultActionViewHandler)
+    }
+
+    private val handlers = if (useDefaultHandlers) defaultHandlers else mutableMapOf()
+
+    /**
+     * Processes the given intent by invoking the registered handler.
+     *
+     * @param intent the intent to process
+     * @return true if the intent was processed, otherwise false.
+     */
+    fun process(intent: Intent): Boolean {
+        return handlers[intent.action]?.invoke(intent) ?: false
+    }
+
+    /**
+     * Registers the given handler to be invoked for intents with the given action. If a
+     * handler is already present it will be overwritten.
+     *
+     * @param action the intent action which should trigger the provided handler.
+     * @param handler the intent handler to be registered.
+     */
+    fun registerHandler(action: String, handler: IntentHandler) {
+        handlers[action] = handler
+    }
+
+    /**
+     * Removes the registered handler for the given intent action, if present.
+     *
+     * @param action the intent action for which the handler should be removed.
+     */
+    fun unregisterHandler(action: String) {
+        handlers.remove(action)
+    }
+}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionIntentProcessorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionIntentProcessorTest.kt
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import android.content.Intent
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SessionIntentProcessorTest {
+    private val sessionManager = mock(SessionManager::class.java)
+    private val engine = mock(Engine::class.java)
+    private val engineSession = mock(EngineSession::class.java)
+    private val sessionMapping = mock(SessionMapping::class.java)
+    private val useCases = SessionUseCases(sessionManager, engine, sessionMapping)
+
+    @Before
+    fun setup() {
+        `when`(sessionMapping.getOrCreate(engine, sessionManager.selectedSession)).thenReturn(engineSession)
+    }
+
+    @Test
+    fun testProcessWIthDefaultHandlers() {
+        val handler = SessionIntentProcessor(useCases)
+        val intent = mock(Intent::class.java)
+        `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
+        `when`(intent.dataString).thenReturn("http://mozilla.org")
+
+        handler.process(intent)
+        verify(engineSession).loadUrl("http://mozilla.org")
+    }
+
+    @Test
+    fun testProcessWithoutDefaultHandlers() {
+        val handler = SessionIntentProcessor(useCases, useDefaultHandlers = false)
+        val intent = mock(Intent::class.java)
+        `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
+        `when`(intent.dataString).thenReturn("http://mozilla.org")
+
+        handler.process(intent)
+        verifyZeroInteractions(engineSession)
+    }
+
+    @Test
+    fun testProcessWithCustomHandlers() {
+        val handler = SessionIntentProcessor(useCases, useDefaultHandlers = false)
+        val intent = mock(Intent::class.java)
+        `when`(intent.action).thenReturn(Intent.ACTION_SEND)
+
+        var handlerInvoked = false
+        handler.registerHandler(Intent.ACTION_SEND, { intent ->
+            handlerInvoked = true
+            true
+        })
+
+        handler.process(intent)
+        assertTrue(handlerInvoked)
+
+        handlerInvoked = false
+        handler.unregisterHandler(Intent.ACTION_SEND)
+
+        handler.process(intent)
+        assertFalse(handlerInvoked)
+    }
+}

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -17,6 +17,13 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -9,6 +9,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.browser.engine.system.SystemEngine
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.SessionProvider
+import mozilla.components.feature.session.SessionIntentProcessor
 import mozilla.components.feature.session.SessionMapping
 import mozilla.components.feature.session.SessionUseCases
 import org.mozilla.geckoview.GeckoRuntime
@@ -30,4 +31,5 @@ class Components(private val applcationContext: Context) {
     val sessionManager : SessionManager by lazy { SessionManager(sessionProvider) }
     val sessionMapping = SessionMapping()
     val sessionUseCases = SessionUseCases(sessionManager, engine, sessionMapping)
+    val sessionIntentProcessor = SessionIntentProcessor(sessionUseCases)
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
@@ -30,6 +30,8 @@ class MainActivity : AppCompatActivity() {
                 components.sessionMapping)
 
         toolbarFeature = ToolbarFeature(components.sessionManager, components.sessionUseCases.loadUrl, toolbar)
+
+        components.sessionIntentProcessor.process(intent)
     }
 
     override fun onResume() {


### PR DESCRIPTION
Idea is to have feature-specific intent processors. They get access to their feature's use cases and have default intent handlers. Custom intent handlers can be specified, so that the app is ultimately in control how intents are processed.