### PR TITLE
RFC: Adding "consumable" properties to Session.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Download.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Download.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session
+
+import android.os.Environment
+
+data class Download(
+    val url: String,
+    val contentDisposition: String,
+    val mimeType: String,
+    val contentLength: Long,
+    val userAgent: String, // TODO: needed??
+    val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS
+)

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.session
 
 import mozilla.components.browser.session.engine.EngineSessionHolder
 import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.support.utils.observer.Consumable
 import mozilla.components.support.utils.observer.Observable
 import mozilla.components.support.utils.observer.ObserverRegistry
 import java.util.UUID
@@ -36,6 +37,7 @@ class Session(
         fun onSearch(session: Session, searchTerms: String) = Unit
         fun onSecurityChanged(session: Session, securityInfo: SecurityInfo) = Unit
         fun onCustomTabConfigChanged(session: Session, customTabConfig: CustomTabConfig?) = Unit
+        fun onDownload(session: Session, download: Download): Boolean = false
     }
 
     /**
@@ -105,6 +107,11 @@ class Session(
         _, _, new -> notifyObservers { onCustomTabConfigChanged(this@Session, new) }
     }
 
+    var download: Consumable<Download> by Delegates.vetoable(Consumable.empty()) { _, _, download ->
+        download.consume(wrapConsumers { onDownload(this@Session, download.peek()) })
+        !download.isConsumed()
+    }
+
     /**
      * Returns whether or not this session is used for a Custom Tab.
      */
@@ -132,3 +139,4 @@ class Session(
         return id.hashCode()
     }
 }
+

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -30,4 +30,8 @@ internal class EngineObserver(val session: Session) : EngineSession.Observer {
         session.securityInfo = Session.SecurityInfo(secure, host
                 ?: "", issuer ?: "")
     }
+
+    override fun onExternalResource(url: String, fileName: String?, contentLength: Long?, contentType: String?, cookie: String?, userAgent: String?) {
+        TODO("not implemented")
+    }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -7,9 +7,13 @@ package mozilla.components.browser.session
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.utils.observer.Consumable
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -223,4 +227,115 @@ class SessionTest {
         assertEquals("test", map[session2])
         assertEquals(session1.hashCode(), session2.hashCode())
     }
+
+    @Test
+    fun `Download will be set on Session if no observer is registered`() {
+        val download: Download = mock()
+
+        val session = Session("https://www.mozilla.org")
+        session.download = Consumable.from(download)
+
+        assertFalse(session.download.isConsumed())
+        assertEquals(download, session.download.peek())
+    }
+
+    @Test
+    fun `Download will not be set on Session if consumed by observer`() {
+        var callbackExecuted = false
+
+        val session = Session("https://www.mozilla.org")
+        session.register(object : Session.Observer {
+            override fun onDownload(session: Session, download: Download): Boolean {
+                callbackExecuted = true
+                return true // Consume download
+            }
+        })
+
+        val download: Download = mock()
+        session.download = Consumable.from(download)
+
+        assertTrue(callbackExecuted)
+        assertTrue(session.download.isConsumed())
+    }
+
+    @Test
+    fun `All observers will not be notified about a download`() {
+        var firstCallbackExecuted = false
+        var secondCallbackExecuted = false
+
+        val session = Session("https://www.mozilla.org")
+        session.register(object : Session.Observer {
+            override fun onDownload(session: Session, download: Download): Boolean {
+                firstCallbackExecuted = true
+                return true // Consume download
+            }
+        })
+        session.register(object : Session.Observer {
+            override fun onDownload(session: Session, download: Download): Boolean {
+                secondCallbackExecuted = true
+                return false // Do not consume download
+            }
+        })
+
+        val download: Download = mock()
+        session.download = Consumable.from(download)
+
+        assertTrue(firstCallbackExecuted)
+        assertTrue(secondCallbackExecuted)
+        assertTrue(session.download.isConsumed())
+    }
+
+    @Test
+    fun `Download will be set on Session if no observer consumes it`() {
+        var firstCallbackExecuted = false
+        var secondCallbackExecuted = false
+
+        val session = Session("https://www.mozilla.org")
+        session.register(object : Session.Observer {
+            override fun onDownload(session: Session, download: Download): Boolean {
+                firstCallbackExecuted = true
+                return false // Do not consume download
+            }
+        })
+        session.register(object : Session.Observer {
+            override fun onDownload(session: Session, download: Download): Boolean {
+                secondCallbackExecuted = true
+                return false // Do not consume download
+            }
+        })
+
+        val download: Download = mock()
+        session.download = Consumable.from(download)
+
+        assertTrue(firstCallbackExecuted)
+        assertTrue(secondCallbackExecuted)
+        assertFalse(session.download.isConsumed())
+    }
+
+    @Test
+    fun `Download can be consumed`() {
+        val session = Session("https://www.mozilla.org")
+        session.download = Consumable.from(mock())
+
+        assertFalse(session.download.isConsumed())
+
+        var consumerExecuted = false
+        session.download.consume {
+            consumerExecuted = true
+            false // Do not consume
+        }
+
+        assertTrue(consumerExecuted)
+        assertFalse(session.download.isConsumed())
+
+        consumerExecuted = false
+        session.download.consume {
+            consumerExecuted = true
+            true // Consume download
+        }
+
+        assertTrue(consumerExecuted)
+        assertTrue(session.download.isConsumed())
+    }
+
 }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/observer/Consumable.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/observer/Consumable.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils.observer
+
+class Consumable<T> private constructor(
+    var value: T?
+) {
+    inline fun consume(block: (value: T) -> Boolean) {
+        if (value?.let(block) == true) {
+            value = null
+        }
+    }
+
+    fun consume(blocks: List<(value: T) -> Boolean>) {
+        value?.let { x ->
+            if (blocks.map { f -> f(x) }.contains(true)) {
+                value = null
+            }
+        }
+    }
+
+    fun peek(): T = value!!
+
+    fun isConsumed() = value == null
+
+    companion object {
+        fun <T> from(value: T): Consumable<T> = Consumable(value)
+
+        fun <T> empty(): Consumable<T> = Consumable(null)
+    }
+}

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/observer/Observable.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/observer/Observable.kt
@@ -50,4 +50,7 @@ interface Observable<T> {
      * Notify all registered observers about a change.
      */
     fun notifyObservers(block: T.() -> Unit)
+
+
+    fun <R> wrapConsumers(block: T.() -> Boolean): List<(value: R) -> Boolean>
 }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/observer/ObserverRegistry.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/observer/ObserverRegistry.kt
@@ -108,6 +108,18 @@ class ObserverRegistry<T> : Observable<T> {
         }
     }
 
+    override fun <R> wrapConsumers(block: T.() -> Boolean): List<(value: R) -> Boolean> {
+        val consumers: MutableList<(value: R) -> Boolean> = mutableListOf()
+
+        synchronized(observers) {
+            observers.forEach { observer ->
+                consumers.add { observer.block() }
+            }
+        }
+
+        return consumers
+    }
+
     /**
      * GenericLifecycleObserver implementation to bind an observer to a Lifecycle.
      */


### PR DESCRIPTION
(This PR is not for merging - only for discussion).

I would like to add properties to Session that are _consumable_. This means when setting the value of a _consumable property_ an `Observer` can decide to consume it. This means the value won't be set on `Session` and the property value will be `null`. If the value is not consumed then it will be set and can be read from `Session` to be consumed later.

Some properties like a `Download` are something that an observer processes and then there is no need to keep a reference to the value anymore. Sometimes the value can't be processed immediately (e.g. we need to request a permission first) and then it is helpful to store it in `Session` to be consumed later. There will be more properties in the future that following this _consumer_ pattern.

The following PR implements this behavior for a Download. The PR is not complete to be actually merged.

I would like to make it more clear that this property can/should be consumed. For the observer case it's clear. But when consuming this property later a _processor_ would need to read (is it null?), then process, then set it to `null` which is not super nice.