### PR TITLE
Build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    // Synchronized version numbers for dependencies used by (some) modules
-    ext.dependencies = [
-        kotlin: '1.2.60',
-        coroutines: '0.23.4',
-        supportLibraries: '27.1.1',
-        fxa: '0.2.3',
-        jna: '4.5.2',
-        // Test only:
-        junit: '4.12',
-        robolectric: '3.8',
-        mockito: '2.19.0',
-        mockwebserver: '3.10.0',
-        // Docs only"
-        dokka: '0.9.16'
-    ]
-
-    // Synchronized build configuration for all modules
-    ext.build = [
-        compileSdkVersion: 27,
-        targetSdkVersion: 27,
-        minSdkVersion: 21
-    ]
-
-    // Synchronized library configuration for all modules
-    ext.library = [
-        version: '0.20'
-    ]
-
     // Synchronized versions numbers of GeckoView (Nightly) artifacts.
     ext.geckoNightly = [
         // Discover nightly builds: https://tools.taskcluster.net/index/gecko.v2.mozilla-central.nightly
@@ -54,13 +26,13 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${project.ext.dependencies['kotlin']}"
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:${project.ext.dependencies['dokka']}"
+        classpath Deps.tools_androidgradle
+        classpath Deps.tools_kotlingradle
+        classpath Deps.tools_dokka
 
         // Publish.
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath Deps.tools_bintray
+        classpath Deps.tools_mavengradle
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+plugins {
+    `kotlin-dsl`
+}

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+object Config {
+    // Synchronized library configuration for all modules
+    const val componentsVersion = "0.20"
+
+    // Synchronized build configuration for all modules
+    const val compileSdkVersion = 27
+    const val minSdkVersion = 21
+    const val targetSdkVersion = 27
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Synchronized version numbers for dependencies used by (some) modules
+private object Versions {
+    const val kotlin = "1.2.60"
+    const val coroutines = "0.23.4"
+
+    const val junit = "4.12"
+    const val robolectric = "3.8"
+    const val mockito = "2.19.0"
+    const val mockwebserver = "3.10.0"
+
+    const val support_libraries = "27.1.1"
+    const val constraint_layout = "1.1.2"
+
+    const val dokka = "0.9.16"
+    const val android_gradle_plugin = "3.1.3"
+    const val bintray_gradle_plugin = "1.7.3"
+    const val maven_gradle_plugin = "2.1"
+    const val lint = "26.1.3"
+
+    const val jna = "4.5.2"
+
+    const val fxa = "0.2.3"
+}
+
+// Synchronized dependencies used by (some) modules
+object Deps {
+    const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
+    const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
+
+    const val testing_junit = "junit:junit:${Versions.junit}"
+    const val testing_robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
+    const val testing_mockito = "org.mockito:mockito-core:${Versions.mockito}"
+    const val testing_mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.mockwebserver}"
+
+    const val support_annotations = "com.android.support:support-annotations:${Versions.support_libraries}"
+    const val support_cardview = "com.android.support:cardview-v7:${Versions.support_libraries}"
+    const val support_recyclerview = "com.android.support:recyclerview-v7:${Versions.support_libraries}"
+    const val support_appcompat = "com.android.support:appcompat-v7:${Versions.support_libraries}"
+    const val support_customtabs = "com.android.support:customtabs:${Versions.support_libraries}"
+    const val support_fragment = "com.android.support:support-fragment:${Versions.support_libraries}"
+    const val support_constraintlayout = "com.android.support.constraint:constraint-layout:${Versions.constraint_layout}"
+    const val support_compat = "com.android.support:support-compat:${Versions.support_libraries}"
+
+    const val tools_dokka = "org.jetbrains.dokka:dokka-android-gradle-plugin:${Versions.dokka}"
+    const val tools_androidgradle = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
+    const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
+    const val tools_bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:${Versions.bintray_gradle_plugin}"
+    const val tools_mavengradle = "com.github.dcendents:android-maven-gradle-plugin:${Versions.maven_gradle_plugin}"
+
+    const val tools_lint = "com.android.tools.lint:lint:${Versions.lint}"
+    const val tools_lintapi = "com.android.tools.lint:lint-api:${Versions.lint}"
+    const val tools_linttests = "com.android.tools.lint:lint-tests:${Versions.lint}"
+
+    const val mozilla_fxa = "mozilla:fxa_client_android:${Versions.fxa}@zip"
+
+    const val jna = "net.java.dev.jna:jna:${Versions.jna}@aar"
+    const val jnaForTest = "net.java.dev.jna:jna:${Versions.jna}@jar"
+}

--- a/components/browser/domains/build.gradle
+++ b/components/browser/domains/build.gradle
@@ -6,15 +6,15 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-    
+
     buildTypes {
         release {
             minifyEnabled false
@@ -24,12 +24,12 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "domains"

--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -30,13 +30,12 @@ dependencies {
     compileOnly "org.mozilla:geckoview-beta-armeabi-v7a:${rootProject.ext.geckoBeta['version']}"
     testImplementation "org.mozilla:geckoview-beta-armeabi-v7a:${rootProject.ext.geckoBeta['version']}"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
-    testImplementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "engine-gecko-beta"

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -30,14 +30,14 @@ dependencies {
     compileOnly "org.mozilla:geckoview-nightly-armeabi-v7a:${rootProject.ext.geckoNightly['version']}"
     testImplementation "org.mozilla:geckoview-nightly-armeabi-v7a:${rootProject.ext.geckoNightly['version']}"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
-    testImplementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
 }
 
 archivesBaseName = "engine-gecko-nightly"

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -30,13 +30,12 @@ dependencies {
     compileOnly "org.mozilla:geckoview-release-armeabi-v7a:${rootProject.ext.geckoRelease['version']}"
     testImplementation "org.mozilla:geckoview-release-armeabi-v7a:${rootProject.ext.geckoRelease['version']}"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
-    testImplementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "engine-gecko"

--- a/components/browser/engine-system/build.gradle
+++ b/components/browser/engine-system/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     lintOptions {
@@ -31,12 +31,13 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "engine-system"

--- a/components/browser/errorpages/build.gradle
+++ b/components/browser/errorpages/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -32,9 +32,9 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_annotations
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 }
 
 archivesBaseName = "errorpages"

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
     
     buildTypes {
@@ -24,15 +24,15 @@ android {
 dependencies {
     implementation project(':support-ktx')
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:recyclerview-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:cardview-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
+    implementation Deps.support_recyclerview
+    implementation Deps.support_cardview
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "menu"

--- a/components/browser/search/build.gradle
+++ b/components/browser/search/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -35,12 +35,12 @@ android {
 dependencies {
     implementation project(':support-ktx')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "search"

--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -26,17 +26,18 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':support-ktx')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "com.android.support:customtabs:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.support_customtabs
 
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "utils".
     api project(':support-base')
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "session"

--- a/components/browser/tabstray/build.gradle
+++ b/components/browser/tabstray/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     lintOptions {
@@ -32,16 +32,17 @@ dependencies {
     implementation project(':ui-icons')
     implementation project(':ui-colors')
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:cardview-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    api "com.android.support:recyclerview-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
+    implementation Deps.support_cardview
+    api Deps.support_recyclerview
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "tabstray"

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -31,13 +31,12 @@ dependencies {
 
     implementation project(':support-ktx')
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
+    implementation Deps.kotlin_stdlib
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "toolbar"

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -22,17 +22,17 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_annotations
 
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "base".
     api project(':support-base')
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "engine"

--- a/components/concept/tabstray/build.gradle
+++ b/components/concept/tabstray/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -25,7 +25,7 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':support-base')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 }
 
 archivesBaseName = "concept-tabstray"

--- a/components/concept/toolbar/build.gradle
+++ b/components/concept/toolbar/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -22,13 +22,13 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_annotations
+    implementation Deps.support_appcompat
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
 }
 
 archivesBaseName = "abstract-toolbar"

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -28,11 +28,11 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':concept-engine')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "feature-search"

--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -26,12 +26,13 @@ dependencies {
     implementation project(':concept-engine')
     implementation project(':support-utils')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
-    testImplementation "com.android.support:customtabs:${rootProject.ext.dependencies['supportLibraries']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+
+    testImplementation Deps.support_customtabs
 }
 
 archivesBaseName = "feature-session"

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -31,19 +31,20 @@ dependencies {
     implementation project(':ui-icons')
     implementation project(':support-ktx')
 
-    implementation "com.android.support:support-fragment:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:recyclerview-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_fragment
+    implementation Deps.support_recyclerview
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
     // In tests we are constructing our own SessionManager instance which needs to know about an "engine".
     testImplementation project(':concept-engine')
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "feature-tabs"

--- a/components/feature/toolbar/build.gradle
+++ b/components/feature/toolbar/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -28,7 +28,7 @@ dependencies {
 
     implementation project(':support-ktx')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 }
 
 archivesBaseName = "feature-toolbar"

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     lintOptions {
@@ -56,18 +56,19 @@ configurations {
 }
 
 dependencies {
-    jnaForTest "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}@jar"
+    jnaForTest Deps.jnaForTest
 
-    fxa "mozilla:fxa_client_android:${rootProject.ext.dependencies['fxa']}@zip"
+    fxa Deps.mozilla_fxa
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "net.java.dev.jna:jna:${rootProject.ext.dependencies['jna']}@aar"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.jna
+    implementation Deps.kotlin_coroutines
 
     testImplementation files(configurations.jnaForTest.files)
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 ext.jniOutputDir = "src/main/jniLibs"

--- a/components/service/fretboard/build.gradle
+++ b/components/service/fretboard/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -24,14 +24,16 @@ android {
 dependencies {
     implementation project(':support-ktx')
     implementation project(':support-base')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
-    testImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.ext.dependencies['mockwebserver']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+    testImplementation Deps.testing_mockwebserver
 }
 
 archivesBaseName = "fretboard"

--- a/components/service/telemetry/build.gradle
+++ b/components/service/telemetry/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -24,15 +24,15 @@ android {
 dependencies {
     implementation project(':support-base')
 
-    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_annotations
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 
-    testImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.ext.dependencies['mockwebserver']}"
+    testImplementation Deps.testing_mockwebserver
 }
 
 archivesBaseName = "telemetry"

--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -25,15 +25,16 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
     // We expose the app-compat as API so that consumers get access to the Lifecycle classes automatically
-    api "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    api Deps.support_appcompat
 
     testImplementation project(':support-test')
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "base"

--- a/components/support/ktx/build.gradle
+++ b/components/support/ktx/build.gradle
@@ -6,11 +6,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -23,13 +24,13 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "com.android.support:support-compat:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_compat
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "ktx"

--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -28,9 +28,9 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    implementation Deps.testing_mockito
 }
 
 archivesBaseName = "test"

--- a/components/support/utils/build.gradle
+++ b/components/support/utils/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -27,17 +27,17 @@ android {
 dependencies {
     implementation project(':support-base')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "com.android.support:support-annotations:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:support-compat:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_annotations
+    implementation Deps.support_compat
 
     // We expose the app-compat as API so that consumers get access to the Lifecycle classes automatically
-    api "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    api Deps.support_appcompat
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "utils"

--- a/components/tooling/lint/build.gradle
+++ b/components/tooling/lint/build.gradle
@@ -9,11 +9,11 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compileOnly "com.android.tools.lint:lint-api:26.1.3"
-  compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+  compileOnly Deps.tools_lintapi
+  compileOnly Deps.kotlin_stdlib
 
-  testImplementation "com.android.tools.lint:lint:26.1.3"
-  testImplementation "com.android.tools.lint:lint-tests:26.1.3"
+  testImplementation Deps.tools_lint
+  testImplementation Deps.tools_linttests
 }
 
 jar {

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -24,13 +24,13 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "autocomplete"

--- a/components/ui/colors/build.gradle
+++ b/components/ui/colors/build.gradle
@@ -5,11 +5,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {

--- a/components/ui/fonts/build.gradle
+++ b/components/ui/fonts/build.gradle
@@ -5,11 +5,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {

--- a/components/ui/icons/build.gradle
+++ b/components/ui/icons/build.gradle
@@ -5,11 +5,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     lintOptions {

--- a/components/ui/progress/build.gradle
+++ b/components/ui/progress/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -24,13 +24,13 @@ android {
 dependencies {
     implementation project(':ui-colors')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    implementation "com.android.support:support-v4:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "progress"

--- a/components/ui/tabcounter/build.gradle
+++ b/components/ui/tabcounter/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
     }
 
     buildTypes {
@@ -30,11 +30,11 @@ android {
 dependencies {
     implementation project(':support-utils')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
+    implementation Deps.kotlin_stdlib
 
-    testImplementation "junit:junit:${rootProject.ext.dependencies['junit']}"
-    testImplementation "org.robolectric:robolectric:${rootProject.ext.dependencies['robolectric']}"
-    testImplementation "org.mockito:mockito-core:${rootProject.ext.dependencies['mockito']}"
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
 }
 
 archivesBaseName = "tabcounter"

--- a/publish.gradle
+++ b/publish.gradle
@@ -52,7 +52,7 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
 
     apply plugin: 'com.jfrog.bintray'
 
-    version = rootProject.ext.library['version']
+    version = Config.componentsVersion
 
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
         applicationId "org.mozilla.samples.browser"
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 
@@ -113,9 +113,9 @@ dependencies {
     productionX86Implementation "org.mozilla:geckoview-release-x86:${rootProject.ext.geckoRelease['version']}"
     productionAarch64Implementation "org.mozilla:geckoview-release-arm64-v8a:${rootProject.ext.geckoRelease['version']}"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support.constraint:constraint-layout:1.1.2"
+    implementation Deps.support_appcompat
+    implementation Deps.support_constraintlayout
 }

--- a/samples/firefox-accounts/build.gradle
+++ b/samples/firefox-accounts/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
         applicationId "org.mozilla.samples.fxa"
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 
@@ -38,10 +38,9 @@ android {
 dependencies {
     implementation project(':service-firefox-accounts')   
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:customtabs:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:support-v4:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
+    implementation Deps.support_customtabs
 }

--- a/samples/toolbar/build.gradle
+++ b/samples/toolbar/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion rootProject.ext.build['compileSdkVersion']
+    compileSdkVersion Config.compileSdkVersion
 
     defaultConfig {
         applicationId "org.mozilla.samples.toolbar"
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 
@@ -38,9 +38,9 @@ dependencies {
 
     implementation project(':support-ktx')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.dependencies['kotlin']}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.dependencies['coroutines']}"
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
 
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.dependencies['supportLibraries']}"
-    implementation "com.android.support:recyclerview-v7:${rootProject.ext.dependencies['supportLibraries']}"
+    implementation Deps.support_appcompat
+    implementation Deps.support_recyclerview
 }


### PR DESCRIPTION
This patch uses the `buildSrc` feature of Gradle. With that we can write Kotlin code to configure dependencies (and later other build related things). That's nicer than Groovy and you get autocompletion in Android Studio. Yay! 

Also fixes #621.