### PR TITLE
Issue #517 - Switch to published AAR for JNA.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         coroutines: '0.23.4',
         supportLibraries: '27.1.1',
         fxa: '0.2.1',
-        jna: '4.5.1',
+        jna: '4.5.2',
         // Test only:
         junit: '4.12',
         robolectric: '3.8',

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -33,31 +33,38 @@ repositories {
             artifact '/project.fxaclient.builds.[revision]/artifacts/public/bin/[organisation]/[module]_[revision].[ext]'
         }
     }
-
-    ivy {
-        url 'https://github.com/'
-        layout 'pattern', {
-            artifact '/java-native-access/[organisation]/raw/[revision]/dist/[module].[ext]'
-        }
-    }
 }
 
-configurations{
+configurations {
     fxa
-    jna
+
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
 }
 
 dependencies {
+    jnaForTest "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}@jar"
+
     fxa "mozilla:fxa_client_android:${rootProject.ext.dependencies['fxa']}@zip"
     fxa "mozilla:fxa_client_android_deps:${rootProject.ext.dependencies['fxa']}@zip"
-    jna "jna:android-armv7:${rootProject.ext.dependencies['jna']}@jar"
-    jna "jna:android-aarch64:${rootProject.ext.dependencies['jna']}@jar"
-    jna "jna:android-x86:${rootProject.ext.dependencies['jna']}@jar"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}"
+    implementation "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}@aar"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
 
+    testImplementation files(configurations.jnaForTest.files)
     testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
     testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
     testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
@@ -65,18 +72,7 @@ dependencies {
 
 ext.jniOutputDir = "src/main/jniLibs"
 
-ext.jnaUnzip = { task, source, target ->
-    configure(task) {
-        from zipTree(configurations.jna.find { it.name.startsWith(source) })
-        include 'libjnidispatch.so'
-        into "$jniOutputDir/$target"
-    }
-}
-task unzipJnaArm(type: Copy) { t -> jnaUnzip(t, "android-armv7", "armeabi-v7a") }
-task unzipJnaArm64(type: Copy) { t -> jnaUnzip(t, "android-aarch64", "arm64") }
-task unzipJnaX86(type: Copy) { t -> jnaUnzip(t, "android-x86", "x86") }
-
-task unzipFxaLibs(dependsOn: [unzipJnaArm, unzipJnaArm64, unzipJnaX86], type: Copy) {
+task unzipFxaLibs(type: Copy) {
     from configurations.fxa.files.collect { zipTree(it) }
     into jniOutputDir
 }


### PR DESCRIPTION
This allows a consuming application to use multiple libraries that
transitively depend on JNA (@aar type).

Tested by:

- bumping the android-components version
- `./gradlew :service-firefox-accounts:install` to install bumped version locally
- adding `repository { mavenLocal() }` to consuming application
- requiring bumped version in consuming application

This special `jnaForTest` construction is not necessary when invoking
tests with Gradle; it is necessary when invoking tests with Android
Studio.  This is lifted from Mentat, where I initially worked out
these details -- see
https://github.com/mozilla/mentat/blob/f8478835a2052a0857f1052105676747fdd2cc6e/sdks/android/Mentat/library/build.gradle#L71-L89.