### PR TITLE
Issue #521: Add support for modifying engine session settings

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.engine.Settings
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -33,4 +34,13 @@ class GeckoEngine(
     }
 
     override fun name(): String = "Gecko"
+
+    /**
+     * See [Engine.settings]
+     */
+    override val settings: Settings = object : Settings {
+        override var javascriptEnabled: Boolean
+            get() = runtime.settings.javaScriptEnabled
+            set(value) { runtime.settings.javaScriptEnabled = value }
+    }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -366,4 +366,9 @@ class GeckoEngineSessionTest {
         val privateEngineSession = GeckoEngineSession(runtime, true)
         assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
     }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun testSettings() {
+        GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+    }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -4,11 +4,17 @@
 
 package mozilla.components.browser.engine.gecko
 
-import org.junit.Assert
+import mozilla.components.concept.engine.UnsupportedSettingException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -19,16 +25,39 @@ class GeckoEngineTest {
 
     @Test
     fun testCreateView() {
-        Assert.assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
+        assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
     }
 
     @Test
     fun testCreateSession() {
-        Assert.assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
+        assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
     }
 
     @Test
     fun testName() {
-        Assert.assertEquals("Gecko", GeckoEngine(runtime).name())
+        assertEquals("Gecko", GeckoEngine(runtime).name())
+    }
+
+    @Test
+    fun testSettings() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
+        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        `when`(runtime.settings).thenReturn(runtimeSettings)
+        val engine = GeckoEngine(runtime)
+
+        assertTrue(engine.settings.javascriptEnabled)
+        engine.settings.javascriptEnabled = false
+        verify(runtimeSettings).javaScriptEnabled = false
+
+        try {
+            engine.settings.domStorageEnabled
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedSettingException) { }
+
+        try {
+            engine.settings.domStorageEnabled = false
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedSettingException) { }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.engine.Settings
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -33,4 +34,13 @@ class GeckoEngine(
     }
 
     override fun name(): String = "Gecko"
+
+    /**
+     * See [Engine.settings]
+     */
+    override val settings: Settings = object : Settings {
+        override var javascriptEnabled: Boolean
+            get() = runtime.settings.javaScriptEnabled
+            set(value) { runtime.settings.javaScriptEnabled = value }
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.Settings
 import org.mozilla.gecko.util.ThreadUtils
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
@@ -18,7 +19,7 @@ import org.mozilla.geckoview.GeckoSessionSettings
  */
 @Suppress("TooManyFunctions")
 class GeckoEngineSession(
-    private val runtime: GeckoRuntime,
+    runtime: GeckoRuntime,
     privateMode: Boolean = false
 ) : EngineSession() {
 
@@ -119,6 +120,29 @@ class GeckoEngineSession(
             geckoSession.restoreState(sessionState)
         }
     }
+
+    /**
+     * See [EngineSession.enableTrackingProtection]
+     */
+    override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION, true)
+        notifyObservers { onTrackerBlockingEnabledChange(true) }
+    }
+
+    /**
+     * See [EngineSession.disableTrackingProtection]
+     */
+    override fun disableTrackingProtection() {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION, false)
+        notifyObservers { onTrackerBlockingEnabledChange(false) }
+    }
+
+    /**
+     * See [EngineSession.settings]
+     */
+    override val settings: Settings
+        get() = throw UnsupportedOperationException("""Not supported by this implementation:
+            Use Engine.settings instead""".trimIndent())
 
     /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
@@ -238,18 +262,6 @@ class GeckoEngineSession(
     private fun createTrackingProtectionDelegate() = GeckoSession.TrackingProtectionDelegate {
         session, uri, _ ->
             session?.let { uri?.let { notifyObservers { onTrackerBlocked(it) } } }
-    }
-
-    override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {
-        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION, true)
-        runtime.settings.trackingProtectionCategories = policy.categories
-        notifyObservers { onTrackerBlockingEnabledChange(true) }
-    }
-
-    override fun disableTrackingProtection() {
-        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION, false)
-        runtime.settings.trackingProtectionCategories = TrackingProtectionPolicy.none().categories
-        notifyObservers { onTrackerBlockingEnabledChange(false) }
     }
 
     companion object {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -390,4 +390,9 @@ class GeckoEngineSessionTest {
         val privateEngineSession = GeckoEngineSession(runtime, true)
         assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
     }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun testSettings() {
+        GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -4,11 +4,17 @@
 
 package mozilla.components.browser.engine.gecko
 
-import org.junit.Assert
+import mozilla.components.concept.engine.UnsupportedSettingException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -19,16 +25,39 @@ class GeckoEngineTest {
 
     @Test
     fun testCreateView() {
-        Assert.assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
+        assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
     }
 
     @Test
     fun testCreateSession() {
-        Assert.assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
+        assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
     }
 
     @Test
     fun testName() {
-        Assert.assertEquals("Gecko", GeckoEngine(runtime).name())
+        assertEquals("Gecko", GeckoEngine(runtime).name())
+    }
+
+    @Test
+    fun testSettings() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
+        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        `when`(runtime.settings).thenReturn(runtimeSettings)
+        val engine = GeckoEngine(runtime)
+
+        assertTrue(engine.settings.javascriptEnabled)
+        engine.settings.javascriptEnabled = false
+        verify(runtimeSettings).javaScriptEnabled = false
+
+        try {
+            engine.settings.domStorageEnabled
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedSettingException) { }
+
+        try {
+            engine.settings.domStorageEnabled = false
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedSettingException) { }
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.engine.Settings
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -36,4 +37,13 @@ class GeckoEngine(
      * See [Engine.name]
      */
     override fun name(): String = "Gecko"
+
+    /**
+     * See [Engine.settings]
+     */
+    override val settings: Settings = object : Settings {
+        override var javascriptEnabled: Boolean
+            get() = runtime.settings.javaScriptEnabled
+            set(value) { runtime.settings.javaScriptEnabled = value }
+    }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -379,4 +379,9 @@ class GeckoEngineSessionTest {
         val privateEngineSession = GeckoEngineSession(runtime, true)
         assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
     }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun testSettings() {
+        GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+    }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -4,11 +4,17 @@
 
 package mozilla.components.browser.engine.gecko
 
-import org.junit.Assert
+import mozilla.components.concept.engine.UnsupportedSettingException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -19,16 +25,39 @@ class GeckoEngineTest {
 
     @Test
     fun testCreateView() {
-        Assert.assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
+        assertTrue(GeckoEngine(runtime).createView(RuntimeEnvironment.application) is GeckoEngineView)
     }
 
     @Test
     fun testCreateSession() {
-        Assert.assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
+        assertTrue(GeckoEngine(runtime).createSession() is GeckoEngineSession)
     }
 
     @Test
     fun testName() {
-        Assert.assertEquals("Gecko", GeckoEngine(runtime).name())
+        assertEquals("Gecko", GeckoEngine(runtime).name())
+    }
+
+    @Test
+    fun testSettings() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
+        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        `when`(runtime.settings).thenReturn(runtimeSettings)
+        val engine = GeckoEngine(runtime)
+
+        assertTrue(engine.settings.javascriptEnabled)
+        engine.settings.javascriptEnabled = false
+        verify(runtimeSettings).javaScriptEnabled = false
+
+        try {
+            engine.settings.domStorageEnabled
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedSettingException) { }
+
+        try {
+            engine.settings.domStorageEnabled = false
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedSettingException) { }
     }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.engine.Settings
 
 /**
  * WebView-based implementation of the Engine interface.
@@ -37,4 +38,11 @@ class SystemEngine : Engine {
      * See [Engine.name]
      */
     override fun name(): String = "System"
+
+    /**
+     * See [Engine.settings]
+     */
+    override val settings: Settings
+        get() = throw UnsupportedOperationException("""Not supported by this implementation:
+            Use EngineSession.settings instead""".trimIndent())
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -10,6 +10,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.ktx.kotlin.toBundle
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.experimental.launch
+import mozilla.components.concept.engine.Settings
 
 /**
  * WebView-based EngineSession implementation.
@@ -123,6 +124,22 @@ class SystemEngineSession : EngineSession() {
         trackingProtectionEnabled = false
         notifyObservers { onTrackerBlockingEnabledChange(false) }
     }
+
+    /**
+     * See [EngineSession.settings]
+     */
+    override val settings: Settings
+        get() = currentView()?.settings?.let {
+            return object : Settings {
+                override var javascriptEnabled: Boolean
+                    get() = it.javaScriptEnabled
+                    set(value) { it.javaScriptEnabled = value }
+
+                override var domStorageEnabled: Boolean
+                    get() = it.domStorageEnabled
+                    set(value) { it.domStorageEnabled = value }
+            }
+        } ?: throw IllegalStateException("System engine not initialized")
 
     internal fun currentView(): WebView? {
         return view?.get()?.currentWebView

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -1,6 +1,7 @@
 package mozilla.components.browser.engine.system
 
 import android.os.Bundle
+import android.webkit.WebSettings
 import android.webkit.WebView
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.browser.engine.system.matcher.UrlMatcher
@@ -9,6 +10,7 @@ import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
@@ -197,5 +199,29 @@ class SystemEngineSessionTest {
         assertFalse(engineSession.trackingProtectionEnabled)
         assertNotNull(enabledObserved)
         assertFalse(enabledObserved!!)
+    }
+
+    @Test
+    fun testSettings() {
+        val engineSession = spy(SystemEngineSession())
+        val webView = mock(WebView::class.java)
+        val webViewSettings = mock(WebSettings::class.java)
+        `when`(webViewSettings.javaScriptEnabled).thenReturn(false)
+        `when`(webViewSettings.domStorageEnabled).thenReturn(false)
+        `when`(webView.settings).thenReturn(webViewSettings)
+
+        try {
+            engineSession.settings.javascriptEnabled = true
+            fail("Expected IllegalStateException")
+        } catch (e: IllegalStateException) { }
+
+        `when`(engineSession.currentView()).thenReturn(webView)
+        assertFalse(engineSession.settings.javascriptEnabled)
+        engineSession.settings.javascriptEnabled = true
+        verify(webViewSettings).javaScriptEnabled = true
+
+        assertFalse(engineSession.settings.domStorageEnabled)
+        engineSession.settings.domStorageEnabled = true
+        verify(webViewSettings).domStorageEnabled = true
     }
 }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
@@ -35,4 +35,9 @@ class SystemEngineTest {
     fun testName() {
         assertEquals("System", SystemEngine().name())
     }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun testSettings() {
+        SystemEngine().settings
+    }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -6,11 +6,13 @@ package mozilla.components.browser.session.engine
 
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.Settings
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mockito.mock
 
 class EngineObserverTest {
 
@@ -18,6 +20,9 @@ class EngineObserverTest {
     fun testEngineSessionObserver() {
         val session = Session("")
         val engineSession = object : EngineSession() {
+            override val settings: Settings
+                get() = mock(Settings::class.java)
+
             override fun goBack() {}
             override fun goForward() {}
             override fun reload() {}
@@ -57,6 +62,9 @@ class EngineObserverTest {
     fun testEngineSessionObserverWithSecurityChanges() {
         val session = Session("")
         val engineSession = object : EngineSession() {
+            override val settings: Settings
+                get() = mock(Settings::class.java)
+
             override fun goBack() {}
             override fun goForward() {}
             override fun stopLoading() {}
@@ -90,6 +98,9 @@ class EngineObserverTest {
     fun testEngineSessionObserverWithTrackingProtection() {
         val session = Session("")
         val engineSession = object : EngineSession() {
+            override val settings: Settings
+                get() = mock(Settings::class.java)
+
             override fun goBack() {}
             override fun goForward() {}
             override fun stopLoading() {}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -39,4 +39,9 @@ interface Engine {
      * @return the engine name as specified by concrete implementations.
      */
     fun name(): String
+
+    /**
+     * Provides access to the settings of this engine.
+     */
+    val settings: Settings
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -42,6 +42,11 @@ abstract class EngineSession(
     }
 
     /**
+     * Provides access to the settings of this engine session.
+     */
+    abstract val settings: Settings
+
+    /**
      * Represents a tracking protection policy which is a combination of
      * tracker categories that should be blocked.
      */

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine
+
+/**
+ * Holds settings of an engine or session. Concrete engine
+ * implementations define how these settings are applied i.e.
+ * whether a setting is applied on an engine or session instance.
+ */
+interface Settings {
+    /**
+     * Setting to control whether or not JavaScript is enabled.
+     */
+    var javascriptEnabled: Boolean
+        get() = throw UnsupportedSettingException()
+        set(_) = throw UnsupportedSettingException()
+
+    /**
+     * Setting to control whether or not DOM Storage is enabled.
+     */
+    var domStorageEnabled: Boolean
+        get() = throw UnsupportedSettingException()
+        set(_) = throw UnsupportedSettingException()
+}
+
+/**
+ * Exception thrown by default if a setting is not supported by an engine or session.
+ */
+class UnsupportedSettingException : RuntimeException("Setting not supported by this engine")

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -174,6 +174,9 @@ class EngineSessionTest {
 }
 
 open class DummyEngineSession : EngineSession() {
+    override val settings: Settings
+        get() = mock(Settings::class.java)
+
     override fun restoreState(state: Map<String, Any>) {}
 
     override fun saveState(): Map<String, Any> { return emptyMap() }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine
+
+import org.junit.Assert.fail
+import org.junit.Test
+
+class SettingsTest {
+
+    @Test
+    fun testSettingsThrowByDefault() {
+        val settings = object : Settings { }
+        expectUnsupportedSettingException { settings.javascriptEnabled }
+        expectUnsupportedSettingException { settings.javascriptEnabled = false }
+        expectUnsupportedSettingException { settings.domStorageEnabled }
+        expectUnsupportedSettingException { settings.domStorageEnabled = false }
+    }
+
+    private fun expectUnsupportedSettingException(f: () -> Unit) {
+        try {
+            f()
+            fail("Expected UnsupportedSettingException")
+        } catch (e: UnsupportedSettingException) { }
+    }
+}


### PR DESCRIPTION
Only added the settings we wanted to use so far. We'd have to add specific settings as needed. They're all implemented differently in WebView and GeckoView.

Some thoughts:
Do we need this abstraction of `Settings`? I think we need *an* abstraction as consumers and other components interact with our abstract `EngineSession` and we shouldn't leak internals of concrete implementations. Alternatively, we could simply use a `Map<String, Any>` for settings and expose it, but then we'd need to document all possible keys and map them back to the individual implementations. So, decided for this approach instead...