### PR TITLE
Closes #301 - Replaced deprecated 'Assert' in MapTest.kt 💫

### DIFF
--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/MapTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/MapTest.kt
@@ -9,7 +9,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.util.Size
 import android.util.SizeF
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -81,7 +81,7 @@ class MapTest {
         assertEquals(char, resultBundle.getChar("char"))
         assertEquals(charArray, resultBundle.getCharArray("charArray"))
         assertEquals(charSequence, resultBundle.getCharSequence("charSequence"))
-        assertEquals(double, resultBundle.getDouble("double"))
+        assertEquals(double, resultBundle.getDouble("double"), Double.MIN_VALUE)
         assertEquals(doubleArray, resultBundle.getDoubleArray("doubleArray"))
         assertEquals(float, resultBundle.getFloat("float"))
         assertEquals(floatArray, resultBundle.getFloatArray("floatArray"))


### PR DESCRIPTION
Removed out-dated `junit.framework` with `org.junit`.

Note that `assertEquals(Double, Double)` is deprecated, so I updated to use `assertEquals(Double, Double, Double)`, where the last parameter is a delta to determine if two doubles are equal. I could have used `0.0` but I'm not sure if this would introduce flakiness in this test. Any thoughts about it? I can quickly update my PR, if necessary.