### PR TITLE
Move FxA jnidispatch files to armeabi-v7a directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlin: '1.2.51',
         coroutines: '0.23.4',
         supportLibraries: '27.1.1',
-        fxa: '0.2.0',
+        fxa: '0.2.1',
         jna: '4.5.1',
         // Test only:
         junit: '4.12',

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -72,7 +72,7 @@ ext.jnaUnzip = { task, source, target ->
         into "$jniOutputDir/$target"
     }
 }
-task unzipJnaArm(type: Copy) { t -> jnaUnzip(t, "android-armv7", "armeabi") }
+task unzipJnaArm(type: Copy) { t -> jnaUnzip(t, "android-armv7", "armeabi-v7a") }
 task unzipJnaArm64(type: Copy) { t -> jnaUnzip(t, "android-aarch64", "arm64") }
 task unzipJnaX86(type: Copy) { t -> jnaUnzip(t, "android-x86", "x86") }
 


### PR DESCRIPTION
Blocked on https://github.com/mozilla/application-services/issues/128
Also requires a version update for the fxa client

cc @vladikoff @csadilek 