### PR TITLE
Severin/fix keyboard desync

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -470,8 +470,16 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                     // are deleting, we should delete the autocomplete text first.
                     // Make the IME aware that we interrupted the deleteSurroundingText call,
                     // by restarting the IME.
-                    val imm = ctx.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                    imm.restartInput(this@InlineAutocompleteEditText)
+                    post {
+                        // On some devices this method can lead to race conditions (see Javadoc on
+                        // [InputConnection#deleteSurroundingText], and in at least one case this
+                        // caused our soft keyboard to desynchronize from its backing EditText.
+                        //
+                        // It is not known exactly how this method interacts with platform code
+                        // to create problems, but posting has resolved the reported issue.
+                        val imm = ctx.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                        imm.restartInput(this@InlineAutocompleteEditText)
+                    }
                     return false
                 }
                 return super.deleteSurroundingText(beforeLength, afterLength)

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -28,6 +28,7 @@ import org.robolectric.annotation.Config
 
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.Companion.AUTOCOMPLETE_SPAN
+import org.mockito.ArgumentMatchers.any
 
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class)
@@ -320,6 +321,17 @@ class InlineAutocompleteEditTextTest {
         icw?.setComposingText("text", 4)
         assertEquals(AutocompleteResult.emptyResult(), et.autocompleteResult)
         assertEquals("text", et.text.toString())
+    }
+
+    @Test
+    fun testPostIsCalledWhenAutocompletedTextIsDeleted() {
+        val et = spy(InlineAutocompleteEditText(context, attributes))
+        val icw = et.onCreateInputConnection(mock(EditorInfo::class.java))
+
+        et.setText("text")
+        et.applyAutocompleteResult(AutocompleteResult("text completed", "source", 1))
+        icw?.deleteSurroundingText(0, 1)
+        verify(et).post(any<Runnable>())
     }
 
     @Test


### PR DESCRIPTION
This fixes a bug we're seeing on Fire TV, where certain actions will cause our EditText to desynchronize from the soft keyboard.
