### PR TITLE
Closes #334: Storage should not restore state from different engine 🍄

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -19,16 +19,21 @@ class GeckoEngine(
 ) : Engine {
 
     /**
-     * Create a new Gecko-based EngineView.
+     * Creates a new Gecko-based EngineView.
      */
     override fun createView(context: Context, attrs: AttributeSet?): EngineView {
         return GeckoEngineView(context, attrs)
     }
 
     /**
-     * Create a new Gecko-based EngineSession.
+     * Creates a new Gecko-based EngineSession.
      */
     override fun createSession(): EngineSession {
         return GeckoEngineSession(runtime)
     }
+
+    /**
+     * See [Engine.name]
+     */
+    override fun name(): String = "Gecko"
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mozilla.geckoview.GeckoRuntime
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineTest {
+
+    private val runtime: GeckoRuntime = mock(GeckoRuntime::class.java)
+
+    @Test
+    fun testCreateView() {
+        Assert.assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
+    }
+
+    @Test
+    fun testCreateSession() {
+        Assert.assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
+    }
+
+    @Test
+    fun testName() {
+        Assert.assertEquals("Gecko", GeckoEngine(runtime).name())
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -31,4 +31,6 @@ class GeckoEngine(
     override fun createSession(): EngineSession {
         return GeckoEngineSession(runtime)
     }
+
+    override fun name(): String = "Gecko"
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mozilla.geckoview.GeckoRuntime
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineTest {
+
+    private val runtime: GeckoRuntime = mock(GeckoRuntime::class.java)
+
+    @Test
+    fun testCreateView() {
+        Assert.assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
+    }
+
+    @Test
+    fun testCreateSession() {
+        Assert.assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
+    }
+
+    @Test
+    fun testName() {
+        Assert.assertEquals("Gecko", GeckoEngine(runtime).name())
+    }
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -18,16 +18,21 @@ class GeckoEngine(
 ) : Engine {
 
     /**
-     * Create a new Gecko-based EngineView.
+     * Creates a new Gecko-based EngineView.
      */
     override fun createView(context: Context, attrs: AttributeSet?): EngineView {
         return GeckoEngineView(context, attrs)
     }
 
     /**
-     * Create a new Gecko-based EngineSession.
+     * Creates a new Gecko-based EngineSession.
      */
     override fun createSession(): EngineSession {
         return GeckoEngineSession(context)
     }
+
+    /**
+     * See [Engine.name]
+     */
+    override fun name(): String = "Gecko"
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import android.content.Context
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineTest {
+
+    private val context: Context = RuntimeEnvironment.application
+
+    @Test
+    fun testCreateView() {
+        Assert.assertTrue(GeckoEngine(context).createView(RuntimeEnvironment.application) is GeckoEngineView)
+    }
+
+    @Test
+    fun testCreateSession() {
+        Assert.assertTrue(GeckoEngine(context).createSession() is GeckoEngineSession)
+    }
+
+    @Test
+    fun testName() {
+        Assert.assertEquals("Gecko", GeckoEngine(context).name())
+    }
+}

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -14,17 +14,23 @@ import mozilla.components.concept.engine.EngineView
  * WebView-based implementation of the Engine interface.
  */
 class SystemEngine : Engine {
+
     /**
-     * Create a new WebView-based EngineView implementation.
+     * Createa a new WebView-based EngineView implementation.
      */
     override fun createView(context: Context, attrs: AttributeSet?): EngineView {
         return SystemEngineView(context, attrs)
     }
 
     /**
-     * Create a new WebView-based EngineSession implementation.
+     * Createa a new WebView-based EngineSession implementation.
      */
     override fun createSession(): EngineSession {
         return SystemEngineSession()
     }
+
+    /**
+     * See [Engine.name]
+     */
+    override fun name(): String = "System"
 }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.system
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SystemEngineTest {
+
+    @Test
+    fun testCreateView() {
+        assertTrue(SystemEngine().createView(RuntimeEnvironment.application) is SystemEngineView)
+    }
+
+    @Test
+    fun testCreateSession() {
+        assertTrue(SystemEngine().createSession() is SystemEngineSession)
+    }
+
+    @Test
+    fun testName() {
+        assertEquals("System", SystemEngine().name())
+    }
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -14,7 +14,7 @@ import mozilla.components.support.utils.observer.ObserverRegistry
  * This class provides access to a centralized registry of all active sessions.
  */
 class SessionManager(
-    private val engine: Engine,
+    val engine: Engine,
     delegate: Observable<SessionManager.Observer> = ObserverRegistry()
 ) : Observable<SessionManager.Observer> by delegate {
     private val values = mutableListOf<Session>()

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SessionStorage.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SessionStorage.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.session.storage
 
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.concept.engine.Engine
 
 /**
  * Storage component for browser and engine sessions.
@@ -23,11 +22,10 @@ interface SessionStorage {
     /**
      * Restores the session storage state by reading from the latest persisted version.
      *
-     * @param engine the engine instance to use when creating new engine sessions.
-     * @param sessionManager the session manager to restore into
+     * @param sessionManager the session manager to restore into.
      * @return map of all restored sessions, and the currently selected session id.
      */
-    fun restore(engine: Engine, sessionManager: SessionManager): Boolean
+    fun restore(sessionManager: SessionManager): Boolean
 
     /**
      * Starts saving the state frequently and automatically.

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/DefaultSessionStorageTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/DefaultSessionStorageTest.kt
@@ -47,6 +47,7 @@ class DefaultSessionStorageTest {
         `when`(engineSession.saveState()).thenReturn(engineSessionState)
 
         val engine = mock(Engine::class.java)
+        `when`(engine.name()).thenReturn("gecko")
         `when`(engine.createSession()).thenReturn(mock(EngineSession::class.java))
 
         val sessionManager = SessionManager(engine)
@@ -59,7 +60,7 @@ class DefaultSessionStorageTest {
 
         // Restore session using a fresh SessionManager
         val restoredSessionManager = SessionManager(engine)
-        val restored = storage.restore(engine, restoredSessionManager)
+        val restored = storage.restore(restoredSessionManager)
         assertTrue(restored)
         assertEquals(1, restoredSessionManager.sessions.size)
 
@@ -83,6 +84,7 @@ class DefaultSessionStorageTest {
         `when`(engineSession.saveState()).thenReturn(engineSessionState)
 
         val engine = mock(Engine::class.java)
+        `when`(engine.name()).thenReturn("gecko")
         `when`(engine.createSession()).thenReturn(mock(EngineSession::class.java))
 
         val sessionManager = SessionManager(engine)
@@ -95,7 +97,7 @@ class DefaultSessionStorageTest {
 
         // Restore session using a fresh SessionManager
         val restoredSessionManager = SessionManager(engine)
-        val restored = storage.restore(engine, restoredSessionManager)
+        val restored = storage.restore(restoredSessionManager)
         assertTrue(restored)
 
         // Nothing to restore as CustomTab sessions should not be persisted
@@ -105,14 +107,16 @@ class DefaultSessionStorageTest {
     @Test
     fun testRestoreReturnsFalseOnIOException() {
         val engine = mock(Engine::class.java)
+        `when`(engine.name()).thenReturn("gecko")
+
         val context = spy(RuntimeEnvironment.application)
         val storage = spy(DefaultSessionStorage(context))
         val file = mock(AtomicFile::class.java)
 
-        doReturn(file).`when`(storage).getFile()
+        doReturn(file).`when`(storage).getFile(anyString())
         doThrow(FileNotFoundException::class.java).`when`(file).openRead()
 
-        val restored = storage.restore(engine, SessionManager(engine))
+        val restored = storage.restore(SessionManager(engine))
         assertFalse(restored)
     }
 
@@ -122,6 +126,7 @@ class DefaultSessionStorageTest {
         val engineSession = mock(EngineSession::class.java)
 
         val engine = mock(Engine::class.java)
+        `when`(engine.name()).thenReturn("gecko")
         `when`(engine.createSession()).thenReturn(engineSession)
 
         val sessionManager = SessionManager(engine)
@@ -132,13 +137,15 @@ class DefaultSessionStorageTest {
         assertTrue(persisted)
 
         doThrow(JSONException::class.java).`when`(storage).deserializeSession(anyString(), anyJson())
-        val restored = storage.restore(engine, SessionManager(engine))
+        val restored = storage.restore(SessionManager(engine))
         assertFalse(restored)
     }
 
     @Test
     fun testPersistReturnsFalseOnIOException() {
         val engine = mock(Engine::class.java)
+        `when`(engine.name()).thenReturn("gecko")
+
         val session = Session("http://mozilla.org")
         val engineSession = mock(EngineSession::class.java)
         val context = spy(RuntimeEnvironment.application)
@@ -148,7 +155,7 @@ class DefaultSessionStorageTest {
         val sessionManager = SessionManager(engine)
         sessionManager.add(session, true, engineSession)
 
-        doReturn(file).`when`(storage).getFile()
+        doReturn(file).`when`(storage).getFile(anyString())
         doThrow(IOException::class.java).`when`(file).startWrite()
 
         val persisted = storage.persist(sessionManager)
@@ -158,6 +165,8 @@ class DefaultSessionStorageTest {
     @Test
     fun testPersistReturnsFalseOnJSONException() {
         val engine = mock(Engine::class.java)
+        `when`(engine.name()).thenReturn("gecko")
+
         val session = Session("http://mozilla.org")
         val engineSession = mock(EngineSession::class.java)
         val context = spy(RuntimeEnvironment.application)
@@ -167,7 +176,7 @@ class DefaultSessionStorageTest {
         val sessionManager = SessionManager(engine)
         sessionManager.add(session, true, engineSession)
 
-        doReturn(file).`when`(storage).getFile()
+        doReturn(file).`when`(storage).getFile(anyString())
         doThrow(JSONException::class.java).`when`(storage).serializeSession(session)
 
         val persisted = storage.persist(sessionManager)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -11,13 +11,30 @@ import android.util.AttributeSet
  * Entry point for interacting with the engine implementation.
  */
 interface Engine {
+
     /**
-     * Create a new view for rendering web content.
+     * Creates a new view for rendering web content.
+     *
+     * @param context an application context
+     * @param attrs optional set of attributes
+     *
+     * @return new newly created [EngineView].
      */
     fun createView(context: Context, attrs: AttributeSet? = null): EngineView
 
     /**
-     * Create a new engine session.
+     * Creates a new engine session.
+     *
+     * @return the newly created [EngineSession].
      */
     fun createSession(): EngineSession
+
+    /**
+     * Returns the name of this engine. The returned string might be used
+     * in filenames and must therefore only contain valid filename
+     * characters.
+     *
+     * @return the engine name as specified by concrete implementations.
+     */
+    fun name(): String
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -31,7 +31,7 @@ class Components(private val applicationContext: Context) {
 
     val sessionManager by lazy {
         SessionManager(engine).apply {
-            sessionStorage.restore(engine, this)
+            sessionStorage.restore(this)
 
             if (size == 0) {
                 val initialSession = Session("https://www.mozilla.org")


### PR DESCRIPTION
This is quite a simple approach but it works well. We basically have two different storage files now

mozilla_components_sessiont_storage_gecko.json and mozilla_components_sessiont_storage_system.json

We can always also change the name of the Gecko Nightly and Beta engines should they become incompatible.