### PR TITLE
Issue #662: Provide API to set engine/session defaults

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import org.mozilla.geckoview.GeckoRuntime
@@ -16,7 +17,8 @@ import org.mozilla.geckoview.GeckoRuntime
  * Gecko-based implementation of Engine interface.
  */
 class GeckoEngine(
-    private val runtime: GeckoRuntime
+    private val runtime: GeckoRuntime,
+    private val defaultSettings: Settings? = null
 ) : Engine {
 
     /**
@@ -30,7 +32,7 @@ class GeckoEngine(
      * Creates a new Gecko-based EngineSession.
      */
     override fun createSession(private: Boolean): EngineSession {
-        return GeckoEngineSession(runtime, private)
+        return GeckoEngineSession(runtime, private, defaultSettings)
     }
 
     override fun name(): String = "Gecko"
@@ -42,5 +44,18 @@ class GeckoEngine(
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }
+
+        override var trackingProtectionPolicy: TrackingProtectionPolicy?
+            get() = TrackingProtectionPolicy.select(runtime.settings.trackingProtectionCategories)
+            set(value) {
+                value?.let {
+                    runtime.settings.trackingProtectionCategories = it.categories
+                }
+            }
+    }.apply {
+        defaultSettings?.let {
+            this.javascriptEnabled = it.javascriptEnabled
+            this.trackingProtectionPolicy = it.trackingProtectionPolicy
+        }
     }
 }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -28,13 +28,15 @@ import org.mozilla.geckoview.GeckoSessionSettings
 @Suppress("TooManyFunctions")
 class GeckoEngineSession(
     runtime: GeckoRuntime,
-    privateMode: Boolean = false
+    privateMode: Boolean = false,
+    defaultSettings: Settings? = null
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
     private var initialLoad = true
 
     init {
+        defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko
 
 import android.os.Handler
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.HitResult
@@ -376,6 +377,16 @@ class GeckoEngineSessionTest {
     @Test(expected = UnsupportedOperationException::class)
     fun testSettings() {
         GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+    }
+
+    @Test
+    fun testDefaultSettings() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        val defaultSettings = DefaultSettings(trackingProtectionPolicy = TrackingProtectionPolicy.all())
+        val session = GeckoEngineSession(runtime, false, defaultSettings)
+        assertTrue(session.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import org.mozilla.geckoview.GeckoRuntime
@@ -16,7 +17,8 @@ import org.mozilla.geckoview.GeckoRuntime
  * Gecko-based implementation of Engine interface.
  */
 class GeckoEngine(
-    private val runtime: GeckoRuntime
+    private val runtime: GeckoRuntime,
+    private val defaultSettings: Settings? = null
 ) : Engine {
 
     /**
@@ -30,7 +32,7 @@ class GeckoEngine(
      * Creates a new Gecko-based EngineSession.
      */
     override fun createSession(private: Boolean): EngineSession {
-        return GeckoEngineSession(runtime, private)
+        return GeckoEngineSession(runtime, private, defaultSettings)
     }
 
     override fun name(): String = "Gecko"
@@ -42,5 +44,18 @@ class GeckoEngine(
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }
+
+        override var trackingProtectionPolicy: TrackingProtectionPolicy?
+            get() = TrackingProtectionPolicy.select(runtime.settings.trackingProtectionCategories)
+            set(value) {
+                value?.let {
+                    runtime.settings.trackingProtectionCategories = it.categories
+                }
+            }
+    }.apply {
+        defaultSettings?.let {
+            this.javascriptEnabled = it.javascriptEnabled
+            this.trackingProtectionPolicy = it.trackingProtectionPolicy
+        }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -28,7 +28,8 @@ import org.mozilla.geckoview.GeckoSessionSettings
 @Suppress("TooManyFunctions")
 class GeckoEngineSession(
     runtime: GeckoRuntime,
-    privateMode: Boolean = false
+    privateMode: Boolean = false,
+    defaultSettings: Settings? = null
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
@@ -36,6 +37,7 @@ class GeckoEngineSession(
     private var initialLoad = true
 
     init {
+        defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko
 
 import android.os.Handler
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.HitResult
@@ -400,6 +401,16 @@ class GeckoEngineSessionTest {
     @Test(expected = UnsupportedOperationException::class)
     fun testSettings() {
         GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+    }
+
+    @Test
+    fun testDefaultSettings() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        val defaultSettings = DefaultSettings(trackingProtectionPolicy = TrackingProtectionPolicy.all())
+        val session = GeckoEngineSession(runtime, false, defaultSettings)
+        assertTrue(session.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_TRACKING_PROTECTION))
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -16,7 +16,8 @@ import org.mozilla.geckoview.GeckoRuntime
  * Gecko-based implementation of Engine interface.
  */
 class GeckoEngine(
-    private val runtime: GeckoRuntime
+    private val runtime: GeckoRuntime,
+    defaultSettings: Settings? = null
 ) : Engine {
 
     /**
@@ -45,5 +46,9 @@ class GeckoEngine(
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }
+    }.apply {
+        defaultSettings?.let {
+            this.javascriptEnabled = defaultSettings.javascriptEnabled
+        }
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.UnsupportedSettingException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -59,5 +60,16 @@ class GeckoEngineTest {
             engine.settings.domStorageEnabled = false
             fail("Expected UnsupportedOperationException")
         } catch (e: UnsupportedSettingException) { }
+    }
+
+    @Test
+    fun testDefaultSettings() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
+        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        `when`(runtime.settings).thenReturn(runtimeSettings)
+
+        GeckoEngine(runtime, DefaultSettings(javascriptEnabled = false))
+        verify(runtimeSettings).javaScriptEnabled = false
     }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.system
 
 import android.content.Context
 import android.util.AttributeSet
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
@@ -14,7 +15,9 @@ import mozilla.components.concept.engine.Settings
 /**
  * WebView-based implementation of the Engine interface.
  */
-class SystemEngine : Engine {
+class SystemEngine(
+    private val defaultSettings: DefaultSettings? = null
+) : Engine {
 
     /**
      * Creates a new WebView-based EngineView implementation.
@@ -31,7 +34,7 @@ class SystemEngine : Engine {
             // TODO Implement private browsing: https://github.com/mozilla-mobile/android-components/issues/649
             throw UnsupportedOperationException("Private browsing is not supported in ${this::class.java.simpleName}")
         }
-        return SystemEngineSession()
+        return SystemEngineSession(defaultSettings)
     }
 
     /**

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -60,6 +60,7 @@ class SystemEngineView @JvmOverloads constructor(
         this.session = internalSession
 
         internalSession.view = WeakReference(this)
+        internalSession.initSettings()
 
         internalSession.scheduledLoad.data?.let {
             currentWebView.loadData(it, internalSession.scheduledLoad.mimeType, "UTF-8")

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -65,6 +65,17 @@ abstract class EngineSession(
             fun select(vararg categories: Int): TrackingProtectionPolicy =
                 TrackingProtectionPolicy(categories.sum())
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is TrackingProtectionPolicy) return false
+            if (categories != other.categories) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return categories
+        }
     }
 
     /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.concept.engine
 
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+
 /**
  * Holds settings of an engine or session. Concrete engine
  * implementations define how these settings are applied i.e.
@@ -23,7 +25,23 @@ interface Settings {
     var domStorageEnabled: Boolean
         get() = throw UnsupportedSettingException()
         set(_) = throw UnsupportedSettingException()
+
+    /**
+     * Setting to control tracking protection.
+     */
+    var trackingProtectionPolicy: TrackingProtectionPolicy?
+        get() = throw UnsupportedSettingException()
+        set(_) = throw UnsupportedSettingException()
 }
+
+/**
+ * [Settings] implementation used to set defaults for [Engine] and [EngineSession].
+ */
+data class DefaultSettings(
+    override var javascriptEnabled: Boolean = true,
+    override var domStorageEnabled: Boolean = true,
+    override var trackingProtectionPolicy: TrackingProtectionPolicy? = null
+) : Settings
 
 /**
  * Exception thrown by default if a setting is not supported by an engine or session.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -7,6 +7,12 @@ package mozilla.components.concept.engine
 import org.junit.Assert.fail
 import org.junit.Test
 
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+
 class SettingsTest {
 
     @Test
@@ -16,6 +22,8 @@ class SettingsTest {
         expectUnsupportedSettingException { settings.javascriptEnabled = false }
         expectUnsupportedSettingException { settings.domStorageEnabled }
         expectUnsupportedSettingException { settings.domStorageEnabled = false }
+        expectUnsupportedSettingException { settings.trackingProtectionPolicy }
+        expectUnsupportedSettingException { settings.trackingProtectionPolicy = TrackingProtectionPolicy.all() }
     }
 
     private fun expectUnsupportedSettingException(f: () -> Unit) {
@@ -23,5 +31,18 @@ class SettingsTest {
             f()
             fail("Expected UnsupportedSettingException")
         } catch (e: UnsupportedSettingException) { }
+    }
+
+    @Test
+    fun testDefaultSettings() {
+        val settings = DefaultSettings()
+        assertTrue(settings.domStorageEnabled)
+        assertTrue(settings.javascriptEnabled)
+        assertNull(settings.trackingProtectionPolicy)
+
+        val trackingProtectionSettings = DefaultSettings(false, false, TrackingProtectionPolicy.all())
+        assertFalse(trackingProtectionSettings.domStorageEnabled)
+        assertFalse(trackingProtectionSettings.javascriptEnabled)
+        assertEquals(TrackingProtectionPolicy.all(), trackingProtectionSettings.trackingProtectionPolicy)
     }
 }


### PR DESCRIPTION
In #521, we introduced both engine and engine session settings and handled the differences between GeckoView and WebView settings. When providing default settings, we can hide this complexity from the consumer. An API user should simply be able to pass default settings to the engine and not worry about whether these are handled by the engine or session implementation, as these settings should be applied to all sessions anyway (by default).

So, our engine now accepts optional default settings, which will be forwarded to the engine sessions, as needed. If you wanted to build a browser that always has tracking protection on:

```
val engine: Engine by lazy {
   val runtime = GeckoRuntime.getDefault(applicationContext)
   val settings = DefaultSettings(trackingProtectionPolicy=TrackingProtectionPolicy.all())
   GeckoEngine(runtime, settings)
}
```

or

```
val engine: Engine by lazy {
   SystemEngine(DefaultSettings(trackingProtectionPolicy=TrackingProtectionPolicy.all()))
}
```

Notes:
- This also brings back setting tracking protection categories, which we lost in a recent update. It's also dealt with correctly now (as a runtime setting, not session setting)
- Why are browser sessions not affected? We handle browser sessions directly in use cases e.g. there's a `AddNewPrivateTabUseCase` which sets the corresponding properties on the browser session. It seems to me we only need this API for engine sessions. We can file a follow-up if we need it though.