### PR TITLE
Closes: #126: Remove or rename View.layoutDirection

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -15,16 +15,6 @@ import mozilla.components.support.ktx.android.content.systemService
 import java.lang.ref.WeakReference
 
 /**
- * The resolved layout direction for this view.
- *
- * @return {@link #LAYOUT_DIRECTION_RTL} if the layout direction is RTL or returns
- * {@link #LAYOUT_DIRECTION_LTR} if the layout direction is not RTL.
- */
-val View.layoutDirection: Int
-    get() =
-        ViewCompat.getLayoutDirection(this)
-
-/**
  * Is the horizontal layout direction of this view from Right to Left?
  */
 val View.isRTL: Boolean


### PR DESCRIPTION
I proceeded  to remove this extension property, we have the same behavior as the one provided by view.getLayoutDirection (added on added in API level 17), this method was added on ViewCompat to provide backward support for API level less than 17 and our minSdkVersion is 21, so we're good to go.

I verified that it wasn't use in the following consumers repositories:
* firefox-tv
* focus-android
* mozilla-tw/Rocket

References:
https://developer.android.com/reference/android/content/res/Configuration#getLayoutDirection()