### PR TITLE
Closes #657: Forward lifecycle events to EngineView

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -52,4 +52,12 @@ class GeckoEngineView @JvmOverloads constructor(
             currentGeckoView.session = internalSession.geckoSession
         }
     }
+
+    override fun onStart() {
+        currentGeckoView.session.setActive(true)
+    }
+
+    override fun onStop() {
+        currentGeckoView.session.setActive(false)
+    }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -35,4 +35,19 @@ class GeckoEngineViewTest {
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
     }
+
+    @Test
+    fun testLifecycleMethods() {
+        val geckoView = mock(GeckoView::class.java)
+        val geckoSession = mock(GeckoSession::class.java)
+        val engineView = GeckoEngineView(RuntimeEnvironment.application)
+        `when`(geckoView.session).thenReturn(geckoSession)
+        engineView.currentGeckoView = geckoView
+
+        engineView.onStart()
+        verify(geckoSession).setActive(true)
+
+        engineView.onStop()
+        verify(geckoSession).setActive(false)
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -52,4 +52,12 @@ class GeckoEngineView @JvmOverloads constructor(
             currentGeckoView.session = internalSession.geckoSession
         }
     }
+
+    override fun onStart() {
+        currentGeckoView.session.setActive(true)
+    }
+
+    override fun onStop() {
+        currentGeckoView.session.setActive(false)
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -35,4 +35,19 @@ class GeckoEngineViewTest {
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
     }
+
+    @Test
+    fun testLifecycleMethods() {
+        val geckoView = mock(GeckoView::class.java)
+        val geckoSession = mock(GeckoSession::class.java)
+        val engineView = GeckoEngineView(RuntimeEnvironment.application)
+        `when`(geckoView.session).thenReturn(geckoSession)
+        engineView.currentGeckoView = geckoView
+
+        engineView.onStart()
+        verify(geckoSession).setActive(true)
+
+        engineView.onStop()
+        verify(geckoSession).setActive(false)
+    }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -38,4 +38,12 @@ class GeckoEngineView @JvmOverloads constructor(
             currentGeckoView.session = internalSession.geckoSession
         }
     }
+
+    override fun onStart() {
+        currentGeckoView.session.setActive(true)
+    }
+
+    override fun onStop() {
+        currentGeckoView.session.setActive(false)
+    }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -35,4 +35,19 @@ class GeckoEngineViewTest {
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
     }
+
+    @Test
+    fun testLifecycleMethods() {
+        val geckoView = mock(GeckoView::class.java)
+        val geckoSession = mock(GeckoSession::class.java)
+        val engineView = GeckoEngineView(RuntimeEnvironment.application)
+        `when`(geckoView.session).thenReturn(geckoSession)
+        engineView.currentGeckoView = geckoView
+
+        engineView.onStart()
+        verify(geckoSession).setActive(true)
+
+        engineView.onStop()
+        verify(geckoSession).setActive(false)
+    }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -36,6 +36,7 @@ import java.net.URI
 /**
  * WebView-based implementation of EngineView.
  */
+@Suppress("TooManyFunctions")
 class SystemEngineView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -76,6 +77,20 @@ class SystemEngineView @JvmOverloads constructor(
     override fun onLongClick(view: View?): Boolean {
         val result = currentWebView.hitTestResult
         return handleLongClick(result.type, result.extra)
+    }
+
+    override fun onPause() {
+        currentWebView.onPause()
+        currentWebView.pauseTimers()
+    }
+
+    override fun onResume() {
+        currentWebView.onResume()
+        currentWebView.resumeTimers()
+    }
+
+    override fun onDestroy() {
+        currentWebView.destroy()
     }
 
     private fun createWebView(context: Context): WebView {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -314,4 +314,22 @@ class SystemEngineViewTest {
         listener.onFindResultReceived(0, 1, true)
         assertTrue(observerNotified)
     }
+
+    @Test
+    fun testLifecycleMethods() {
+        val webView = mock(WebView::class.java)
+        val engineView = SystemEngineView(RuntimeEnvironment.application)
+        engineView.currentWebView = webView
+
+        engineView.onPause()
+        verify(webView).onPause()
+        verify(webView).pauseTimers()
+
+        engineView.onResume()
+        verify(webView).onResume()
+        verify(webView).resumeTimers()
+
+        engineView.onDestroy()
+        verify(webView).destroy()
+    }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.concept.engine
 
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.OnLifecycleEvent
 import android.view.View
 
 /**
@@ -20,4 +23,76 @@ interface EngineView {
      * Render the content of the given session.
      */
     fun render(session: EngineSession)
+
+    /**
+     * To be called in response to [Lifecycle.Event.ON_RESUME]. See [EngineView]
+     * implementations for details.
+     */
+    fun onResume() = Unit
+
+    /**
+     * To be called in response to [Lifecycle.Event.ON_PAUSE]. See [EngineView]
+     * implementations for details.
+     */
+    fun onPause() = Unit
+
+    /**
+     * To be called in response to [Lifecycle.Event.ON_START]. See [EngineView]
+     * implementations for details.
+     */
+    fun onStart() = Unit
+
+    /**
+     * To be called in response to [Lifecycle.Event.ON_STOP]. See [EngineView]
+     * implementations for details.
+     */
+    fun onStop() = Unit
+
+    /**
+     * To be called in response to [Lifecycle.Event.ON_CREATE]. See [EngineView]
+     * implementations for details.
+     */
+    fun onCreate() = Unit
+
+    /**
+     * To be called in response to [Lifecycle.Event.ON_DESTROY]. See [EngineView]
+     * implementations for details.
+     */
+    fun onDestroy() = Unit
+}
+
+/**
+ * [LifecycleObserver] which dispatches lifecycle events to an [EngineView].
+ */
+class LifecycleObserver(val engineView: EngineView) : LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    fun onPause() {
+        engineView.onPause()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    fun onResume() {
+        engineView.onResume()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    fun onStart() {
+        engineView.onStart()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun onStop() {
+        engineView.onStop()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun onCreate() {
+        engineView.onCreate()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun onDestroy() {
+        engineView.onDestroy()
+    }
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
@@ -9,6 +9,8 @@ import android.widget.FrameLayout
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import java.lang.ClassCastException
@@ -28,6 +30,30 @@ class EngineViewTest {
     fun `asView method fails if class is not a view`() {
         val engineView = BrokenEngineView()
         engineView.asView()
+    }
+
+    @Test
+    fun testLifecycleObserver() {
+        val engineView = spy(createDummyEngineView(RuntimeEnvironment.application))
+        val observer = LifecycleObserver(engineView)
+
+        observer.onCreate()
+        verify(engineView).onCreate()
+
+        observer.onDestroy()
+        verify(engineView).onDestroy()
+
+        observer.onStart()
+        verify(engineView).onStart()
+
+        observer.onStop()
+        verify(engineView).onStop()
+
+        observer.onPause()
+        verify(engineView).onPause()
+
+        observer.onResume()
+        verify(engineView).onResume()
     }
 
     private fun createDummyEngineView(context: Context): EngineView = DummyEngineView(context)


### PR DESCRIPTION
Some thoughts / open questions:

- Focus calls `setActive` on the GeckoSession `onPause/onResume`, not `onStart/onStop`. According to the Javadoc in GV we should only call `setActive(false)` when not visible. So, this implementation seems correct.

- Should we save state by default in `onPause` or let the app decide / handle that?