### PR TITLE
Do not build "release" variants of sample browser.

### DIFF
--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -51,6 +51,14 @@ android {
             dimension "abi"
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 kotlin {


### PR DESCRIPTION
We only need the "debug" variants. Hopefully this will make things a little bit faster on taskcluster. Building all those variants takes quite a while.