### PR TITLE
Closes #349, #340: Add FxaResult async type and FxaException

### DIFF
--- a/components/service/fxa/build.gradle
+++ b/components/service/fxa/build.gradle
@@ -24,6 +24,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    kotlin {
+        experimental {
+            coroutines 'enable'
+        }
+    }
 }
 
 repositories {
@@ -45,6 +51,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
     implementation "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
 
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -11,23 +11,23 @@ class Config(override var rawPointer: FxaClient.RawConfig?) : RustObject<FxaClie
     }
 
     companion object {
-        fun release(): Config? {
+        fun release(): FxaResult<Config> {
             val e = Error.ByReference()
             val cfg = FxaClient.INSTANCE.fxa_get_release_config(e)
-            if (e.isSuccess()) {
-                return Config(cfg)
+            if (e.isFailure()) {
+                return FxaResult.fromException(FxaException.fromConsuming(e))
             } else {
-                return null
+                return FxaResult.fromValue(Config(cfg))
             }
         }
 
-        fun custom(content_base: String): Config? {
+        fun custom(content_base: String): FxaResult<Config> {
             val e = Error.ByReference()
             val cfg = FxaClient.INSTANCE.fxa_get_custom_config(content_base, e)
-            if (e.isSuccess()) {
-                return Config(cfg)
+            if (e.isFailure()) {
+                return FxaResult.fromException(FxaException.fromConsuming(e))
             } else {
-                return null
+                return FxaResult.fromValue(Config(cfg))
             }
         }
     }

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -4,117 +4,136 @@
 
 package mozilla.components.service.fxa
 
+import kotlinx.coroutines.experimental.launch
+
 class FirefoxAccount(override var rawPointer: FxaClient.RawFxAccount?) : RustObject<FxaClient.RawFxAccount>() {
 
     constructor(config: Config, clientId: String): this(null) {
         val e = Error.ByReference()
         val result = FxaClient.INSTANCE.fxa_new(config.consumePointer(), clientId, e)
-        if (e.isSuccess()) {
-            this.rawPointer = result
-        } else {
-            this.rawPointer = null
-        }
+        if (e.isFailure()) throw FxaException.fromConsuming(e)
+        this.rawPointer = result
     }
 
     override fun destroyPointer(p: FxaClient.RawFxAccount) {
         FxaClient.INSTANCE.fxa_free(p)
     }
 
-    fun beginOAuthFlow(redirectURI: String, scopes: Array<String>, wantsKeys: Boolean): String? {
-        val scope = scopes.joinToString(" ")
-        val e = Error.ByReference()
-        val p = FxaClient.INSTANCE.fxa_begin_oauth_flow(this.validPointer(), redirectURI, scope, wantsKeys, e)
-        if (e.isSuccess()) {
-            return getAndConsumeString(p)
-        } else {
-            return null
+    fun beginOAuthFlow(redirectURI: String, scopes: Array<String>, wantsKeys: Boolean): FxaResult<String> {
+        val result = FxaResult<String>()
+        val accountPointer = this.validPointer()
+        launch {
+            val scope = scopes.joinToString(" ")
+            val e = Error.ByReference()
+            val p = FxaClient.INSTANCE.fxa_begin_oauth_flow(accountPointer, redirectURI, scope, wantsKeys, e)
+            if (e.isFailure()) {
+                result.completeExceptionally(FxaException.fromConsuming(e))
+            } else {
+                result.complete(getAndConsumeString(p))
+            }
         }
+        return result
     }
 
-    fun getProfile(ignoreCache: Boolean): Profile? {
-        val e = Error.ByReference()
-        val p = FxaClient.INSTANCE.fxa_profile(this.validPointer(), ignoreCache, e)
-        if (e.isSuccess()) {
-            return Profile(p)
-        } else {
-            return null
+    fun getProfile(ignoreCache: Boolean): FxaResult<Profile> {
+        val result = FxaResult<Profile>()
+        val accountPointer = this.validPointer()
+        launch {
+            val e = Error.ByReference()
+            val p = FxaClient.INSTANCE.fxa_profile(accountPointer, ignoreCache, e)
+            if (e.isFailure()) {
+                result.completeExceptionally(FxaException.fromConsuming(e))
+            } else {
+                result.complete(Profile(p))
+            }
         }
+        return result
+    }
+
+    fun getProfile(): FxaResult<Profile> {
+        return getProfile(false)
     }
 
     fun newAssertion(audience: String): String? {
         val e = Error.ByReference()
         val p = FxaClient.INSTANCE.fxa_assertion_new(this.validPointer(), audience, e)
-        if (e.isSuccess()) {
-            return getAndConsumeString(p)
-        } else {
-            return null
-        }
+        if (e.isFailure()) throw FxaException.fromConsuming(e)
+        return getAndConsumeString(p)
     }
 
     fun getTokenServerEndpointURL(): String? {
         val e = Error.ByReference()
         val p = FxaClient.INSTANCE.fxa_get_token_server_endpoint_url(this.validPointer(), e)
-        if (e.isSuccess()) {
-            return getAndConsumeString(p)
-        } else {
-            return null
-        }
+        if (e.isFailure()) throw FxaException.fromConsuming(e)
+        return getAndConsumeString(p)
     }
 
-    fun getSyncKeys(): SyncKeys? {
+    fun getSyncKeys(): SyncKeys {
         val e = Error.ByReference()
         val p = FxaClient.INSTANCE.fxa_get_sync_keys(this.validPointer(), e)
-        if (e.isSuccess()) {
-            return SyncKeys(p)
-        } else {
-            return null
-        }
+        if (e.isFailure()) throw FxaException.fromConsuming(e)
+        return SyncKeys(p)
     }
 
-    fun getProfile(): Profile? {
-        return getProfile(false)
+    fun completeOAuthFlow(code: String, state: String): FxaResult<OAuthInfo> {
+        val result = FxaResult<OAuthInfo>()
+        val accountPointer = this.validPointer()
+        launch {
+            val e = Error.ByReference()
+            val p = FxaClient.INSTANCE.fxa_complete_oauth_flow(accountPointer, code, state, e)
+            if (e.isFailure()) {
+                result.completeExceptionally(FxaException.fromConsuming(e))
+            } else {
+                result.complete(OAuthInfo(p))
+            }
+        }
+        return result
     }
 
-    fun completeOAuthFlow(code: String, state: String): OAuthInfo? {
-        val e = Error.ByReference()
-        val p = FxaClient.INSTANCE.fxa_complete_oauth_flow(this.validPointer(), code, state, e)
-        if (e.isSuccess()) {
-            return OAuthInfo(p)
-        } else {
-            return null
+    fun getOAuthToken(scopes: Array<String>): FxaResult<OAuthInfo> {
+        val result = FxaResult<OAuthInfo>()
+        val accountPointer = this.validPointer()
+        launch {
+            val scope = scopes.joinToString(" ")
+            val e = Error.ByReference()
+            val p = FxaClient.INSTANCE.fxa_get_oauth_token(accountPointer, scope, e)
+            if (e.isFailure()) {
+                result.completeExceptionally(FxaException.fromConsuming(e))
+            } else {
+                result.complete(OAuthInfo(p))
+            }
         }
-    }
-
-    fun getOAuthToken(scopes: Array<String>): OAuthInfo? {
-        val scope = scopes.joinToString(" ")
-        val e = Error.ByReference()
-        val p = FxaClient.INSTANCE.fxa_get_oauth_token(this.validPointer(), scope, e)
-        if (e.isSuccess()) {
-            return OAuthInfo(p)
-        } else {
-            return null
-        }
+        return result
     }
 
     companion object {
-        fun from(config: Config, clientId: String, webChannelResponse: String): FirefoxAccount? {
-            val e = Error.ByReference()
-            val raw = FxaClient.INSTANCE.fxa_from_credentials(config.consumePointer(), clientId, webChannelResponse, e)
-            if (e.isSuccess()) {
-                return FirefoxAccount(raw)
-            } else {
-                return null
+        fun from(config: Config, clientId: String, webChannelResponse: String): FxaResult<FirefoxAccount> {
+            val result = FxaResult<FirefoxAccount>()
+            launch {
+                val e = Error.ByReference()
+                val raw = FxaClient.INSTANCE.fxa_from_credentials(config.consumePointer(),
+                        clientId, webChannelResponse, e)
+                if (e.isFailure()) {
+                    result.completeExceptionally(FxaException.fromConsuming(e))
+                } else {
+                    result.complete(FirefoxAccount(raw))
+                }
             }
+            return result
         }
 
-        fun fromJSONString(json: String): FirefoxAccount? {
-            val e = Error.ByReference()
-            val raw = FxaClient.INSTANCE.fxa_from_json(json, e)
-            if (e.isSuccess()) {
-                return FirefoxAccount(raw)
-            } else {
-                return null
+        fun fromJSONString(json: String): FxaResult<FirefoxAccount> {
+            val result = FxaResult<FirefoxAccount>()
+            launch {
+                val e = Error.ByReference()
+                val raw = FxaClient.INSTANCE.fxa_from_json(json, e)
+                if (e.isFailure()) {
+                    result.completeExceptionally(FxaException.fromConsuming(e))
+                } else {
+                    result.complete(FirefoxAccount(raw))
+                }
             }
+            return result
         }
     }
 }

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaClient.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaClient.kt
@@ -26,6 +26,11 @@ interface FxaClient : Library {
         }
     }
 
+    // This is ultra hacky and takes advantage of the zero-based error codes returned in Rust.
+    enum class ErrorCode {
+        NoError, Other, AuthenticationError, InternalPanic
+    }
+
     class RawFxAccount : PointerType()
     class RawConfig : PointerType()
 

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaException.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaException.kt
@@ -1,0 +1,18 @@
+package mozilla.components.service.fxa
+
+open class FxaException(message: String) : Exception(message) {
+    class Unspecified(msg: String) : FxaException(msg)
+    class Unauthorized(msg: String) : FxaException(msg)
+    class Panic(msg: String) : FxaException(msg)
+
+    companion object {
+        fun fromConsuming(e: Error): FxaException {
+            val message = e.consumeMessage() ?: ""
+            return when (e.code) {
+                FxaClient.ErrorCode.AuthenticationError.ordinal -> Unauthorized(message)
+                FxaClient.ErrorCode.InternalPanic.ordinal -> Panic(message)
+                else -> Unspecified(message)
+            }
+        }
+    }
+}

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaResult.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaResult.kt
@@ -1,0 +1,212 @@
+package mozilla.components.service.fxa
+
+import java.util.ArrayList
+
+/**
+ * FxaResult is a class that represents an asynchronous result.
+ *
+ * @param <T> The type of the value delivered via the FxaResult.
+ */
+class FxaResult<T> {
+
+    private var mComplete: Boolean = false
+    private var mValue: T? = null
+    private var mError: Exception? = null
+
+    private val mListeners: ArrayList<Listener<T>> = ArrayList()
+
+    private interface Listener<T> {
+        fun onValue(value: T?)
+
+        fun onException(exception: Exception)
+    }
+
+    /**
+     * Completes this result based on another result.
+     *
+     * @param other The result that this result should mirror
+     */
+    private fun completeFrom(other: FxaResult<T>?) {
+        if (other == null) {
+            complete(null)
+            return
+        }
+
+        other.then(object : OnValueListener<T, Void> {
+            override fun onValue(value: T?): FxaResult<Void>? {
+                complete(value)
+                return null
+            }
+        }, object : OnExceptionListener<Void> {
+            override fun onException(exception: Exception): FxaResult<Void>? {
+                completeExceptionally(exception)
+                return null
+            }
+        })
+    }
+
+    /**
+     * Convenience method allowing [FxaResult] to be called with a lambda expression on a value.
+     *
+     * @param fn A lambda expression with the same method signature as [OnValueListener],
+     * called when the [FxaResult] is completed with a value.
+     */
+    fun <U> then(fn: (value: T?) -> FxaResult<U>?): FxaResult<U> {
+        val listener = object : OnValueListener<T, U> {
+            override fun onValue(value: T?): FxaResult<U>? = fn(value)
+        }
+        return then(listener, null)
+    }
+
+    /**
+     * Convenience method allowing [FxaResult] to be called with lambda expressions on a value
+     * and on an exception.
+     *
+     * @param vfn A lambda expression with the same method signature as [OnValueListener],
+     * called when the [FxaResult] is completed with a value.
+     * @param efn A lambda expression with the same method signature as [OnExceptionListener],
+     * called when the [FxaResult] is completed with an exception.
+     */
+    fun <U> then(vfn: (value: T?) -> FxaResult<U>?, efn: (exception: Exception) -> FxaResult<U>?): FxaResult<U> {
+        val valueListener = object : OnValueListener<T, U> {
+            override fun onValue(value: T?): FxaResult<U>? = vfn(value)
+        }
+
+        val exceptionListener = object : OnExceptionListener<U> {
+            override fun onException(exception: Exception): FxaResult<U>? = efn(exception)
+        }
+        return then(valueListener, exceptionListener)
+    }
+
+    /**
+     * Adds listeners to be called when the [FxaResult] is completed either with
+     * a value or [Exception]. Listeners will be invoked on the same thread in which the
+     * [FxaResult] was completed.
+     *
+     * @param valueListener An instance of [OnValueListener], called when the
+     * [FxaResult] is completed with a value.
+     * @param exceptionListener An instance of [OnExceptionListener], called when the
+     * [FxaResult] is completed with an [Exception].
+     */
+    @Synchronized
+    @Suppress("ComplexMethod")
+    fun <U> then(valueListener: OnValueListener<T, U>, exceptionListener: OnExceptionListener<U>?): FxaResult<U> {
+        val result = FxaResult<U>()
+        val listener = object : Listener<T> {
+            override fun onValue(value: T?) {
+                result.completeFrom(valueListener.onValue(value))
+            }
+
+            override fun onException(exception: Exception) {
+                if (exceptionListener == null) {
+                    return
+                }
+
+                result.completeFrom(exceptionListener.onException(exception))
+            }
+        }
+
+        if (mComplete) {
+            mError?.let { listener.onException(it) }
+            mValue?.let { listener.onValue(it) }
+        } else {
+            mListeners.add(listener)
+        }
+
+        return result
+    }
+
+    /**
+     * This completes the result with the specified value. IllegalStateException is thrown
+     * if the result is already complete.
+     *
+     * @param value The value used to complete the result.
+     * @throws IllegalStateException
+     */
+    @Synchronized
+    fun complete(value: T?) {
+        if (mComplete) {
+            throw IllegalStateException("result is already complete")
+        }
+
+        mValue = value
+        mComplete = true
+
+        ArrayList(mListeners).forEach { it.onValue(mValue) }
+    }
+
+    /**
+     * This completes the result with the specified [Exception]. IllegalStateException is thrown
+     * if the result is already complete.
+     *
+     * @param exception The [Exception] used to complete the result.
+     * @throws IllegalStateException
+     */
+    @Synchronized
+    fun completeExceptionally(exception: Exception) {
+        if (mComplete) {
+            throw IllegalStateException("result is already complete")
+        }
+
+        mError = exception
+        mComplete = true
+
+        ArrayList(mListeners).forEach { it.onException(exception) }
+    }
+
+    /**
+     * An interface used to deliver values to listeners of a [FxaResult]
+     *
+     * @param <T> This is the type of the value delivered via [.onValue]
+     * @param <U> This is the type of the value for the result returned from [.onValue]
+     */
+    @FunctionalInterface
+    interface OnValueListener<T, U> {
+        /**
+         * Called when a [FxaResult] is completed with a value. This will be
+         * called on the same thread in which the result was completed.
+         *
+         * @param value The value of the [FxaResult]
+         * @return A new [FxaResult], used for chaining results together.
+         * May be null.
+         */
+        fun onValue(value: T?): FxaResult<U>?
+    }
+
+    /**
+     * An interface used to deliver exceptions to listeners of a [FxaResult]
+     *
+     * @param <V> This is the type of the vale for the result returned from [.onException]
+     */
+    @FunctionalInterface
+    interface OnExceptionListener<V> {
+        fun onException(exception: Exception): FxaResult<V>?
+    }
+
+    companion object {
+        /**
+         * This constructs a result that is fulfilled with the specified value.
+         *
+         * @param value The value used to complete the newly created result.
+         * @return The completed [FxaResult]
+         */
+        fun <U> fromValue(value: U): FxaResult<U> {
+            val result = FxaResult<U>()
+            result.complete(value)
+            return result
+        }
+
+        /**
+         * This constructs a result that is completed with the specified [Exception].
+         * May not be null.
+         *
+         * @param exception The exception used to complete the newly created result.
+         * @return The completed [FxaResult]
+         */
+        fun <T> fromException(exception: Exception): FxaResult<T> {
+            val result = FxaResult<T>()
+            result.completeExceptionally(exception)
+            return result
+        }
+    }
+}

--- a/components/service/fxa/src/test/java/mozilla/components/service/fxa/FxaResultTest.kt
+++ b/components/service/fxa/src/test/java/mozilla/components/service/fxa/FxaResultTest.kt
@@ -1,0 +1,48 @@
+package mozilla.components.service.fxa
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FxaResultTest {
+
+    @Test
+    fun thenWithResult() {
+        FxaResult.fromValue(42).then { value: Int? ->
+            assertEquals(value, 42)
+            FxaResult<Void>()
+        }
+    }
+
+    @Test
+    fun thenWithException() {
+        FxaResult.fromException<Void>(Exception("exception message")).then({ value: Void? ->
+            assertNull("valueListener should not be called", value)
+            FxaResult<Void>()
+        }, { value: Exception ->
+            assertEquals(value.message, "exception message")
+            FxaResult()
+        })
+    }
+
+    @Test
+    fun resultChaining() {
+        FxaResult.fromValue(42).then { value: Int? ->
+            assertEquals(value, 42)
+            FxaResult.fromValue("string")
+        }.then { value: String? ->
+            assertEquals(value, "string")
+            FxaResult.fromException<Void>(Exception("exception message"))
+        }.then({
+            fail("valueListener should not be called")
+            FxaResult<Void>()
+        }, { value: Exception ->
+            assertEquals(value.message, "exception message")
+            FxaResult()
+        })
+    }
+}


### PR DESCRIPTION
Adds 
- FxaResult, a Promise-like type derived from [GeckoResult][1]. Since this is a "homegrown" promise type, the library will continue to support apps written in Java 6+ and Kotlin.
- FxaException, a general Exception class for errors from the FxA library which turns the Rust error codes into something Java-like

r? @csadilek, @eoger
ping @thomcc after pto to make sure there aren't any memory leaks

[1]: https://reviewboard.mozilla.org/r/250560/diff/3/