### PR TITLE
Issue #493: Use WorkManager in fretboard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         supportLibraries: '27.1.1',
         fxa: '0.2.1',
         jna: '4.5.1',
+        workmanager: '1.0.0-alpha06',
         // Test only:
         junit: '4.12',
         robolectric: '3.8',

--- a/components/service/fretboard/build.gradle
+++ b/components/service/fretboard/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':support-ktx')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation "android.arch.work:work-runtime:${rootProject.ext.dependencies['workmanager']}"
 
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/workmanager/SyncWorker.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/workmanager/SyncWorker.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard.scheduler.workmanager
+
+import androidx.work.Worker
+import mozilla.components.service.fretboard.Fretboard
+
+abstract class SyncWorker : Worker() {
+    override fun doWork(): Result {
+        getFretboard().updateExperiments()
+        return Result.SUCCESS
+    }
+
+    /**
+     * Used to provide the instance of Fretboard
+     * the app is using
+     *
+     * @return current Fretboard instance
+     */
+    abstract fun getFretboard(): Fretboard
+}

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/workmanager/WorkManagerSyncScheduler.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/workmanager/WorkManagerSyncScheduler.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard.scheduler.workmanager
+
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import java.util.concurrent.TimeUnit
+
+/**
+ * Class used to schedule sync of experiment
+ * configuration from the server using WorkManager
+ */
+class WorkManagerSyncScheduler {
+    /**
+     * Schedule sync with the request specified
+     *
+     * @param request object with the sync request configuration
+     */
+    fun schedule(request: WorkRequest) {
+        WorkManager.getInstance().enqueue(request)
+    }
+
+    /**
+     * Schedule sync with the default constraints
+     * (once a day and charging)
+     *
+     * @param worker worker class
+     */
+    fun schedule(worker: Class<out SyncWorker>) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+        val syncWork = PeriodicWorkRequest.Builder(SyncWorker::class.java, 1, TimeUnit.DAYS)
+            .setConstraints(constraints)
+            .build()
+        schedule(syncWork)
+    }
+}


### PR DESCRIPTION
This pull request adds a possible implementation of a `WorkManager`-based scheduler for Fretboard. However, it is using the latest version (which is currently an alpha, 1.0.0-alpha05), and it adds a lot of transitive dependencies (as detailed by @pocmo on #493)

Closes #493