### PR TITLE
Closes #412: Introduce method to complete FxA promise chain

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaResult.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaResult.kt
@@ -45,7 +45,9 @@ class FxaResult<T> {
     }
 
     /**
-     * Convenience method allowing [FxaResult] to be called with a lambda expression on a value.
+     * Adds a value listener to be called when the [FxaResult] is completed with
+     * a value. Listeners will be invoked on the same thread in which the
+     * [FxaResult] was completed.
      *
      * @param fn A lambda expression with the same method signature as [OnValueListener],
      * called when the [FxaResult] is completed with a value.
@@ -58,8 +60,9 @@ class FxaResult<T> {
     }
 
     /**
-     * Convenience method allowing [FxaResult] to be called with lambda expressions on a value
-     * and on an exception.
+     * Adds listeners to be called when the [FxaResult] is completed either with
+     * a value or [Exception]. Listeners will be invoked on the same thread in which the
+     * [FxaResult] was completed.
      *
      * @param vfn A lambda expression with the same method signature as [OnValueListener],
      * called when the [FxaResult] is completed with a value.
@@ -118,6 +121,24 @@ class FxaResult<T> {
         }
 
         return result
+    }
+
+    /**
+     * Adds a value listener to be called when the [FxaResult] and the whole chain of [then]
+     * calls is completed with a value. Listeners will be invoked on the same thread in
+     * which the [FxaResult] was completed.
+     *
+     * @param fn A lambda expression with the same method signature as [OnValueListener],
+     * called when the [FxaResult] is completed with a value.
+     */
+    fun whenComplete(fn: (value: T) -> Unit) {
+        val listener = object : OnValueListener<T, Void> {
+            override fun onValue(value: T): FxaResult<Void>? {
+                fn(value)
+                return FxaResult()
+            }
+        }
+        then(listener, null)
     }
 
     /**

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaResultTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaResultTest.kt
@@ -2,6 +2,7 @@ package mozilla.components.service.fxa
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,25 +13,37 @@ class FxaResultTest {
 
     @Test
     fun thenWithResult() {
+        var chainComplete = false
+
         FxaResult.fromValue(42).then { value: Int ->
             assertEquals(value, 42)
+            chainComplete = true
             FxaResult<Void>()
         }
+
+        assertTrue(chainComplete)
     }
 
     @Test
     fun thenWithException() {
+        var chainComplete = false
+
         FxaResult.fromException<Void>(Exception("exception message")).then({ value: Void ->
             assertNull("valueListener should not be called", value)
             FxaResult<Void>()
         }, { value: Exception ->
             assertEquals(value.message, "exception message")
+            chainComplete = true
             FxaResult()
         })
+
+        assertTrue(chainComplete)
     }
 
     @Test
     fun thenWithThrownException() {
+        var chainComplete = false
+
         FxaResult.fromValue(42).then { _: Int ->
             throw Exception("exception message")
             FxaResult<Void>()
@@ -39,12 +52,17 @@ class FxaResultTest {
             FxaResult<Void>()
         }, { value: Exception ->
             assertEquals(value.message, "exception message")
+            chainComplete = true
             FxaResult()
         })
+
+        assertTrue(chainComplete)
     }
 
     @Test
     fun resultChaining() {
+        var chainComplete = false
+
         FxaResult.fromValue(42).then { value: Int ->
             assertEquals(value, 42)
             FxaResult.fromValue("string")
@@ -56,7 +74,25 @@ class FxaResultTest {
             FxaResult<Void>()
         }, { value: Exception ->
             assertEquals(value.message, "exception message")
+            chainComplete = true
             FxaResult()
         })
+
+        assertTrue(chainComplete)
+    }
+
+    @Test
+    fun whenComplete() {
+        var chainComplete = false
+
+        FxaResult.fromValue(42).then { value: Int ->
+            assertEquals(value, 42)
+            FxaResult.fromValue("string")
+        }.whenComplete { value: String ->
+            assertEquals(value, "string")
+            chainComplete = true
+        }
+
+        assertTrue(chainComplete)
     }
 }


### PR DESCRIPTION
This simplifies the API as we no longer have to return a value from our listeners, if not needed (if they are the last in the chain). It cleans up the sample app and makes it easier to read.

/cc @carolkng 