### PR TITLE
Issue #487: Fretboard: Add helper method to get active experiments

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -56,10 +56,10 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
     }
 
     private fun isInBucket(userBucket: Int, experiment: Experiment): Boolean {
-        return !(experiment.bucket?.min == null ||
-            userBucket < experiment.bucket.min ||
-            experiment.bucket.max == null ||
-            userBucket >= experiment.bucket.max)
+        return (experiment.bucket?.min == null ||
+            userBucket >= experiment.bucket.min) &&
+            (experiment.bucket?.max == null ||
+            userBucket < experiment.bucket.max)
     }
 
     private fun getUserBucket(context: Context): Int {

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -90,6 +90,17 @@ class Fretboard(
     }
 
     /**
+     * Provides the list of active experiments
+     *
+     * @param context context
+     *
+     * @return active experiments
+     */
+    fun getActiveExperiments(context: Context): List<Experiment> {
+        return experiments.filter { isInExperiment(context, ExperimentDescriptor(it.id)) }.toList()
+    }
+
+    /**
      * Overrides a specified experiment
      *
      * @param descriptor descriptor of the experiment


### PR DESCRIPTION
This pull request adds a helper method `getActiveExperiments` to `Fretboard` in order to get the list of currently active experiments.

Closes #487