### PR TITLE
Update createdTimestamp and createdDate fields for mobile-metrics ping

### DIFF
--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedDateMeasurementNew.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedDateMeasurementNew.java
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.measurement;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+
+public class CreatedDateMeasurementNew extends TelemetryMeasurement {
+    private static final String FIELD_NAME = "createdDate";
+
+    public CreatedDateMeasurementNew() {
+        super(FIELD_NAME);
+    }
+
+    @Override
+    public Object flush() {
+        final DateFormat pingCreationDateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        final Calendar nowCalendar = Calendar.getInstance();
+
+        return pingCreationDateFormat.format(nowCalendar.getTime());
+    }
+}

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedDateMeasurementNew.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedDateMeasurementNew.java
@@ -9,6 +9,9 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 
+/**
+ * The field 'created' from CreatedDateMeasurement will be deprecated for the `createdDate` field
+ */
 public class CreatedDateMeasurementNew extends TelemetryMeasurement {
     private static final String FIELD_NAME = "createdDate";
 

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedTimestampMeasurementNew.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedTimestampMeasurementNew.java
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.measurement;
+
+public class CreatedTimestampMeasurementNew extends TelemetryMeasurement {
+    private static final String FIELD_NAME = "createdTimestamp";
+
+    public CreatedTimestampMeasurementNew() {
+        super(FIELD_NAME);
+    }
+
+    @Override
+    public Object flush() {
+        return System.currentTimeMillis();
+    }
+}

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedTimestampMeasurementNew.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/CreatedTimestampMeasurementNew.java
@@ -4,6 +4,9 @@
 
 package org.mozilla.telemetry.measurement;
 
+/**
+ * The field 'created' from CreatedTimestampMeasurement will be deprecated for the `createdTimestamp` field
+ */
 public class CreatedTimestampMeasurementNew extends TelemetryMeasurement {
     private static final String FIELD_NAME = "createdTimestamp";
 

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryMobileMetricsPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryMobileMetricsPingBuilder.java
@@ -7,7 +7,8 @@ package org.mozilla.telemetry.ping;
 import org.json.JSONObject;
 import org.mozilla.telemetry.config.TelemetryConfiguration;
 import org.mozilla.telemetry.measurement.ArchMeasurement;
-import org.mozilla.telemetry.measurement.CreatedTimestampMeasurement;
+import org.mozilla.telemetry.measurement.CreatedDateMeasurementNew;
+import org.mozilla.telemetry.measurement.CreatedTimestampMeasurementNew;
 import org.mozilla.telemetry.measurement.DeviceMeasurement;
 import org.mozilla.telemetry.measurement.FirstRunProfileDateMeasurement;
 import org.mozilla.telemetry.measurement.LocaleMeasurement;
@@ -39,7 +40,8 @@ public class TelemetryMobileMetricsPingBuilder extends TelemetryPingBuilder {
         addMeasurement(new FirstRunProfileDateMeasurement(configuration));
         addMeasurement(new OperatingSystemMeasurement());
         addMeasurement(new OperatingSystemVersionMeasurement());
-        addMeasurement(new CreatedTimestampMeasurement());
+        addMeasurement(new CreatedDateMeasurementNew());
+        addMeasurement(new CreatedTimestampMeasurementNew());
         addMeasurement(new TimezoneOffsetMeasurement());
         addMeasurement(new MetricsMeasurement(snapshots));
     }

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileMetricsPingBuilderTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileMetricsPingBuilderTest.java
@@ -52,7 +52,9 @@ public class TelemetryMobileMetricsPingBuilderTest {
         assertTrue(results.containsKey("device"));
         assertFalse(TextUtils.isEmpty((String) results.get("device")));
 
-        assertTrue(results.containsKey("created")); // createdTimestamp and createdDate have the same key?
+        assertTrue(results.containsKey("createdDate"));
+
+        assertTrue(results.containsKey("createdTimestamp"));
 
         assertTrue(results.containsKey("tz"));
 


### PR DESCRIPTION
Not sure what to name these new field's classes but the created field is being deprecated for createdTimestamp and createdDate fields, but we already have CreatedTimestampMeasurement and CreatedDateMeasurement being used by core and event pings. 