### PR TITLE
Closes #164: Add concept-session-storage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ _API contracts and abstraction layers for browser components._
 
 * **Engine** - Abstraction layer that allows hiding the actual browser engine implementation.
 
+* **Session-Storage** - Abstraction layer and contracts for hiding the actual session storage implementation.
+
 * **Toolbar** - Abstract definition of a browser toolbar component.
 
 ## Feature

--- a/components/concept/session-storage/build.gradle
+++ b/components/concept/session-storage/build.gradle
@@ -27,21 +27,16 @@ android {
 }
 
 dependencies {
-    implementation project(':browser-session')
-    implementation project(':concept-engine')
-    implementation project(':concept-session-storage')
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    implementation project(':concept-engine')
+    implementation project(':browser-session')
 }
 
-archivesBaseName = "feature-session"
+archivesBaseName = "session-storage"
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(
         'org.mozilla.components',
-        'feature-session',
-        'Feature implementation connecting an engine implementation with the session module.')
+        'session-storage',
+        'An abstract layer and contracts for hiding the actual session storage implementation.')

--- a/components/concept/session-storage/proguard-rules.pro
+++ b/components/concept/session-storage/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/concept/session-storage/src/main/AndroidManifest.xml
+++ b/components/concept/session-storage/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.concept.session.storage" />

--- a/components/concept/session-storage/src/main/java/mozilla/components/concept/session/storage/SessionStorage.kt
+++ b/components/concept/session-storage/src/main/java/mozilla/components/concept/session/storage/SessionStorage.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.feature.session
+package mozilla.components.concept.session.storage
 
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.Engine

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/DefaultSessionStorage.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/DefaultSessionStorage.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.session.storage.SessionStorage
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.FileNotFoundException

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProvider.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProvider.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.session.storage.SessionStorage
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -43,7 +44,7 @@ class SessionProvider(
 
         if (savePeriodically) {
             scheduler.scheduleAtFixedRate(
-                { sessionStorage.persist(sessions, sessionManager.selectedSession?.id) },
+                { sessionStorage.persist(sessions, selectedSession.id) },
                 saveIntervalInSeconds,
                 saveIntervalInSeconds,
                 TimeUnit.SECONDS)
@@ -70,7 +71,6 @@ class SessionProvider(
      * Stops this provider and periodic saves.
      */
     fun stop() {
-        sessions.clear()
         scheduler.shutdown()
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProviderTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProviderTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.session
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.session.storage.SessionStorage
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -30,6 +30,7 @@ android {
 
 dependencies {
     implementation project(':concept-engine')
+    implementation project(':concept-session-storage')
     implementation project(':concept-toolbar')
 
     implementation project(':browser-engine-system')

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,9 @@ project(':concept-toolbar').projectDir = new File(rootDir, 'components/concept/t
 include ':concept-engine'
 project(':concept-engine').projectDir = new File(rootDir, 'components/concept/engine')
 
+include ':concept-session-storage'
+project(':concept-session-storage').projectDir = new File(rootDir, 'components/concept/session-storage')
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Features
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Brings in a new concept module for `SessionStorage`. Custom implementations then only need to depend on this module and not `feature-session`.