### PR TITLE
Don't set composing region after removing autocomplete

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -490,7 +490,6 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                     // Make the IME aware that we interrupted the setComposingText call,
                     // by having finishComposingText() send change notifications to the IME.
                     finishComposingText()
-                    setComposingRegion(composingStart, composingEnd)
                     return true
                 }
                 return false

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -321,4 +321,24 @@ class InlineAutocompleteEditTextTest {
         assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
         assertEquals("text", et.text.toString())
     }
+
+    @Test
+    fun testRemoveAutocompleteOnComposing() {
+        val et = InlineAutocompleteEditText(context, attributes)
+        val ic = et.onCreateInputConnection(mock(EditorInfo::class.java))
+
+        ic?.setComposingText("text", 1)
+        assertEquals("text", et.text.toString())
+
+        et.applyAutocompleteResult(AutocompleteResult("text completed", "source", 1))
+        assertEquals("text completed", et.text.toString())
+
+        // Simulating a backspace which should remove the autocomplete and leave original text
+        ic?.setComposingText("tex", 1)
+        assertEquals("text", et.text.toString())
+
+        // Verify that we finished composing
+        assertEquals(-1, BaseInputConnection.getComposingSpanStart(et.text))
+        assertEquals(-1, BaseInputConnection.getComposingSpanEnd(et.text))
+    }
 }


### PR DESCRIPTION
Seems like composing span is applied anyway.
Closes #348