### PR TITLE
Issue #115: Core ping: Report experiments

### DIFF
--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
@@ -23,6 +23,7 @@ import org.mozilla.telemetry.storage.TelemetryStorage;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -186,6 +187,27 @@ public class Telemetry {
         final TelemetryCorePingBuilder builder = (TelemetryCorePingBuilder) pingBuilders.get(TelemetryCorePingBuilder.TYPE);
         builder.getSearchesMeasurement()
                 .recordSearch(location, identifier);
+
+        return this;
+    }
+
+    /**
+     * Records the list of active experiments
+     *
+     * @param activeExperimentsIds list of active experiments ids
+     */
+    public Telemetry recordActiveExperiments(List<String> activeExperimentsIds) {
+        if (!configuration.isCollectionEnabled()) {
+            return this;
+        }
+
+        if (!pingBuilders.containsKey(TelemetryCorePingBuilder.TYPE)) {
+            throw new IllegalStateException("This configuration does not contain a core ping builder");
+        }
+
+        final TelemetryCorePingBuilder builder = (TelemetryCorePingBuilder) pingBuilders.get(TelemetryCorePingBuilder.TYPE);
+        builder.getExperimentsMeasurement()
+                .setActiveExperiments(activeExperimentsIds);
 
         return this;
     }

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/ExperimentsMeasurement.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/ExperimentsMeasurement.java
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.measurement;
+
+import org.json.JSONArray;
+
+import java.util.List;
+
+public class ExperimentsMeasurement extends TelemetryMeasurement {
+    private static final String FIELD_NAME = "experiments";
+    private JSONArray experimentsIds;
+
+    public ExperimentsMeasurement() {
+        super(FIELD_NAME);
+        experimentsIds = new JSONArray();
+    }
+
+    public void setActiveExperiments(List<String> activeExperimentsIds) {
+        experimentsIds = new JSONArray(activeExperimentsIds);
+    }
+
+    @Override
+    public Object flush() {
+        return experimentsIds;
+    }
+}

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryCorePingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryCorePingBuilder.java
@@ -9,6 +9,7 @@ import org.mozilla.telemetry.measurement.ArchMeasurement;
 import org.mozilla.telemetry.measurement.CreatedDateMeasurement;
 import org.mozilla.telemetry.measurement.DefaultSearchMeasurement;
 import org.mozilla.telemetry.measurement.DeviceMeasurement;
+import org.mozilla.telemetry.measurement.ExperimentsMeasurement;
 import org.mozilla.telemetry.measurement.FirstRunProfileDateMeasurement;
 import org.mozilla.telemetry.measurement.LocaleMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemMeasurement;
@@ -35,6 +36,7 @@ public class TelemetryCorePingBuilder extends TelemetryPingBuilder {
     private SessionDurationMeasurement sessionDurationMeasurement;
     private DefaultSearchMeasurement defaultSearchMeasurement;
     private SearchesMeasurement searchesMeasurement;
+    private ExperimentsMeasurement experimentsMeasurement;
 
     public TelemetryCorePingBuilder(TelemetryConfiguration configuration) {
         super(configuration, TYPE, VERSION);
@@ -52,6 +54,7 @@ public class TelemetryCorePingBuilder extends TelemetryPingBuilder {
         addMeasurement(sessionCountMeasurement = new SessionCountMeasurement(configuration));
         addMeasurement(sessionDurationMeasurement = new SessionDurationMeasurement(configuration));
         addMeasurement(searchesMeasurement = new SearchesMeasurement(configuration));
+        addMeasurement(experimentsMeasurement = new ExperimentsMeasurement());
     }
 
     public SessionCountMeasurement getSessionCountMeasurement() {
@@ -68,6 +71,10 @@ public class TelemetryCorePingBuilder extends TelemetryPingBuilder {
 
     public DefaultSearchMeasurement getDefaultSearchMeasurement() {
         return defaultSearchMeasurement;
+    }
+
+    public ExperimentsMeasurement getExperimentsMeasurement() {
+        return experimentsMeasurement;
     }
 
     @Override

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/TelemetryTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/TelemetryTest.java
@@ -38,9 +38,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -94,6 +93,8 @@ public class TelemetryTest {
         Thread.sleep(2100);
         telemetry.recordSessionEnd();
 
+        telemetry.recordActiveExperiments(Arrays.asList("first-experiment-id", "second-experiment-id"));
+
         telemetry.queuePing(TelemetryCorePingBuilder.TYPE);
         telemetry.scheduleUpload();
 
@@ -126,9 +127,15 @@ public class TelemetryTest {
         assertTrue(object.has("tz"));
         assertTrue(object.has("sessions"));
         assertTrue(object.has("durations"));
+        assertTrue(object.has("experiments"));
 
         assertEquals(1, object.getInt("sessions"));
         assertTrue(object.getInt("durations") > 0);
+
+        final JSONArray experimentsArray = object.getJSONArray("experiments");
+        assertEquals(2, experimentsArray.length());
+        assertEquals("first-experiment-id", experimentsArray.get(0));
+        assertEquals("second-experiment-id", experimentsArray.get(1));
 
         server.shutdown();
     }


### PR DESCRIPTION
This pull request adds active experiments to telemetry core ping. It adds an `ExperimentsMeasurement` class and adds it to the `TelemetryCorePingBuilder`. It also adds a `recordActiveExperiments` method to the `Telemetry` class and tests it inside `TelemetryTest`, I think that's all that's needed in order for an app to provide such values.

Closes #115 