### PR TITLE
Add cleanBuildCache to Gradle command for PR builds

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -30,7 +30,7 @@ tasks:
           git fetch {{ event.head.repo.url }} {{ event.head.repo.branch }}
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
-          && ./gradlew --no-daemon clean assemble test detektCheck ktlint lint
+          && ./gradlew --no-daemon cleanBuildCache clean assemble test detektCheck ktlint lint
       artifacts:
         'public/reports':
           type: 'directory'


### PR DESCRIPTION
Ran this build 4 times now. No failures. Not conclusive, of course, but worth trying..