### PR TITLE
Issue #400: Prevent side effects / glitches in Observable implementations.

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/observer/SideEffects.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/observer/SideEffects.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils.observer
+
+import java.util.LinkedList
+
+/**
+ * This helper class prevents side effects (glitches) in an <code>Observable</code> implementation
+ * where an observer can modify the internal state of an <code>Observable</code> from an observer
+ * callback. In this situation follow-up observers may see a modified state that may conflict with
+ * the change the observer was notified about.
+ *
+ * To avoid those side effects in an <code>Observable</code> create an internal instance of
+ * <code>SideEffects</code> and wrap methods modifying the <code>Observable</code> state inside
+ * <code>modifyWithoutSideEffects()</code>. Methods that just read the current state can be wrapped
+ * in <code>readWithLock</code>.
+ *
+ * SideEffects queues modifications to an <code>Observable</code> until all observers have been
+ * notified and then performs them sequentially
+ *
+ * For an example of observer side effects / glitches see SideEffectsTest<code>.
+ */
+class SideEffects {
+    // Those properties have 'internal' visibility with @PublishedApi annotation so that they can be
+    // inlined by the compiler.
+    @PublishedApi internal val lock = Any()
+    @PublishedApi internal val queue: LinkedList<() -> Unit> = LinkedList()
+    @PublishedApi internal var isProcessing = false
+
+    inline fun modifyWithoutSideEffects(crossinline action: () -> Unit) {
+        synchronized(lock) {
+            if (isProcessing) {
+                queue.add { action() }
+            } else {
+                isProcessing = true
+
+                try {
+                    action()
+                } finally {
+                    processQueue()
+                }
+
+                isProcessing = false
+            }
+        }
+    }
+
+    @PublishedApi internal fun processQueue() {
+        while (!queue.isEmpty()) {
+            val action = queue.poll()
+            action()
+        }
+    }
+
+    inline fun <R> readWithLock(action: () -> R): R = synchronized(lock) {
+        action()
+    }
+}

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/observer/SideEffectsNestedLambaTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/observer/SideEffectsNestedLambaTest.kt
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils.observer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * This test verifies the behavior of SideEffect when observers modify the Observable in a nested
+ * structure.
+ */
+class SideEffectsNestedLambaTest {
+    @Test
+    fun testReturningFromInlinedLambda() {
+        val observable = TestObservable()
+
+        val observer1 = CollectingObserver().also { observable.register(it) }
+        val observer2 = AddingMoreObserver().also { observable.register(it) }
+        val observer3 = AddingObserver().also { observable.register(it) }
+        val observer4 = CollectingObserver().also { observable.register(it) }
+
+        observable.changeValue(2)
+        observable.changeValue(0) // Will be ignored by observable
+        observable.changeValue(1) // Will emit 23 and this will emit 0 (will ne ignored)
+        observable.changeValue(5)
+
+        // Observers should see: 2, 1, 23, 5
+
+        listOf(
+            observer1.numbers, observer2.numbers, observer3.numbers, observer4.numbers
+        ).forEach { numbers ->
+            assertEquals(4, numbers.size)
+
+            assertEquals(2, numbers[0])
+            assertEquals(1, numbers[1])
+            assertEquals(23, numbers[2])
+            assertEquals(5, numbers[3])
+        }
+    }
+
+    /**
+     * This observer just collects all values it receives in a list.
+     */
+    private open class CollectingObserver(
+        val numbers: MutableList<Int> = mutableListOf()
+    ) : TestObserver {
+        override fun onValueChanges(observable: TestObservable, value: Int) {
+            numbers.add(value)
+        }
+    }
+
+    /**
+     * This observer collects all values and adds a 23 whenever it sees a 1.
+     */
+    private class AddingObserver : CollectingObserver() {
+        override fun onValueChanges(observable: TestObservable, value: Int) {
+            super.onValueChanges(observable, value)
+
+            if (value == 1) {
+                observable.changeValue(23)
+            }
+        }
+    }
+
+    /**
+     * This observers collects all values and adds a 0 whenever it sees a 23.
+     */
+    private class AddingMoreObserver : CollectingObserver() {
+        override fun onValueChanges(observable: TestObservable, value: Int) {
+            super.onValueChanges(observable, value)
+
+            if (value == 23) {
+                observable.changeValue(0)
+            }
+        }
+    }
+
+    /**
+     * This observable notifies all observers about changed values except if the value is a 0.
+     */
+    private class TestObservable(
+        private val registry: ObserverRegistry<TestObserver> = ObserverRegistry()
+    ) : Observable<TestObserver> by registry {
+        private val sideEffects = SideEffects()
+
+        fun changeValue(value: Int) = sideEffects.modifyWithoutSideEffects {
+            if (value == 0) {
+                return@modifyWithoutSideEffects
+            }
+
+            notifyObservers { onValueChanges(this@TestObservable, value) }
+        }
+    }
+
+    private interface TestObserver {
+        fun onValueChanges(observable: TestObservable, value: Int)
+    }
+}

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/observer/SideEffectsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/observer/SideEffectsTest.kt
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils.observer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * This test class demonstrates the side effects / glitches that can happen when an
+ * <code>Observable</code> is modified from an observer. The test cases demonstrate that those
+ * side effects can be prevent by wrapping code in the helper methods provided by the SideEffects
+ * class.
+ *
+ * Scenario: An implementation of <code>ObservableCharacters</code> is an <code>Observable</code>
+ * that allows adding characters and removing characters. Registered observer get notified whenever
+ * a character gets added or removed.
+ *
+ * There are two registered observers:
+ * (1) <code>NeverEmptyObserver</code> makes sure that we are never running out of characters. If
+ * <code>ObservableCharacters</code> is empty it will add an "X" to it so that there will always
+ * be at least one character in it.
+ * (2) <code>TestPrintCharacterObserver</code> listens to changes and prints the added and removed
+ * characters prefixed with a "+" or "-" depending on whether they got added or removed. If
+ * <code>ObservableCharacters</code> is empty it will print "EMPTY".
+ *
+ * In the test cases we will add "A" and "B" to <code>ObservableCharacters</code>. After that we
+ * will remove "B" and "A" in opposite order again. It is expected that
+ * <code>TestPrintCharacterObserver</code> will print: +A, +B, -B, -A, EMPTY, +X. However the actual
+ * output of <code>TestPrintCharacterObserver</code> will be: +A, +B, -B, +X, -A. In the actual
+ * output X gets added before A gets removed and <code>TestPrintCharacterObserver</code> never saw
+ * the empty state of <code>ObservableCharacters</code>.
+ *
+ * The reason for that is more obvious when looking at the order of callbacks:
+ * .
+ * ├─ addCharacter(A) -> (A)
+ * │  ├─ NeverEmptyObserver.onCharacterAdded(A): (Does nothing)
+ * │  └─ TestPrintCharacterObserver.onCharacterAdded(A): Prints +A
+ * ├─ addCharacter(B) -> (A, B)
+ * │  ├─ NeverEmptyObserver.onCharacterAdded(B): (Does nothing)
+ * │  └─ TestPrintCharacterObserver.onCharacterAdded(B): Prints +B
+ * ├─ onCharacterRemoved(B) -> (A)
+ * │  ├─ NeverEmptyObserver.onCharacterRemoved(B): (Does nothing)
+ * │  └─ TestPrintCharacterObserver.onCharacterRemoved(B): Prints -B
+ * └── onCharacterRemoved(A) -> ()
+ *    ├─ NeverEmptyObserver.onCharacterRemoved(A): Adds an X because the list of characters is empty.
+ *    │  └─ addCharacter(X) -> (X)
+ *    │     ├─ NeverEmptyObserver.onCharacterAdded(X): (Does nothing)
+ *    │     └─ TestPrintCharacterObserver.onCharacterAdded(X): Prints +X
+ *    └─ TestPrintCharacterObserver.onCharacterRemoved(A): Only prints -A (List ist not empty anymore)
+ *
+ * SideEffects queues modifications to an <code>Observable</code> and performs them sequentially.
+ */
+class SideEffectsTest {
+    @Test
+    fun `registry prevents side effects if observer callback modifies observable`() {
+        val noSideEffects = ObservableCharactersWithoutSideEffects()
+        val withSideEffects = ObservableCharactersWithSideEffects()
+
+        NeverEmptyObserver().also {
+            noSideEffects.register(it)
+            withSideEffects.register(it)
+        }
+
+        val printNoSideEffects = TestPrintCharacterObserver().also { noSideEffects.register(it) }
+        val printWidthSideEffects = TestPrintCharacterObserver().also { withSideEffects.register(it) }
+
+        'A'.let { character ->
+            noSideEffects.addCharacter(character)
+            withSideEffects.addCharacter(character)
+        }
+
+        'B'.let { character ->
+            noSideEffects.addCharacter(character)
+            withSideEffects.addCharacter(character)
+        }
+
+        'B'.let { character ->
+            noSideEffects.removeCharacter(character)
+            withSideEffects.removeCharacter(character)
+        }
+
+        'A'.let { character ->
+            noSideEffects.removeCharacter(character)
+            withSideEffects.removeCharacter(character)
+        }
+
+        assertEquals(5, printWidthSideEffects.printed.size)
+        assertEquals("+A", printWidthSideEffects.printed[0])
+        assertEquals("+B", printWidthSideEffects.printed[1])
+        assertEquals("-B", printWidthSideEffects.printed[2])
+        assertEquals("+X", printWidthSideEffects.printed[3])
+        assertEquals("-A", printWidthSideEffects.printed[4])
+
+        assertEquals(6, printNoSideEffects.printed.size)
+        assertEquals("+A", printNoSideEffects.printed[0])
+        assertEquals("+B", printNoSideEffects.printed[1])
+        assertEquals("-B", printNoSideEffects.printed[2])
+        assertEquals("-A", printNoSideEffects.printed[3])
+        assertEquals("EMPTY", printNoSideEffects.printed[4])
+        assertEquals("+X", printNoSideEffects.printed[5])
+    }
+
+    private class ObservableCharactersWithoutSideEffects(
+        private val registry: ObserverRegistry<TestCharacterObserver> = ObserverRegistry()
+    ) : Observable<TestCharacterObserver> by registry, ObservableCharacters {
+        private val sideEffects = SideEffects()
+        private val characters: MutableList<Char> = mutableListOf()
+
+        override fun isEmpty(): Boolean = sideEffects.readWithLock { characters.isEmpty() }
+
+        override fun addCharacter(character: Char) = sideEffects.modifyWithoutSideEffects {
+            characters.add(character)
+            notifyObservers { onCharacterAdded(this@ObservableCharactersWithoutSideEffects, character) }
+        }
+
+        override fun removeCharacter(character: Char) = sideEffects.modifyWithoutSideEffects {
+            if (characters.remove(character)) {
+                notifyObservers { onCharacterRemoved(this@ObservableCharactersWithoutSideEffects, character) }
+            }
+        }
+    }
+
+    private class ObservableCharactersWithSideEffects(
+        private val registry: ObserverRegistry<TestCharacterObserver> = ObserverRegistry()
+    ) : Observable<TestCharacterObserver> by registry, ObservableCharacters {
+        private val characters: MutableList<Char> = mutableListOf()
+
+        override fun isEmpty(): Boolean = characters.isEmpty()
+
+        override fun addCharacter(character: Char) {
+            characters.add(character)
+            notifyObservers { onCharacterAdded(this@ObservableCharactersWithSideEffects, character) }
+        }
+
+        override fun removeCharacter(character: Char) {
+            if (characters.remove(character)) {
+                notifyObservers { onCharacterRemoved(this@ObservableCharactersWithSideEffects, character) }
+            }
+        }
+    }
+
+    private class NeverEmptyObserver : TestCharacterObserver {
+        override fun onCharacterAdded(observable: ObservableCharacters, character: Char) = Unit
+
+        override fun onCharacterRemoved(observable: ObservableCharacters, character: Char) {
+            if (observable.isEmpty()) {
+                observable.addCharacter('X')
+            }
+        }
+    }
+
+    private class TestPrintCharacterObserver : TestCharacterObserver {
+        var printed = mutableListOf<String>()
+
+        override fun onCharacterAdded(observable: ObservableCharacters, character: Char) {
+            printed.add("+$character")
+        }
+
+        override fun onCharacterRemoved(observable: ObservableCharacters, character: Char) {
+            printed.add("-$character")
+
+            if (observable.isEmpty()) {
+                printed.add("EMPTY")
+            }
+        }
+    }
+
+    private interface TestCharacterObserver {
+        fun onCharacterAdded(observable: ObservableCharacters, character: Char)
+        fun onCharacterRemoved(observable: ObservableCharacters, character: Char)
+    }
+
+    private interface ObservableCharacters {
+        fun isEmpty(): Boolean
+        fun addCharacter(character: Char)
+        fun removeCharacter(character: Char)
+    }
+}


### PR DESCRIPTION
This is a first version of a helper to fix the issue described in #400.

It's not used in any `Observable` yet. We may want to use it in `SessionManager` and `Session` but probably not `EngineSession` implementations because observers do not really modify the internal state.