### PR TITLE
Closes #352: Expose tracking protection in session/engine

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import android.os.Handler
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -21,8 +22,10 @@ import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.gecko.util.ThreadUtils
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.ProgressDelegate.SecurityInformation
+import org.mozilla.geckoview.GeckoSessionSettings
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -253,5 +256,57 @@ class GeckoEngineSessionTest {
 
         engineSession.geckoSession.navigationDelegate.onLocationChange(null, "about:blank")
         assertEquals("about:blank", observedUrl)
+    }
+
+    @Test
+    fun testTrackingProtectionDelegateNotifiesObservers() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+
+        var trackerBlocked = ""
+        engineSession.register(object : EngineSession.Observer {
+            override fun onTrackerBlocked(url: String) {
+                trackerBlocked = url
+            }
+        })
+
+        engineSession.geckoSession.trackingProtectionDelegate.onTrackerBlocked(engineSession.geckoSession, "tracker1", 0)
+        assertEquals("tracker1", trackerBlocked)
+    }
+
+    @Test
+    fun testEnableTrackingProtection() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val engineSession = GeckoEngineSession(runtime)
+
+        var trackerBlockingEnabledObserved = false
+        engineSession.register(object : EngineSession.Observer {
+            override fun onTrackerBlockingEnabledChange(enabled: Boolean) {
+                trackerBlockingEnabledObserved = enabled
+            }
+        })
+
+        engineSession.enableTrackingProtection(TrackingProtectionPolicy.select(
+                TrackingProtectionPolicy.ANALYTICS, TrackingProtectionPolicy.AD))
+        assertTrue(trackerBlockingEnabledObserved)
+        assertTrue(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
+    }
+
+    @Test
+    fun testDisableTrackingProtection() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val engineSession = GeckoEngineSession(runtime)
+
+        var trackerBlockingDisabledObserved = false
+        engineSession.register(object : EngineSession.Observer {
+            override fun onTrackerBlockingEnabledChange(enabled: Boolean) {
+                trackerBlockingDisabledObserved = !enabled
+            }
+        })
+
+        engineSession.disableTrackingProtection()
+        assertTrue(trackerBlockingDisabledObserved)
+        Assert.assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -11,12 +11,14 @@ import org.mozilla.gecko.util.ThreadUtils
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoSessionSettings
 
 /**
  * Gecko-based EngineSession implementation.
  */
+@Suppress("TooManyFunctions")
 class GeckoEngineSession(
-    runtime: GeckoRuntime
+    private val runtime: GeckoRuntime
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
@@ -29,6 +31,7 @@ class GeckoEngineSession(
         geckoSession.navigationDelegate = createNavigationDelegate()
         geckoSession.progressDelegate = createProgressDelegate()
         geckoSession.contentDelegate = createContentDelegate()
+        geckoSession.trackingProtectionDelegate = createTrackingProtectionDelegate()
     }
 
     /**
@@ -206,6 +209,23 @@ class GeckoEngineSession(
         }
 
         override fun onFocusRequest(session: GeckoSession) = Unit
+    }
+
+    private fun createTrackingProtectionDelegate() = GeckoSession.TrackingProtectionDelegate {
+        session, uri, _ ->
+            session?.let { uri?.let { notifyObservers { onTrackerBlocked(it) } } }
+    }
+
+    override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION, true)
+        runtime.settings.trackingProtectionCategories = policy.categories
+        notifyObservers { onTrackerBlockingEnabledChange(true) }
+    }
+
+    override fun disableTrackingProtection() {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION, false)
+        runtime.settings.trackingProtectionCategories = TrackingProtectionPolicy.none().categories
+        notifyObservers { onTrackerBlockingEnabledChange(false) }
     }
 
     companion object {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -11,10 +11,12 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.utils.observer.Consumable
 
 internal class EngineObserver(val session: Session) : EngineSession.Observer {
+
     override fun onLocationChange(url: String) {
         session.url = url
         session.searchTerms = ""
         session.title = ""
+        session.trackersBlocked = emptyList()
     }
 
     override fun onTitleChange(title: String) {
@@ -37,6 +39,14 @@ internal class EngineObserver(val session: Session) : EngineSession.Observer {
     override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) {
         session.securityInfo = Session.SecurityInfo(secure, host
                 ?: "", issuer ?: "")
+    }
+
+    override fun onTrackerBlocked(url: String) {
+        session.trackersBlocked += url
+    }
+
+    override fun onTrackerBlockingEnabledChange(enabled: Boolean) {
+        session.trackerBlockingEnabled = enabled
     }
 
     override fun onExternalResource(

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -371,4 +371,46 @@ class SessionTest {
         assertTrue(session.title.isEmpty())
         assertEquals("", session.title)
     }
+
+    @Test
+    fun `observer is notified when tracker is blocked`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.trackersBlocked += "trackerUrl1"
+
+        verify(observer).onTrackerBlocked(
+                eq(session),
+                eq("trackerUrl1"),
+                eq(listOf("trackerUrl1")))
+
+        assertEquals(listOf("trackerUrl1"), session.trackersBlocked)
+
+        session.trackersBlocked += "trackerUrl2"
+
+        verify(observer).onTrackerBlocked(
+                eq(session),
+                eq("trackerUrl2"),
+                eq(listOf("trackerUrl1", "trackerUrl2")))
+
+        assertEquals(listOf("trackerUrl1", "trackerUrl2"), session.trackersBlocked)
+    }
+
+    @Test
+    fun `observer is notified when tracker blocking is enabled`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.trackerBlockingEnabled = true
+
+        verify(observer).onTrackerBlockingEnabledChanged(
+                eq(session),
+                eq(true))
+
+        assertTrue(session.trackerBlockingEnabled)
+    }
 }


### PR DESCRIPTION
This exposes tracking protection in our session/engine. It's currently only implemented for GeckoEngine. I suggest filing a follow-up for making this work with WebView so we can make some progress? 