### PR TITLE
Closes #156: Gecko crashes when activity/app is paused and resumed

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -20,7 +20,7 @@ class GeckoEngineView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
 
-    private val currentGeckoView = GeckoView(context)
+    internal var currentGeckoView = GeckoView(context)
 
     init {
         // Currently this is just a FrameLayout with a single GeckoView instance. Eventually this
@@ -34,6 +34,8 @@ class GeckoEngineView @JvmOverloads constructor(
     override fun render(session: EngineSession) {
         val internalSession = session as GeckoEngineSession
 
-        currentGeckoView.session = internalSession.geckoSession
+        if (currentGeckoView.session != internalSession.geckoSession) {
+            currentGeckoView.session = internalSession.geckoSession
+        }
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoView
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineViewTest {
+
+    @Test
+    fun testRender() {
+        val engineView = GeckoEngineView(RuntimeEnvironment.application)
+        val engineSession = mock(GeckoEngineSession::class.java)
+        val geckoSession = mock(GeckoSession::class.java)
+        val geckoView = mock(GeckoView::class.java)
+
+        `when`(engineSession.geckoSession).thenReturn(geckoSession)
+        engineView.currentGeckoView = geckoView
+
+        engineView.render(engineSession)
+        verify(geckoView, times(1)).setSession(geckoSession)
+
+        `when`(geckoView.session).thenReturn(geckoSession)
+        engineView.render(engineSession)
+        verify(geckoView, times(1)).setSession(geckoSession)
+    }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -17,9 +17,9 @@ import org.mozilla.geckoview.GeckoRuntime
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
-class Components(private val applcationContext: Context) {
+class Components(private val applicationContext: Context) {
     private val geckoRuntime by lazy {
-        GeckoRuntime.create(applcationContext)
+        GeckoRuntime.getDefault(applicationContext)
     }
 
     val engine : Engine by lazy { GeckoEngine(geckoRuntime) }


### PR DESCRIPTION
- Added check to not set session to the same value.
- Switched to `GeckoRuntime.getDefault` for now which includes a check to not initialize if already initialized.