### PR TITLE
Use Android SDK 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,15 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.2
+    - android-28
 
 sudo: false
 
 before_install:
   - touch local.properties
   - yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "platforms;android-28"
 
 script:
   - ./gradlew --no-daemon clean test -Pcoverage

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -7,9 +7,9 @@ object Config {
     const val componentsVersion = "0.25"
 
     // Synchronized build configuration for all modules
-    const val compileSdkVersion = 27
+    const val compileSdkVersion = 28
     const val minSdkVersion = 21
-    const val targetSdkVersion = 27
+    const val targetSdkVersion = 28
 
     // Component lib-dataprotect requires functionality from API 23.
     const val minSdkVersion_dataprotect = 23

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ private object Versions {
     const val workmanager = "1.0.0-alpha09"
 
     const val dokka = "0.9.16"
-    const val android_gradle_plugin = "3.1.3"
+    const val android_gradle_plugin = "3.1.4"
     const val bintray_gradle_plugin = "1.7.3"
     const val maven_gradle_plugin = "2.1"
     const val lint = "26.1.3"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,11 +8,11 @@ private object Versions {
     const val coroutines = "0.23.4"
 
     const val junit = "4.12"
-    const val robolectric = "3.8"
+    const val robolectric = "4.0-alpha-3"
     const val mockito = "2.21.0"
     const val mockwebserver = "3.10.0"
 
-    const val support_libraries = "27.1.1"
+    const val support_libraries = "28.0.0"
     const val constraint_layout = "1.1.2"
     const val workmanager = "1.0.0-alpha09"
 

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
@@ -16,10 +16,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class)
 class DomainAutoCompleteProviderTest {
 
     @After

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
@@ -34,4 +34,4 @@ internal class BrowserMenuAdapter(
     }
 }
 
-class BrowserMenuItemViewHolder(itemView: View?) : RecyclerView.ViewHolder(itemView)
+class BrowserMenuItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
@@ -28,7 +28,7 @@ class BrowserMenuBuilderTest {
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
         assertNotNull(recyclerView)
 
-        val recyclerAdapter = recyclerView.adapter
+        val recyclerAdapter = recyclerView.adapter!!
         assertNotNull(recyclerAdapter)
         assertEquals(2, recyclerAdapter.itemCount)
     }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -50,7 +50,7 @@ class BrowserMenuTest {
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
         assertNotNull(recyclerView)
 
-        val recyclerAdapter = recyclerView.adapter
+        val recyclerAdapter = recyclerView.adapter!!
         assertNotNull(recyclerAdapter)
         assertEquals(2, recyclerAdapter.itemCount)
     }

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/measurement/OperatingSystemVersionMeasurementTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/measurement/OperatingSystemVersionMeasurementTest.java
@@ -25,7 +25,7 @@ public class OperatingSystemVersionMeasurementTest {
 
         final String version = (String) value;
         assertFalse(TextUtils.isEmpty(version));
-        assertEquals("27", version); // 16 is the default API level of this Robolectric version
+        assertEquals("28", version);
     }
 
     @Test

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryCorePingBuilderTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryCorePingBuilderTest.java
@@ -46,7 +46,7 @@ public class TelemetryCorePingBuilderTest {
         assertEquals("Android", results.get("os"));
 
         assertTrue(results.containsKey("osversion"));
-        assertEquals("27", results.get("osversion")); // API 16 is the default used by this Robolectric version
+        assertEquals("28", results.get("osversion")); // API 16 is the default used by this Robolectric version
 
         assertTrue(results.containsKey("device"));
         assertFalse(TextUtils.isEmpty((String) results.get("device")));

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilderTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilderTest.java
@@ -42,7 +42,7 @@ public class TelemetryEventPingBuilderTest {
         assertEquals("Android", results.get("os"));
 
         assertTrue(results.containsKey("osversion"));
-        assertEquals("27", results.get("osversion"));
+        assertEquals("28", results.get("osversion"));
     }
 
     @Test

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilderTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilderTest.java
@@ -42,7 +42,7 @@ public class TelemetryMobileEventPingBuilderTest {
         assertEquals("Android", results.get("os"));
 
         assertTrue(results.containsKey("osversion"));
-        assertEquals("27", results.get("osversion"));
+        assertEquals("28", results.get("osversion"));
     }
 
     @Test

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileMetricsPingBuilderTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileMetricsPingBuilderTest.java
@@ -47,7 +47,7 @@ public class TelemetryMobileMetricsPingBuilderTest {
         assertEquals("Android", results.get("os"));
 
         assertTrue(results.containsKey("osversion"));
-        assertEquals("27", results.get("osversion"));
+        assertEquals("28", results.get("osversion"));
 
         assertTrue(results.containsKey("device"));
         assertFalse(TextUtils.isEmpty((String) results.get("device")));

--- a/components/support/base/src/test/java/mozilla/components/support/base/log/sink/AndroidLogSinkTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/log/sink/AndroidLogSinkTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.support.base.log.sink
 import mozilla.components.support.base.log.Log
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -16,6 +17,11 @@ import java.io.PrintWriter
 
 @RunWith(RobolectricTestRunner::class)
 class AndroidLogSinkTest {
+    @Before
+    fun setUp() {
+        ShadowLog.clear()
+    }
+
     @Test
     fun `debug log will be print to Android log`() {
         val sink = AndroidLogSink()
@@ -91,7 +97,7 @@ class AndroidLogSinkTest {
     }
 
     @Test
-    @Config(sdk = [android.os.Build.VERSION_CODES.LOLLIPOP])
+    @Config(sdk = [21])
     fun `Tag will be truncated on SDK 21+`() {
         val sink = AndroidLogSink("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789")
         sink.log(message = "Hello!")
@@ -123,7 +129,7 @@ class AndroidLogSinkTest {
     }
 
     @Test
-    @Config(sdk = [android.os.Build.VERSION_CODES.N])
+    @Config(sdk = [24])
     fun `Tag will not be truncated on SDK 24+`() {
         val sink = AndroidLogSink("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789")
         sink.log(message = "Hello!")

--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -235,6 +235,10 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
         resetAutocompleteState()
     }
 
+    override fun getText(): Editable {
+        return super.getText() as Editable
+    }
+
     override fun sendAccessibilityEventUnchecked(event: AccessibilityEvent) {
         // We need to bypass the isShown() check in the default implementation
         // for TYPE_VIEW_TEXT_SELECTION_CHANGED events so that accessibility
@@ -485,6 +489,7 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                 return super.deleteSurroundingText(beforeLength, afterLength)
             }
 
+            @Suppress("ComplexCondition")
             private fun removeAutocompleteOnComposing(text: CharSequence): Boolean {
                 val editable = getText()
                 val composingStart = BaseInputConnection.getComposingSpanStart(editable)

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -24,14 +24,12 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.doReturn
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.Companion.AUTOCOMPLETE_SPAN
 import org.mockito.ArgumentMatchers.any
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class)
 class InlineAutocompleteEditTextTest {
     private val context: Context = RuntimeEnvironment.application
     private val attributes: AttributeSet = mock(AttributeSet::class.java)


### PR DESCRIPTION
Work in progress.

* [x] Support libraries not final yet: ~28.0.0-rc01~ ~28.0.0-rc02~
* [ ] Robolectric 4.0 (with support for API 28) not final yet: 4.0-alpha-3
* [x] The new support libraries added a bunch of nullable annotations and we need to update some Kotlin code to deal with potential nulls now. I did that for the components code already. But there's still some test code left that needs to be updated.