### PR TITLE
Closes #516: Add JNA-specific proguard rules for consumers of FxA service

### DIFF
--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -22,6 +22,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules-consumer.pro'
         }
     }
 }

--- a/components/service/firefox-accounts/proguard-rules-consumer.pro
+++ b/components/service/firefox-accounts/proguard-rules-consumer.pro
@@ -1,0 +1,7 @@
+# ProGuard rules for consumers of this library.
+
+# JNA specific rules
+# See https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
+-dontwarn java.awt.*
+-keep class com.sun.jna.* { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }


### PR DESCRIPTION
These rules are being applied for library consumers. Easy way to test this is to activate proguard in our sample-firefox-accounts app and run `gradle clean assembleRelease`. This will fail without these changes and pass with them. So, adding this so that consumers don't have to.