### PR TITLE
Closes #79: Review usage of suspend/coroutines

### DIFF
--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/CustomDomains.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/CustomDomains.kt
@@ -21,7 +21,7 @@ object CustomDomains {
      * @param context the application context
      * @return list of custom domains
      */
-    suspend fun load(context: Context): List<String> =
+    fun load(context: Context): List<String> =
             preferences(context).getString(KEY_DOMAINS, "")
                 .split(SEPARATOR)
                 .filter { !it.isEmpty() }
@@ -45,7 +45,7 @@ object CustomDomains {
      * @param context the application context
      * @param domain the domain to add
      */
-    suspend fun add(context: Context, domain: String) {
+    fun add(context: Context, domain: String) {
         val domains = mutableListOf<String>()
         domains.addAll(load(context))
         domains.add(domain)
@@ -59,7 +59,7 @@ object CustomDomains {
      * @param context the application context
      * @param domains the domain to remove
      */
-    suspend fun remove(context: Context, domains: List<String>) {
+    fun remove(context: Context, domains: List<String>) {
         save(context, load(context) - domains)
     }
 

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/Domains.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/Domains.kt
@@ -23,11 +23,11 @@ object Domains {
      * @param context the application context
      * @return list of domains
      */
-    suspend fun load(context: Context): List<String> {
+    fun load(context: Context): List<String> {
         return load(context, getCountriesInDefaultLocaleList())
     }
 
-    internal suspend fun load(context: Context, countries: Set<String>): List<String> {
+    internal fun load(context: Context, countries: Set<String>): List<String> {
         val domains = LinkedHashSet<String>()
         val availableLists = getAvailableDomainLists(context)
 

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
@@ -34,7 +34,7 @@ class CustomDomainsTest {
     }
 
     @Test
-    fun testSaveAndRemoveDomains() = runBlocking {
+    fun testSaveAndRemoveDomains() {
         CustomDomains.save(RuntimeEnvironment.application, listOf(
                 "mozilla.org",
                 "example.org",
@@ -51,7 +51,7 @@ class CustomDomainsTest {
     }
 
     @Test
-    fun testAddAndLoadDomains() = runBlocking {
+    fun testAddAndLoadDomains() {
         CustomDomains.add(RuntimeEnvironment.application, "mozilla.org")
         val domains = CustomDomains.load(RuntimeEnvironment.application)
         assertEquals(1, domains.size)
@@ -59,7 +59,7 @@ class CustomDomainsTest {
     }
 
     @Test
-    fun testSaveAndLoadDomains() = runBlocking {
+    fun testSaveAndLoadDomains() {
         CustomDomains.save(RuntimeEnvironment.application, listOf(
                 "mozilla.org",
                 "example.org",

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.browser.domains
 
-import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,14 +14,14 @@ import org.robolectric.RuntimeEnvironment
 class DomainsTest {
 
     @Test
-    fun testLoadDomains() = runBlocking {
+    fun testLoadDomains() {
         val domains = Domains.load(RuntimeEnvironment.application, setOf("us"))
         Assert.assertFalse(domains.isEmpty())
         Assert.assertTrue(domains.contains("reddit.com"))
     }
 
     @Test
-    fun testLoadDomainsWithDefaultCountries() = runBlocking {
+    fun testLoadDomainsWithDefaultCountries() {
         val domains = Domains.load(RuntimeEnvironment.application)
         Assert.assertFalse(domains.isEmpty())
         // From the global list


### PR DESCRIPTION
This removes `suspend` where it's not necessary, essentially for functions that are not interrupted and continued later, so they don't need to be suspending functions. Using them in coroutine builders is still fine, i.e. this usage in Focus is still fine:
```
launch(CommonPool) {
  CustomDomains.save(activity.applicationContext, domains)
}
```

The usage of `suspend` in browser-search was fine as there we actually use `.await` e.g: https://github.com/mozilla-mobile/android-components/blob/master/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt#L67

In general we can rely on our IDE to tell us when we need suspend. Any function that's interrupted either needs to be a coroutine or suspending function. So, we'd be getting this error otherwise:
`Suspend function 'name' should be called only from a coroutine or another suspend function`