### PR TITLE
Use jacoco 0.8.2 for code coverage reports.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ subprojects {
 
     afterEvaluate {
         if (it.hasProperty('android')) {
+            jacoco {
+                toolVersion = "0.8.2"
+            }
+
             dependencies {
                 lintChecks project(':tooling-lint')
             }


### PR DESCRIPTION
Jacoco 0.8.2 was released. Let's see how this affects code coverage. According to the release notes a bunch of Kotlin improvements landed:
https://github.com/jacoco/jacoco/releases