### PR TITLE
README: Remove sputnik badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Task Status](https://github.taskcluster.net/v1/repository/mozilla-mobile/android-components/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla-mobile/android-components/master/latest)
 [![Build Status](https://travis-ci.org/mozilla-mobile/android-components.svg?branch=master)](https://travis-ci.org/mozilla-mobile/android-components)
 [![codecov](https://codecov.io/gh/mozilla-mobile/android-components/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla-mobile/android-components)
-[![Sputnik](https://sputnik.ci/conf/badge)](https://sputnik.ci/app#/builds/mozilla-mobile/android-components)
 ![](https://api.bintray.com/packages/pocmo/Mozilla-Mobile/errorpages/images/download.svg)
 
 _A collection of Android libraries to build browsers or browser-like applications._


### PR DESCRIPTION
Just noticed that there's still the sputnik badge in the README even though we are not using sputnik anymore.