### PR TITLE
Issue #174: Sample browser: Move "browser behavior" into standalone fragment. 🦄🐳🐠

### DIFF
--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BackHandler.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BackHandler.kt
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser
+
+/**
+ * Interface for fragments that want to handle 'back' button presses.
+ */
+interface BackHandler {
+    fun onBackPressed(): Boolean
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_browser.*
+import mozilla.components.feature.session.SessionFeature
+import mozilla.components.feature.toolbar.ToolbarFeature
+import org.mozilla.samples.browser.ext.components
+
+class BrowserFragment : Fragment(), BackHandler {
+    private lateinit var sessionFeature: SessionFeature
+    private lateinit var toolbarFeature: ToolbarFeature
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_browser, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        toolbar.setMenuBuilder(components.menuBuilder)
+
+        val sessionId = arguments?.getString(SESSION_ID)
+
+        sessionFeature = SessionFeature(
+                components.sessionManager,
+                components.sessionUseCases,
+                engineView,
+                components.sessionStorage,
+                sessionId)
+
+        toolbarFeature = ToolbarFeature(
+                toolbar,
+                components.sessionManager,
+                components.sessionUseCases.loadUrl,
+                components.defaultSearchUseCase,
+                sessionId)
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        sessionFeature.start()
+        toolbarFeature.start()
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        sessionFeature.stop()
+        toolbarFeature.stop()
+    }
+
+    override fun onBackPressed(): Boolean {
+        if (toolbarFeature.handleBackPressed()) {
+            return true
+        }
+
+        if (sessionFeature.handleBackPressed()) {
+            return true
+        }
+
+        return false
+    }
+
+    companion object {
+        private const val SESSION_ID = "session_id"
+
+        fun create(sessionId: String? = null): BrowserFragment = BrowserFragment().apply {
+            arguments = Bundle().apply {
+                putString(SESSION_ID, sessionId)
+            }
+        }
+    }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -34,7 +34,7 @@ class Components(private val applicationContext: Context) {
             sessionStorage.restore(engine, this)
 
             if (size == 0) {
-                val initialSession =  Session("https://www.mozilla.org")
+                val initialSession = Session("https://www.mozilla.org")
                 add(initialSession)
             }
         }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ext/Fragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ext/Fragment.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser.ext
+
+import android.support.v4.app.Fragment
+import org.mozilla.samples.browser.Components
+
+/**
+ * Get the components of this application.
+ */
+val Fragment.components: Components
+    get() = context!!.components

--- a/samples/browser/src/main/res/layout/activity_main.xml
+++ b/samples/browser/src/main/res/layout/activity_main.xml
@@ -2,23 +2,8 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".BrowserActivity">
+    android:layout_height="match_parent" />
 
-    <mozilla.components.browser.toolbar.BrowserToolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#aaaaaa" />
-
-    <mozilla.components.concept.engine.EngineView
-        android:id="@+id/engineView"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-
-</LinearLayout>

--- a/samples/browser/src/main/res/layout/fragment_browser.xml
+++ b/samples/browser/src/main/res/layout/fragment_browser.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".MainActivity">
+
+    <mozilla.components.browser.toolbar.BrowserToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:background="#aaaaaa" />
+
+    <mozilla.components.concept.engine.EngineView
+        android:id="@+id/engineView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>


### PR DESCRIPTION
This is in preparation for tab support where we will start to switch between multiple fragments (e.g. browser -> tabs tray). Currently this fragment lives in the sample app. I was thinking to move (partial) functionality back into components.. but this was too complex for now. I first want to see where this is going and then at the end see what parts can be moved to a shared component.

**Observations**

* I'm not super thrilled about the BackHandler (Maybe this moves to a component with the Fragment(s) later on?). But unfortunately Fragments can't intercept the back button handling.

* Passing the sessionStorage into the feature inside the Fragment feels wrong. I think we should refactor this a bit again: The feature, which deals with setting up the view parts, shouldn't deal with the session storage. We should start it whenever we create the SessionManager ... and we want to save from onPause() of the activity... which lifecycle previously overlapped with the feature. But now as we are going to have multiple screens this is no longer true.