### PR TITLE
Issue #358: browser-toolbar: Force showing keyboard when switching to edit mode.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -10,6 +10,7 @@ import android.text.InputType
 import android.view.Gravity
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.ktx.android.view.dp
@@ -75,7 +76,7 @@ class EditToolbar(
      * Focus the URL editing component and show the virtual keyboard if needed.
      */
     fun focus() {
-        urlView.showKeyboard()
+        urlView.showKeyboard(flags = InputMethodManager.SHOW_FORCED)
     }
 
     // We measure the views manually to avoid overhead by using complex ViewGroup implementations

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -65,9 +65,12 @@ fun View.isInvisible(): Boolean {
 
 /**
  * Tries to focus this view and show the soft input window for it.
+ *
+ *  @param flags Provides additional operating flags to be used with InputMethodManager.showSoftInput().
+ *  Currently may be 0, SHOW_IMPLICIT or SHOW_FORCED.
  */
-fun View.showKeyboard() {
-    ShowKeyboard(this).post()
+fun View.showKeyboard(flags: Int = InputMethodManager.SHOW_IMPLICIT) {
+    ShowKeyboard(this, flags).post()
 }
 
 /**
@@ -80,7 +83,10 @@ fun View.hideKeyboard() {
     imm.hideSoftInputFromWindow(windowToken, 0)
 }
 
-private class ShowKeyboard(view: View) : Runnable {
+private class ShowKeyboard(
+    view: View,
+    private val flags: Int = InputMethodManager.SHOW_IMPLICIT
+) : Runnable {
     private val weakReference: WeakReference<View> = WeakReference(view)
     private val handler: Handler = Handler(Looper.getMainLooper())
     private var tries: Int = TRIES
@@ -105,7 +111,7 @@ private class ShowKeyboard(view: View) : Runnable {
                     return
                 }
 
-                if (!imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)) {
+                if (!imm.showSoftInput(view, flags)) {
                     // Showing they keyboard failed. Try again later.
                     post()
                 }

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -23,6 +23,7 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.ktx.android.view.dp
+import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 
 /**
@@ -57,6 +58,12 @@ class ToolbarActivity : AppCompatActivity() {
                         InlineAutocompleteEditText.AutocompleteResult(result.text, result.source, result.size, { result.url }))
             }
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        toolbar.hideKeyboard()
     }
 
     /**


### PR DESCRIPTION
Closes #358 