### PR TITLE
Closes #256: Create CustomTab config and store in Session

### DIFF
--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -27,7 +27,10 @@ android {
 }
 
 dependencies {
+    implementation project(':support-utils')
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation "com.android.support:customtabs:${rootProject.ext.dependencies['supportLibraries']}"
 
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "utils".

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.session
 
 import mozilla.components.support.utils.observer.Observable
 import mozilla.components.support.utils.observer.ObserverRegistry
+import mozilla.components.browser.session.tab.CustomTabConfig
 import java.util.UUID
 import kotlin.properties.Delegates
 
@@ -26,6 +27,7 @@ class Session(
         fun onNavigationStateChanged()
         fun onSearch()
         fun onSecurityChanged()
+        fun onCustomTabConfigChanged() { }
     }
 
     /**
@@ -86,6 +88,13 @@ class Session(
      */
     var securityInfo: SecurityInfo by Delegates.observable(SecurityInfo()) {
         _, old, new -> notifyObservers (old, new, { onSecurityChanged() })
+    }
+
+    /**
+     * Configuration data in case this session is used for a Custom Tab.
+     */
+    var customTabConfig: CustomTabConfig? by Delegates.observable<CustomTabConfig?>(null) {
+        _, _, _ -> notifyObservers ({ onCustomTabConfigChanged() })
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.tab
+
+import android.app.PendingIntent
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.os.Parcelable
+import android.support.annotation.ColorInt
+import android.support.customtabs.CustomTabsIntent
+import android.support.customtabs.CustomTabsIntent.EXTRA_TOOLBAR_COLOR
+import android.support.customtabs.CustomTabsIntent.EXTRA_CLOSE_BUTTON_ICON
+import android.support.customtabs.CustomTabsIntent.EXTRA_ACTION_BUTTON_BUNDLE
+import android.support.customtabs.CustomTabsIntent.KEY_DESCRIPTION
+import android.support.customtabs.CustomTabsIntent.KEY_PENDING_INTENT
+import android.support.customtabs.CustomTabsIntent.EXTRA_ENABLE_URLBAR_HIDING
+import android.support.customtabs.CustomTabsIntent.EXTRA_DEFAULT_SHARE_MENU_ITEM
+import android.support.customtabs.CustomTabsIntent.EXTRA_MENU_ITEMS
+import android.support.customtabs.CustomTabsIntent.KEY_MENU_ITEM_TITLE
+import android.support.customtabs.CustomTabsIntent.EXTRA_TINT_ACTION_BUTTON
+import android.support.customtabs.CustomTabsIntent.EXTRA_REMOTEVIEWS
+import android.support.customtabs.CustomTabsIntent.EXTRA_TOOLBAR_ITEMS
+
+import mozilla.components.support.utils.SafeBundle
+import mozilla.components.support.utils.SafeIntent
+import java.util.ArrayList
+import java.util.Collections
+import java.util.UUID
+
+/**
+ * Holds configuration data for a Custom Tab. Use [createFromIntent] to
+ * create instances.
+ */
+class CustomTabConfig internal constructor(
+    val id: String,
+    @ColorInt val toolbarColor: Int?,
+    val closeButtonIcon: Bitmap?,
+    val disableUrlbarHiding: Boolean,
+    val actionButtonConfig: CustomTabActionButtonConfig?,
+    val showShareMenuItem: Boolean,
+    val menuItems: List<CustomTabMenuItem>,
+    val options: List<String>
+) {
+    companion object {
+        internal const val TOOLBAR_COLOR_OPTION = "hasToolbarColor"
+        internal const val CLOSE_BUTTON_OPTION = "hasCloseButton"
+        internal const val DISABLE_URLBAR_HIDING_OPTION = "disablesUrlbarHiding"
+        internal const val ACTION_BUTTON_OPTION = "hasActionButton"
+        internal const val SHARE_MENU_ITEM_OPTION = "hasShareItem"
+        internal const val CUSTOMIZED_MENU_OPTION = "hasCustomizedMenu"
+        internal const val ACTION_BUTTON_TINT_OPTION = "hasActionButtonTint"
+        internal const val BOTTOM_TOOLBAR_OPTION = "hasBottomToolbar"
+        internal const val EXIT_ANIMATION_OPTION = "hasExitAnimation"
+        internal const val PAGE_TITLE_OPTION = "hasPageTitle"
+        private const val MAX_CLOSE_BUTTON_SIZE_DP = 24
+
+        /**
+         * Checks if the provided intent is a custom tab intent.
+         *
+         * @param intent the intent to check, wrapped as a SafeIntent.
+         * @return true if the intent is a custom tab intent, otherwise false.
+         */
+        fun isCustomTabIntent(intent: SafeIntent): Boolean {
+            return intent.hasExtra(CustomTabsIntent.EXTRA_SESSION)
+        }
+
+        /**
+         * Creates a CustomTabConfig instance based on the provided intent.
+         *
+         * @param intent the intent, wrapped as a SafeIntent, which is processed
+         * to extract configuration data.
+         * @return the CustomTabConfig instance.
+         */
+        @Suppress("ComplexMethod")
+        fun createFromIntent(intent: SafeIntent): CustomTabConfig {
+            val id = UUID.randomUUID().toString()
+
+            val options = mutableListOf<String>()
+
+            val toolbarColor = if (intent.hasExtra(EXTRA_TOOLBAR_COLOR)) {
+                options.add(TOOLBAR_COLOR_OPTION)
+                intent.getIntExtra(EXTRA_TOOLBAR_COLOR, -1)
+            } else {
+                null
+            }
+
+            val closeButtonIcon = run {
+                val icon = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
+                if (icon != null && icon.width <= MAX_CLOSE_BUTTON_SIZE_DP && icon.height <= MAX_CLOSE_BUTTON_SIZE_DP) {
+                    options.add(CLOSE_BUTTON_OPTION)
+                    icon
+                } else {
+                    null
+                }
+            }
+
+            val disableUrlbarHiding = !intent.getBooleanExtra(EXTRA_ENABLE_URLBAR_HIDING, true)
+            if (!disableUrlbarHiding) {
+                options.add(DISABLE_URLBAR_HIDING_OPTION)
+            }
+
+            val actionButtonConfig = getActionButtonConfig(intent)
+            if (actionButtonConfig != null) {
+                options.add(ACTION_BUTTON_OPTION)
+            }
+
+            val showShareMenuItem = intent.getBooleanExtra(EXTRA_DEFAULT_SHARE_MENU_ITEM, true)
+            if (showShareMenuItem) {
+                options.add(SHARE_MENU_ITEM_OPTION)
+            }
+
+            val menuItems = getMenuItems(intent)
+            if (menuItems.isNotEmpty()) {
+                options.add(CUSTOMIZED_MENU_OPTION)
+            }
+
+            if (intent.hasExtra(EXTRA_TINT_ACTION_BUTTON)) {
+                options.add(ACTION_BUTTON_TINT_OPTION)
+            }
+
+            if (intent.hasExtra(EXTRA_REMOTEVIEWS) || intent.hasExtra(EXTRA_TOOLBAR_ITEMS)) {
+                options.add(BOTTOM_TOOLBAR_OPTION)
+            }
+
+            if (intent.hasExtra(CustomTabsIntent.EXTRA_EXIT_ANIMATION_BUNDLE)) {
+                options.add(EXIT_ANIMATION_OPTION)
+            }
+
+            if (intent.hasExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE)) {
+                val titleVisibility = intent.getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, 0)
+                if (titleVisibility == CustomTabsIntent.SHOW_PAGE_TITLE) {
+                    options.add(PAGE_TITLE_OPTION)
+                }
+            }
+
+            // We are currently ignoring EXTRA_SECONDARY_TOOLBAR_COLOR and EXTRA_ENABLE_INSTANT_APPS
+            // due to https://github.com/mozilla-mobile/focus-android/issues/629
+
+            return CustomTabConfig(id, toolbarColor, closeButtonIcon, disableUrlbarHiding, actionButtonConfig,
+                    showShareMenuItem, menuItems, Collections.unmodifiableList(options))
+        }
+
+        private fun getActionButtonConfig(intent: SafeIntent): CustomTabActionButtonConfig? {
+            var buttonConfig: CustomTabActionButtonConfig? = null
+            if (intent.hasExtra(EXTRA_ACTION_BUTTON_BUNDLE)) {
+                val abBundle = intent.getBundleExtra(EXTRA_ACTION_BUTTON_BUNDLE)
+                val description = abBundle?.getString(KEY_DESCRIPTION)
+                val icon = abBundle?.getParcelable(CustomTabsIntent.KEY_ICON) as? Bitmap
+                val pendingIntent = abBundle?.getParcelable(KEY_PENDING_INTENT) as? PendingIntent
+                if (description != null && icon != null && pendingIntent != null) {
+                    buttonConfig = CustomTabActionButtonConfig(description, icon, pendingIntent)
+                }
+            }
+            return buttonConfig
+        }
+
+        private fun getMenuItems(intent: SafeIntent): List<CustomTabMenuItem> {
+            if (!intent.hasExtra(EXTRA_MENU_ITEMS)) {
+                return emptyList()
+            }
+
+            val menuItems = mutableListOf<CustomTabMenuItem>()
+            val menuItemBundles: ArrayList<Parcelable>? = intent.getParcelableArrayListExtra(EXTRA_MENU_ITEMS)
+            menuItemBundles?.forEach {
+                if (it is Bundle) {
+                    val bundle = SafeBundle(it)
+                    val name = bundle.getString(KEY_MENU_ITEM_TITLE)
+                    val pendingIntent = bundle.getParcelable(KEY_PENDING_INTENT) as? PendingIntent
+                    if (name != null && pendingIntent != null) {
+                        menuItems.add(CustomTabMenuItem(name, pendingIntent))
+                    }
+                }
+            }
+            return menuItems
+        }
+    }
+}
+
+data class CustomTabActionButtonConfig(val description: String, val icon: Bitmap, val pendingIntent: PendingIntent)
+data class CustomTabMenuItem(val name: String, val pendingIntent: PendingIntent)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -4,8 +4,10 @@
 
 package mozilla.components.browser.session
 
+import mozilla.components.browser.session.tab.CustomTabConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -149,6 +151,23 @@ class SessionTest {
 
         assertEquals(Session.SecurityInfo(true, "mozilla.org", "issuer"), session.securityInfo)
         verify(observer, times(1)).onSecurityChanged()
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is notified when custom tab config is set`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        assertNull(session.customTabConfig)
+
+        val customTabConfig = CustomTabConfig("id", null, null, true, null, true, listOf(), listOf())
+        session.customTabConfig = customTabConfig
+
+        assertEquals(customTabConfig, session.customTabConfig)
+        verify(observer, times(1)).onCustomTabConfigChanged()
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.tab
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.Bundle
+import android.support.customtabs.CustomTabsIntent
+import mozilla.components.support.utils.SafeIntent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class CustomTabConfigTest {
+
+    @Test
+    fun testIsCustomTabIntent() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        assertTrue(CustomTabConfig.isCustomTabIntent(SafeIntent(customTabsIntent.intent)))
+        assertFalse(CustomTabConfig.isCustomTabIntent(SafeIntent(mock(Intent::class.java))))
+    }
+
+    @Test
+    fun testCreateFromIntentAssignsId() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((customTabsIntent.intent)))
+        assertTrue(customTabConfig.id.isNotBlank())
+    }
+
+    @Test
+    fun testCreateFromIntentWithToolbarColor() {
+        val builder = CustomTabsIntent.Builder()
+        builder.setToolbarColor(Color.BLACK)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertEquals(Color.BLACK, customTabConfig.toolbarColor)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.TOOLBAR_COLOR_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithCloseButton() {
+        val size = 24
+        val builder = CustomTabsIntent.Builder()
+        val closeButtonIcon = Bitmap.createBitmap(IntArray(size * size), size, size, Bitmap.Config.ARGB_8888)
+        builder.setCloseButtonIcon(closeButtonIcon)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertEquals(closeButtonIcon, customTabConfig.closeButtonIcon)
+        assertEquals(size, customTabConfig.closeButtonIcon?.width)
+        assertEquals(size, customTabConfig.closeButtonIcon?.height)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithMaxOversizedCloseButton() {
+        val size = 64
+        val builder = CustomTabsIntent.Builder()
+        val closeButtonIcon = Bitmap.createBitmap(IntArray(size * size), size, size, Bitmap.Config.ARGB_8888)
+        builder.setCloseButtonIcon(closeButtonIcon)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertNull(customTabConfig.closeButtonIcon)
+        assertFalse(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithInvalidCloseButton() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        // Intent is a parcelable but not a Bitmap
+        customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_CLOSE_BUTTON_ICON, Intent())
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((customTabsIntent.intent)))
+        assertNull(customTabConfig.closeButtonIcon)
+        assertFalse(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithUrlbarHiding() {
+        val builder = CustomTabsIntent.Builder()
+        builder.enableUrlBarHiding()
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertFalse(customTabConfig.disableUrlbarHiding)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.DISABLE_URLBAR_HIDING_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithShareMenuItem() {
+        val builder = CustomTabsIntent.Builder()
+        builder.addDefaultShareMenuItem()
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertTrue(customTabConfig.showShareMenuItem)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.SHARE_MENU_ITEM_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithCustomizedMenu() {
+        val builder = CustomTabsIntent.Builder()
+        val pendingIntent = PendingIntent.getActivity(null, 0, null, 0)
+        builder.addMenuItem("menuitem1", pendingIntent)
+        builder.addMenuItem("menuitem2", pendingIntent)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertEquals(2, customTabConfig.menuItems.size)
+        assertEquals("menuitem1", customTabConfig.menuItems[0].name)
+        assertSame(pendingIntent, customTabConfig.menuItems[0].pendingIntent)
+        assertEquals("menuitem2", customTabConfig.menuItems[1].name)
+        assertSame(pendingIntent, customTabConfig.menuItems[1].pendingIntent)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.CUSTOMIZED_MENU_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithActionButton() {
+        val builder = CustomTabsIntent.Builder()
+
+        val bitmap = mock(Bitmap::class.java)
+        val intent = PendingIntent.getActivity(RuntimeEnvironment.application, 0, Intent("testAction"), 0)
+        builder.setActionButton(bitmap, "desc", intent)
+
+        val customTabsIntent = builder.build()
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent(customTabsIntent.intent))
+
+        assertNotNull(customTabConfig.actionButtonConfig)
+        assertEquals("desc", customTabConfig.actionButtonConfig?.description)
+        assertEquals(intent, customTabConfig.actionButtonConfig?.pendingIntent)
+        assertEquals(bitmap, customTabConfig.actionButtonConfig?.icon)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.ACTION_BUTTON_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithInvalidActionButton() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+
+        val invalid = Bundle()
+        customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_ACTION_BUTTON_BUNDLE, invalid)
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent(customTabsIntent.intent))
+
+        assertNull(customTabConfig.actionButtonConfig)
+    }
+
+    @Test
+    fun testCreateFromIntentWithInvalidExtras() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+
+        val extrasField = Intent::class.java.getDeclaredField("mExtras")
+        extrasField.isAccessible = true
+        extrasField.set(customTabsIntent.intent, null)
+        extrasField.isAccessible = false
+
+        assertFalse(CustomTabConfig.isCustomTabIntent(SafeIntent(customTabsIntent.intent)))
+
+        // Make sure we're not failing
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent(customTabsIntent.intent))
+        assertNotNull(customTabConfig)
+        assertNull(customTabConfig.actionButtonConfig)
+    }
+
+    @Test
+    fun testCreateFromIntentWithActionButtonTint() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_TINT_ACTION_BUTTON, true)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((customTabsIntent.intent)))
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.ACTION_BUTTON_TINT_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithBottomToolbarOption() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_TOOLBAR_ITEMS, Bundle())
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((customTabsIntent.intent)))
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.BOTTOM_TOOLBAR_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithExitAnimationOption() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_EXIT_ANIMATION_BUNDLE, Bundle())
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((customTabsIntent.intent)))
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.EXIT_ANIMATION_OPTION))
+    }
+
+    @Test
+    fun testCreateFromIntentWithPageTitleOption() {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.SHOW_PAGE_TITLE)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((customTabsIntent.intent)))
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.PAGE_TITLE_OPTION))
+    }
+}


### PR DESCRIPTION
Porting this over from Focus, simplifying (kotlinizing) it, and adding some more tests. Enhancing browser-session to hold an optional reference to `CustomTabConfig`.

This is the first step. We need #282 next :). 