### PR TITLE
Closes #643: FullScreen mode support...

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.annotation.SuppressLint
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
@@ -194,6 +195,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.findNext]
      */
+    @SuppressLint("WrongConstant") // FinderFindFlags annotation doesn't include a 0 value.
     override fun findNext(forward: Boolean) {
         val findFlags = if (forward) 0 else GeckoSession.FINDER_FIND_BACKWARDS
         geckoSession.finder.find(null, findFlags).then { result: GeckoSession.FinderResult? ->
@@ -209,6 +211,13 @@ class GeckoEngineSession(
      */
     override fun clearFindMatches() {
         geckoSession.finder.clear()
+    }
+
+    /**
+     * See [EngineSession.exitFullScreenMode]
+     */
+    override fun exitFullScreenMode() {
+        geckoSession.exitFullScreen()
     }
 
     /**
@@ -319,7 +328,9 @@ class GeckoEngineSession(
 
         override fun onCrash(session: GeckoSession?) = Unit
 
-        override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) = Unit
+        override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) {
+            notifyObservers { onFullScreenChange(fullScreen) }
+        }
 
         override fun onExternalResponse(session: GeckoSession, response: GeckoSession.WebResponseInfo) {
             notifyObservers {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -666,4 +666,37 @@ class GeckoEngineSessionTest {
         engineSession.clearFindMatches()
         assertTrue(clearMatchesReceived)
     }
+
+    @Test
+    fun `toggle fullscreen mode triggers exit event`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val geckoSession = spy(engineSession.geckoSession)
+        engineSession.geckoSession = geckoSession
+        val observer: EngineSession.Observer = mock()
+
+        // Verify the event is triggered for exiting fullscreen mode and GeckoView is called.
+        var fullScreenExitReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(
+            BundleEventListener { _, _, _ -> fullScreenExitReceived = true },
+            "GeckoViewContent:ExitFullScreen"
+        )
+        engineSession.exitFullScreenMode()
+        assertTrue(fullScreenExitReceived)
+        verify(geckoSession).exitFullScreen()
+
+        // Verify the call to the observer.
+        engineSession.register(observer)
+        engineSession.geckoSession.contentDelegate.onFullScreen(geckoSession, true)
+        verify(observer).onFullScreenChange(true)
+    }
+
+    @Test
+    fun `toggle fullscreen true has no interaction`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val geckoSession = spy(engineSession.geckoSession)
+        engineSession.geckoSession = geckoSession
+
+        engineSession.exitFullScreenMode()
+        verify(geckoSession).exitFullScreen()
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -4,15 +4,16 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.annotation.SuppressLint
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.request.RequestInterceptor
-import mozilla.components.support.ktx.kotlin.isPhone
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
+import mozilla.components.support.ktx.kotlin.isPhone
 import org.mozilla.gecko.util.ThreadUtils
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
@@ -194,6 +195,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.findNext]
      */
+    @SuppressLint("WrongConstant") // FinderFindFlags annotation doesn't include a 0 value.
     override fun findNext(forward: Boolean) {
         val findFlags = if (forward) 0 else GeckoSession.FINDER_FIND_BACKWARDS
         geckoSession.finder.find(null, findFlags).then { result: GeckoSession.FinderResult? ->
@@ -209,6 +211,13 @@ class GeckoEngineSession(
      */
     override fun clearFindMatches() {
         geckoSession.finder.clear()
+    }
+
+    /**
+     * See [EngineSession.exitFullScreenMode]
+     */
+    override fun exitFullScreenMode() {
+        geckoSession.exitFullScreen()
     }
 
     /**
@@ -319,7 +328,9 @@ class GeckoEngineSession(
 
         override fun onCrash(session: GeckoSession?) = Unit
 
-        override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) = Unit
+        override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) {
+            notifyObservers { onFullScreenChange(fullScreen) }
+        }
 
         override fun onExternalResponse(session: GeckoSession, response: GeckoSession.WebResponseInfo) {
             notifyObservers {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -666,4 +666,37 @@ class GeckoEngineSessionTest {
         engineSession.clearFindMatches()
         assertTrue(clearMatchesReceived)
     }
+
+    @Test
+    fun testExitFullScreenModeTriggersExitEvent() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val geckoSession = spy(engineSession.geckoSession)
+        engineSession.geckoSession = geckoSession
+        val observer: EngineSession.Observer = mock()
+
+        // Verify the event is triggered for exiting fullscreen mode and GeckoView is called.
+        var fullScreenExitReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(
+            BundleEventListener { _, _, _ -> fullScreenExitReceived = true },
+            "GeckoViewContent:ExitFullScreen"
+        )
+        engineSession.exitFullScreenMode()
+        assertTrue(fullScreenExitReceived)
+        verify(geckoSession).exitFullScreen()
+
+        // Verify the call to the observer.
+        engineSession.register(observer)
+        engineSession.geckoSession.contentDelegate.onFullScreen(geckoSession, true)
+        verify(observer).onFullScreenChange(true)
+    }
+
+    @Test
+    fun testExitFullscreenTrueHasNoInteraction() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val geckoSession = spy(engineSession.geckoSession)
+        engineSession.geckoSession = geckoSession
+
+        engineSession.exitFullScreenMode()
+        verify(geckoSession).exitFullScreen()
+    }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -198,6 +198,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.exitFullScreenMode]
+     */
+    override fun exitFullScreenMode() {
+        geckoSession.exitFullScreen()
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     private fun createNavigationDelegate() = object : GeckoSession.NavigationDelegate {
@@ -303,7 +310,9 @@ class GeckoEngineSession(
 
         override fun onCrash(session: GeckoSession?) = Unit
 
-        override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) = Unit
+        override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) {
+            notifyObservers { onFullScreenChange(fullScreen) }
+        }
 
         override fun onExternalResponse(session: GeckoSession, response: GeckoSession.WebResponseInfo) {
             notifyObservers {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -606,4 +606,36 @@ class GeckoEngineSessionTest {
         engineSession.clearFindMatches()
         assertTrue(clearMatchesReceived)
     }
+
+    fun `toggle fullscreen mode triggers exit event`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val geckoSession = Mockito.spy(engineSession.geckoSession)
+        engineSession.geckoSession = geckoSession
+        val observer: EngineSession.Observer = mock(EngineSession.Observer::class.java)
+
+        // Verify the event is triggered for exiting fullscreen mode and GeckoView is called.
+        var fullScreenExitReceived = false
+        engineSession.geckoSession.eventDispatcher.registerUiThreadListener(
+            BundleEventListener { _, _, _ -> fullScreenExitReceived = true },
+            "GeckoViewContent:ExitFullScreen"
+        )
+        engineSession.exitFullScreenMode()
+        assertTrue(fullScreenExitReceived)
+        verify(geckoSession).exitFullScreen()
+
+        // Verify the call to the observer.
+        engineSession.register(observer)
+        engineSession.geckoSession.contentDelegate.onFullScreen(geckoSession, true)
+        verify(observer).onFullScreenChange(true)
+    }
+
+    @Test
+    fun `toggle fullscreen true has no interaction`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val geckoSession = Mockito.spy(engineSession.geckoSession)
+        engineSession.geckoSession = geckoSession
+
+        engineSession.exitFullScreenMode()
+        verify(geckoSession).exitFullScreen()
+    }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -6,12 +6,12 @@ package mozilla.components.browser.engine.system
 
 import android.os.Bundle
 import android.webkit.WebView
-import mozilla.components.concept.engine.EngineSession
-import mozilla.components.support.ktx.kotlin.toBundle
-import java.lang.ref.WeakReference
 import kotlinx.coroutines.experimental.launch
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.support.ktx.kotlin.toBundle
+import java.lang.ref.WeakReference
 
 internal val additionalHeaders = mapOf(
     // For every request WebView sends a "X-requested-with" header with the package name of the
@@ -26,6 +26,7 @@ internal val additionalHeaders = mapOf(
  */
 @Suppress("TooManyFunctions")
 class SystemEngineSession(private val defaultSettings: Settings? = null) : EngineSession() {
+
     internal var view: WeakReference<SystemEngineView>? = null
     internal var scheduledLoad = ScheduledLoad(null)
     @Volatile internal var trackingProtectionEnabled = false
@@ -215,6 +216,13 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
                 view.reload()
             }
         }
+    }
+
+    /**
+     * See [EngineSession.exitFullScreenMode]
+     */
+    override fun exitFullScreenMode() {
+        // no-op
     }
 
     internal fun toggleDesktopUA(userAgent: String, requestDesktop: Boolean): String {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -26,9 +26,9 @@ import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.never
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -394,7 +394,7 @@ class SystemEngineSessionTest {
     }
 
     @Test
-    fun `desktop mode UA`() {
+    fun testDesktopModeUA() {
         val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
         val userAgentDesktop = "Mozilla/5.0 (Linux; diordnA 9) AppleWebKit/537.36 eliboM Safari/537.36"
         val engineSession = spy(SystemEngineSession())

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -48,6 +48,7 @@ class Session(
         fun onLongPress(session: Session, hitResult: HitResult): Boolean = false
         fun onFindResult(session: Session, result: FindResult) = Unit
         fun onDesktopModeChanged(session: Session, enabled: Boolean) = Unit
+        fun onFullScreenChanged(session: Session, enabled: Boolean) = Unit
     }
 
     /**
@@ -232,9 +233,14 @@ class Session(
      * Desktop Mode state, true if the desktop mode is requested, otherwise false.
      */
     var desktopMode: Boolean by Delegates.observable(false) { _, old, new ->
-        notifyObservers(old, new) {
-            onDesktopModeChanged(this@Session, new)
-        }
+        notifyObservers(old, new) { onDesktopModeChanged(this@Session, new) }
+    }
+
+    /**
+     * Exits fullscreen mode if it's in that state.
+     */
+    var fullScreenMode: Boolean by Delegates.observable(false) { _, old, new ->
+        notifyObservers(old, new) { notifyObservers { onFullScreenChanged(this@Session, fullScreenMode) } }
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -81,4 +81,8 @@ internal class EngineObserver(val session: Session) : EngineSession.Observer {
     override fun onDesktopModeChange(enabled: Boolean) {
         session.desktopMode = enabled
     }
+
+    override fun onFullScreenChange(enabled: Boolean) {
+        session.fullScreenMode = enabled
+    }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -7,10 +7,10 @@ package mozilla.components.browser.session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
-import mozilla.components.support.base.observer.Consumable
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -498,12 +498,23 @@ class SessionTest {
         val observer = mock(Session.Observer::class.java)
         val session = Session("https://www.mozilla.org")
         session.register(observer)
-
         session.desktopMode = true
-
         verify(observer).onDesktopModeChanged(
                 eq(session),
                 eq(true))
         assertTrue(session.desktopMode)
+    }
+
+    @Test
+    fun `observer is notified on fullscreen mode`() {
+        val observer = mock(Session.Observer::class.java)
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+        session.fullScreenMode = true
+        verify(observer).onFullScreenChanged(session, true)
+        reset(observer)
+        session.unregister(observer)
+        session.fullScreenMode = false
+        verify(observer, never()).onFullScreenChanged(session, false)
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -6,8 +6,8 @@ package mozilla.components.browser.session.engine
 
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.Settings
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,13 +32,12 @@ class EngineObserverTest {
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
-                notifyObservers {
-                    onDesktopModeChange(enable)
-                }
+                notifyObservers { onDesktopModeChange(enable) }
             }
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
+            override fun exitFullScreenMode() {}
             override fun saveState(): Map<String, Any> {
                 return emptyMap()
             }
@@ -87,6 +86,7 @@ class EngineObserverTest {
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
+            override fun exitFullScreenMode() {}
             override fun saveState(): Map<String, Any> {
                 return emptyMap()
             }
@@ -138,6 +138,7 @@ class EngineObserverTest {
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
+            override fun exitFullScreenMode() {}
         }
         val observer = EngineObserver(session)
         engineSession.register(observer)
@@ -226,5 +227,16 @@ class EngineObserverTest {
 
         observer.onLoadingStateChange(true)
         assertEquals(emptyList<String>(), session.findResults)
+    }
+
+    @Test
+    fun testEngineObserverNotifiesFullscreenMode() {
+        val session = Session("https://www.mozilla.org")
+        val observer = EngineObserver(session)
+
+        observer.onFullScreenChange(true)
+        assertEquals(true, session.fullScreenMode)
+        observer.onFullScreenChange(false)
+        assertEquals(false, session.fullScreenMode)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -33,6 +33,7 @@ abstract class EngineSession(
         fun onDesktopModeChange(enabled: Boolean) = Unit
         fun onFind(text: String) = Unit
         fun onFindResult(activeMatchOrdinal: Int, numberOfMatches: Int, isDoneCounting: Boolean) = Unit
+        fun onFullScreenChange(enabled: Boolean) = Unit
 
         @Suppress("LongParameterList")
         fun onExternalResource(
@@ -178,6 +179,11 @@ abstract class EngineSession(
      * Clears the highlighted results of previous calls to [findAll] / [findNext].
      */
     abstract fun clearFindMatches()
+
+    /**
+     * Exits fullscreen mode if currently in it that state.
+     */
+    abstract fun exitFullScreenMode()
 
     /**
      * Close the session. This may free underlying objects. Call this when you are finished using

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -4,8 +4,8 @@
 
 package mozilla.components.concept.engine
 
-import org.junit.Assert.assertEquals
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -36,6 +36,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
+        session.notifyInternalObservers { onFullScreenChange(true) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
@@ -49,6 +50,7 @@ class EngineSessionTest {
         verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
+        verify(observer).onFullScreenChange(true)
         verifyNoMoreInteractions(observer)
     }
 
@@ -69,6 +71,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
+        session.notifyInternalObservers { onFullScreenChange(true) }
 
         session.unregister(observer)
 
@@ -82,6 +85,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search2") }
         session.notifyInternalObservers { onFindResult(0, 1, false) }
+        session.notifyInternalObservers { onFullScreenChange(false) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -93,6 +97,7 @@ class EngineSessionTest {
         verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
+        verify(observer).onFullScreenChange(true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -103,6 +108,7 @@ class EngineSessionTest {
         verify(observer, never()).onDesktopModeChange(false)
         verify(observer, never()).onFind("search2")
         verify(observer, never()).onFindResult(0, 1, false)
+        verify(observer, never()).onFullScreenChange(false)
         verifyNoMoreInteractions(observer)
     }
 
@@ -125,6 +131,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
+        session.notifyInternalObservers { onFullScreenChange(true) }
 
         session.unregisterObservers()
 
@@ -138,6 +145,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search2") }
         session.notifyInternalObservers { onFindResult(0, 1, false) }
+        session.notifyInternalObservers { onFullScreenChange(false) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -149,6 +157,7 @@ class EngineSessionTest {
         verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
+        verify(observer).onFullScreenChange(true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -159,6 +168,7 @@ class EngineSessionTest {
         verify(observer, never()).onDesktopModeChange(false)
         verify(observer, never()).onFind("search2")
         verify(observer, never()).onFindResult(0, 1, false)
+        verify(observer, never()).onFullScreenChange(false)
         verify(otherObserver, never()).onLocationChange("https://www.firefox.com")
         verify(otherObserver, never()).onProgress(100)
         verify(otherObserver, never()).onLoadingStateChange(false)
@@ -169,6 +179,7 @@ class EngineSessionTest {
         verify(otherObserver, never()).onDesktopModeChange(false)
         verify(otherObserver, never()).onFind("search2")
         verify(otherObserver, never()).onFindResult(0, 1, false)
+        verify(otherObserver, never()).onFullScreenChange(false)
     }
 
     @Test
@@ -188,6 +199,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
+        session.notifyInternalObservers { onFullScreenChange(true) }
 
         session.close()
 
@@ -201,6 +213,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search2") }
         session.notifyInternalObservers { onFindResult(0, 1, false) }
+        session.notifyInternalObservers { onFullScreenChange(false) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -212,6 +225,7 @@ class EngineSessionTest {
         verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
+        verify(observer).onFullScreenChange(true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -222,6 +236,7 @@ class EngineSessionTest {
         verify(observer, never()).onDesktopModeChange(false)
         verify(observer, never()).onFind("search2")
         verify(observer, never()).onFindResult(0, 1, false)
+        verify(observer, never()).onFullScreenChange(false)
         verifyNoMoreInteractions(observer)
     }
 
@@ -244,6 +259,7 @@ class EngineSessionTest {
         otherSession.notifyInternalObservers { onDesktopModeChange(true) }
         otherSession.notifyInternalObservers { onFind("search") }
         otherSession.notifyInternalObservers { onFindResult(0, 1, true) }
+        otherSession.notifyInternalObservers { onFullScreenChange(true) }
         verify(observer, never()).onLocationChange("https://www.mozilla.org")
         verify(observer, never()).onProgress(25)
         verify(observer, never()).onLoadingStateChange(true)
@@ -254,6 +270,7 @@ class EngineSessionTest {
         verify(observer, never()).onDesktopModeChange(true)
         verify(observer, never()).onFind("search")
         verify(observer, never()).onFindResult(0, 1, true)
+        verify(observer, never()).onFullScreenChange(true)
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
@@ -265,6 +282,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
+        session.notifyInternalObservers { onFullScreenChange(true) }
         verify(observer, times(1)).onLocationChange("https://www.mozilla.org")
         verify(observer, times(1)).onProgress(25)
         verify(observer, times(1)).onLoadingStateChange(true)
@@ -275,6 +293,7 @@ class EngineSessionTest {
         verify(observer, times(1)).onDesktopModeChange(false)
         verify(observer, times(1)).onFind("search")
         verify(observer, times(1)).onFindResult(0, 1, true)
+        verify(observer, times(1)).onFullScreenChange(true)
         verifyNoMoreInteractions(observer)
     }
 
@@ -407,6 +426,8 @@ open class DummyEngineSession : EngineSession() {
     override fun findNext(forward: Boolean) {}
 
     override fun clearFindMatches() {}
+
+    override fun exitFullScreenMode() {}
 
     // Helper method to access the protected method from test cases.
     fun notifyInternalObservers(block: Observer.() -> Unit) {

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.support.ktx.android.view
+
+import android.app.Activity
+import android.view.View
+import android.view.WindowManager
+
+/**
+ * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
+ */
+fun Activity.enterToImmersiveMode() {
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+        or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+        or View.SYSTEM_UI_FLAG_FULLSCREEN
+        or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+}
+
+/**
+ * Attempts to come out from immersive mode using the View.
+ */
+fun Activity.exitImmersiveModeIfNeeded() {
+    if (WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON and window.attributes.flags == 0) {
+        // We left immersive mode already.
+        return
+    }
+
+    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    window.decorView.systemUiVisibility =
+        View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.support.ktx.android.view
+
+import android.app.Activity
+import android.view.View
+import android.view.Window
+import android.view.WindowManager
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+class ActivityTest {
+
+    @Test
+    fun `check enterImmersibleMode sets the correct flags`() {
+        val activity = mock(Activity::class.java)
+        val mockWindow = mock(Window::class.java)
+        val mockDecorView = mock(View::class.java)
+        val expectedFlags = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+            or View.SYSTEM_UI_FLAG_FULLSCREEN
+            or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+
+        `when`(activity.window).thenReturn(mockWindow)
+        `when`(mockWindow.decorView).thenReturn(mockDecorView)
+
+        activity.enterToImmersiveMode()
+        verify(mockWindow).addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        verify(mockDecorView).systemUiVisibility = expectedFlags
+    }
+
+    @Test
+    fun `check exitImmersiveModeIfNeeded sets the correct flags`() {
+        val activity = mock(Activity::class.java)
+        val window = mock(Window::class.java)
+        val decorView = mock(View::class.java)
+        val attributes = mock(WindowManager.LayoutParams::class.java)
+        val expectedFlags = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN)
+
+        `when`(activity.window).thenReturn(window)
+        `when`(window.decorView).thenReturn(decorView)
+        `when`(window.attributes).thenReturn(attributes)
+        attributes.flags = 0
+
+        activity.exitImmersiveModeIfNeeded()
+
+        verify(window, never()).clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        verify(decorView, never()).systemUiVisibility = expectedFlags
+
+        attributes.flags = WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+
+        activity.exitImmersiveModeIfNeeded()
+
+        verify(window).clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        verify(decorView).systemUiVisibility = expectedFlags
+    }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
@@ -4,19 +4,19 @@
 
 package mozilla.components.support.ktx.android.view
 
+import android.util.DisplayMetrics
+import android.view.View
 import android.widget.EditText
 import android.widget.TextView
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.shadows.ShadowLooper
-import android.util.DisplayMetrics
-import android.view.View
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 
 @RunWith(RobolectricTestRunner::class)
 class ViewTest {


### PR DESCRIPTION
This was difficult to wrap my head around in the beginning for the known reasons of having different APIs for both the engines. I solved this by having an optional callback for `EngineSession#fullScreenMode` which is called from the SystemWebView.

For GeckoView, we don't need to inform the engine about entering fullscreen mode, so calling `fullScreenMode(true)` does nothing. Only exiting, requires us to notify the engine.

Another difference is that in the `SystemEngineSession` we have access to the current view attached to the EngineSession and we're able to enter and exit Immersive Mode thanks to that, but we're not able to do it for GeckoView, which requires the callers to remember to do it (if they want to?).