### PR TITLE
Issue #232: Add READMEs for every component and link them from the root README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,69 +22,69 @@ We encourage you to participate in this open source project. We love Pull Reques
 
 High-level components for building browser(-like) apps.
 
-* 🔵 **Domains** Localized and customizable domain lists for auto-completion in browsers.
+* 🔵 [**Domains**](components/browser/domains/README.md) Localized and customizable domain lists for auto-completion in browsers.
 
-* 🔴 **Engine-Gecko** - *Engine* implementation based on [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView).
+* 🔴 [**Engine-Gecko**](components/browser/engine-gecko/README.md) - *Engine* implementation based on [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView).
 
-* 🔴 **Engine-System** - *Engine* implementation based on the system's WebView.
+* 🔴 [**Engine-System**](components/browser/engine-system/README.md) - *Engine* implementation based on the system's WebView.
 
-* ⚪ **Erropages** - Responsive browser error pages for Android apps.
+* ⚪ [**Erropages**](components/browser/errorpages/README.md) - Responsive browser error pages for Android apps.
 
-* 🔴 **Menu** - A generic menu with customizable items primarily for browser toolbars.
+* 🔴 [**Menu**](components/browser/menu/README.md) - A generic menu with customizable items primarily for browser toolbars.
 
-* 🔵 **Search** - Search plugins and companion code to load, parse and use them.
+* 🔵 [**Search**](components/browser/search/README.md) - Search plugins and companion code to load, parse and use them.
 
-* 🔴 **Session** - A generic representation of a browser session.
+* 🔴 [**Session**](components/browser/session/README.md) - A generic representation of a browser session.
 
-* 🔴 **Toolbar** - A customizable toolbar for browsers.
+* 🔴 [**Toolbar**](components/browser/toolbar/README.md) - A customizable toolbar for browsers.
 
 ## Concept
 
 _API contracts and abstraction layers for browser components._
 
-* 🔴 **Engine** - Abstraction layer that allows hiding the actual browser engine implementation.
+* 🔴 [**Engine**](components/concept/engine/README.md) - Abstraction layer that allows hiding the actual browser engine implementation.
 
-* 🔴 **Session-Storage** - Abstraction layer and contracts for hiding the actual session storage implementation.
+* 🔴 [**Session-Storage**](components/concept/session-storage/README.md) - Abstraction layer and contracts for hiding the actual session storage implementation.
 
-* 🔴 **Toolbar** - Abstract definition of a browser toolbar component.
+* 🔴 [**Toolbar**](components/concept/toolbar/README.md) - Abstract definition of a browser toolbar component.
 
 ## Feature
 
 _Combined components to implement feature-specific use cases._
 
-* 🔴 **Search** - A component that connects an (concept) engine implementation with the browser search module.
+* 🔴 [**Search**](components/feature/search/README.md) - A component that connects an (concept) engine implementation with the browser search module.
 
-* 🔴 **Session** - A component that connects an (concept) engine implementation with the browser session module.
+* 🔴 [**Session**](components/feature/session/README.md) - A component that connects an (concept) engine implementation with the browser session module.
 
-* 🔴 **Toolbar** - A component that connects a (concept) toolbar implementation with the browser session module.
+* 🔴 [**Toolbar**](components/feature/toolbar/README.md) - A component that connects a (concept) toolbar implementation with the browser session module.
 
 ## UI
 
 _Generic low-level UI components for building apps._
 
-* 🔵 **Autocomplete** - A set of components to provide autocomplete functionality.
+* 🔵 [**Autocomplete**](components/ui/autocomplete/README.md) - A set of components to provide autocomplete functionality.
 
-* 🔵 **Colors** - The standard set of [Photon](https://design.firefox.com/photon/) colors.
+* 🔵 [**Colors**](components/ui/colors/README.md) - The standard set of [Photon](https://design.firefox.com/photon/) colors.
 
-* 🔵 **Fonts** - The standard set of fonts used by Mozilla Android products.
+* 🔵 [**Fonts**](components/ui/fonts/README.md) - The standard set of fonts used by Mozilla Android products.
 
-* 🔵 **Icons** - A collection of often used browser icons.
+* 🔵 [**Icons**](components/ui/icons/README.md) - A collection of often used browser icons.
 
-* 🔵 **Progress** - An animated progress bar following the Photon Design System. 
+* 🔵 [**Progress**](components/ui/progress/README.md) - An animated progress bar following the Photon Design System. 
 
 ## Service
 
 _Components and libraries to interact with backend services._
 
-* 🔵 **Telemetry** - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
+* 🔵 [**Telemetry**](components/service/telemetry/README.md) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 
 ## Support
 
 _Supporting components with generic helper code._
 
-* 🔵 **Ktx** - A set of Kotlin extensions on top of the Android framework and Kotlin standard library.
+* 🔵 [**Ktx**](components/support/ktx/README.md) - A set of Kotlin extensions on top of the Android framework and Kotlin standard library.
 
-* 🔵 **Utils** - Generic utility classes to be shared between projects.
+* 🔵 [**Utils**](components/support/utils/README.md) - Generic utility classes to be shared between projects.
 
 # License
 

--- a/components/browser/domains/README.md
+++ b/components/browser/domains/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Domains
+
+Localized and customizable domain lists for auto-completion in browsers.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:domains:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/engine-gecko/README.md
+++ b/components/browser/engine-gecko/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Engine-Gecko
+
+[*Engine*](../../concept/engine/README.md) implementation based on [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView).
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:engine-gecko:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/engine-system/README.md
+++ b/components/browser/engine-system/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Engine-System
+
+[*Engine*](../../concept/engine/README.md) implementation based on the system's WebView.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:engine-system:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/errorpages/README.md
+++ b/components/browser/errorpages/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Errorpages
+
+Responsive browser error pages for Android apps.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:errorpages:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Menu
+
+A generic menu with customizable items primarily for browser toolbars.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:menu:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/search/README.md
+++ b/components/browser/search/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Search
+
+Search plugins and companion code to load, parse and use them.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:search:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/session/README.md
+++ b/components/browser/session/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Session
+
+A generic representation of a browser session.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:session:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/toolbar/README.md
+++ b/components/browser/toolbar/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Toolbar
+
+A customizable toolbar for browsers.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:toolbar:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/concept/engine/README.md
+++ b/components/concept/engine/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Concept > Engine
+
+Abstraction layer that allows hiding the actual browser engine implementation.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:engine:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/concept/session-storage/README.md
+++ b/components/concept/session-storage/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Concept > Session-Storage
+
+Abstraction layer and contracts for hiding the actual session storage implementation.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:session-storage:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/concept/toolbar/README.md
+++ b/components/concept/toolbar/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Concept > Toolbar
+
+Abstract definition of a browser toolbar component.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:abstract-toolbar:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/search/README.md
+++ b/components/feature/search/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Feature > Search
+
+A component that connects an (concept) engine implementation with the browser search module.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:feature-search:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/session/README.md
+++ b/components/feature/session/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Feature > Session
+
+A component that connects an (concept) engine implementation with the browser session module.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:feature-session:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/toolbar/README.md
+++ b/components/feature/toolbar/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Feature > Toolbar
+
+A component that connects a (concept) toolbar implementation with the browser session module.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:feature-toolbar:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/service/telemetry/README.md
+++ b/components/service/telemetry/README.md
@@ -1,8 +1,4 @@
-[![Build Status](https://travis-ci.org/mozilla-mobile/telemetry-android.svg?branch=master)](https://travis-ci.org/mozilla-mobile/telemetry-android) 
-[![Coverage Status](https://coveralls.io/repos/github/mozilla-mobile/telemetry-android/badge.svg?branch=master)](https://coveralls.io/github/mozilla-mobile/telemetry-android?branch=master)
-
-telemetry-android
-=================
+# [Android Components](../../../README.md) > Service > Telemetry
 
 A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 
@@ -10,15 +6,16 @@ A generic library for sending telemetry pings from Android applications to Mozil
 
 The goal of this library is to provide a generic set of components to support a variety of telemetry use cases. It tries to not be opinionated about dependency injection frameworks or http clients. The only dependency is ``support-annotations`` to ensure code quality.
 
-## Getting involved
+## Usage
 
-We encourage you to participate in this open source project. We love Pull Requests, Bug Reports, ideas, (security) code reviews or any kind of positive contribution. Please read the [Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
+### Setting up the dependency
 
-* Issues: [https://github.com/mozilla-mobile/android-components/issues](https://github.com/mozilla-mobile/android-components/issues)
+Use gradle to download the library from JCenter:
 
-* IRC: [#mobile (irc.mozilla.org)](https://wiki.mozilla.org/IRC)
+```Groovy
+implementation "org.mozilla.components:telemetry:{latest-version}
+```
 
-* Mailing list: [mobile-firefox-dev](https://mail.mozilla.org/listinfo/mobile-firefox-dev)
 
 ## License
 

--- a/components/support/ktx/README.md
+++ b/components/support/ktx/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Support > Ktx
+
+A set of Kotlin extensions on top of the Android framework and Kotlin standard library.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:ktx:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/support/utils/README.md
+++ b/components/support/utils/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Support > Utils
+
+Generic utility classes to be shared between projects.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:utils:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/ui/autocomplete/README.md
+++ b/components/ui/autocomplete/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > UI > Autocomplete
+
+A set of components to provide autocomplete functionality.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:autocomplete:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/ui/colors/README.md
+++ b/components/ui/colors/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > UI > Colors
+
+The standard set of [Photon](https://design.firefox.com/photon/) colors.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.photon:colors:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/ui/fonts/README.md
+++ b/components/ui/fonts/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > UI > Fonts
+
+The standard set of fonts used by Mozilla Android products.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.photon:fonts:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/ui/icons/README.md
+++ b/components/ui/icons/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > UI > Icons
+
+A collection of often used browser icons.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.photon:icons:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/ui/progress/README.md
+++ b/components/ui/progress/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > UI > Progress
+
+An animated progress bar following the Photon Design System. 
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.photon:progress:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/


### PR DESCRIPTION
* This allows us to document the components better. I want to do that at least for the toolbar soon.

* It's a place where we can list the gradle config line :) (#232)