### PR TITLE
Fixed issue #365 of typo of 'Mobule' to 'Module'

### DIFF
--- a/automation/taskcluster/decision_task_pull_request.py
+++ b/automation/taskcluster/decision_task_pull_request.py
@@ -28,7 +28,7 @@ def fetch_module_names():
     if exit_code is not 0:
         print "Gradle command returned error:", exit_code
 
-    return re.findall('mobule: (.*)', output, re.M)
+    return re.findall('module: (.*)', output, re.M)
 
 
 def schedule_task(queue, taskId, task):

--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ task ktlint(type: JavaExec, group: "verification") {
 task printModules {
     doLast {
         subprojects.each { p ->
-            println "mobule: " + p.path
+            println "module: " + p.path
         }
     }
 }


### PR DESCRIPTION
I have fixed the typo from 'Mobule' to 'Module' as reported in issue #365 