### PR TITLE
Closes #163: Remove duplicated state in SessionProvider/Storage

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -4,13 +4,15 @@
 
 package mozilla.components.browser.session
 
+import java.util.UUID
 import kotlin.properties.Delegates
 
 /**
  * Value type that represents the state of a browser session. Changes can be observed.
  */
 class Session(
-    initialUrl: String
+    initialUrl: String,
+    val id: String = UUID.randomUUID().toString()
 ) {
     /**
      * Interface to be implemented by classes that want to observe a session.

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -26,8 +26,12 @@ class SessionManager(initialSession: Session) {
     /**
      * Adds the provided session.
      */
-    fun add(session: Session) {
+    fun add(session: Session, selected: Boolean = false) {
         sessions.add(session)
+
+        if (selected) {
+            select(session)
+        }
     }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -15,10 +15,11 @@ class SessionManagerTest {
     @Test
     fun `session can be added`() {
         val manager = SessionManager(Session("http://www.mozilla.org"))
-        manager.add(Session("http://www.firefox.com"))
+        manager.add(Session("http://getpocket.com"))
+        manager.add(Session("http://www.firefox.com"), true)
 
-        assertEquals(2, manager.size)
-        assertEquals("http://www.mozilla.org", manager.selectedSession.url)
+        assertEquals(3, manager.size)
+        assertEquals("http://www.firefox.com", manager.selectedSession.url)
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.session
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -127,5 +128,15 @@ class SessionTest {
         val session = Session("https://www.mozilla.org")
 
         assertEquals("https://www.mozilla.org", session.url)
+    }
+
+    @Test
+    fun `Session always has an ID`() {
+        var session = Session("https://www.mozilla.org")
+        assertNotNull(session.id)
+
+        session = Session("https://www.mozilla.org", "s1")
+        assertNotNull(session.id)
+        assertEquals("s1", session.id)
     }
 }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
@@ -8,9 +8,8 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.browser.session.Session
 
 /**
- * Represents a combination of a browser and engine session and acts as a proxy that
- * will subscribe to an EngineSession and update the Session object whenever new
- * data is available.
+ * Proxy class that will subscribe to an engine session and update the browser session object
+ * whenever new data is available.
  */
 class SessionProxy(
     val session: Session,

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionStorage.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionStorage.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.session
 
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
 
 /**
  * Storage component for browser and engine sessions.
@@ -13,52 +14,19 @@ import mozilla.components.concept.engine.Engine
 interface SessionStorage {
 
     /**
-     * Persists the current storage state (all active sessions).
+     * Persists the state of the provided sessions.
      *
-     * @param selectedSession the currently selected session, optional.
+     * @param sessions a map from browser session to engine session
+     * @param selectedSession an optional ID of the currently selected session.
      * @return true if the state was persisted, otherwise false.
      */
-    fun persist(selectedSession: Session? = null): Boolean
+    fun persist(sessions: Map<Session, EngineSession>, selectedSession: String = ""): Boolean
 
     /**
-     * Restores the storage state by reading from the latest persisted version.
+     * Restores the session storage state by reading from the latest persisted version.
      *
-     * @param engine the engine instance to use. Required to create new engine
-     * sessions.
-     * @return list of all restored sessions
+     * @param engine the engine instance to use when creating new engine sessions.
+     * @return map of all restored sessions, and the currently selected session id.
      */
-    fun restore(engine: Engine): List<SessionProxy>
-
-    /**
-     * Adds the provided session. The state change is not persisted until
-     * [persist] is called.
-     *
-     * @param session the session to add.
-     * @return unique ID of the session.
-     */
-    fun add(session: SessionProxy): String
-
-    /**
-     * Removes the session with the provided ID. The state change is not persisted until
-     * [persist] is called.
-     *
-     * @param id the ID of the session to remove.
-     * @return true if the session was found and removed, otherwise false.
-     */
-    fun remove(id: String): Boolean
-
-    /**
-     * Returns the session for the provided ID.
-     *
-     * @param id the ID of the session.
-     * @return the session if found, otherwise null.
-     */
-    fun get(id: String): SessionProxy?
-
-    /**
-     * Returns the selected session.
-     *
-     * @return the selected session, null if no session is selected.
-     */
-    fun getSelected(): Session?
+    fun restore(engine: Engine): Pair<Map<Session, EngineSession>, String>
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProviderTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProviderTest.kt
@@ -29,11 +29,11 @@ class SessionProviderTest {
         val engine = mock(Engine::class.java)
         val engineSession = mock(EngineSession::class.java)
         val session = Session("http://mozilla.org")
-        val sessionList = listOf(SessionProxy(session, engineSession))
-        `when`(storage.restore(engine)).thenReturn(sessionList)
-        `when`(storage.getSelected()).thenReturn(session)
+        val sessionMap = mapOf(session to engineSession)
 
-        val provider = SessionProvider(context = RuntimeEnvironment.application, storage = storage)
+        `when`(storage.restore(engine)).thenReturn(Pair(sessionMap, session.id))
+
+        val provider = SessionProvider(context = RuntimeEnvironment.application, sessionStorage = storage)
         provider.start(engine)
 
         assertEquals(2, provider.sessionManager.size)
@@ -82,5 +82,14 @@ class SessionProviderTest {
         actualEngineSession = provider.getOrCreateEngineSession(engine, session)
         // Should still be the original (already created) engine session
         assertEquals(engineSession1, actualEngineSession)
+    }
+
+    @Test
+    fun testSelectedSession() {
+        val session = Session("http://mozilla.org")
+        val provider = SessionProvider(context = RuntimeEnvironment.application, initialSession = session)
+        provider.sessionManager.select(session)
+
+        assertEquals(session, provider.selectedSession)
     }
 }


### PR DESCRIPTION
This simplifies the `SessionStorage` concept and removes the duplicated state. `SessionStorage` no longer has any state at all. This also makes it easier to provide custom storage implementations.

- The mapping of browser session to engine session is stored in `SessionProvider` only
- Which browser session is currently selected is stored in `SessionManager` only

`SessionStorage` also no longer operates on `SessionProxy`. I did not need to introduce a new `SessionPair`. Also, every `Session` now has a UUID.

I *think* this is much simpler. At least, the negative line count makes me somewhat optimistic :)