### PR TITLE
Issue #631: Reduce CPU usage of ui-progress when idling.

### DIFF
--- a/components/ui/progress/src/main/java/mozilla/components/ui/progress/AnimatedProgressBar.kt
+++ b/components/ui/progress/src/main/java/mozilla/components/ui/progress/AnimatedProgressBar.kt
@@ -103,6 +103,11 @@ class AnimatedProgressBar @JvmOverloads constructor(
 
     private fun setVisibilityImmediately(value: Int) {
         super.setVisibility(value)
+
+        progressDrawable?.also {
+            // Update the visibility state of the drawable too to start/stop animating it.
+            it.setVisible(value == View.VISIBLE, true)
+        }
     }
 
     internal fun animateClosing() {
@@ -159,6 +164,12 @@ class AnimatedProgressBar @JvmOverloads constructor(
             progressDrawable = resources.getDrawable(R.drawable.mozac_progressbar, context.theme)
         }
         progressDrawable = buildWrapDrawable(progressDrawable, wrap, duration, resID)
+
+        if (progress == 0) {
+            // If the progress is 0 then we set the view to GONE immediately to avoid animating the
+            // invisible progress.
+            setVisibilityImmediately(View.GONE)
+        }
 
         a.recycle()
     }

--- a/components/ui/progress/src/main/java/mozilla/components/ui/progress/ShiftDrawable.kt
+++ b/components/ui/progress/src/main/java/mozilla/components/ui/progress/ShiftDrawable.kt
@@ -31,19 +31,15 @@ internal class ShiftDrawable @JvmOverloads constructor(
                 invalidateSelf()
             }
         }
-        animator.start()
     }
 
     override fun setVisible(visible: Boolean, restart: Boolean): Boolean {
-        val result = super.setVisible(visible, restart)
-
-        if (isVisible) {
-            animator.start()
-        } else {
-            animator.end()
+        return super.setVisible(visible, restart).also { isDifferent ->
+            when {
+                isDifferent && visible -> animator.start()
+                isDifferent && !visible -> animator.end()
+            }
         }
-
-        return result
     }
 
     override fun onBoundsChange(bounds: Rect) {


### PR DESCRIPTION
This fixes the high CPU usage when idling. We should still merge #632. However we could land this one in 0.19.1 too because it will help Focus (and potentially Rocket if they want/can switch to the component version of the progress bar).