### PR TITLE
Issue #464: Let app access a list of experiments

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -22,6 +22,12 @@ class Fretboard(
     private val evaluator = ExperimentEvaluator(valuesProvider)
 
     /**
+     * Provides the list of experiments (active or not)
+     */
+    val experiments: List<Experiment>
+        get() = experimentsResult.experiments.toList()
+
+    /**
      * Loads experiments from local storage
      */
     @Synchronized

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.fretboard
 
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -57,5 +59,35 @@ class FretboardTest {
         fretboard.updateExperiments()
         verify(experimentSource).getExperiments(ExperimentsSnapshot(listOf(Experiment("id0")), null))
         verify(experimentStorage).save(ExperimentsSnapshot(listOf(Experiment("id")), null))
+    }
+
+    @Test
+    fun testExperiments() {
+        val experimentSource = mock(ExperimentSource::class.java)
+        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experiments = listOf(
+            Experiment("first-id"),
+            Experiment("second-id")
+        )
+        `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(experiments, null))
+        val fretboard = Fretboard(experimentSource, experimentStorage)
+        var returnedExperiments = fretboard.experiments
+        assertEquals(0, returnedExperiments.size)
+        fretboard.loadExperiments()
+        returnedExperiments = fretboard.experiments
+        assertEquals(2, returnedExperiments.size)
+        assertTrue(returnedExperiments.contains(experiments[0]))
+        assertTrue(returnedExperiments.contains(experiments[1]))
+    }
+
+    @Test
+    fun testExperimentsNoExperiments() {
+        val experimentSource = mock(ExperimentSource::class.java)
+        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experiments = listOf<Experiment>()
+        `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(experiments, null))
+        val fretboard = Fretboard(experimentSource, experimentStorage)
+        val returnedExperiments = fretboard.experiments
+        assertEquals(0, returnedExperiments.size)
     }
 }


### PR DESCRIPTION
This pull request adds a `getExperiments` method, which returns a copy of the list of experiments (active or not).

Closes #464 