### PR TITLE
Issue #622: browser-toolbar: Do not use ui-progress due to high CPU usage.

### DIFF
--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
     api project(':ui-autocomplete')
     implementation project(':ui-icons')
-    implementation project(':ui-progress')
 
     implementation project(':support-ktx')
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -20,7 +21,6 @@ import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.ktx.android.view.dp
 import mozilla.components.support.ktx.android.view.isVisible
-import mozilla.components.ui.progress.AnimatedProgressBar
 
 /**
  * Sub-component of the browser toolbar responsible for displaying the URL and related controls.
@@ -56,6 +56,7 @@ import mozilla.components.ui.progress.AnimatedProgressBar
  *
  */
 @SuppressLint("ViewConstructor") // This view is only instantiated in code
+@Suppress("LargeClass")
 internal class DisplayToolbar(
     context: Context,
     val toolbar: BrowserToolbar
@@ -114,7 +115,11 @@ internal class DisplayToolbar(
         }
     }
 
-    private val progressView = AnimatedProgressBar(context)
+    private val progressView = ProgressBar(
+        context, null, android.R.attr.progressBarStyleHorizontal
+    ).apply {
+        visibility = View.GONE
+    }
 
     private val browserActions: MutableList<DisplayAction> = mutableListOf()
     private val pageActions: MutableList<DisplayAction> = mutableListOf()

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -9,12 +9,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.ktx.android.view.forEach
-import mozilla.components.ui.progress.AnimatedProgressBar
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -565,11 +565,11 @@ class DisplayToolbarTest {
             return textView ?: throw AssertionError("Could not find URL view")
         }
 
-        private fun extractProgressView(displayToolbar: DisplayToolbar): AnimatedProgressBar {
-            var progressView: AnimatedProgressBar? = null
+        private fun extractProgressView(displayToolbar: DisplayToolbar): ProgressBar {
+            var progressView: ProgressBar? = null
 
             displayToolbar.forEach {
-                if (it is AnimatedProgressBar) {
+                if (it is ProgressBar) {
                     progressView = it
                     return@forEach
                 }


### PR DESCRIPTION
That's the quickest fix for 0.19.1. The app that wants to ship with `browser-toolbar` doesn't even use the integrated progress bar - so let's replace it with the system one for now. I filed a new issue in 0.20 to look at the CPU usage issues in `ui-progress`.