### PR TITLE
Closes #92: Perform search via default search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ _API contracts and abstraction layers for browser components._
 
 _Combined components to implement feature-specific use cases._
 
-* 🔴 **Session** - A component thats connects an (concept) engine implementation with the browser session module.
+* 🔴 **Search** - A component that connects an (concept) engine implementation with the browser search module.
 
-* 🔴 **Toolbar** - A component thats connects a (concept) toolbar implementation with the browser session module.
+* 🔴 **Session** - A component that connects an (concept) engine implementation with the browser session module.
+
+* 🔴 **Toolbar** - A component that connects a (concept) toolbar implementation with the browser session module.
 
 ## UI
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -22,6 +22,7 @@ class Session(
         fun onProgress()
         fun onLoadingStateChanged()
         fun onNavigationStateChanged()
+        fun onSearch()
     }
 
     private val observers = mutableListOf<Observer>()
@@ -59,6 +60,13 @@ class Session(
      */
     var canGoForward: Boolean by Delegates.observable(false) {
         _, old, new -> notifyObservers (old, new, { onNavigationStateChanged() })
+    }
+
+    /**
+     * The currently / last used search terms.
+     */
+    var searchTerms: String by Delegates.observable("") {
+        _, _, new -> notifyObservers ({ if (!new.isEmpty()) onSearch() })
     }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -139,4 +139,19 @@ class SessionTest {
         assertNotNull(session.id)
         assertEquals("s1", session.id)
     }
+
+    @Test
+    fun `observer is notified when search terms are set`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.searchTerms = ""
+        session.searchTerms = "mozilla android"
+
+        assertEquals("mozilla android", session.searchTerms)
+        verify(observer, times(1)).onSearch()
+        verifyNoMoreInteractions(observer)
+    }
 }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -48,6 +48,7 @@ class BrowserToolbar @JvmOverloads constructor(
 
     private var state: State = State.DISPLAY
     private var url: String = ""
+    private var searchTerms: String = ""
     private var listener: ((String) -> Unit)? = null
 
     init {
@@ -96,6 +97,10 @@ class BrowserToolbar @JvmOverloads constructor(
         this.url = url
     }
 
+    override fun setSearchTerms(searchTerms: String) {
+        this.searchTerms = searchTerms
+    }
+
     override fun displayProgress(progress: Int) {
         displayToolbar.updateProgress(progress)
     }
@@ -118,7 +123,8 @@ class BrowserToolbar @JvmOverloads constructor(
      * Switches to URL editing mode.
      */
     fun editMode() {
-        editToolbar.updateUrl(url)
+        val urlValue = if (searchTerms.isEmpty()) url else searchTerms
+        editToolbar.updateUrl(urlValue)
 
         updateState(State.EDIT)
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -248,4 +248,25 @@ class BrowserToolbarTest {
 
         verify(displayToolbar).addAction(action)
     }
+
+    fun `URL update does not override search terms in edit mode`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        val displayToolbar = mock(DisplayToolbar::class.java)
+        val editToolbar = mock(EditToolbar::class.java)
+
+        toolbar.displayToolbar = displayToolbar
+        toolbar.editToolbar = editToolbar
+
+        toolbar.setSearchTerms("mozilla android")
+        toolbar.displayUrl("https://www.mozilla.org")
+        toolbar.editMode()
+        verify(displayToolbar).updateUrl("https://www.mozilla.org")
+        verify(editToolbar).updateUrl("mozilla android")
+
+        toolbar.setSearchTerms("")
+        toolbar.displayUrl("https://www.mozilla.org")
+        toolbar.editMode()
+        verify(displayToolbar).updateUrl("https://www.mozilla.org")
+        verify(editToolbar).updateUrl("https://www.mozilla.org")
+    }
 }

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -18,6 +18,13 @@ interface Toolbar {
     fun displayUrl(url: String)
 
     /**
+     * Displays the currently used search terms as part of this Toolbar.
+     *
+     * @param searchTerms the search terms used by the current session
+     */
+    fun setSearchTerms(searchTerms: String)
+
+    /**
      * Displays the given loading progress. Expects values in the range [0, 100].
      */
     fun displayProgress(progress: Int)

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':browser-search')
+
+    implementation project(':feature-session')
+    implementation project(':browser-session')
+    implementation project(':concept-engine')
+    implementation project(':concept-session-storage')
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+
+    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
+    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+}
+
+archivesBaseName = "feature-search"
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.components',
+        'feature-search',
+        'Feature implementation connecting an engine implementation with the search module.')

--- a/components/feature/search/proguard-rules.pro
+++ b/components/feature/search/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/search/src/main/AndroidManifest.xml
+++ b/components/feature/search/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.search" />

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.search
+
+import android.content.Context
+import mozilla.components.browser.search.SearchEngineManager
+import mozilla.components.browser.session.Session
+import mozilla.components.feature.session.SessionProvider
+
+/**
+ * Contains use cases related to the search feature.
+ */
+class SearchUseCases(
+    private val context: Context,
+    private val searchEngineManager: SearchEngineManager,
+    private val sessionProvider: SessionProvider
+) {
+
+    class DefaultSearchUrlUseCase(
+        private val context: Context,
+        private val searchEngineManager: SearchEngineManager,
+        private val sessionProvider: SessionProvider
+    ) {
+
+        /**
+         * Triggers a search using the default search engine for the provided search terms.
+         *
+         * @param searchTerms the search terms.
+         * @param session the session to use, or the currently selected session if none
+         * is provided.
+         */
+        fun invoke(searchTerms: String, session: Session = sessionProvider.sessionManager.selectedSession) {
+            val searchEngine = searchEngineManager.getDefaultSearchEngine(context)
+            val searchUrl = searchEngine.buildSearchUrl(searchTerms)
+
+            session.searchTerms = searchTerms
+
+            val engineSession = sessionProvider.getEngineSession(session)
+            engineSession?.loadUrl(searchUrl)
+        }
+    }
+
+    val defaultSearch: DefaultSearchUrlUseCase by lazy {
+        DefaultSearchUrlUseCase(context, searchEngineManager, sessionProvider)
+    }
+}

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.search
+
+import mozilla.components.browser.search.SearchEngine
+import mozilla.components.browser.search.SearchEngineManager
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.feature.session.SessionProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SearchUseCasesTest {
+
+    private val searchEngine = mock(SearchEngine::class.java)
+    private val searchEngineManager = mock(SearchEngineManager::class.java)
+    private val sessionProvider = mock(SessionProvider::class.java)
+    private val useCases = SearchUseCases(RuntimeEnvironment.application, searchEngineManager, sessionProvider)
+
+    @Test
+    fun testDefaultSearch() {
+        val searchTerms = "mozilla android"
+        val searchUrl = "http://search-url.com?$searchTerms"
+
+        val session = Session("mozilla.org")
+        val engineSession = mock(EngineSession::class.java)
+
+        `when`(searchEngine.buildSearchUrl(searchTerms)).thenReturn(searchUrl)
+        `when`(searchEngineManager.getDefaultSearchEngine(RuntimeEnvironment.application)).thenReturn(searchEngine)
+        `when`(sessionProvider.getEngineSession(session)).thenReturn(engineSession)
+
+        useCases.defaultSearch.invoke(searchTerms, session)
+
+        assertEquals(searchTerms, session.searchTerms)
+        verify(engineSession).loadUrl(searchUrl)
+    }
+}

--- a/components/feature/search/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/search/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionProxy.kt
@@ -22,6 +22,7 @@ class SessionProxy(
 
     override fun onLocationChange(url: String) {
         session.url = url
+        session.searchTerms = ""
     }
 
     override fun onProgress(progress: Int) {

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProxyTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionProxyTest.kt
@@ -34,6 +34,7 @@ class SessionProxyTest {
 
         engineSession.loadUrl("http://mozilla.org")
         assertEquals("http://mozilla.org", session.url)
+        assertEquals("", session.searchTerms)
         assertEquals(100, session.progress)
         assertEquals(true, session.loading)
         assertEquals(true, session.canGoForward)

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
@@ -9,15 +9,22 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.session.SessionUseCases
 
 /**
+ * A function representing the search use case, accepting
+ * the search terms as string.
+ */
+typealias SearchUseCase = (String) -> Unit
+
+/**
  * Feature implementation for connecting a toolbar implementation with the session module.
  */
 class ToolbarFeature(
+    val toolbar: Toolbar,
     sessionManager: SessionManager,
     loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
-    val toolbar: Toolbar
+    searchUseCase: SearchUseCase? = null
 ) {
-    private val presenter = ToolbarPresenter(sessionManager, toolbar)
-    private val interactor = ToolbarInteractor(loadUrlUseCase, toolbar)
+    private val presenter = ToolbarPresenter(toolbar, sessionManager)
+    private val interactor = ToolbarInteractor(toolbar, loadUrlUseCase, searchUseCase)
 
     /**
      * Start feature: App is in the foreground.

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
@@ -6,14 +6,16 @@ package mozilla.components.feature.toolbar
 
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.ktx.kotlin.isUrl
 import mozilla.components.support.ktx.kotlin.toNormalizedUrl
 
 /**
  * Connects a toolbar instance to the browser engine via use cases
  */
 class ToolbarInteractor(
+    private val toolbar: Toolbar,
     private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
-    private val toolbar: Toolbar
+    private val searchUseCase: SearchUseCase? = null
 ) {
 
     /**
@@ -22,7 +24,13 @@ class ToolbarInteractor(
      * in response.
      */
     fun start() {
-        toolbar.setOnUrlChangeListener { url -> loadUrlUseCase.invoke(url.toNormalizedUrl()) }
+        toolbar.setOnUrlChangeListener { text ->
+            if (text.isUrl()) {
+                loadUrlUseCase.invoke(text.toNormalizedUrl())
+            } else {
+                searchUseCase?.invoke(text) ?: loadUrlUseCase.invoke(text)
+            }
+        }
     }
 
     /**

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -13,8 +13,8 @@ import mozilla.components.browser.session.SessionManager
  * the state of the selected session changes.
  */
 class ToolbarPresenter(
-    private val sessionManager: SessionManager,
-    private val toolbar: Toolbar
+    private val toolbar: Toolbar,
+    private val sessionManager: SessionManager
 ) : SessionManager.Observer, Session.Observer {
 
     var session: Session = sessionManager.selectedSession
@@ -57,10 +57,15 @@ class ToolbarPresenter(
 
     override fun onUrlChanged() {
         toolbar.displayUrl(session.url)
+        toolbar.setSearchTerms(session.searchTerms)
     }
 
     override fun onProgress() {
         toolbar.displayProgress(session.progress)
+    }
+
+    override fun onSearch() {
+        toolbar.setSearchTerms(session.searchTerms)
     }
 
     override fun onLoadingStateChanged() { }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -11,10 +11,22 @@ import android.text.TextUtils
  * Normalizes a URL string.
  */
 fun String.toNormalizedUrl(): String {
-    val trimmedInput = this.trim({ it <= ' ' })
+    val trimmedInput = this.trim()
     var uri = Uri.parse(trimmedInput)
     if (TextUtils.isEmpty(uri.scheme)) {
         uri = Uri.parse("http://" + trimmedInput)
     }
     return uri.toString()
+}
+
+/**
+ * Checks if this string is a URL.
+ */
+fun String.isUrl(): Boolean {
+    val trimmedUrl = this.trim()
+    if (trimmedUrl.contains(" ")) {
+        return false
+    }
+
+    return trimmedUrl.contains(".") || trimmedUrl.contains(":")
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -5,6 +5,8 @@
 package mozilla.components.support.ktx.kotlin
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -18,5 +20,19 @@ class StringTest {
         assertEquals(expectedUrl, "http://mozilla.org".toNormalizedUrl())
         assertEquals(expectedUrl, "  http://mozilla.org  ".toNormalizedUrl())
         assertEquals(expectedUrl, "mozilla.org".toNormalizedUrl())
+    }
+
+    @Test
+    fun testIsUrl() {
+        assertTrue("mozilla.org".isUrl())
+        assertTrue(" mozilla.org ".isUrl())
+        assertTrue("http://mozilla.org".isUrl())
+        assertTrue("https://mozilla.org".isUrl())
+        assertTrue("file://somefile.txt".isUrl())
+        assertTrue("http://mozilla".isUrl())
+
+        assertFalse("mozilla".isUrl())
+        assertFalse("mozilla android".isUrl())
+        assertFalse(" mozilla android ".isUrl())
     }
 }

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -35,10 +35,12 @@ dependencies {
     implementation project(':browser-engine-system')
     implementation project(':browser-engine-gecko')
 
+    implementation project(':browser-search')
     implementation project(':browser-session')
     implementation project(':browser-toolbar')
     implementation project(':browser-menu')
 
+    implementation project(':feature-search')
     implementation project(':feature-session')
     implementation project(':feature-toolbar')
 
@@ -48,6 +50,7 @@ dependencies {
     //implementation "org.mozilla:geckoview-nightly-x86:${rootProject.ext.gecko['version']}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
 
     implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/MainActivity.kt
@@ -35,9 +35,10 @@ class MainActivity : AppCompatActivity() {
             engineView)
 
         toolbarFeature = ToolbarFeature(
+            toolbar,
             components.sessionProvider.sessionManager,
             components.sessionUseCases.loadUrl,
-            toolbar)
+            components.defaultSearchUseCase)
 
         components.sessionIntentProcessor.process(intent)
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,9 @@ project(':concept-session-storage').projectDir = new File(rootDir, 'components/c
 // Features
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+include ':feature-search'
+project(':feature-search').projectDir = new File(rootDir, 'components/feature/search')
+
 include ':feature-session'
 project(':feature-session').projectDir = new File(rootDir, 'components/feature/session')
 


### PR DESCRIPTION
I think this covers the basic functionality for #92. Worth taking a look before we go deeper ;).

- Introduces a new feature-search module which contains the use case
- Makes sure searching and therefore the feature dependency is optional
- Stores the search terms in the session
- Resurfaces the search terms in edit mode if a search is active
- Adds a String extension to check if a String is a URL