### PR TITLE
Issue #141: Support device back button for navigation

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -12,7 +12,8 @@ import mozilla.components.browser.session.SessionManager
  * Feature implementation for connecting the engine module with the session module.
  */
 class SessionFeature(
-    sessionManager: SessionManager,
+    private val sessionManager: SessionManager,
+    private val sessionUseCases: SessionUseCases,
     engine: Engine,
     engineView: EngineView,
     sessionMapping: SessionMapping = SessionMapping()
@@ -24,6 +25,20 @@ class SessionFeature(
      */
     fun start() {
         presenter.start()
+    }
+
+    /**
+     * Handler for back pressed events in activities that use this feature.
+     *
+     * @return true if the event was handled, otherwise false.
+     */
+    fun handleBackPressed(): Boolean {
+        if (sessionManager.selectedSession.canGoBack) {
+            sessionUseCases.goBack.invoke()
+            return true
+        }
+
+        return false
     }
 
     /**

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -4,29 +4,61 @@
 
 package mozilla.components.feature.session
 
+import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.SessionProvider
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import org.junit.Test
-import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class SessionFeatureTest {
-    private val sessionManager = Mockito.mock(SessionManager::class.java)
-    private val engine = Mockito.mock(Engine::class.java)
-    private val engineView = Mockito.mock(EngineView::class.java)
-    private val sessionMapping = Mockito.mock(SessionMapping::class.java)
+    private val sessionManager = mock(SessionManager::class.java)
+    private val engine = mock(Engine::class.java)
+    private val engineView = mock(EngineView::class.java)
+    private val sessionMapping = mock(SessionMapping::class.java)
+    private val sessionUseCases = SessionUseCases(sessionManager, engine, sessionMapping)
 
     @Test
     fun testStartEngineViewPresenter() {
-        val feature = SessionFeature(sessionManager, engine, engineView, sessionMapping)
+        val feature = SessionFeature(sessionManager, sessionUseCases, engine, engineView, sessionMapping)
         feature.start()
         verify(sessionManager).register(feature.presenter)
     }
 
     @Test
+    fun testHandleBackPressed() {
+        val engineSession = mock(EngineSession::class.java)
+        `when`(sessionMapping.getOrCreate(engine, sessionManager.selectedSession)).thenReturn(engineSession)
+
+        val session = Session("https://www.mozilla.org")
+
+        val sessionProvider = object : SessionProvider {
+            override fun getInitialSessions(): Pair<List<Session>, Int> {
+                val sessions = mutableListOf(session)
+                return Pair(sessions, 0)
+            }
+        }
+        val sessionManager = SessionManager(sessionProvider)
+        sessionManager.select(session)
+
+        val feature = SessionFeature(sessionManager, sessionUseCases, engine, engineView, sessionMapping)
+
+        feature.handleBackPressed()
+        verify(engineSession, never()).goBack()
+
+        session.canGoBack = true
+        feature.handleBackPressed()
+        verify(engineSession).goBack()
+    }
+
+    @Test
     fun testStopEngineViewPresenter() {
-        val feature = SessionFeature(sessionManager, engine, engineView, sessionMapping)
+        val feature = SessionFeature(sessionManager, sessionUseCases, engine, engineView, sessionMapping)
         feature.stop()
         verify(sessionManager).unregister(feature.presenter)
     }

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
@@ -28,6 +28,15 @@ class ToolbarFeature(
     }
 
     /**
+     * Handler for back pressed events in activities that use this feature.
+     *
+     * @return true if the event was handled, otherwise false.
+     */
+    fun handleBackPressed(): Boolean {
+        return false
+    }
+
+    /**
      * Stop feature: App is in the background.
      */
     fun stop() {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
@@ -26,8 +26,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        sessionFeature = SessionFeature(components.sessionManager, components.engine, engineView,
-                components.sessionMapping)
+        sessionFeature = SessionFeature(components.sessionManager, components.sessionUseCases,
+            components.engine, engineView, components.sessionMapping)
 
         toolbarFeature = ToolbarFeature(components.sessionManager, components.sessionUseCases.loadUrl, toolbar)
 
@@ -46,6 +46,16 @@ class MainActivity : AppCompatActivity() {
 
         sessionFeature?.stop()
         toolbarFeature?.stop()
+    }
+
+    override fun onBackPressed() {
+        if (toolbarFeature?.handleBackPressed() == true)
+            return
+
+        if (sessionFeature?.handleBackPressed() == true)
+            return
+
+        super.onBackPressed()
     }
 
     override fun onCreateView(parent: View?, name: String?, context: Context?, attrs: AttributeSet?): View? {


### PR DESCRIPTION
This works out quite OK with our existing component functionality. So, I think, right now this seems enough?

One thought I had is that we might want to address the train wrecks by referencing the individual components directly, but that's a separate discussion for later (when we add it to Fenix).