### PR TITLE
Issue #673: Engine: Allow consumers to intercept requests and inject content.

### DIFF
--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation Deps.testing_junit
     testImplementation Deps.testing_robolectric
     testImplementation Deps.testing_mockito
+
+    testImplementation project(':support-test')
 }
 
 archivesBaseName = "engine-gecko-beta"

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -7,15 +7,16 @@ package mozilla.components.browser.engine.gecko
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
 import org.mozilla.gecko.util.ThreadUtils
+import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
-import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_AUDIO
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_IMAGE
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_NONE
@@ -33,10 +34,20 @@ class GeckoEngineSession(
 ) : EngineSession() {
 
     internal var geckoSession = GeckoSession()
+
+    /**
+     * See [EngineSession.settings]
+     */
+    override val settings: Settings = object : Settings {
+        override var requestInterceptor: RequestInterceptor? = null
+    }
+
     private var initialLoad = true
 
     init {
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
+        defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
+
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 
@@ -149,13 +160,6 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override val settings: Settings
-        get() = throw UnsupportedOperationException("""Not supported by this implementation:
-            Use Engine.settings instead""".trimIndent())
-
-    /**
-     * See [EngineSession.settings]
-     */
     override fun setDesktopMode(enable: Boolean, reload: Boolean) {
         // no-op (requires v63+)
     }
@@ -179,8 +183,15 @@ class GeckoEngineSession(
             uri: String,
             target: Int,
             flags: Int
-        ): GeckoResult<Boolean> {
-            return GeckoResult.fromValue(false)
+        ): GeckoResult<Boolean>? {
+            val response = settings.requestInterceptor?.onLoadRequest(
+                this@GeckoEngineSession,
+                uri
+            )?.apply {
+                loadData(data, mimeType, encoding)
+            }
+
+            return GeckoResult.fromValue(response != null)
         }
 
         override fun onCanGoForward(session: GeckoSession?, canGoForward: Boolean) {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.support.ktx.kotlin.isPhone
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
@@ -34,10 +35,19 @@ class GeckoEngineSession(
 
     internal var geckoSession = GeckoSession()
 
+    /**
+     * See [EngineSession.settings]
+     */
+    override val settings: Settings = object : Settings {
+        override var requestInterceptor: RequestInterceptor? = null
+    }
+
     private var initialLoad = true
 
     init {
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
+        defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
+
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)
 
@@ -150,13 +160,6 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override val settings: Settings
-        get() = throw UnsupportedOperationException("""Not supported by this implementation:
-            Use Engine.settings instead""".trimIndent())
-
-    /**
-     * See [EngineSession.settings]
-     */
     override fun setDesktopMode(enable: Boolean, reload: Boolean) {
         val currentMode = geckoSession.settings.getInt(GeckoSessionSettings.USER_AGENT_MODE)
         val newMode = if (enable) {
@@ -198,7 +201,14 @@ class GeckoEngineSession(
             target: Int,
             flags: Int
         ): GeckoResult<Boolean>? {
-            return GeckoResult.fromValue(false)
+            val response = settings.requestInterceptor?.onLoadRequest(
+                this@GeckoEngineSession,
+                uri
+            )?.apply {
+                loadData(data, mimeType, encoding)
+            }
+
+            return GeckoResult.fromValue(response != null)
         }
 
         override fun onCanGoForward(session: GeckoSession?, canGoForward: Boolean) {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -9,6 +9,9 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.UnsupportedSettingException
+import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -22,6 +25,8 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mozilla.gecko.util.BundleEventListener
 import org.mozilla.gecko.util.GeckoBundle
@@ -398,9 +403,80 @@ class GeckoEngineSessionTest {
         assertTrue(privateEngineSession.geckoSession.settings.getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE))
     }
 
-    @Test(expected = UnsupportedOperationException::class)
-    fun testSettings() {
-        GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+    @Test
+    fun testUnsupportedSettings() {
+        val settings = GeckoEngineSession(mock(GeckoRuntime::class.java)).settings
+
+        expectException(UnsupportedSettingException::class) {
+            settings.javascriptEnabled = true
+        }
+
+        expectException(UnsupportedSettingException::class) {
+            settings.domStorageEnabled = false
+        }
+
+        expectException(UnsupportedSettingException::class) {
+            settings.trackingProtectionPolicy = TrackingProtectionPolicy.all()
+        }
+    }
+
+    @Test
+    fun testSettingRequestInterceptor() {
+        var interceptorCalledWithUri: String? = null
+
+        val interceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+                interceptorCalledWithUri = uri
+                return RequestInterceptor.InterceptionResponse("<h1>Hello World</h1>")
+            }
+        }
+
+        val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
+
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+        engineSession.geckoSession = spy(engineSession.geckoSession)
+
+        engineSession.geckoSession.navigationDelegate.onLoadRequest(
+            engineSession.geckoSession, "sample:about", 0, 0)
+
+        assertEquals("sample:about", interceptorCalledWithUri!!)
+        verify(engineSession.geckoSession).loadString("<h1>Hello World</h1>", "text/html")
+    }
+
+    @Test
+    fun testOnLoadRequestWithoutInterceptor() {
+        val defaultSettings = DefaultSettings()
+
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+        engineSession.geckoSession = spy(engineSession.geckoSession)
+
+        engineSession.geckoSession.navigationDelegate.onLoadRequest(
+            engineSession.geckoSession, "sample:about", 0, 0)
+
+        verify(engineSession.geckoSession, never()).loadString(anyString(), anyString())
+    }
+
+    @Test
+    fun testOnLoadRequestWithInterceptorThatDoesNotIntercept() {
+        var interceptorCalledWithUri: String? = null
+
+        val interceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+                interceptorCalledWithUri = uri
+                return null
+            }
+        }
+
+        val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
+
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+        engineSession.geckoSession = spy(engineSession.geckoSession)
+
+        engineSession.geckoSession.navigationDelegate.onLoadRequest(
+            engineSession.geckoSession, "sample:about", 0, 0)
+
+        assertEquals("sample:about", interceptorCalledWithUri!!)
+        verify(engineSession.geckoSession, never()).loadString(anyString(), anyString())
     }
 
     @Test

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -11,6 +11,7 @@ import mozilla.components.support.ktx.kotlin.toBundle
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.experimental.launch
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.request.RequestInterceptor
 
 /**
  * WebView-based EngineSession implementation.
@@ -147,16 +148,18 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
 
                 override var trackingProtectionPolicy: TrackingProtectionPolicy?
                     get() = if (trackingProtectionEnabled)
-                        TrackingProtectionPolicy.all()
-                    else
-                        TrackingProtectionPolicy.none()
-
+                            TrackingProtectionPolicy.all()
+                        else
+                            TrackingProtectionPolicy.none()
                     set(value) = value?.let { enableTrackingProtection(it) } ?: disableTrackingProtection()
+
+                override var requestInterceptor: RequestInterceptor? = null
             }.apply {
                 defaultSettings?.let {
                     this.javascriptEnabled = defaultSettings.javascriptEnabled
                     this.domStorageEnabled = defaultSettings.domStorageEnabled
                     this.trackingProtectionPolicy = defaultSettings.trackingProtectionPolicy
+                    this.requestInterceptor = defaultSettings.requestInterceptor
                 }
             }
             return _settings as Settings

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -41,7 +41,7 @@ class SystemEngineView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView, View.OnLongClickListener {
-    internal val currentWebView = createWebView(context)
+    internal var currentWebView = createWebView(context)
     internal var currentUrl = ""
     private var session: SystemEngineSession? = null
 
@@ -139,6 +139,17 @@ class SystemEngineView @JvmOverloads constructor(
                     return WebResourceResponse(null, null, null)
                 }
             }
+
+            session?.let { session ->
+                session.settings.requestInterceptor?.let { interceptor ->
+                    interceptor.onLoadRequest(
+                        session, request.url.toString()
+                    )?.apply {
+                        return WebResourceResponse(mimeType, encoding, data.byteInputStream())
+                    }
+                }
+            }
+
             return super.shouldInterceptRequest(view, request)
         }
     }

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testImplementation Deps.testing_junit
     testImplementation Deps.testing_robolectric
     testImplementation Deps.testing_mockito
+
+    testImplementation project(':support-test')
 }
 
 archivesBaseName = "engine"

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.engine
 
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.request.RequestInterceptor
 
 /**
  * Holds settings of an engine or session. Concrete engine
@@ -32,6 +33,13 @@ interface Settings {
     var trackingProtectionPolicy: TrackingProtectionPolicy?
         get() = throw UnsupportedSettingException()
         set(_) = throw UnsupportedSettingException()
+
+    /**
+     * Setting to intercept and override requests.
+     */
+    var requestInterceptor: RequestInterceptor?
+        get() = throw UnsupportedSettingException()
+        set(_) = throw UnsupportedSettingException()
 }
 
 /**
@@ -40,7 +48,8 @@ interface Settings {
 data class DefaultSettings(
     override var javascriptEnabled: Boolean = true,
     override var domStorageEnabled: Boolean = true,
-    override var trackingProtectionPolicy: TrackingProtectionPolicy? = null
+    override var trackingProtectionPolicy: TrackingProtectionPolicy? = null,
+    override var requestInterceptor: RequestInterceptor? = null
 ) : Settings
 
 /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.request
+
+import mozilla.components.concept.engine.EngineSession
+
+/**
+ * Interface for classes that want to intercept load requests to allow custom behavior.
+ */
+interface RequestInterceptor {
+    /**
+     * An alternative response for an intercepted request.
+     */
+    data class InterceptionResponse(
+        val data: String,
+        val mimeType: String = "text/html",
+        val encoding: String = "UTF-8"
+    )
+
+    /**
+     * A request to open an URI. This is called before each page load to allow custom behavior implementation.
+     *
+     * @param session The engine session that initiated the callback.
+     * @return An InterceptionResponse object containing alternative content if the request should be intercepted.
+     *         <code>null</code> otherwise.
+     */
+    fun onLoadRequest(session: EngineSession, uri: String): InterceptionResponse?
+}

--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -30,6 +30,7 @@ android {
 dependencies {
     implementation Deps.kotlin_stdlib
 
+    implementation Deps.testing_junit
     implementation Deps.testing_mockito
 }
 

--- a/components/support/test/src/main/java/mozilla/components/support/test/Expect.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/Expect.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.test
+
+import org.junit.Assert.fail
+import kotlin.reflect.KClass
+
+/**
+ * Expect [block] to throw an exception. Otherwise fail the test (junit).
+ */
+inline fun <reified T : Throwable> expectException(clazz: KClass<T>, block: () -> Unit) {
+    try {
+        block()
+        fail("Expected exception to be thrown: $clazz")
+    } catch (e: Throwable) {
+        if (e !is T) {
+            throw e
+        }
+    }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -16,12 +16,14 @@ import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.DefaultSessionStorage
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionIntentProcessor
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.samples.browser.request.SampleRequestInterceptor
 
 /**
  * Helper class for lazily instantiating components needed by the application.
@@ -29,8 +31,12 @@ import org.mozilla.geckoview.GeckoRuntime
 class Components(private val applicationContext: Context) {
     // Engine
     val engine: Engine by lazy {
+        val defaultSettings = DefaultSettings().apply {
+            requestInterceptor = SampleRequestInterceptor()
+        }
+
         val runtime = GeckoRuntime.getDefault(applicationContext)
-        GeckoEngine(runtime)
+        GeckoEngine(runtime, defaultSettings)
     }
 
     // Session

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser.request
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.request.RequestInterceptor
+
+class SampleRequestInterceptor : RequestInterceptor {
+    override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+        return when (uri) {
+            "sample:about" -> RequestInterceptor.InterceptionResponse("<h1>I am the sample browser</h1>")
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
@csadilek This is not done (I need to add KDoc and tests..). But I would like to know if the proposed Settings API looks good to you?