### PR TITLE
Update GeckoView Nightly to 2018.08.01 and GeckoView Beta to 62.0b13.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,16 +32,16 @@ buildscript {
     // Synchronized versions numbers of GeckoView (Nightly) artifacts.
     ext.geckoNightly = [
         // Discover nightly builds: https://tools.taskcluster.net/index/gecko.v2.mozilla-central.nightly
-        nightlyDate: '2018.07.24',
-        revision: '1e5fa52a612e8985e12212d1950a732954e00e45',
-        version: '63.0.20180724100046'
+        nightlyDate: '2018.08.01',
+        revision: 'af6a7edf0069549543f2fba6a8ee3ea251b20829',
+        version: '63.0.20180801100114'
     ]
 
     // Synchronized versions numbers of GeckoView (Beta) artifacts.
     ext.geckoBeta = [
-        // mozilla-beta: FENNEC_62_0b9_RELEASE
-        revision: 'd7ab2f3df0840cdb8557659afd46f61afa310379',
-        version: '62.0.20180713213322'
+        // mozilla-beta: FENNEC_62_0b13_RELEASE
+        revision: 'dd92dec96711e60a8c6a49ebe584fa23a453a292',
+        version: '62.0.20180730180407'
     ]
 
     ext.geckoRelease = [

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
 import org.mozilla.gecko.util.ThreadUtils
-import org.mozilla.geckoview.GeckoResponse
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoResult
@@ -117,13 +116,12 @@ class GeckoEngineSession(
         }
 
         override fun onLoadRequest(
-            session: GeckoSession?,
-            uri: String?,
+            session: GeckoSession,
+            uri: String,
             target: Int,
-            flags: Int,
-            response: GeckoResponse<Boolean>
-        ) {
-            response.respond(false)
+            flags: Int
+        ): GeckoResult<Boolean> {
+            return GeckoResult.fromValue(false)
         }
 
         override fun onCanGoForward(session: GeckoSession?, canGoForward: Boolean) {
@@ -135,10 +133,11 @@ class GeckoEngineSession(
         }
 
         override fun onNewSession(
-            session: GeckoSession?,
-            uri: String?,
-            response: GeckoResponse<GeckoSession>
-        ) {}
+            session: GeckoSession,
+            uri: String
+        ): GeckoResult<GeckoSession> {
+            return GeckoResult.fromValue(null)
+        }
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -106,6 +106,8 @@ class GeckoEngineSession(
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     private fun createNavigationDelegate() = object : GeckoSession.NavigationDelegate {
+        override fun onLoadError(session: GeckoSession?, uri: String?, category: Int, error: Int) = Unit
+
         override fun onLocationChange(session: GeckoSession?, url: String) {
             // Ignore initial load of about:blank (see https://github.com/mozilla-mobile/android-components/issues/403)
             if (initialLoad && url == ABOUT_BLANK) {
@@ -143,6 +145,10 @@ class GeckoEngineSession(
     * ProgressDelegate implementation for forwarding callbacks to observers of the session.
     */
     private fun createProgressDelegate() = object : GeckoSession.ProgressDelegate {
+        override fun onProgressChange(session: GeckoSession?, progress: Int) {
+            notifyObservers { onProgress(progress) }
+        }
+
         override fun onSecurityChange(
             session: GeckoSession?,
             securityInfo: GeckoSession.ProgressDelegate.SecurityInformation?


### PR DESCRIPTION
This Nightly includes the white screen fix for tab switching :)