### PR TITLE
Create generic helper class for creating observable classes

### DIFF
--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -29,6 +29,10 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
 
+    // We expose this as API because we are using Observable in our public API and do not want every
+    // consumer to have to manually import "utils".
+    api project(':support-utils')
+
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
     testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.browser.session
 
+import mozilla.components.support.utils.observer.Observable
+import mozilla.components.support.utils.observer.ObserverRegistry
 import java.util.UUID
 import kotlin.properties.Delegates
 
@@ -13,7 +15,7 @@ import kotlin.properties.Delegates
 class Session(
     initialUrl: String,
     val id: String = UUID.randomUUID().toString()
-) {
+) : Observable<Session.Observer> by registry {
     /**
      * Interface to be implemented by classes that want to observe a session.
      */
@@ -25,8 +27,6 @@ class Session(
         fun onSearch()
         fun onSecurityChanged()
     }
-
-    private val observers = mutableListOf<Observer>()
 
     /**
      * A value type holding security information for a Session.
@@ -89,31 +89,12 @@ class Session(
     }
 
     /**
-     * Registers an observer that gets notified when the session changes.
-     */
-    fun register(observer: Observer) = synchronized(observers) {
-        observers.add(observer)
-    }
-
-    /**
-     * Unregisters an observer.
-     */
-    fun unregister(observer: Observer) = synchronized(observers) {
-        observers.remove(observer)
-    }
-
-    /**
      * Helper method to notify observers.
      */
-
-    private fun notifyObservers(old: Any, new: Any, block: Observer.() -> Unit) = synchronized(observers) {
+    private fun notifyObservers(old: Any, new: Any, block: Observer.() -> Unit) {
         if (old != new) {
             notifyObservers(block)
         }
-    }
-
-    internal fun notifyObservers(block: Observer.() -> Unit) = synchronized(observers) {
-        observers.forEach { it.block() }
     }
 
     override fun equals(other: Any?): Boolean {
@@ -129,3 +110,5 @@ class Session(
         return id.hashCode()
     }
 }
+
+private val registry = ObserverRegistry<Session.Observer>()

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -4,12 +4,16 @@
 
 package mozilla.components.browser.session
 
+import mozilla.components.support.utils.observer.Observable
+import mozilla.components.support.utils.observer.ObserverRegistry
+
 /**
  * This class provides access to a centralized registry of all active sessions.
  */
-class SessionManager(initialSession: Session) {
+class SessionManager(
+    initialSession: Session
+) : Observable<SessionManager.Observer> by registry {
     private val sessions: ObservableList<Session> = ObservableList(mutableListOf(initialSession), 0)
-    private val observers = mutableListOf<Observer>()
 
     /**
      * Returns the number of sessions.
@@ -35,27 +39,14 @@ class SessionManager(initialSession: Session) {
     }
 
     /**
-     * Registers an observer to get notified about changes regarding sessions (e.g. adding a new
-     * session or removing an existing session).
-     */
-    fun register(observer: Observer) {
-        observers.add(observer)
-    }
-
-    /**
-     * Unregisters an observer.
-     */
-    fun unregister(observer: Observer) {
-        observers.remove(observer)
-    }
-
-    /**
      * Marks the given session as selected.
      */
     fun select(session: Session) {
         sessions.select(session)
 
-        observers.forEach { it.onSessionSelected(session) }
+        registry.notifyObservers {
+            onSessionSelected(session)
+        }
     }
 
     /**
@@ -68,3 +59,5 @@ class SessionManager(initialSession: Session) {
         fun onSessionSelected(session: Session)
     }
 }
+
+private val registry = ObserverRegistry<SessionManager.Observer>()

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 
     implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
 
+    // We expose this as API because we are using Observable in our public API and do not want every
+    // consumer to have to manually import "utils".
+    api project(':support-utils')
+
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
     testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"

--- a/components/support/utils/build.gradle
+++ b/components/support/utils/build.gradle
@@ -31,8 +31,12 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+
     implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
     implementation "com.android.support:support-compat:${rootProject.ext.dependencies['supportLibraries']}"
+
+    // We expose the app-compat as API so that consumers get access to the Lifecycle classes automatically
+    api "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
 
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/observer/Observable.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/observer/Observable.kt
@@ -1,0 +1,40 @@
+package mozilla.components.support.utils.observer
+
+import android.arch.lifecycle.LifecycleOwner
+
+/**
+ * Interface for observables. This interface is implemented by ObserverRegistry so that classes that
+ * want to be observable can implement the interface by delegation:
+ *
+ * <code>
+ *     val registry = ObserverRegistry<MyObserverInterface>()
+ *
+ *     class MyObservableClass : Observable<MyObserverInterface> by registry {
+ *       ...
+ *     }
+ * </code>
+ */
+interface Observable<T> {
+    /**
+     * Registers an observer to get notified about changes.
+     *
+     * Optionally a LifecycleOwner can be provided. Once the lifecycle state becomes DESTROYED the
+     * observer is automatically unregistered.
+     */
+    fun register(observer: T, owner: LifecycleOwner? = null)
+
+    /**
+     * Unregisters an observer.
+     */
+    fun unregister(observer: T)
+
+    /**
+     * Unregisters all observers.
+     */
+    fun unregisterObservers()
+
+    /**
+     * Notify all registered observers about a change.
+     */
+    fun notifyObservers(block: T.() -> Unit)
+}

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/observer/ObserverRegistry.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/observer/ObserverRegistry.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils.observer
+
+import android.arch.lifecycle.GenericLifecycleObserver
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleOwner
+import java.util.WeakHashMap
+
+/**
+ * A helper for classes that want to get observed. This class keeps track of registered observers
+ * and can automatically unregister observers if a LifecycleOwner is provided.
+ */
+class ObserverRegistry<T> : Observable<T> {
+    private val observers = mutableListOf<T>()
+    private val lifecycleObservers = WeakHashMap<T, LifecycleBoundObserver<T>>()
+
+    /**
+     * Registers an observer to get notified about changes.
+     *
+     * Optionally a LifecycleOwner can be provided. Once the lifecycle state becomes DESTROYED the
+     * observer is automatically unregistered.
+     */
+    override fun register(observer: T, owner: LifecycleOwner?) {
+        if (owner?.lifecycle?.currentState == Lifecycle.State.DESTROYED) {
+            return
+        }
+
+        synchronized(observers) {
+            observers.add(observer)
+        }
+
+        owner?.let {
+            val lifecycleObserver = LifecycleBoundObserver(
+                    owner,
+                    registry = this,
+                    observer = observer)
+
+            lifecycleObservers[observer] = lifecycleObserver
+
+            it.lifecycle.addObserver(lifecycleObserver)
+        }
+    }
+
+    /**
+     * Unregisters an observer.
+     */
+    override fun unregister(observer: T) {
+        synchronized(observers) {
+            observers.remove(observer)
+        }
+
+        lifecycleObservers[observer]?.remove()
+    }
+
+    /**
+     * Unregisters all observers.
+     */
+    override fun unregisterObservers() {
+        synchronized(observers) {
+            observers.forEach {
+                lifecycleObservers[it]?.remove()
+            }
+            observers.clear()
+        }
+    }
+
+    /**
+     * Notify all registered observers about a change.
+     */
+    override fun notifyObservers(block: T.() -> Unit) {
+        synchronized(observers) {
+            observers.forEach {
+                it.block()
+            }
+        }
+    }
+
+    /**
+     * GenericLifecycleObserver implementation to bind an observer to a Lifecycle.
+     */
+    private class LifecycleBoundObserver<T>(
+        private val owner: LifecycleOwner,
+        private val registry: ObserverRegistry<T>,
+        private val observer: T
+    ) : GenericLifecycleObserver {
+        override fun onStateChanged(source: LifecycleOwner?, event: Lifecycle.Event?) {
+            if (owner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+                registry.unregister(observer)
+            }
+        }
+
+        fun remove() {
+            owner.lifecycle.removeObserver(this)
+        }
+    }
+}

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/observer/ObserverRegistryTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/observer/ObserverRegistryTest.kt
@@ -1,0 +1,226 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils.observer
+
+import android.arch.lifecycle.GenericLifecycleObserver
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.LifecycleOwner
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObserverRegistryTest {
+    @Test
+    fun `registered observer gets notified`() {
+        val registry = ObserverRegistry<TestObserver>()
+
+        val observer = TestObserver()
+        registry.register(observer)
+
+        assertFalse(observer.notified)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertTrue(observer.notified)
+    }
+
+    @Test
+    fun `observer does not get notified again after unregistering`() {
+        val registry = ObserverRegistry<TestObserver>()
+
+        val observer = TestObserver()
+        registry.register(observer)
+
+        assertFalse(observer.notified)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertTrue(observer.notified)
+
+        observer.notified = false
+        registry.unregister(observer)
+
+        assertFalse(observer.notified)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertFalse(observer.notified)
+    }
+
+    @Test
+    fun `observer gets notified multiple times`() {
+        val registry = ObserverRegistry<TestObserver>()
+
+        val observer = TestObserver()
+        registry.register(observer)
+
+        assertFalse(observer.notified)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertTrue(observer.notified)
+        observer.notified = false
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertTrue(observer.notified)
+    }
+
+    @Test
+    fun `observer does not get notified when unregistered immediately`() {
+        val registry = ObserverRegistry<TestObserver>()
+
+        val observer = TestObserver()
+
+        registry.register(observer)
+        registry.unregister(observer)
+
+        assertFalse(observer.notified)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertFalse(observer.notified)
+    }
+
+    @Test
+    fun `observer will not get registered if lifecycle state is DESTROYED`() {
+        val owner = MockedLifecycleOwner(MockedLifecycle(Lifecycle.State.DESTROYED))
+
+        val registry = ObserverRegistry<TestObserver>()
+        val observer = TestObserver()
+
+        registry.register(observer, owner)
+
+        assertFalse(observer.notified)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertFalse(observer.notified)
+    }
+
+    @Test
+    fun `observer will get removed if lifecycle gets destroyed`() {
+        val mockedLifecycle = MockedLifecycle(Lifecycle.State.STARTED)
+        val owner = MockedLifecycleOwner(mockedLifecycle)
+
+        val registry = ObserverRegistry<TestObserver>()
+        val observer = TestObserver()
+
+        registry.register(observer, owner)
+
+        // Observer gets notified
+        assertFalse(observer.notified)
+        registry.notifyObservers { somethingChanged() }
+        assertTrue(observer.notified)
+
+        // Pretend lifecycle gets destroyed
+        mockedLifecycle.state = Lifecycle.State.DESTROYED
+        mockedLifecycle.observer?.onStateChanged(null, null)
+
+        observer.notified = false
+        registry.notifyObservers { somethingChanged() }
+        assertFalse(observer.notified)
+    }
+
+    @Test
+    fun `non-destroy lifecycle changes do not affect observer`() {
+        val mockedLifecycle = MockedLifecycle(Lifecycle.State.STARTED)
+        val owner = MockedLifecycleOwner(mockedLifecycle)
+
+        val registry = ObserverRegistry<TestObserver>()
+        val observer = TestObserver()
+
+        registry.register(observer, owner)
+
+        // STARTED
+        assertFalse(observer.notified)
+        registry.notifyObservers { somethingChanged() }
+        assertTrue(observer.notified)
+
+        // RESUMED
+        mockedLifecycle.state = Lifecycle.State.RESUMED
+        mockedLifecycle.observer?.onStateChanged(null, null)
+        observer.notified = false
+        registry.notifyObservers { somethingChanged() }
+        assertTrue(observer.notified)
+
+        // CREATED
+        mockedLifecycle.state = Lifecycle.State.CREATED
+        mockedLifecycle.observer?.onStateChanged(null, null)
+        observer.notified = false
+        registry.notifyObservers { somethingChanged() }
+        assertTrue(observer.notified)
+    }
+
+    @Test
+    fun `unregisterObservers unregisters all observers`() {
+        val registry = ObserverRegistry<TestObserver>()
+
+        val observer1 = TestObserver()
+        val observer2 = TestObserver()
+
+        registry.register(observer1)
+        registry.register(observer2)
+
+        assertFalse(observer1.notified)
+        assertFalse(observer2.notified)
+
+        registry.notifyObservers { somethingChanged() }
+
+        assertTrue(observer1.notified)
+        assertTrue(observer2.notified)
+
+        observer1.notified = false
+        observer2.notified = false
+
+        registry.unregisterObservers()
+
+        registry.notifyObservers { somethingChanged() }
+
+        assertFalse(observer1.notified)
+        assertFalse(observer2.notified)
+    }
+
+    private class TestObserver {
+        var notified: Boolean = false
+
+        fun somethingChanged() {
+            notified = true
+        }
+    }
+
+    private class MockedLifecycle(var state: State) : Lifecycle() {
+        var observer: GenericLifecycleObserver? = null
+
+        override fun addObserver(observer: LifecycleObserver) {
+            this.observer = observer as GenericLifecycleObserver
+        }
+
+        override fun removeObserver(observer: LifecycleObserver) {
+            this.observer = null
+        }
+
+        override fun getCurrentState(): State = state
+    }
+
+    private class MockedLifecycleOwner(private val lifecycle: MockedLifecycle) : LifecycleOwner {
+        override fun getLifecycle(): Lifecycle = lifecycle
+    }
+}


### PR DESCRIPTION
See #288 - Attaching an observer to a lifecycle and automatically unregistering is super helpful and something we do a lot in our existing apps (by using LiveData currently).