### PR TITLE
Closes #120: Generate and publish JavaDocs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -80,7 +80,7 @@ tasks:
           git fetch origin --tags
           && git config advice.detachedHead false
           && git checkout {{ event.version }}
-          && ./gradlew --no-daemon clean test detektCheck ktlint assembleRelease
+          && ./gradlew --no-daemon clean test detektCheck ktlint assembleRelease docs
           && python automation/taskcluster/release/fetch-bintray-api-key.py
           && ./gradlew bintrayUpload --debug
       features:

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,8 @@ buildscript {
         junit: '4.12',
         robolectric: '3.8',
         mockito: '2.18.0',
-        mockwebserver: '3.7.0'
+        mockwebserver: '3.7.0',
+        dokka: '0.9.16'
     ]
 
     // Synchronized build configuration for all modules
@@ -41,6 +42,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${project.ext.dependencies['kotlin']}"
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:${project.ext.dependencies['dokka']}"
 
         // Publish.
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
@@ -66,6 +68,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'jacoco'
+    apply plugin: 'org.jetbrains.dokka-android'
 
     afterEvaluate {
         if (it.hasProperty('android')) {
@@ -74,6 +77,12 @@ subprojects {
                     unitTests {
                         includeAndroidResources = true
                     }
+                }
+
+                task docs(type: org.jetbrains.dokka.gradle.DokkaAndroidTask) {
+                    outputFormat = 'javadoc'
+                    reportUndocumented = false
+                    outputDirectory = "${project.rootDir}/build/javadoc/${project.name}"
                 }
             }
 

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/DomainAutoCompleteProvider.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/DomainAutoCompleteProvider.kt
@@ -13,8 +13,8 @@ import java.util.Locale
 
 /**
  * Provides autocomplete functionality for domains, based on a provided list
- * of assets (see @{link Domains}) and/or a custom domain list managed
- * by {@link CustomDomains}.
+ * of assets (see [Domains]) and/or a custom domain list managed by
+ * [CustomDomains].
  */
 class DomainAutoCompleteProvider {
     object AutocompleteSource {
@@ -102,7 +102,7 @@ class DomainAutoCompleteProvider {
      * @param useShippedDomains true (default) if the domains provided by this
      * module should be used, otherwise false.
      * @param useCustomDomains true if the custom domains provided by
-     * {@see CustomDomains} should be used, otherwise false (default).
+     * [CustomDomains] should be used, otherwise false (default).
      * @param loadDomainsFromDisk true (default) if domains should be loaded,
      * otherwise false. This parameter is for testing purposes only.
      */

--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -39,26 +39,25 @@ typealias OnWindowsFocusChangeListener = (Boolean) -> Unit
 typealias TextFormatter = (String) -> String
 
 /**
- * An {@link EditText} component which supports inline autocompletion.
+ * A UI edit text component which supports inline autocompletion.
  *
  * The background color of autocomplete spans can be configured using
  * the custom autocompleteBackgroundColor attribute e.g.
  * app:autocompleteBackgroundColor="#ffffff".
  *
- * A filter listener (see {@link setOnFilterListener}) needs to be attached to
+ * A filter listener (see [setOnFilterListener]) needs to be attached to
  * provide autocomplete results. It will be invoked when the input
  * text changes. The listener gets direct access to this component (via its view
  * parameter), so it can call {@link onAutocomplete} in return.
  *
- * A commit listener (see {@link setOnCommitListener}) can be attached which is
+ * A commit listener (see [setOnCommitListener]) can be attached which is
  * invoked when the user selected the result i.e. is done editing.
  *
  * Various other listeners can be attached to enhance default behaviour e.g.
- * {@link setOnSelectionChangedListener} and
- * {@link setOnWindowsFocusChangeListener} which will be invoked in response to
- * {@link onSelectionChanged} and {@link onWindowFocusChanged} respectively
- * (see also {@link setOnTextChangeListener},
- * {@link setOnSelectionChangedListener}, {@link setOnWindowsFocusChangeListener}).
+ * [setOnSelectionChangedListener] and [setOnWindowsFocusChangeListener] which
+ * will be invoked in response to [onSelectionChanged] and [onWindowFocusChanged]
+ * respectively (see also [setOnTextChangeListener],
+ * [setOnSelectionChangedListener], and [setOnWindowsFocusChangeListener]).
  */
 open class InlineAutocompleteEditText @JvmOverloads constructor(
     val ctx: Context,


### PR DESCRIPTION
This adds a gradle task (`gradle docs`) to generate JavaDocs for all projects and puts them under `/docs/javadoc/[component-name]`. When this is merged, we can activate GitHub pages for the `/docs` folder of this repo. The result will look like this:

https://csadilek.github.io/android-components/javadoc/concept-engine
https://csadilek.github.io/android-components/javadoc/feature-session

etc.


