### PR TITLE
Download statically linked fxa library

### DIFF
--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     jnaForTest "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}@jar"
 
     fxa "mozilla:fxa_client_android:${rootProject.ext.dependencies['fxa']}@zip"
-    fxa "mozilla:fxa_client_android_deps:${rootProject.ext.dependencies['fxa']}@zip"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
     implementation "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}@aar"

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaClient.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaClient.kt
@@ -18,8 +18,6 @@ internal interface FxaClient : Library {
 
         init {
             try {
-                System.loadLibrary("crypto")
-                System.loadLibrary("ssl")
                 System.loadLibrary("fxa_client")
                 INSTANCE = Native.loadLibrary(JNA_LIBRARY_NAME, FxaClient::class.java) as FxaClient
             } catch (e: UnsatisfiedLinkError) {


### PR DESCRIPTION
Following https://github.com/mozilla/application-services/issues/172, `openssl` is now baked into `fxa` and we don't generate the dependencies zip file anymore.