### PR TITLE
Issue #541: Fretboard: ExperimentDescriptor should use the experiment name instead of the id

### DIFF
--- a/components/service/fretboard/README.md
+++ b/components/service/fretboard/README.md
@@ -98,10 +98,10 @@ And then you have to register it on the manifest, just like any other `JobServic
 ### Checking if a user is part of an experiment
 In order to check if a user is part of a specific experiment, Fretboard provides two APIs: a Kotlin-friendly
 `withExperiment` API and a more Java-like `isInExperiment`. In both cases you pass an instance of `ExperimentDescriptor`
-with the id of the experiment you want to check:
+with the name of the experiment you want to check:
 
 ```Kotlin
-val descriptor = ExperimentDescriptor("first-experiment-id")
+val descriptor = ExperimentDescriptor("first-experiment-name")
 fretboard.withExperiment(descriptor) {
     someButton.setBackgroundColor(Color.RED)
 }
@@ -110,11 +110,11 @@ otherButton.isEnabled = fretboard.isInExperiment(descriptor)
 ```
 
 ### Getting experiment metadata
-Fretboard allows experiments to carry associated metadata, which can be retrieved using the kotlin-friendly 
+Fretboard allows experiments to carry associated metadata, which can be retrieved using the Kotlin-friendly 
 `withExperiment` API or the more Java-like `getExperiment` API, like this:
 
 ```Kotlin
-val descriptor = ExperimentDescriptor("first-experiment-id")
+val descriptor = ExperimentDescriptor("first-experiment-name")
 fretboard.withExperiment(descriptor) {
     toolbar.setColor(Color.parseColor(it.payload?.get("color") as String))
 }
@@ -126,14 +126,14 @@ Fretboard allows you to force activate / deactivate a specific experiment via `s
 simply have to pass true to activate it, false to deactivate:
 
 ```Kotlin
-val descriptor = ExperimentDescriptor("first-experiment-id")
+val descriptor = ExperimentDescriptor("first-experiment-name")
 fretboard.setOverride(context, descriptor, true)
 ```
 
 You can also clear an override for an experiment or all overrides:
 
 ```Kotlin
-val descriptor = ExperimentDescriptor("first-experiment-id")
+val descriptor = ExperimentDescriptor("first-experiment-name")
 fretboard.clearOverride(context, descriptor)
 fretboard.clearAllOverrides(context)
 ```

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
@@ -17,7 +17,7 @@ data class Experiment(
     /**
      * Human-readable name of the experiment
      */
-    val name: String? = null,
+    val name: String,
     /**
      * Detailed description of the experiment
      */

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentDescriptor.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentDescriptor.kt
@@ -4,4 +4,4 @@
 
 package mozilla.components.service.fretboard
 
-data class ExperimentDescriptor(val id: String)
+data class ExperimentDescriptor(val name: String)

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -18,12 +18,12 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
         val experiment = getExperiment(experimentDescriptor, experiments) ?: return null
         val isEnabled = isInBucket(userBucket, experiment) && matches(context, experiment)
         context.getSharedPreferences(OVERRIDES_PREF_NAME, Context.MODE_PRIVATE).let {
-            return if (it.getBoolean(experimentDescriptor.id, isEnabled)) experiment else null
+            return if (it.getBoolean(experimentDescriptor.name, isEnabled)) experiment else null
         }
     }
 
     fun getExperiment(descriptor: ExperimentDescriptor, experiments: List<Experiment>): Experiment? {
-        return experiments.firstOrNull { it.id == descriptor.id }
+        return experiments.firstOrNull { it.name == descriptor.name }
     }
 
     private fun matches(context: Context, experiment: Experiment): Boolean {
@@ -73,14 +73,14 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
     fun setOverride(context: Context, descriptor: ExperimentDescriptor, active: Boolean) {
         context.getSharedPreferences(OVERRIDES_PREF_NAME, Context.MODE_PRIVATE)
             .edit()
-            .putBoolean(descriptor.id, active)
+            .putBoolean(descriptor.name, active)
             .apply()
     }
 
     fun clearOverride(context: Context, descriptor: ExperimentDescriptor) {
         context.getSharedPreferences(OVERRIDES_PREF_NAME, Context.MODE_PRIVATE)
             .edit()
-            .remove(descriptor.id)
+            .remove(descriptor.name)
             .apply()
     }
 

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -97,7 +97,7 @@ class Fretboard(
      * @return active experiments
      */
     fun getActiveExperiments(context: Context): List<Experiment> {
-        return experiments.filter { isInExperiment(context, ExperimentDescriptor(it.id)) }.toList()
+        return experiments.filter { isInExperiment(context, ExperimentDescriptor(it.name)) }.toList()
     }
 
     /**

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/JSONExperimentParser.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/JSONExperimentParser.kt
@@ -43,7 +43,7 @@ class JSONExperimentParser {
         val payloadJson: JSONObject? = jsonObject.optJSONObject(PAYLOAD_KEY)
         val payload = if (payloadJson != null) jsonToPayload(payloadJson) else null
         return Experiment(jsonObject.getString(ID_KEY),
-            jsonObject.tryGetString(NAME_KEY),
+            jsonObject.getString(NAME_KEY),
             jsonObject.tryGetString(DESCRIPTION_KEY),
             matcher,
             bucket,

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
@@ -47,7 +47,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -56,12 +56,12 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 21))
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 69))
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 19))
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 70))
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 71))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 21))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 69))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 19))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 70))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 71))
     }
 
     @Test
@@ -88,7 +88,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("other.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -97,9 +97,9 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
         `when`(context.packageName).thenReturn("test")
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -126,7 +126,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -135,7 +135,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
         experiment = Experiment(
             "testid",
             "testexperiment",
@@ -154,7 +154,7 @@ class ExperimentEvaluatorTest {
                 20
             ),
             1528916183)
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -181,7 +181,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -190,7 +190,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
 
         experiment = Experiment(
             "testid",
@@ -211,7 +211,7 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -238,7 +238,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -247,10 +247,10 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
 
         packageInfo.versionName = "other.version"
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -277,7 +277,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -286,7 +286,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
 
         experiment = Experiment(
             "testid",
@@ -307,7 +307,7 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -334,7 +334,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -343,7 +343,7 @@ class ExperimentEvaluatorTest {
         `when`(context.packageManager).thenReturn(packageManager)
 
         val evaluator = ExperimentEvaluator()
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
 
         experiment = Experiment(
             "testid",
@@ -364,7 +364,7 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -391,7 +391,7 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         `when`(context.packageName).thenReturn("test.appId")
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("testid"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val packageManager = mock(PackageManager::class.java)
         val packageInfo = PackageInfo()
@@ -405,7 +405,7 @@ class ExperimentEvaluatorTest {
             }
         })
 
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
 
         evaluator = ExperimentEvaluator(object : ValuesProvider() {
             override fun getRegion(context: Context): String? {
@@ -413,7 +413,7 @@ class ExperimentEvaluatorTest {
             }
         })
 
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testid"), listOf(experiment), 20))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("testexperiment"), listOf(experiment), 20))
     }
 
     @Test
@@ -423,29 +423,29 @@ class ExperimentEvaluatorTest {
         `when`(sharedPreferences.getBoolean(eq("id"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
-        val experiment = Experiment("id", bucket = Experiment.Bucket(100, 0))
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("id"), listOf(experiment), -1))
-        `when`(sharedPreferences.getBoolean(eq("id"), anyBoolean())).thenReturn(true)
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("id"), listOf(experiment), -1))
+        val experiment = Experiment("id", name = "name", bucket = Experiment.Bucket(100, 0))
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("name"), listOf(experiment), -1))
+        `when`(sharedPreferences.getBoolean(eq("name"), anyBoolean())).thenReturn(true)
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("name"), listOf(experiment), -1))
     }
 
     @Test
     fun testEvaluateDeactivateOverride() {
         val context = mock(Context::class.java)
         val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.getBoolean(eq("id"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(sharedPreferences.getBoolean(eq("name"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
-        val experiment = Experiment("id", bucket = Experiment.Bucket(100, 0))
-        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("id"), listOf(experiment), 50))
-        `when`(sharedPreferences.getBoolean(eq("id"), anyBoolean())).thenReturn(false)
-        assertNull(evaluator.evaluate(context, ExperimentDescriptor("id"), listOf(experiment), 50))
+        val experiment = Experiment("id", name = "name", bucket = Experiment.Bucket(100, 0))
+        assertNotNull(evaluator.evaluate(context, ExperimentDescriptor("name"), listOf(experiment), 50))
+        `when`(sharedPreferences.getBoolean(eq("name"), anyBoolean())).thenReturn(false)
+        assertNull(evaluator.evaluate(context, ExperimentDescriptor("name"), listOf(experiment), 50))
     }
 
     @Test
     fun testEvaluateNoExperimentSameAsDescriptor() {
-        val savedExperiment = Experiment("wrongid")
-        val descriptor = ExperimentDescriptor("testid")
+        val savedExperiment = Experiment("wrongid", name = "wrongname")
+        val descriptor = ExperimentDescriptor("testname")
         val context = mock(Context::class.java)
         assertNull(ExperimentEvaluator().evaluate(context, descriptor, listOf(savedExperiment), 20))
     }
@@ -459,8 +459,8 @@ class ExperimentEvaluatorTest {
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
-        evaluator.setOverride(context, ExperimentDescriptor("exp-id"), true)
-        verify(sharedPreferencesEditor).putBoolean("exp-id", true)
+        evaluator.setOverride(context, ExperimentDescriptor("exp-name"), true)
+        verify(sharedPreferencesEditor).putBoolean("exp-name", true)
     }
 
     @Test
@@ -468,12 +468,12 @@ class ExperimentEvaluatorTest {
         val context = mock(Context::class.java)
         val sharedPreferences = mock(SharedPreferences::class.java)
         val sharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
-        `when`(sharedPreferencesEditor.putBoolean(eq("exp-2-id"), anyBoolean())).thenReturn(sharedPreferencesEditor)
+        `when`(sharedPreferencesEditor.putBoolean(eq("exp-2-name"), anyBoolean())).thenReturn(sharedPreferencesEditor)
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
-        evaluator.setOverride(context, ExperimentDescriptor("exp-2-id"), false)
-        verify(sharedPreferencesEditor).putBoolean("exp-2-id", false)
+        evaluator.setOverride(context, ExperimentDescriptor("exp-2-name"), false)
+        verify(sharedPreferencesEditor).putBoolean("exp-2-name", false)
     }
 
     @Test
@@ -485,8 +485,8 @@ class ExperimentEvaluatorTest {
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
-        evaluator.clearOverride(context, ExperimentDescriptor("exp-id"))
-        verify(sharedPreferencesEditor).remove("exp-id")
+        evaluator.clearOverride(context, ExperimentDescriptor("exp-name"))
+        verify(sharedPreferencesEditor).remove("exp-name")
     }
 
     @Test

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentTest.kt
@@ -40,7 +40,7 @@ class ExperimentTest {
 
     @Test
     fun testHashCode() {
-        val experiment = Experiment("id")
+        val experiment = Experiment("id", "name")
         assertEquals(experiment.id.hashCode(), experiment.hashCode())
     }
 }

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
@@ -45,25 +45,25 @@ class FretboardTest {
     fun testUpdateExperimentsEmptyStorage() {
         val experimentSource = mock(ExperimentSource::class.java)
         val result = ExperimentsSnapshot(listOf(), null)
-        `when`(experimentSource.getExperiments(result)).thenReturn(ExperimentsSnapshot(listOf(Experiment("id")), null))
+        `when`(experimentSource.getExperiments(result)).thenReturn(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))
         val experimentStorage = mock(ExperimentStorage::class.java)
         `when`(experimentStorage.retrieve()).thenReturn(result)
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
         verify(experimentSource).getExperiments(result)
-        verify(experimentStorage).save(ExperimentsSnapshot(listOf(Experiment("id")), null))
+        verify(experimentStorage).save(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))
     }
 
     @Test
     fun testUpdateExperimentsFromStorage() {
         val experimentSource = mock(ExperimentSource::class.java)
-        `when`(experimentSource.getExperiments(ExperimentsSnapshot(listOf(Experiment("id0")), null))).thenReturn(ExperimentsSnapshot(listOf(Experiment("id")), null))
+        `when`(experimentSource.getExperiments(ExperimentsSnapshot(listOf(Experiment("id0", "name0")), null))).thenReturn(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))
         val experimentStorage = mock(ExperimentStorage::class.java)
-        `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(listOf(Experiment("id0")), null))
+        `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(listOf(Experiment("id0", "name0")), null))
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
-        verify(experimentSource).getExperiments(ExperimentsSnapshot(listOf(Experiment("id0")), null))
-        verify(experimentStorage).save(ExperimentsSnapshot(listOf(Experiment("id")), null))
+        verify(experimentSource).getExperiments(ExperimentsSnapshot(listOf(Experiment("id0", "name0")), null))
+        verify(experimentStorage).save(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))
     }
 
     @Test
@@ -71,8 +71,8 @@ class FretboardTest {
         val experimentSource = mock(ExperimentSource::class.java)
         val experimentStorage = mock(ExperimentStorage::class.java)
         val experiments = listOf(
-            Experiment("first-id"),
-            Experiment("second-id")
+            Experiment("first-id", "first-name"),
+            Experiment("second-id", "second-name")
         )
         `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(experiments, null))
         val fretboard = Fretboard(experimentSource, experimentStorage)
@@ -101,17 +101,26 @@ class FretboardTest {
         val experimentSource = mock(ExperimentSource::class.java)
         val experimentStorage = mock(ExperimentStorage::class.java)
         val experiments = listOf(
-            Experiment("first-id", match = Experiment.Matcher(
-                manufacturer = "manufacturer-1"
-            )),
-            Experiment("second-id", match = Experiment.Matcher(
-                manufacturer = "unknown",
-                appId = "test.appId"
-            )),
-            Experiment("third-id", match = Experiment.Matcher(
-                manufacturer = "unknown",
-                version = "version.name"
-            ))
+            Experiment("first-id",
+                name = "first-name",
+                match = Experiment.Matcher(
+                    manufacturer = "manufacturer-1"
+                )
+            ),
+            Experiment("second-id",
+                name = "second-name",
+                match = Experiment.Matcher(
+                    manufacturer = "unknown",
+                    appId = "test.appId"
+                )
+            ),
+            Experiment("third-id",
+                name = "third-name",
+                match = Experiment.Matcher(
+                    manufacturer = "unknown",
+                    version = "version.name"
+                )
+            )
         )
         `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(experiments, null))
         val fretboard = Fretboard(experimentSource, experimentStorage)

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/JSONExperimentParserTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/JSONExperimentParserTest.kt
@@ -50,13 +50,14 @@ class JSONExperimentParserTest {
 
     @Test
     fun testToJsonNullValues() {
-        val experiment = Experiment("id")
+        val experiment = Experiment("id", "name")
         val jsonObject = JSONExperimentParser().toJson(experiment)
         val buckets = jsonObject.getJSONObject("buckets")
         assertEquals(0, buckets.length())
         val match = jsonObject.getJSONObject("match")
         assertEquals(0, match.length())
         assertEquals("id", jsonObject.getString("id"))
+        assertEquals("name", jsonObject.getString("name"))
     }
 
     @Test
@@ -73,16 +74,16 @@ class JSONExperimentParserTest {
 
     @Test
     fun testFromJsonNonPresentValues() {
-        val json = """{"id":"id"}"""
-        assertEquals(Experiment("id"), JSONExperimentParser().fromJson(JSONObject(json)))
+        val json = """{"id":"id","name":"name"}"""
+        assertEquals(Experiment("id", "name"), JSONExperimentParser().fromJson(JSONObject(json)))
     }
 
     @Test
     fun testFromJsonNullValues() {
-        val json = """{"buckets":null,"name":null,"match":null,"description":null,"id":"sample-id","last_modified":null}"""
-        assertEquals(Experiment("sample-id"), JSONExperimentParser().fromJson(JSONObject(json)))
-        val emptyObjects = """{"id":"sample-id","buckets":{"min":null,"max":null},"match":{"lang":null,"appId":null,"region":null}}"""
-        assertEquals(Experiment("sample-id", bucket = Experiment.Bucket(), match = Experiment.Matcher()),
+        val json = """{"buckets":null,"name":"sample-name","match":null,"description":null,"id":"sample-id","last_modified":null}"""
+        assertEquals(Experiment("sample-id", "sample-name"), JSONExperimentParser().fromJson(JSONObject(json)))
+        val emptyObjects = """{"id":"sample-id","name":"sample-name","buckets":{"min":null,"max":null},"match":{"lang":null,"appId":null,"region":null}}"""
+        assertEquals(Experiment("sample-id", name = "sample-name", bucket = Experiment.Bucket(), match = Experiment.Matcher()),
             JSONExperimentParser().fromJson(JSONObject(emptyObjects)))
     }
 
@@ -105,7 +106,7 @@ class JSONExperimentParserTest {
         payload.put("c", 3.5)
         payload.put("d", true)
         payload.put("e", listOf(1, 2, 3, 4))
-        val experiment = Experiment("id", payload = payload)
+        val experiment = Experiment("id", name = "name", payload = payload)
         val json = JSONExperimentParser().toJson(experiment)
         val payloadJson = json.getJSONObject("payload")
         assertEquals("a", payloadJson.getString("a"))


### PR DESCRIPTION
This pull request makes `ExperimentDescriptor` use the experiment name instead of the id, and due to that it also makes the `name` property non-null.

Closes #541