### PR TITLE
Issue #282: Process CustomTab intent

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -106,6 +106,11 @@ class Session(
     }
 
     /**
+     * Returns whether or not this session is used for a Custom Tab.
+     */
+    fun isCustomTabSession() = customTabConfig != null
+
+    /**
      * Helper method to notify observers.
      */
     private fun notifyObservers(old: Any, new: Any, block: Observer.() -> Unit) {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -38,9 +38,15 @@ class SessionManager(
         }
 
     /**
-     * Gets all sessions.
+     * Returns a list of active sessions and filters out sessions used for CustomTabs.
      */
     val sessions: List<Session>
+        get() = synchronized(values) { values.filter { !it.isCustomTabSession() } }
+
+    /**
+     * Returns a list of all active sessions.
+     */
+    val all: List<Session>
         get() = synchronized(values) { values.toList() }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/DefaultSessionStorage.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/DefaultSessionStorage.kt
@@ -84,7 +84,6 @@ class DefaultSessionStorage(
                     val jsonSession = jsonRoot.getJSONObject(it)
                     val session = deserializeSession(it, jsonSession.getJSONObject(SESSION_KEY))
                     val engineSession = deserializeEngineSession(engine, jsonSession.getJSONObject(ENGINE_SESSION_KEY))
-
                     sessionManager.add(session, engineSession = engineSession)
                 }
 
@@ -110,12 +109,12 @@ class DefaultSessionStorage(
             json.put(VERSION_KEY, VERSION)
             json.put(SELECTED_SESSION_KEY, sessionManager.selectedSession.id)
 
-            sessionManager.sessions.forEach({ session ->
+            sessionManager.sessions.forEach { session ->
                 val sessionJson = JSONObject()
                 sessionJson.put(SESSION_KEY, serializeSession(session))
                 sessionJson.put(ENGINE_SESSION_KEY, serializeEngineSession(sessionManager.getEngineSession(session)))
                 json.put(session.id, sessionJson)
-            })
+            }
 
             file = getFile()
             outputStream = file.startWrite()

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabsService.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabsService.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.tab
+
+import android.app.Service
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.os.IBinder
+import android.support.customtabs.ICustomTabsCallback
+import android.support.customtabs.ICustomTabsService
+
+class CustomTabsService : Service() {
+    override fun onBind(intent: Intent): IBinder? {
+        return object : ICustomTabsService.Stub() {
+            override fun warmup(flags: Long): Boolean = true
+            override fun newSession(cb: ICustomTabsCallback) = true
+            override fun mayLaunchUrl(cb: ICustomTabsCallback, url: Uri, extras: Bundle, bundles: List<Bundle>) = true
+            override fun extraCommand(s: String, bundle: Bundle): Bundle? = null
+            override fun updateVisuals(cb: ICustomTabsCallback, bundle: Bundle) = false
+            override fun requestPostMessageChannel(cb: ICustomTabsCallback, uri: Uri): Boolean = false
+            override fun postMessage(cb: ICustomTabsCallback, s: String, bundle: Bundle): Int = 0
+            override fun validateRelationship(cb: ICustomTabsCallback, i: Int, uri: Uri, bundle: Bundle) = false
+        }
+    }
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabsServiceTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabsServiceTest.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.tab
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.support.customtabs.ICustomTabsCallback
+import android.support.customtabs.ICustomTabsService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CustomTabsServiceTest {
+
+    @Test
+    fun testCustomTabService() {
+        val customTabsService = CustomTabsService()
+        val customTabsServiceStub = customTabsService.onBind(mock(Intent::class.java))
+        assertNotNull(customTabsServiceStub)
+
+        val stub = customTabsServiceStub as ICustomTabsService.Stub
+        assertTrue(stub.warmup(123))
+        assertTrue(stub.newSession(mock(ICustomTabsCallback::class.java)))
+        assertNull(stub.extraCommand("", mock(Bundle::class.java)))
+        assertFalse(stub.updateVisuals(mock(ICustomTabsCallback::class.java), mock(Bundle::class.java)))
+        assertFalse(stub.requestPostMessageChannel(mock(ICustomTabsCallback::class.java), mock(Uri::class.java)))
+        assertEquals(0, stub.postMessage(mock(ICustomTabsCallback::class.java), "", mock(Bundle::class.java)))
+        assertFalse(stub.validateRelationship(
+                mock(ICustomTabsCallback::class.java),
+                0,
+                mock(Uri::class.java),
+                mock(Bundle::class.java)))
+        assertTrue(stub.mayLaunchUrl(
+                mock(ICustomTabsCallback::class.java),
+                mock(Uri::class.java),
+                mock(Bundle::class.java), emptyList<Bundle>()))
+    }
+}

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -71,6 +71,11 @@ interface Toolbar {
     fun addNavigationAction(action: Action)
 
     /**
+     * Casts this toolbar to an Android View object.
+     */
+    fun asView(): View = this as View
+
+    /**
      * Generic interface for actions to be added to the toolbar.
      */
     interface Action {

--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
     testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation "com.android.support:customtabs:${rootProject.ext.dependencies['supportLibraries']}"
 }
 
 archivesBaseName = "feature-session"

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/EngineViewPresenter.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/EngineViewPresenter.kt
@@ -13,14 +13,16 @@ import mozilla.components.concept.engine.EngineView
  */
 class EngineViewPresenter(
     private val sessionManager: SessionManager,
-    private val engineView: EngineView
+    private val engineView: EngineView,
+    private val sessionId: String? = null
 ) : SessionManager.Observer {
 
     /**
      * Start presenter and display data in view.
      */
     fun start() {
-        renderSession(sessionManager.selectedSession)
+        val session = sessionId?.let { sessionManager.findSessionById(sessionId) } ?: sessionManager.selectedSession
+        renderSession(session)
 
         sessionManager.register(this)
     }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -15,9 +15,10 @@ class SessionFeature(
     private val sessionManager: SessionManager,
     private val sessionUseCases: SessionUseCases,
     engineView: EngineView,
-    private val sessionStorage: SessionStorage? = null
+    private val sessionStorage: SessionStorage? = null,
+    sessionId: String? = null
 ) {
-    internal val presenter = EngineViewPresenter(sessionManager, engineView)
+    internal val presenter = EngineViewPresenter(sessionManager, engineView, sessionId)
 
     /**
      * Start feature: App is in the foreground.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -18,12 +18,14 @@ class SessionUseCases(
         private val sessionManager: SessionManager
     ) {
         /**
-         * Loads the provided URL using the currently selected session.
+         * Loads the provided URL using the provided session (or the currently
+         * selected session if none is provided).
          *
          * @param url url to load.
+         * @param session the session for which the URL should be loaded.
          */
-        fun invoke(url: String) {
-            sessionManager.getOrCreateEngineSession().loadUrl(url)
+        fun invoke(url: String, session: Session = sessionManager.selectedSession) {
+            sessionManager.getOrCreateEngineSession(session).loadUrl(url)
         }
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.session
 
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import org.junit.Test
@@ -17,13 +18,15 @@ import org.mockito.Mockito.verify
 class SessionFeatureTest {
     private val sessionManager = mock(SessionManager::class.java)
     private val engineView = mock(EngineView::class.java)
+    private val sessionStorage = mock(SessionStorage::class.java)
     private val sessionUseCases = SessionUseCases(sessionManager)
 
     @Test
-    fun testStartEngineViewPresenter() {
-        val feature = SessionFeature(sessionManager, sessionUseCases, engineView)
+    fun testStart() {
+        val feature = SessionFeature(sessionManager, sessionUseCases, engineView, sessionStorage)
         feature.start()
         verify(sessionManager).register(feature.presenter)
+        verify(sessionStorage).start(sessionManager)
     }
 
     @Test
@@ -45,9 +48,10 @@ class SessionFeatureTest {
     }
 
     @Test
-    fun testStopEngineViewPresenter() {
-        val feature = SessionFeature(sessionManager, sessionUseCases, engineView)
+    fun testStop() {
+        val feature = SessionFeature(sessionManager, sessionUseCases, engineView, sessionStorage)
         feature.stop()
         verify(sessionManager).unregister(feature.presenter)
+        verify(sessionStorage).stop()
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -32,6 +32,9 @@ class SessionUseCasesTest {
     fun testLoadUrl() {
         useCases.loadUrl.invoke("http://mozilla.org")
         verify(selectedEngineSession).loadUrl("http://mozilla.org")
+
+        useCases.loadUrl.invoke("http://getpocket.com", selectedSession)
+        verify(selectedEngineSession).loadUrl("http://getpocket.com")
     }
 
     @Test

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
@@ -21,9 +21,10 @@ class ToolbarFeature(
     val toolbar: Toolbar,
     sessionManager: SessionManager,
     loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
-    searchUseCase: SearchUseCase? = null
+    searchUseCase: SearchUseCase? = null,
+    sessionId: String? = null
 ) {
-    private val presenter = ToolbarPresenter(toolbar, sessionManager)
+    private val presenter = ToolbarPresenter(toolbar, sessionManager, sessionId)
     private val interactor = ToolbarInteractor(toolbar, loadUrlUseCase, searchUseCase)
 
     /**

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="org.mozilla.samples.browser">
 
     <application
@@ -10,13 +11,28 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-        <activity android:name=".MainActivity">
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+        android:name=".SampleApplication">
+        <activity android:name=".BrowserActivity"
+            android:launchMode="singleTask"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity android:name=".CustomTabActivity"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
+            android:windowSoftInputMode="adjustResize|stateAlwaysHidden"
+            android:exported="false"
+            android:taskAffinity=""
+            android:persistableMode="persistNever"
+            android:autoRemoveFromRecents="false"
+            android:label="@string/app_name" />
+
+        <activity android:name=".IntentReceiverActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -25,6 +41,16 @@
                 <data android:scheme="https" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="mozilla.components.browser.session.tab.CustomTabsService"
+            android:exported="true"
+            tools:ignore="ExportedService">
+            <intent-filter>
+                <action android:name="android.support.customtabs.action.CustomTabsService" />
+            </intent-filter>
+        </service>
+
     </application>
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -23,10 +23,10 @@ import mozilla.components.feature.session.SessionUseCases
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) {
+    // Engine
     val engine: Engine by lazy { EngineProvider.createEngine(applicationContext) }
 
     // Session
-
     val sessionStorage by lazy { DefaultSessionStorage(applicationContext) }
 
     val sessionManager by lazy {
@@ -41,7 +41,7 @@ class Components(private val applicationContext: Context) {
     }
 
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
-    val sessionIntentProcessor by lazy { SessionIntentProcessor(sessionUseCases) }
+    val sessionIntentProcessor by lazy { SessionIntentProcessor(sessionUseCases, sessionManager) }
 
     // Search
     private val searchEngineManager by lazy {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/CustomTabActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/CustomTabActivity.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser
+
+class CustomTabActivity : BrowserActivity()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.support.utils.SafeIntent
+import org.mozilla.samples.browser.ext.components
+
+class IntentReceiverActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        components.sessionIntentProcessor.process(intent)
+
+        val intent = Intent(intent)
+        if (CustomTabConfig.isCustomTabIntent(SafeIntent(intent))) {
+            intent.setClassName(applicationContext, CustomTabActivity::class.java.name)
+        } else {
+            intent.setClassName(applicationContext, BrowserActivity::class.java.name)
+        }
+
+        startActivity(intent)
+        finish()
+    }
+
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser
+
+import android.app.Application
+
+class SampleApplication : Application() {
+    val components by lazy { Components(this) }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ext/Context.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ext/Context.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser.ext
+
+import android.content.Context
+import org.mozilla.samples.browser.Components
+import org.mozilla.samples.browser.SampleApplication
+
+/**
+ * Get the SampleApplication object from a context.
+ */
+val Context.application: SampleApplication
+    get() = applicationContext as SampleApplication
+
+/**
+ * Get the components of this application.
+ */
+val Context.components: Components
+    get() = application.components

--- a/samples/browser/src/main/res/layout/activity_main.xml
+++ b/samples/browser/src/main/res/layout/activity_main.xml
@@ -7,7 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".MainActivity">
+    tools:context=".BrowserActivity">
 
     <mozilla.components.browser.toolbar.BrowserToolbar
         android:id="@+id/toolbar"


### PR DESCRIPTION
This processes CustomTab intents. We currently only use the toolbarColor config. I've filed #306 for the remaining properties.

This only works with WebView right now until the issues mentioned in #158 are all resolved.



