### PR TITLE
Issue #504: Fretboard: Require network for JobScheduler-based scheduler

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/jobscheduler/JobSchedulerSyncScheduler.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/jobscheduler/JobSchedulerSyncScheduler.kt
@@ -35,6 +35,7 @@ class JobSchedulerSyncScheduler(context: Context) {
     fun schedule(jobId: Int, serviceName: ComponentName) {
         val jobInfo = JobInfo.Builder(jobId, serviceName)
             .setPeriodic(TimeUnit.DAYS.toMillis(1))
+            .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
             .build()
         jobScheduler.schedule(jobInfo)
     }


### PR DESCRIPTION
This pull request adds network requirement for `JobScheduler`-based scheduler. I don't know if it might be useful to add more constraints, but it seems obvious to me we need at least the network connectivity requirement.

Closes #504