### PR TITLE
Issue #499: Support private browsing mode

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -19,17 +19,17 @@ class GeckoEngine(
 ) : Engine {
 
     /**
-     * Create a new Gecko-based EngineView.
+     * Creates a new Gecko-based EngineView.
      */
     override fun createView(context: Context, attrs: AttributeSet?): EngineView {
         return GeckoEngineView(context, attrs)
     }
 
     /**
-     * Create a new Gecko-based EngineSession.
+     * Creates a new Gecko-based EngineSession.
      */
-    override fun createSession(): EngineSession {
-        return GeckoEngineSession(runtime)
+    override fun createSession(private: Boolean): EngineSession {
+        return GeckoEngineSession(runtime, private)
     }
 
     override fun name(): String = "Gecko"

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -18,7 +18,8 @@ import org.mozilla.geckoview.GeckoSessionSettings
  */
 @Suppress("TooManyFunctions")
 class GeckoEngineSession(
-    private val runtime: GeckoRuntime
+    private val runtime: GeckoRuntime,
+    privateMode: Boolean = false
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
@@ -26,6 +27,7 @@ class GeckoEngineSession(
     private var initialLoad = true
 
     init {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 
         geckoSession.navigationDelegate = createNavigationDelegate()

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -351,6 +352,18 @@ class GeckoEngineSessionTest {
 
         engineSession.disableTrackingProtection()
         assertTrue(trackerBlockingDisabledObserved)
-        Assert.assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
+        assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
+    }
+
+    @Test
+    fun testSettingPrivateMode() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        val engineSession = GeckoEngineSession(runtime)
+        assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
+
+        val privateEngineSession = GeckoEngineSession(runtime, true)
+        assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -19,17 +19,17 @@ class GeckoEngine(
 ) : Engine {
 
     /**
-     * Create a new Gecko-based EngineView.
+     * Creates a new Gecko-based EngineView.
      */
     override fun createView(context: Context, attrs: AttributeSet?): EngineView {
         return GeckoEngineView(context, attrs)
     }
 
     /**
-     * Create a new Gecko-based EngineSession.
+     * Creates a new Gecko-based EngineSession.
      */
-    override fun createSession(): EngineSession {
-        return GeckoEngineSession(runtime)
+    override fun createSession(private: Boolean): EngineSession {
+        return GeckoEngineSession(runtime, private)
     }
 
     override fun name(): String = "Gecko"

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -18,7 +18,8 @@ import org.mozilla.geckoview.GeckoSessionSettings
  */
 @Suppress("TooManyFunctions")
 class GeckoEngineSession(
-    private val runtime: GeckoRuntime
+    private val runtime: GeckoRuntime,
+    privateMode: Boolean = false
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
@@ -26,6 +27,7 @@ class GeckoEngineSession(
     private var initialLoad = true
 
     init {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 
         geckoSession.navigationDelegate = createNavigationDelegate()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -378,4 +378,16 @@ class GeckoEngineSessionTest {
         assertTrue(trackerBlockingDisabledObserved)
         assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
     }
+
+    @Test
+    fun testSettingPrivateMode() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        val engineSession = GeckoEngineSession(runtime)
+        assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
+
+        val privateEngineSession = GeckoEngineSession(runtime, true)
+        assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
+    }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -28,8 +28,8 @@ class GeckoEngine(
     /**
      * Creates a new Gecko-based EngineSession.
      */
-    override fun createSession(): EngineSession {
-        return GeckoEngineSession(runtime)
+    override fun createSession(private: Boolean): EngineSession {
+        return GeckoEngineSession(runtime, private)
     }
 
     /**

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -18,7 +18,8 @@ import org.mozilla.geckoview.GeckoSessionSettings
  */
 @Suppress("TooManyFunctions")
 class GeckoEngineSession(
-    private val runtime: GeckoRuntime
+    runtime: GeckoRuntime,
+    privateMode: Boolean = false
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
@@ -26,6 +27,7 @@ class GeckoEngineSession(
     private var initialLoad = true
 
     init {
+        geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 
         geckoSession.navigationDelegate = createNavigationDelegate()

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -8,6 +8,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -364,6 +365,18 @@ class GeckoEngineSessionTest {
 
         engineSession.disableTrackingProtection()
         assertTrue(trackerBlockingDisabledObserved)
-        Assert.assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
+        assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
+    }
+
+    @Test
+    fun testSettingPrivateMode() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        val engineSession = GeckoEngineSession(runtime)
+        assertFalse(engineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
+
+        val privateEngineSession = GeckoEngineSession(runtime, true)
+        assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
     }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -16,16 +16,20 @@ import mozilla.components.concept.engine.EngineView
 class SystemEngine : Engine {
 
     /**
-     * Createa a new WebView-based EngineView implementation.
+     * Creates a new WebView-based EngineView implementation.
      */
     override fun createView(context: Context, attrs: AttributeSet?): EngineView {
         return SystemEngineView(context, attrs)
     }
 
     /**
-     * Createa a new WebView-based EngineSession implementation.
+     * Creates a new WebView-based EngineSession implementation.
      */
-    override fun createSession(): EngineSession {
+    override fun createSession(private: Boolean): EngineSession {
+        if (private) {
+            // TODO Implement private browsing: https://github.com/mozilla-mobile/android-components/issues/649
+            throw UnsupportedOperationException("Private browsing is not supported in ${this::class.java.simpleName}")
+        }
         return SystemEngineSession()
     }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.system
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,6 +23,12 @@ class SystemEngineTest {
     @Test
     fun testCreateSession() {
         assertTrue(SystemEngine().createSession() is SystemEngineSession)
+
+        try {
+            SystemEngine().createSession(true)
+            // Private browsing not yet supported
+            fail("Expected UnsupportedOperationException")
+        } catch (e: UnsupportedOperationException) { }
     }
 
     @Test

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -18,6 +18,7 @@ import kotlin.properties.Delegates
 @Suppress("TooManyFunctions")
 class Session(
     initialUrl: String,
+    val private: Boolean = false,
     val source: Source = Source.NONE,
     val id: String = UUID.randomUUID().toString(),
     delegate: Observable<Session.Observer> = ObserverRegistry()

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -93,7 +93,7 @@ class SessionManager(
     fun getOrCreateEngineSession(session: Session = selectedSessionOrThrow): EngineSession {
         getEngineSession(session)?.let { return it }
 
-        return engine.createSession().apply {
+        return engine.createSession(session.private).apply {
             link(session, this)
         }
     }

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/DefaultSessionStorage.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/DefaultSessionStorage.kt
@@ -112,7 +112,7 @@ class DefaultSessionStorage(
             json.put(VERSION_KEY, VERSION)
             json.put(SELECTED_SESSION_KEY, sessionManager.selectedSession?.id ?: "")
 
-            sessionManager.sessions.forEach { session ->
+            sessionManager.sessions.filter { !it.private }.forEach { session ->
                 val sessionJson = JSONObject()
                 sessionJson.put(SESSION_KEY, serializeSession(session))
                 sessionJson.put(ENGINE_SESSION_KEY, serializeEngineSession(sessionManager.getEngineSession(session)))
@@ -152,7 +152,7 @@ class DefaultSessionStorage(
         } catch (e: IllegalArgumentException) {
             Source.NONE
         }
-        return Session(json.getString("url"), source, id)
+        return Session(json.getString("url"), false, source, id)
     }
 
     private fun serializeEngineSession(engineSession: EngineSession?): JSONObject {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -292,7 +292,9 @@ class SessionManagerTest {
         val engine: Engine = mock()
 
         val actualEngineSession: EngineSession = mock()
-        doReturn(actualEngineSession).`when`(engine).createSession()
+        doReturn(actualEngineSession).`when`(engine).createSession(false)
+        val privateEngineSession: EngineSession = mock()
+        doReturn(privateEngineSession).`when`(engine).createSession(true)
 
         val sessionManager = SessionManager(engine)
 
@@ -300,10 +302,14 @@ class SessionManagerTest {
         sessionManager.add(session)
 
         assertNull(sessionManager.getEngineSession(session))
-
         assertEquals(actualEngineSession, sessionManager.getOrCreateEngineSession(session))
         assertEquals(actualEngineSession, sessionManager.getEngineSession(session))
         assertEquals(actualEngineSession, sessionManager.getOrCreateEngineSession(session))
+
+        val privateSession = Session("https://www.mozilla.org", true, Session.Source.NONE)
+        sessionManager.add(privateSession)
+        assertNull(sessionManager.getEngineSession(privateSession))
+        assertEquals(privateEngineSession, sessionManager.getOrCreateEngineSession(privateSession))
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -207,23 +207,23 @@ class SessionTest {
         var session = Session("https://www.mozilla.org")
         assertNotNull(session.id)
 
-        session = Session("https://www.mozilla.org", Source.NONE, "s1")
+        session = Session("https://www.mozilla.org", false, Source.NONE, "s1")
         assertNotNull(session.id)
         assertEquals("s1", session.id)
     }
 
     @Test
     fun `sessions with the same id are equal`() {
-        val session1 = Session("http://mozilla.org", Source.NONE, "123ABC")
-        val session2 = Session("http://mozilla.org", Source.NONE, "123ABC")
+        val session1 = Session("http://mozilla.org", false, Source.NONE, "123ABC")
+        val session2 = Session("http://mozilla.org", false, Source.NONE, "123ABC")
 
         assertEquals(session1, session2)
     }
 
     @Test
     fun `session ID is used for hashCode`() {
-        val session1 = Session("http://mozilla.org", Source.NONE, "123ABC")
-        val session2 = Session("http://mozilla.org", Source.NONE, "123ABC")
+        val session1 = Session("http://mozilla.org", false, Source.NONE, "123ABC")
+        val session2 = Session("http://mozilla.org", false, Source.NONE, "123ABC")
 
         val map = mapOf(session1 to "test")
         assertEquals("test", map[session2])

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -25,9 +25,11 @@ interface Engine {
     /**
      * Creates a new engine session.
      *
+     * @param private whether or not this session should use private mode.
+     *
      * @return the newly created [EngineSession].
      */
-    fun createSession(): EngineSession
+    fun createSession(private: Boolean = false): EngineSession
 
     /**
      * Returns the name of this engine. The returned string might be used

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionIntentProcessor.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionIntentProcessor.kt
@@ -34,7 +34,7 @@ class SessionIntentProcessor(
             TextUtils.isEmpty(url) -> false
 
             CustomTabConfig.isCustomTabIntent(safeIntent) -> {
-                val session = Session(url, Source.CUSTOM_TAB).apply {
+                val session = Session(url, false, Source.CUSTOM_TAB).apply {
                     this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent)
                 }
                 sessionManager.add(session)
@@ -45,9 +45,9 @@ class SessionIntentProcessor(
 
             else -> {
                 val session = if (openNewTab) {
-                    Session(url, Source.ACTION_VIEW).also { sessionManager.add(it, selected = true) }
+                    Session(url, false, Source.ACTION_VIEW).also { sessionManager.add(it, selected = true) }
                 } else {
-                    sessionManager.selectedSession ?: Session(url, Source.ACTION_VIEW)
+                    sessionManager.selectedSession ?: Session(url, false, Source.ACTION_VIEW)
                 }
 
                 sessionUseCases.loadUrl.invoke(url, session)

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -50,7 +50,22 @@ class TabsUseCases(
          * @param selectTab True (default) if the new tab should be selected immediately.
          */
         fun invoke(url: String, selectTab: Boolean = true) {
-            val session = Session(url, Source.NEW_TAB)
+            val session = Session(url, false, Source.NEW_TAB)
+            sessionManager.add(session, selected = selectTab)
+        }
+    }
+
+    class AddNewPrivateTabUseCase internal constructor(
+        private val sessionManager: SessionManager
+    ) {
+        /**
+         * Add a new private tab and load the provided URL.
+         *
+         * @param url The URL to be loaded in the new tab.
+         * @param selectTab True (default) if the new tab should be selected immediately.
+         */
+        fun invoke(url: String, selectTab: Boolean = true) {
+            val session = Session(url, true, Source.NEW_TAB)
             sessionManager.add(session, selected = selectTab)
         }
     }
@@ -58,4 +73,5 @@ class TabsUseCases(
     val selectSession: SelectTabUseCase by lazy { SelectTabUseCase(sessionManager) }
     val removeSession: RemoveTabUseCase by lazy { RemoveTabUseCase(sessionManager) }
     val addSession: AddNewTabUseCase by lazy { AddNewTabUseCase(sessionManager) }
+    val addPrivateSession: AddNewPrivateTabUseCase by lazy { AddNewPrivateTabUseCase(sessionManager) }
 }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -9,6 +9,8 @@ import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
 import org.junit.Assert.assertEquals
 import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
@@ -50,5 +52,21 @@ class TabsUseCasesTest {
         assertEquals(1, sessionManager.size)
         assertEquals("https://www.mozilla.org", sessionManager.selectedSessionOrThrow.url)
         assertEquals(Source.NEW_TAB, sessionManager.selectedSessionOrThrow.source)
+        assertFalse(sessionManager.selectedSessionOrThrow.private)
+    }
+
+    @Test
+    fun `AddNewPrivateTabUseCase - private session will be added to session manager`() {
+        val sessionManager = SessionManager(mock())
+        val useCases = TabsUseCases(sessionManager)
+
+        assertEquals(0, sessionManager.size)
+
+        useCases.addPrivateSession.invoke("https://www.mozilla.org")
+
+        assertEquals(1, sessionManager.size)
+        assertEquals("https://www.mozilla.org", sessionManager.selectedSessionOrThrow.url)
+        assertEquals(Source.NEW_TAB, sessionManager.selectedSessionOrThrow.source)
+        assertTrue(sessionManager.selectedSessionOrThrow.private)
     }
 }


### PR DESCRIPTION
Kept this independent of the settings work after all. Whether or not a session is private should be a direct property of the session rather than a setting, I think.