### PR TITLE
Issue #197: Samples-Browser: Create product flavor for different processor architectures and release channels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ _Supporting components with generic helper code._
 
 * 🔵 [**Utils**](components/support/utils/README.md) - Generic utility classes to be shared between projects.
 
+# Sample apps
+
+_Sample apps using various components._
+
+* [**Browser**](samples/browser) - A simple browser composed from browser components.
+
+* [**Toolbar**](samples/toolbar) - An app demoing multiple customized toolbars using the [**browser-toolbar**](components/browser/toolbar/README.md) component.
+
 # License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     // use at runtime. As the Kotlin/Java API is the same for all ABIs it is not important which one
     // we import here.
     compileOnly "org.mozilla:geckoview-release-armeabi-v7a:${rootProject.ext.geckoRelease['version']}"
-    implementation "org.mozilla:geckoview-release-armeabi-v7a:${rootProject.ext.geckoRelease['version']}"
+    testImplementation "org.mozilla:geckoview-release-armeabi-v7a:${rootProject.ext.geckoRelease['version']}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx4096m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/samples/browser/README.md
+++ b/samples/browser/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../README.md) > Samples > Browser
+
+![](src/main/res/mipmap-xhdpi/ic_launcher.png)
+
+A simple browser app that is composed from the browser components in this repository.
+
+## Build variants
+
+The browser app has two product flavor dimensions:
+
+* **channel**: Using different release channels of GeckoView: _nightly_, _beta_, _production_. In most cases you want to use the _nightly_ flavor as this will support all of the latest functionality.
+
+* **abi**: Using different GeckoView builds based on the processor architecture: _arm_, _x86_, _aarch64_. Lookup the processor architecture that matches your device. For most Android devices that's _arm_ or _aarch64_. For running on an emulator pick _x86_ and a matching hardware-accelerated emulator image.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -26,9 +26,10 @@ android {
         }
     }
 
-    flavorDimensions "channel"
+    flavorDimensions "channel", "abi"
 
     productFlavors {
+        // GeckoView release channels
         nightly {
             dimension "channel"
         }
@@ -37,6 +38,17 @@ android {
         }
         production {
             dimension "channel"
+        }
+
+        // Processor architecture
+        arm {
+            dimension "abi"
+        }
+        x86 {
+            dimension "abi"
+        }
+        aarch64 {
+            dimension "abi"
         }
     }
 }
@@ -47,12 +59,25 @@ kotlin {
     }
 }
 
+configurations {
+    nightlyArmImplementation {}
+    nightlyX86Implementation {}
+    nightlyAarch64Implementation {}
+
+    betaArmImplementation {}
+    betaX86Implementation {}
+    betaAarch64Implementation {}
+
+    productionArmImplementation {}
+    productionX86Implementation {}
+    productionAarch64Implementation {}
+}
+
 dependencies {
     implementation project(':concept-engine')
     implementation project(':concept-toolbar')
 
     implementation project(':browser-engine-system')
-
 
     implementation project(':browser-search')
     implementation project(':browser-session')
@@ -65,15 +90,20 @@ dependencies {
 
     implementation project(':ui-autocomplete')
 
-    nightlyImplementation "org.mozilla:geckoview-nightly-armeabi-v7a:${rootProject.ext.geckoNightly['version']}"
-    //implementation "org.mozilla:geckoview-nightly-x86:${rootProject.ext.geckoNightly['version']}"
     nightlyImplementation project(':browser-engine-gecko-nightly')
+    nightlyArmImplementation "org.mozilla:geckoview-nightly-armeabi-v7a:${rootProject.ext.geckoNightly['version']}"
+    nightlyX86Implementation "org.mozilla:geckoview-nightly-x86:${rootProject.ext.geckoNightly['version']}"
+    nightlyAarch64Implementation "org.mozilla:geckoview-nightly-arm64-v8a:${rootProject.ext.geckoNightly['version']}"
 
-    betaImplementation "org.mozilla:geckoview-beta-armeabi-v7a:61.0.20180614135649"
     betaImplementation project(':browser-engine-gecko-beta')
+    betaArmImplementation "org.mozilla:geckoview-beta-armeabi-v7a:61.0.20180614135649"
+    betaX86Implementation "org.mozilla:geckoview-beta-x86:61.0.20180614135649"
+    betaAarch64Implementation "org.mozilla:geckoview-beta-arm64-v8a:61.0.20180614135649"
 
-    productionImplementation "org.mozilla:geckoview-release-armeabi-v7a:60.0.2"
     productionImplementation project(':browser-engine-gecko')
+    productionArmImplementation "org.mozilla:geckoview-release-armeabi-v7a:60.0.2"
+    productionX86Implementation "org.mozilla:geckoview-release-x86:60.0.2"
+    productionAarch64Implementation "org.mozilla:geckoview-release-arm64-v8a:60.0.2"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"


### PR DESCRIPTION
This will allow us to build the sample browser app for all combinations of: GeckoView release channel (nightly, beta, production) X processor architecture (ARM, x86, aarch64).