### PR TITLE
Introducing browser-menu component

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ High-level components for building browser(-like) apps.
 
 * **Erropages** - Responsive browser error pages for Android apps.
 
+* **Menu** - A generic menu with customizable items primarily for browser toolbars.
+
 * **Search** - Search plugins and companion code to load, parse and use them.
 
 * **Session** - A generic representation of a browser session.

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,15 @@ allprojects {
         google()
         jcenter()
 
-        // Only ARM for now. See issue #51
+        // GeckoView repositories
         maven {
             url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.${gecko['nightlyDate']}.revision.${gecko['revision']}.mobile.android-api-16-opt/artifacts/public/android/maven"
+        }
+        maven {
+            url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.${gecko['nightlyDate']}.revision.${gecko['revision']}.mobile.android-x86-opt/artifacts/public/android/maven"
+        }
+        maven {
+            url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.${gecko['nightlyDate']}.revision.${gecko['revision']}.mobile.android-aarch64-opt/artifacts/public/android/maven"
         }
     }
 }

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -27,7 +27,11 @@ android {
 }
 
 dependencies {
+    implementation project(':support-ktx')
+
     implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation "com.android.support:recyclerview-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation "com.android.support:cardview-v7:${rootProject.ext.dependencies['supportLibraries']}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+}
+
+archivesBaseName = "menu"
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.components',
+        'menu',
+        'A customizable menu for browsers.')

--- a/components/browser/menu/proguard-rules.pro
+++ b/components/browser/menu/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/browser/menu/src/main/AndroidManifest.xml
+++ b/components/browser/menu/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.browser.menu" />

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+class BrowserMenu

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -4,4 +4,62 @@
 
 package mozilla.components.browser.menu
 
-class BrowserMenu
+import android.annotation.SuppressLint
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.WindowManager
+import android.widget.PopupWindow
+import mozilla.components.support.ktx.android.view.dp
+import mozilla.components.support.ktx.android.view.isRTL
+
+/**
+ * A popup menu composed of BrowserMenuItem objects.
+ */
+class BrowserMenu internal constructor(
+    private val adapter: BrowserMenuAdapter
+) {
+    private var currentPopup: PopupWindow? = null
+
+    @SuppressLint("InflateParams")
+    fun show(anchor: View): PopupWindow {
+        val view = LayoutInflater.from(anchor.context).inflate(R.layout.mozac_browser_menu, null)
+
+        adapter.menu = this
+
+        val menuList: RecyclerView = view.findViewById(R.id.mozac_browser_menu_recyclerView)
+        menuList.layoutManager = LinearLayoutManager(anchor.context, LinearLayoutManager.VERTICAL, false)
+        menuList.adapter = adapter
+
+        return PopupWindow(
+                view,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT
+        ).apply {
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            isFocusable = true
+            elevation = view.dp(MENU_ELEVATION_DP).toFloat()
+
+            setOnDismissListener {
+                adapter.menu = null
+                currentPopup = null
+            }
+
+            val xOffset = if (anchor.isRTL) -anchor.width else 0
+            showAsDropDown(anchor, xOffset, -anchor.height)
+        }.also {
+            currentPopup = it
+        }
+    }
+
+    fun dismiss() {
+        currentPopup?.dismiss()
+    }
+
+    companion object {
+        private const val MENU_ELEVATION_DP = 8
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.content.Context
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
+/**
+ * Adapter implementation used by the browser menu to display menu items in a RecyclerView.
+ */
+internal class BrowserMenuAdapter(
+    context: Context,
+    items: List<BrowserMenuItem>
+) : RecyclerView.Adapter<BrowserMenuItemViewHolder>() {
+    var menu: BrowserMenu? = null
+
+    internal val visibleItems = items.filter { it.visible() }
+    private val inflater = LayoutInflater.from(context)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+            BrowserMenuItemViewHolder(inflater.inflate(viewType, parent, false))
+
+    override fun getItemCount() = visibleItems.size
+
+    override fun getItemViewType(position: Int): Int = visibleItems[position].getLayoutResource()
+
+    override fun onBindViewHolder(holder: BrowserMenuItemViewHolder, position: Int) {
+        visibleItems[position].bind(menu!!, holder.itemView)
+    }
+}
+
+class BrowserMenuItemViewHolder(itemView: View?) : RecyclerView.ViewHolder(itemView)

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
@@ -8,15 +8,14 @@ import android.content.Context
 
 /**
  * Helper class for building browser menus.
+ *
+ * @param items List of BrowserMenuItem objects to compose the menu from.
  */
-class BrowserMenuBuilder {
-    /**
-     * List of BrowserMenuItem objects to compose the menu from.
-     */
-    var items: List<BrowserMenuItem>? = null
-
+class BrowserMenuBuilder(
+    private val items: List<BrowserMenuItem>
+) {
     fun build(context: Context): BrowserMenu {
-        val adapter = BrowserMenuAdapter(context, items!!)
+        val adapter = BrowserMenuAdapter(context, items)
 
         return BrowserMenu(adapter)
     }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.content.Context
+
+/**
+ * Helper class for building browser menus.
+ */
+class BrowserMenuBuilder {
+    /**
+     * List of BrowserMenuItem objects to compose the menu from.
+     */
+    var items: List<BrowserMenuItem>? = null
+
+    fun build(context: Context): BrowserMenu {
+        val adapter = BrowserMenuAdapter(context, items!!)
+
+        return BrowserMenu(adapter)
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.view.View
+
+/**
+ * Interface to be implemented by menu items to be shown in the browser menu.
+ */
+interface BrowserMenuItem {
+    /**
+     * Lambda expression that returns true if this item should be shown in the menu. Returns false
+     * if this item should be hidden.
+     */
+    val visible: () -> Boolean
+
+    /**
+     * Returns the layout resource ID of the layout to be inflated for showing a menu item of this
+     * type.
+     */
+    fun getLayoutResource(): Int
+
+    /**
+     * Called by the browser menu to display the data of this item using the passed view.
+     */
+    fun bind(menu: BrowserMenu, view: View)
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.support.v4.content.ContextCompat
+import android.support.v7.widget.AppCompatImageButton
+import android.util.TypedValue
+import android.view.View
+import android.widget.LinearLayout
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuItem
+import mozilla.components.browser.menu.R
+import mozilla.components.support.ktx.android.view.dp
+
+/**
+ * A toolbar of buttons to show inside the browser menu.
+ */
+class BrowserMenuItemToolbar(
+    private val items: List<Button>
+) : BrowserMenuItem {
+    override val visible: () -> Boolean = { true }
+
+    override fun getLayoutResource() = R.layout.mozac_browser_menu_item_toolbar
+
+    override fun bind(menu: BrowserMenu, view: View) {
+        val layout = view as LinearLayout
+        layout.removeAllViews()
+
+        for (item in items) {
+            val button = AppCompatImageButton(view.context)
+            button.setImageResource(item.imageResource)
+
+            val outValue = TypedValue()
+            view.context.theme.resolveAttribute(
+                    android.R.attr.selectableItemBackgroundBorderless,
+                    outValue,
+                    true)
+
+            button.setBackgroundResource(outValue.resourceId)
+            button.contentDescription = item.contentDescription
+            button.setOnClickListener {
+                item.listener.invoke()
+                menu.dismiss()
+            }
+
+            if (item.iconTintColorResource != 0) {
+                button.imageTintList = ContextCompat.getColorStateList(view.context, item.iconTintColorResource)
+            }
+
+            layout.addView(button,
+                LinearLayout.LayoutParams(0, view.dp(ICON_HEIGHT_DP), 1f))
+        }
+    }
+
+    /**
+     * A button to be shown in a toolbar inside the browser menu.
+     *
+     * @param imageResource ID of a drawable resource to be shown as icon.
+     * @param contentDescription The button's content description, used for accessibility support.
+     * @param iconTintColorResource Optional ID of color resource to tint the icon.
+     * @param listener Callback to be invoked when the button is pressed.
+     */
+    class Button(
+        val imageResource: Int,
+        val contentDescription: String,
+        val iconTintColorResource: Int = 0,
+        val listener: () -> Unit
+    )
+
+    companion object {
+        private const val ICON_HEIGHT_DP = 24
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItem.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.View
+import android.widget.TextView
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuItem
+import mozilla.components.browser.menu.R
+
+/**
+ * A simple browser menu item displaying text.
+ *
+ * @param label The visible label of this menu item.
+ * @param listener Callback to be invoked when this menu item is clicked.
+ */
+class SimpleBrowserMenuItem(
+    private val label: String,
+    private val listener: () -> Unit
+) : BrowserMenuItem {
+    override var visible: () -> Boolean = { true }
+
+    override fun getLayoutResource() = R.layout.mozac_browser_menu_item_simple
+
+    override fun bind(menu: BrowserMenu, view: View) {
+        (view as TextView).text = label
+        view.setOnClickListener {
+            listener.invoke()
+            menu.dismiss()
+        }
+    }
+}

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="@dimen/mozac_browser_menu_corner_radius"
+    app:cardElevation="@dimen/mozac_browser_menu_elevation">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/mozac_browser_menu_recyclerView"
+            android:paddingTop="@dimen/mozac_browser_menu_padding_vertical"
+            android:paddingBottom="@dimen/mozac_browser_menu_padding_vertical"
+            android:layout_width="@dimen/mozac_browser_menu_width"
+            android:layout_height="wrap_content" />
+
+</android.support.v7.widget.CardView>

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_simple.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_simple.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@android:style/TextAppearance.Material.Menu"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:ellipsize="end"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:lines="1"
+    android:paddingEnd="16dp"
+    android:paddingStart="16dp"
+    android:textSize="16sp" />

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_toolbar.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_toolbar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@android:style/TextAppearance.Material.Menu"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" />

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <dimen name="mozac_browser_menu_corner_radius">4dp</dimen>
+    <dimen name="mozac_browser_menu_elevation">4dp</dimen>
+    <dimen name="mozac_browser_menu_width">250dp</dimen>
+    <dimen name="mozac_browser_menu_padding_vertical">8dp</dimen>
+</resources>

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserMenuAdapterTest {
+    @Test
+    fun `items that return false from the visible lambda will be filtered out`() {
+        val items = listOf(
+            createMenuItem(1) { true },
+            createMenuItem(2) { true },
+            createMenuItem(3) { false },
+            createMenuItem(4) { false },
+            createMenuItem(5) { true })
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+
+        assertEquals(3, adapter.visibleItems.size)
+
+        adapter.visibleItems.assertTrueForOne { it.getLayoutResource() == 1 }
+        adapter.visibleItems.assertTrueForOne { it.getLayoutResource() == 2 }
+        adapter.visibleItems.assertTrueForOne { it.getLayoutResource() == 5 }
+
+        adapter.visibleItems.assertTrueForAll { it.visible() }
+
+        assertEquals(3, adapter.itemCount)
+    }
+
+    @Test
+    fun `layout resource ID is used as view type`() {
+        val items = listOf(
+                createMenuItem(23),
+                createMenuItem(42))
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+
+        assertEquals(2, adapter.itemCount)
+
+        assertEquals(23, adapter.getItemViewType(0))
+        assertEquals(42, adapter.getItemViewType(1))
+    }
+
+    @Test
+    fun `bind will be forwarded to item implementation`() {
+        val item1 = spy(createMenuItem())
+        val item2 = spy(createMenuItem())
+
+        val menu = mock(BrowserMenu::class.java)
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, listOf(item1, item2))
+        adapter.menu = menu
+
+        val view = mock(View::class.java)
+        val holder = BrowserMenuItemViewHolder(view)
+
+        adapter.onBindViewHolder(holder, 0)
+
+        verify(item1).bind(menu, view)
+        verify(item2, never()).bind(menu, view)
+
+        reset(item1)
+        reset(item2)
+
+        adapter.onBindViewHolder(holder, 1)
+
+        verify(item1, never()).bind(menu, view)
+        verify(item2).bind(menu, view)
+    }
+
+    private fun List<BrowserMenuItem>.assertTrueForOne(predicate: (BrowserMenuItem) -> Boolean) {
+        for (item in this) {
+            if (predicate(item)) {
+                return
+            }
+        }
+        fail("Predicate false for all items")
+    }
+
+    private fun List<BrowserMenuItem>.assertTrueForAll(predicate: (BrowserMenuItem) -> Boolean) {
+        for (item in this) {
+            if (!predicate(item)) {
+                fail("Predicate not true for all items")
+            }
+        }
+    }
+
+    private fun createMenuItem(
+        layout: Int = 0,
+        visible: () -> Boolean = { true }
+    ): BrowserMenuItem {
+        return object : BrowserMenuItem {
+            override val visible = visible
+
+            override fun getLayoutResource() = layout
+
+            override fun bind(menu: BrowserMenu, view: View) {}
+        }
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
@@ -18,8 +18,7 @@ import org.robolectric.RuntimeEnvironment
 class BrowserMenuBuilderTest {
     @Test
     fun `items are forwarded from builder to menu`() {
-        val builder = BrowserMenuBuilder()
-        builder.items = listOf(mockMenuItem(), mockMenuItem())
+        val builder = BrowserMenuBuilder(listOf(mockMenuItem(), mockMenuItem()))
 
         val menu = builder.build(RuntimeEnvironment.application)
 
@@ -32,12 +31,6 @@ class BrowserMenuBuilderTest {
         val recyclerAdapter = recyclerView.adapter
         assertNotNull(recyclerAdapter)
         assertEquals(2, recyclerAdapter.itemCount)
-    }
-
-    @Test(expected = KotlinNullPointerException::class)
-    fun `builder throws exception if no items are set`() {
-        val builder = BrowserMenuBuilder()
-        builder.build(RuntimeEnvironment.application)
     }
 
     private fun mockMenuItem() = object : BrowserMenuItem {

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.widget.ImageButton
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserMenuBuilderTest {
+    @Test
+    fun `items are forwarded from builder to menu`() {
+        val builder = BrowserMenuBuilder()
+        builder.items = listOf(mockMenuItem(), mockMenuItem())
+
+        val menu = builder.build(RuntimeEnvironment.application)
+
+        val anchor = ImageButton(RuntimeEnvironment.application)
+        val popup = menu.show(anchor)
+
+        val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
+        assertNotNull(recyclerView)
+
+        val recyclerAdapter = recyclerView.adapter
+        assertNotNull(recyclerAdapter)
+        assertEquals(2, recyclerAdapter.itemCount)
+    }
+
+    @Test(expected = KotlinNullPointerException::class)
+    fun `builder throws exception if no items are set`() {
+        val builder = BrowserMenuBuilder()
+        builder.build(RuntimeEnvironment.application)
+    }
+
+    private fun mockMenuItem() = object : BrowserMenuItem {
+        override val visible: () -> Boolean = { true }
+
+        override fun getLayoutResource() = R.layout.mozac_browser_menu_item_simple
+
+        override fun bind(menu: BrowserMenu, view: View) {}
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.support.v7.widget.RecyclerView
+import android.widget.Button
+import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserMenuTest {
+    @Test
+    fun `show returns non-null popup window`() {
+        val items = listOf(
+                SimpleBrowserMenuItem("Hello") {},
+                SimpleBrowserMenuItem("World") {})
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+
+        val menu = BrowserMenu(adapter)
+
+        val anchor = Button(RuntimeEnvironment.application)
+        val popup = menu.show(anchor)
+
+        assertNotNull(popup)
+    }
+
+    @Test
+    fun `recyclerview adapter will have items for every menu item`() {
+        val items = listOf(
+                SimpleBrowserMenuItem("Hello") {},
+                SimpleBrowserMenuItem("World") {})
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+
+        val menu = BrowserMenu(adapter)
+
+        val anchor = Button(RuntimeEnvironment.application)
+        val popup = menu.show(anchor)
+
+        val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
+        assertNotNull(recyclerView)
+
+        val recyclerAdapter = recyclerView.adapter
+        assertNotNull(recyclerAdapter)
+        assertEquals(2, recyclerAdapter.itemCount)
+    }
+
+    @Test
+    fun `created popup window is displayed automatically`() {
+        val items = listOf(
+                SimpleBrowserMenuItem("Hello") {},
+                SimpleBrowserMenuItem("World") {})
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+
+        val menu = BrowserMenu(adapter)
+
+        val anchor = Button(RuntimeEnvironment.application)
+        val popup = menu.show(anchor)
+
+        assertTrue(popup.isShowing)
+    }
+
+    @Test
+    fun `dismissing the browser menu will dismiss the popup`() {
+        val items = listOf(
+                SimpleBrowserMenuItem("Hello") {},
+                SimpleBrowserMenuItem("World") {})
+
+        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+
+        val menu = BrowserMenu(adapter)
+
+        val anchor = Button(RuntimeEnvironment.application)
+        val popup = menu.show(anchor)
+
+        assertTrue(popup.isShowing)
+
+        menu.dismiss()
+
+        assertFalse(popup.isShowing)
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.LayoutInflater
+import android.widget.ImageButton
+import android.widget.LinearLayout
+import android.widget.TextView
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserMenuItemToolbarTest {
+    @Test
+    fun `toolbar is visible by default`() {
+        val toolbar = BrowserMenuItemToolbar(emptyList())
+
+        assertTrue(toolbar.visible())
+    }
+
+    @Test
+    fun `layout resource can be inflated`() {
+        val toolbar = BrowserMenuItemToolbar(emptyList())
+
+        val view = LayoutInflater.from(
+                RuntimeEnvironment.application
+        ).inflate(toolbar.getLayoutResource(), null)
+
+        assertNotNull(view)
+    }
+
+    @Test
+    fun `empty toolbar does not add anything to view group`() {
+        val layout = LinearLayout(RuntimeEnvironment.application)
+
+        val menu = mock(BrowserMenu::class.java)
+
+        val toolbar = BrowserMenuItemToolbar(emptyList())
+        toolbar.bind(menu, layout)
+
+        assertEquals(0, layout.childCount)
+    }
+
+    @Test
+    fun `toolbar removes previously existing child views from view group`() {
+        val layout = LinearLayout(RuntimeEnvironment.application)
+        layout.addView(TextView(RuntimeEnvironment.application))
+        layout.addView(TextView(RuntimeEnvironment.application))
+
+        assertEquals(2, layout.childCount)
+
+        val menu = mock(BrowserMenu::class.java)
+
+        val toolbar = BrowserMenuItemToolbar(emptyList())
+        toolbar.bind(menu, layout)
+
+        assertEquals(0, layout.childCount)
+    }
+
+    @Test
+    fun `items are added as ImageButton to view group`() {
+        val buttons = listOf(
+                BrowserMenuItemToolbar.Button(
+                        R.drawable.abc_ic_ab_back_material,
+                        "Button01") {},
+                BrowserMenuItemToolbar.Button(
+                        R.drawable.abc_ic_ab_back_material,
+                        "Button02") {})
+
+        val menu = mock(BrowserMenu::class.java)
+        val layout = LinearLayout(RuntimeEnvironment.application)
+
+        val toolbar = BrowserMenuItemToolbar(buttons)
+        toolbar.bind(menu, layout)
+
+        assertEquals(2, layout.childCount)
+
+        val child1 = layout.getChildAt(0)
+        val child2 = layout.getChildAt(1)
+
+        assertTrue(child1 is ImageButton)
+        assertTrue(child2 is ImageButton)
+
+        assertEquals("Button01", child1.contentDescription)
+        assertEquals("Button02", child2.contentDescription)
+    }
+
+    @Test
+    fun `clicking item view invokes callback and dismisses menu`() {
+        var callbackInvoked = false
+
+        val button = BrowserMenuItemToolbar.Button(
+            R.drawable.abc_ic_ab_back_material,
+            "Test") {
+            callbackInvoked = true
+        }
+
+        assertFalse(callbackInvoked)
+
+        val menu = mock(BrowserMenu::class.java)
+        val layout = LinearLayout(RuntimeEnvironment.application)
+
+        val toolbar = BrowserMenuItemToolbar(listOf(button))
+        toolbar.bind(menu, layout)
+
+        assertEquals(1, layout.childCount)
+
+        val view = layout.getChildAt(0)
+
+        assertFalse(callbackInvoked)
+        verify(menu, never()).dismiss()
+
+        view.performClick()
+
+        assertTrue(callbackInvoked)
+        verify(menu).dismiss()
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.LayoutInflater
+import android.widget.TextView
+import mozilla.components.browser.menu.BrowserMenu
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SimpleBrowserMenuItemTest {
+    @Test
+    fun `simple menu items are always visible by default`() {
+        val item = SimpleBrowserMenuItem("Hello") {
+            // do nothing
+        }
+
+        assertTrue(item.visible())
+    }
+
+    @Test
+    fun `layout resource can be inflated`() {
+        val item = SimpleBrowserMenuItem("Hello") {
+            // do nothing
+        }
+
+        val view = LayoutInflater.from(
+            RuntimeEnvironment.application
+        ).inflate(item.getLayoutResource(), null)
+
+        assertNotNull(view)
+    }
+
+    @Test
+    fun `clicking bound view will invoke callback and dismiss menu`() {
+        var callbackInvoked = false
+
+        val item = SimpleBrowserMenuItem("Hello") {
+            callbackInvoked = true
+        }
+
+        val menu = mock(BrowserMenu::class.java)
+        val view = TextView(RuntimeEnvironment.application)
+
+        item.bind(menu, view)
+
+        view.performClick()
+
+        assertTrue(callbackInvoked)
+        verify(menu).dismiss()
+    }
+}

--- a/components/browser/menu/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/browser/menu/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)
+

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -28,11 +28,14 @@ android {
 
 dependencies {
     implementation project(':concept-toolbar')
-    implementation project(':support-ktx')
+
+    implementation project(':browser-menu')
 
     implementation project(':ui-autocomplete')
     implementation project(':ui-icons')
     implementation project(':ui-progress')
+
+    implementation project(':support-ktx')
 
     implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -9,6 +9,7 @@ import android.support.annotation.VisibleForTesting
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.Toolbar
@@ -33,6 +34,7 @@ import mozilla.components.support.ktx.android.view.forEach
  *  +----------------+ +----------------+
  *
  */
+@Suppress("TooManyFunctions")
 class BrowserToolbar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -118,6 +120,14 @@ class BrowserToolbar @JvmOverloads constructor(
      */
     fun displayMode() {
         updateState(State.DISPLAY)
+    }
+
+    /**
+     * Sets a BrowserMenuBuilder that will be used to create a menu when the menu button is clicked.
+     * The menu button will only be visible if a builder has been set.
+     */
+    fun setMenuBuilder(menuBuilder: BrowserMenuBuilder) {
+        displayToolbar.menuBuilder = menuBuilder
     }
 
     internal fun onUrlEntered(url: String) {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -225,7 +225,7 @@ class BrowserToolbarTest {
 
         assertNull(toolbar.displayToolbar.menuBuilder)
 
-        val menuBuilder = BrowserMenuBuilder()
+        val menuBuilder = BrowserMenuBuilder(emptyList())
         toolbar.setMenuBuilder(menuBuilder)
 
         assertNotNull(toolbar.displayToolbar.menuBuilder)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -5,10 +5,13 @@
 package mozilla.components.browser.toolbar
 
 import android.view.View
+import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -214,5 +217,18 @@ class BrowserToolbarTest {
 
         verify(displayToolbar).layout(100, 100, 1100, 300)
         verify(ediToolbar).layout(100, 100, 1100, 300)
+    }
+
+    @Test
+    fun `menu builder will be forwarded to display toolbar`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        assertNull(toolbar.displayToolbar.menuBuilder)
+
+        val menuBuilder = BrowserMenuBuilder()
+        toolbar.setMenuBuilder(menuBuilder)
+
+        assertNotNull(toolbar.displayToolbar.menuBuilder)
+        assertEquals(menuBuilder, toolbar.displayToolbar.menuBuilder)
     }
 }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -12,11 +12,8 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.ktx.android.view.forEach
-import mozilla.components.support.ktx.android.view.isGone
-import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.ui.progress.AnimatedProgressBar
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -111,7 +111,7 @@ class DisplayToolbarTest {
 
         assertTrue(menuView.visibility == View.GONE)
 
-        displayToolbar.menuBuilder = BrowserMenuBuilder()
+        displayToolbar.menuBuilder = BrowserMenuBuilder(emptyList())
 
         assertTrue(menuView.visibility == View.VISIBLE)
     }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -43,6 +43,27 @@ fun View.dp(pixels: Int) = TypedValue.applyDimension(
     TypedValue.COMPLEX_UNIT_DIP, pixels.toFloat(), resources.displayMetrics).toInt()
 
 /**
+ * Returns true if this view's visibility is set to View.VISIBLE.
+ */
+fun View.isVisible(): Boolean {
+    return visibility == View.VISIBLE
+}
+
+/**
+ * Returns true if this view's visibility is set to View.GONE.
+ */
+fun View.isGone(): Boolean {
+    return visibility == View.GONE
+}
+
+/**
+ * Returns true if this view's visibility is set to View.INVISIBLE.
+ */
+fun View.isInvisible(): Boolean {
+    return visibility == View.INVISIBLE
+}
+
+/**
  * Tries to focus this view and show the soft input window for it.
  */
 fun View.showKeyboard() {

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
@@ -14,6 +14,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.shadows.ShadowLooper
 import android.util.DisplayMetrics
+import android.view.View
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 
@@ -42,5 +43,28 @@ class ViewTest {
             assertEquals(px, view.dp(i))
             assertNotEquals(0, view.dp(i))
         }
+    }
+
+    @Test
+    fun `visibility helper methods`() {
+        val view = TextView(RuntimeEnvironment.application)
+
+        view.visibility = View.GONE
+
+        assertTrue(view.isGone())
+        assertFalse(view.isVisible())
+        assertFalse(view.isInvisible())
+
+        view.visibility = View.VISIBLE
+
+        assertFalse(view.isGone())
+        assertTrue(view.isVisible())
+        assertFalse(view.isInvisible())
+
+        view.visibility = View.INVISIBLE
+
+        assertFalse(view.isGone())
+        assertFalse(view.isVisible())
+        assertTrue(view.isInvisible())
     }
 }

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -25,7 +25,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
@@ -37,6 +36,7 @@ dependencies {
 
     implementation project(':browser-session')
     implementation project(':browser-toolbar')
+    implementation project(':browser-menu')
 
     implementation project(':feature-session')
     implementation project(':feature-toolbar')
@@ -44,6 +44,7 @@ dependencies {
     implementation project(':ui-autocomplete')
 
     implementation "org.mozilla:geckoview-nightly-armeabi-v7a:${rootProject.ext.gecko['version']}"
+    //implementation "org.mozilla:geckoview-nightly-x86:${rootProject.ext.gecko['version']}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -31,11 +31,7 @@ class Components(private val applicationContext: Context) {
     val sessionUseCases = SessionUseCases(sessionProvider, engine)
     val sessionIntentProcessor = SessionIntentProcessor(sessionUseCases)
 
-    val menuBuilder by lazy {
-        val builder = BrowserMenuBuilder()
-        builder.items = menuItems
-        builder
-    }
+    val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
 
     private val menuItems by lazy {
         listOf(

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -5,8 +5,12 @@
 package org.mozilla.samples.browser
 
 import android.content.Context
+import android.widget.Toast
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.menu.BrowserMenuBuilder
+import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
+import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.session.SessionIntentProcessor
 import mozilla.components.feature.session.SessionProvider
@@ -26,4 +30,40 @@ class Components(private val applicationContext: Context) {
     val sessionProvider = SessionProvider(applicationContext, Session("https://www.mozilla.org"))
     val sessionUseCases = SessionUseCases(sessionProvider, engine)
     val sessionIntentProcessor = SessionIntentProcessor(sessionUseCases)
+
+    val menuBuilder by lazy {
+        val builder = BrowserMenuBuilder()
+        builder.items = menuItems
+        builder
+    }
+
+    private val menuItems by lazy {
+        listOf(
+            menuToolbar,
+            SimpleBrowserMenuItem("Share") {
+                Toast.makeText(applicationContext, "Share", Toast.LENGTH_SHORT).show()
+            },
+            SimpleBrowserMenuItem("Settings") {
+                Toast.makeText(applicationContext, "Settings", Toast.LENGTH_SHORT).show()
+            }
+        )
+    }
+
+    private val menuToolbar by lazy {
+        val back = BrowserMenuItemToolbar.Button(
+                mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
+                iconTintColorResource = R.color.photonBlue90,
+                contentDescription = "Forward") {
+            Toast.makeText(applicationContext, "Forward", Toast.LENGTH_SHORT).show()
+        }
+
+        val refresh = BrowserMenuItemToolbar.Button(
+                mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+                iconTintColorResource = R.color.photonBlue90,
+                contentDescription = "Refresh") {
+            Toast.makeText(applicationContext, "Refresh", Toast.LENGTH_SHORT).show()
+        }
+
+        BrowserMenuItemToolbar(listOf(back, refresh))
+    }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
@@ -26,6 +26,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        toolbar.setMenuBuilder(components.menuBuilder)
+
         sessionFeature = SessionFeature(
             components.sessionProvider,
             components.sessionUseCases,

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,9 @@ project(':browser-engine-system').projectDir = new File(rootDir, 'components/bro
 include ':browser-errorpages'
 project(':browser-errorpages').projectDir = new File(rootDir, 'components/browser/errorpages')
 
+include ':browser-menu'
+project(':browser-menu').projectDir = new File(rootDir, 'components/browser/menu')
+
 include ':browser-search'
 project(':browser-search').projectDir = new File(rootDir, 'components/browser/search')
 


### PR DESCRIPTION
![screenshot_2018-05-16 components](https://user-images.githubusercontent.com/89638/40117383-1a8d95a4-5917-11e8-8432-c4c63b92e32b.png)

This PR introduces a new `browser-menu` component and uses it from the toolbar component. At the application level the app can define how the menu will look like using a `BrowserMenuBuilder` that gets assigned to the toolbar.

Menus are build from objects implementing `BrowserMenuItem`. This PR comes with two implementations:
* `SimpleBrowserMenuItem` - A simple menu item that is just a clickable text label
* `BrowserMenuItemToolbar` - A toolbar with clickable icons

I added both menu item types to the sample app and that's how it looks like:
![device-2018-05-16-144354](https://user-images.githubusercontent.com/89638/40117604-b3c73158-5917-11e8-9168-402c913ad744.png)
