### PR TITLE
Issue #604: Add Engine ability to stop loading

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -41,6 +41,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.stopLoading]
+     */
+    override fun stopLoading() {
+        geckoSession.stop()
+    }
+
+    /**
      * See [EngineSession.reload]
      */
     override fun reload() {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -119,6 +119,19 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun testStopLoading() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        var stopLoadingReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(
+                BundleEventListener { _, _, _ -> stopLoadingReceived = true },
+                "GeckoView:Stop"
+        )
+
+        engineSession.stopLoading()
+        assertTrue(stopLoadingReceived)
+    }
+
+    @Test
     fun testReload() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
         engineSession.loadUrl("http://mozilla.org")

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -42,6 +42,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.stopLoading]
+     */
+    override fun stopLoading() {
+        geckoSession.stop()
+    }
+
+    /**
      * See [EngineSession.reload]
      */
     override fun reload() {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -142,6 +142,19 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun testStopLoading() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        var stopLoadingReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(
+                BundleEventListener { _, _, _ -> stopLoadingReceived = true },
+                "GeckoView:Stop"
+        )
+
+        engineSession.stopLoading()
+        assertTrue(stopLoadingReceived)
+    }
+
+    @Test
     fun testReload() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
         engineSession.loadUrl("http://mozilla.org")

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -41,6 +41,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.stopLoading]
+     */
+    override fun stopLoading() {
+        geckoSession.stop()
+    }
+
+    /**
      * See [EngineSession.reload]
      */
     override fun reload() {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -118,6 +118,19 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun testStopLoading() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        var stopLoadingReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(
+                BundleEventListener { _, _, _ -> stopLoadingReceived = true },
+                "GeckoView:Stop"
+        )
+
+        engineSession.stopLoading()
+        assertTrue(stopLoadingReceived)
+    }
+
+    @Test
     fun testReload() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
         engineSession.loadUrl("http://mozilla.org")

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -33,6 +33,13 @@ class SystemEngineSession : EngineSession() {
     }
 
     /**
+     * See [EngineSession.stopLoading]
+     */
+    override fun stopLoading() {
+        currentView()?.stopLoading()
+    }
+
+    /**
      * See [EngineSession.reload]
      */
     override fun reload() {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -7,10 +7,12 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.never
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -40,6 +42,10 @@ class SystemEngineSessionTest {
     fun testLoadUrl() {
         val engineSession = spy(SystemEngineSession())
         val webView = mock(WebView::class.java)
+
+        engineSession.loadUrl("")
+        verify(webView, never()).loadUrl(anyString())
+
         `when`(engineSession.currentView()).thenReturn(webView)
 
         engineSession.loadUrl("http://mozilla.org")
@@ -47,9 +53,27 @@ class SystemEngineSessionTest {
     }
 
     @Test
+    fun testStopLoading() {
+        val engineSession = spy(SystemEngineSession())
+        val webView = mock(WebView::class.java)
+
+        engineSession.stopLoading()
+        verify(webView, never()).stopLoading()
+
+        `when`(engineSession.currentView()).thenReturn(webView)
+
+        engineSession.stopLoading()
+        verify(webView).stopLoading()
+    }
+
+    @Test
     fun testReload() {
         val engineSession = spy(SystemEngineSession())
         val webView = mock(WebView::class.java)
+
+        engineSession.reload()
+        verify(webView, never()).reload()
+
         `when`(engineSession.currentView()).thenReturn(webView)
 
         engineSession.reload()
@@ -60,6 +84,10 @@ class SystemEngineSessionTest {
     fun testGoBack() {
         val engineSession = spy(SystemEngineSession())
         val webView = mock(WebView::class.java)
+
+        engineSession.goBack()
+        verify(webView, never()).goBack()
+
         `when`(engineSession.currentView()).thenReturn(webView)
 
         engineSession.goBack()
@@ -70,6 +98,10 @@ class SystemEngineSessionTest {
     fun testSaveState() {
         val engineSession = spy(SystemEngineSession())
         val webView = mock(WebView::class.java)
+
+        engineSession.saveState()
+        verify(webView, never()).saveState(any(Bundle::class.java))
+
         `when`(engineSession.currentView()).thenReturn(webView)
 
         engineSession.saveState()
@@ -80,6 +112,10 @@ class SystemEngineSessionTest {
     fun testRestoreState() {
         val engineSession = spy(SystemEngineSession())
         val webView = mock(WebView::class.java)
+
+        engineSession.restoreState(emptyMap())
+        verify(webView, never()).restoreState(any(Bundle::class.java))
+
         `when`(engineSession.currentView()).thenReturn(webView)
 
         engineSession.restoreState(emptyMap())

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -21,6 +21,7 @@ class EngineObserverTest {
             override fun goBack() {}
             override fun goForward() {}
             override fun reload() {}
+            override fun stopLoading() {}
             override fun restoreState(state: Map<String, Any>) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
@@ -52,6 +53,7 @@ class EngineObserverTest {
         val engineSession = object : EngineSession() {
             override fun goBack() {}
             override fun goForward() {}
+            override fun stopLoading() {}
             override fun reload() {}
             override fun restoreState(state: Map<String, Any>) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
@@ -83,6 +85,7 @@ class EngineObserverTest {
         val engineSession = object : EngineSession() {
             override fun goBack() {}
             override fun goForward() {}
+            override fun stopLoading() {}
             override fun reload() {}
             override fun restoreState(state: Map<String, Any>) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -66,6 +66,11 @@ abstract class EngineSession(
     abstract fun loadUrl(url: String)
 
     /**
+     * Stops loading the current session.
+     */
+    abstract fun stopLoading()
+
+    /**
      * Reloads the current URL.
      */
     abstract fun reload()

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -180,6 +180,8 @@ open class DummyEngineSession : EngineSession() {
 
     override fun loadUrl(url: String) {}
 
+    override fun stopLoading() {}
+
     override fun reload() {}
 
     override fun goBack() {}

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -43,6 +43,19 @@ class SessionUseCases(
         }
     }
 
+    class StopLoadingUseCase internal constructor(
+        private val sessionManager: SessionManager
+    ) {
+        /**
+         * Stops the current URL of the provided session from loading.
+         *
+         * @param session the session for which loading should be stopped.
+         */
+        fun invoke(session: Session = sessionManager.selectedSessionOrThrow) {
+            sessionManager.getOrCreateEngineSession(session).stopLoading()
+        }
+    }
+
     class GoBackUseCase internal constructor(
         private val sessionManager: SessionManager
     ) {
@@ -67,6 +80,7 @@ class SessionUseCases(
 
     val loadUrl: LoadUrlUseCase by lazy { LoadUrlUseCase(sessionManager) }
     val reload: ReloadUrlUseCase by lazy { ReloadUrlUseCase(sessionManager) }
+    val stopLoading: StopLoadingUseCase by lazy { StopLoadingUseCase(sessionManager) }
     val goBack: GoBackUseCase by lazy { GoBackUseCase(sessionManager) }
     val goForward: GoForwardUseCase by lazy { GoForwardUseCase(sessionManager) }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -52,6 +52,20 @@ class SessionUseCasesTest {
     }
 
     @Test
+    fun testStopLoading() {
+        val engineSession = mock(EngineSession::class.java)
+        val session = mock(Session::class.java)
+        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        useCases.stopLoading.invoke(session)
+        verify(engineSession).stopLoading()
+
+        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        useCases.stopLoading.invoke()
+        verify(selectedEngineSession).stopLoading()
+    }
+
+    @Test
     fun testGoBack() {
         useCases.goBack.invoke()
         verify(selectedEngineSession).goBack()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -89,7 +89,14 @@ class Components(private val applicationContext: Context) {
             sessionUseCases.reload.invoke()
         }
 
-        BrowserMenuItemToolbar(listOf(forward, refresh))
+        val stop = BrowserMenuItemToolbar.Button(
+                mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
+                iconTintColorResource = R.color.photonBlue90,
+                contentDescription = "Stop") {
+            sessionUseCases.stopLoading.invoke()
+        }
+
+        BrowserMenuItemToolbar(listOf(forward, refresh, stop))
     }
 
     // Tabs


### PR DESCRIPTION
Adds the ability to stop loading a session that would have already started.

Some considerations were made about whether `EngineSession.Observer#onLoadingStateChanged` should be called. In our current System Engine and Gecko Engine there isn't any explicit callback for handling a stop loading event so there wouldn't be any way to do this. 