### PR TITLE
Update FxaClient version to 0.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlin: '1.2.51',
         coroutines: '0.23.4',
         supportLibraries: '27.1.1',
-        fxa: '0.1.2',
+        fxa: '0.2.0',
         jna: '4.5.1',
         // Test only:
         junit: '4.12',

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaClient.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaClient.kt
@@ -34,10 +34,11 @@ internal interface FxaClient : Library {
     fun fxa_get_release_config(e: Error.ByReference): RawConfig
     fun fxa_get_custom_config(content_base: String, e: Error.ByReference): RawConfig
 
-    fun fxa_new(config: RawConfig, clientId: String, e: Error.ByReference): RawFxAccount
+    fun fxa_new(config: RawConfig, clientId: String, redirectUri: String, e: Error.ByReference): RawFxAccount
     fun fxa_from_credentials(
         config: RawConfig,
         clientId: String,
+        redirectUri: String,
         webChannelResponse: String,
         e: Error.ByReference
     ): RawFxAccount
@@ -46,7 +47,6 @@ internal interface FxaClient : Library {
 
     fun fxa_begin_oauth_flow(
         fxa: RawFxAccount,
-        redirectUri: String,
         scopes: String,
         wantsKeys: Boolean,
         e: Error.ByReference

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -34,11 +34,11 @@ open class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         Config.custom(CONFIG_URL).whenComplete { value: Config ->
-            account = FirefoxAccount(value, CLIENT_ID)
+            account = FirefoxAccount(value, CLIENT_ID, REDIRECT_URL)
         }
 
         findViewById<View>(R.id.button).setOnClickListener {
-            account?.beginOAuthFlow(REDIRECT_URL, scopes, false)?.whenComplete { openTab(it) }
+            account?.beginOAuthFlow(scopes, false)?.whenComplete { openTab(it) }
         }
     }
 


### PR DESCRIPTION
The new 0.2.0 release of the fxa-rust-client slightly changes the method signatures to begin the OAuth flow and for the FirefoxAccount constructors (https://github.com/mozilla/application-services/commit/c00d61f77e12c85ed14631df0dc9a322864fc24f).

r? @csadilek