### PR TITLE
Closes #383 and #392: FxA fixes / refactorings.

### DIFF
--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -4,9 +4,9 @@
 
 package mozilla.components.service.fxa
 
-class Config(override var rawPointer: FxaClient.RawConfig?) : RustObject<FxaClient.RawConfig>() {
+class Config(override var rawPointer: RawConfig?) : RustObject<RawConfig>() {
 
-    override fun destroyPointer(p: FxaClient.RawConfig) {
+    override fun destroyPointer(p: RawConfig) {
         FxaClient.INSTANCE.fxa_config_free(p)
     }
 

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -6,7 +6,7 @@ package mozilla.components.service.fxa
 
 class Config(override var rawPointer: RawConfig?) : RustObject<RawConfig>() {
 
-    override fun destroyPointer(p: RawConfig) {
+    override fun destroy(p: RawConfig) {
         FxaClient.INSTANCE.fxa_config_free(p)
     }
 

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -6,7 +6,7 @@ package mozilla.components.service.fxa
 
 import kotlinx.coroutines.experimental.launch
 
-class FirefoxAccount(override var rawPointer: FxaClient.RawFxAccount?) : RustObject<FxaClient.RawFxAccount>() {
+class FirefoxAccount(override var rawPointer: RawFxAccount?) : RustObject<RawFxAccount>() {
 
     constructor(config: Config, clientId: String): this(null) {
         val e = Error.ByReference()
@@ -15,7 +15,7 @@ class FirefoxAccount(override var rawPointer: FxaClient.RawFxAccount?) : RustObj
         this.rawPointer = result
     }
 
-    override fun destroyPointer(p: FxaClient.RawFxAccount) {
+    override fun destroyPointer(p: RawFxAccount) {
         FxaClient.INSTANCE.fxa_free(p)
     }
 

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -15,7 +15,7 @@ class FirefoxAccount(override var rawPointer: RawFxAccount?) : RustObject<RawFxA
         this.rawPointer = result
     }
 
-    override fun destroyPointer(p: RawFxAccount) {
+    override fun destroy(p: RawFxAccount) {
         FxaClient.INSTANCE.fxa_free(p)
     }
 

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaClient.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/FxaClient.kt
@@ -11,13 +11,13 @@ import com.sun.jna.NativeLibrary
 import com.sun.jna.PointerType
 
 @Suppress("FunctionNaming", "TooManyFunctions")
-interface FxaClient : Library {
+internal interface FxaClient : Library {
     companion object {
         private const val JNA_LIBRARY_NAME = "fxa_client"
-        lateinit var JNA_NATIVE_LIB: Any
-        lateinit var INSTANCE: FxaClient
+        private val JNA_NATIVE_LIB: Any
+        internal val INSTANCE: FxaClient
 
-        fun init() {
+        init {
             System.loadLibrary("crypto")
             System.loadLibrary("ssl")
             System.loadLibrary("fxa_client")
@@ -30,9 +30,6 @@ interface FxaClient : Library {
     enum class ErrorCode {
         NoError, Other, AuthenticationError, InternalPanic
     }
-
-    class RawFxAccount : PointerType()
-    class RawConfig : PointerType()
 
     fun fxa_get_release_config(e: Error.ByReference): RawConfig
     fun fxa_get_custom_config(content_base: String, e: Error.ByReference): RawConfig
@@ -77,3 +74,6 @@ interface FxaClient : Library {
     fun fxa_profile_free(ptr: Pointer)
     fun fxa_sync_keys_free(ptr: Pointer)
 }
+
+class RawFxAccount : PointerType()
+class RawConfig : PointerType()

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/RustObject.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/RustObject.kt
@@ -29,16 +29,12 @@ abstract class RustObject<T> : Closeable {
         return p
     }
 
-    abstract fun destroyPointer(p: T)
+    protected abstract fun destroy(p: T)
 
     override fun close() {
         if (this.rawPointer != null) {
-            this.destroyPointer(this.consumePointer())
+            destroy(this.consumePointer())
         }
-    }
-
-    protected fun finalize() {
-        this.close()
     }
 
     companion object {

--- a/components/service/fxa/src/main/java/mozilla/components/service/fxa/RustObject.kt
+++ b/components/service/fxa/src/main/java/mozilla/components/service/fxa/RustObject.kt
@@ -29,7 +29,7 @@ abstract class RustObject<T> : Closeable {
         return p
     }
 
-    protected abstract fun destroyPointer(p: T)
+    abstract fun destroyPointer(p: T)
 
     override fun close() {
         if (this.rawPointer != null) {

--- a/samples/fxa/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/fxa/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -45,6 +45,11 @@ open class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        account?.close()
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         val action = intent.action

--- a/samples/fxa/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/fxa/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -13,7 +13,6 @@ import android.content.Intent
 import android.widget.TextView
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
-import mozilla.components.service.fxa.FxaClient
 import mozilla.components.service.fxa.FxaResult
 import mozilla.components.service.fxa.OAuthInfo
 import mozilla.components.service.fxa.Profile
@@ -28,10 +27,6 @@ open class MainActivity : AppCompatActivity() {
         const val CLIENT_ID = "12cc4070a481bc73"
         const val REDIRECT_URL = "fxaclient://android.redirect"
         const val CONFIG_URL = "https://latest.dev.lcip.org"
-
-        init {
-            FxaClient.init()
-        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
First of many refactorings :).

This is to hide the snake_case Rust method wrappers from our public API. There's no value in having the app call `init`. If a project adds the library to the classpath, but doesn't use it, the FxaClient class won't be loaded and therefore not initialized. So, there's no need for extra control.