### PR TITLE
Update fxa component to 0.2.4

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -23,7 +23,7 @@ private object Versions {
 
     const val jna = "4.5.2"
 
-    const val fxa = "0.2.3"
+    const val fxa = "0.2.4"
 }
 
 // Synchronized dependencies used by (some) modules


### PR DESCRIPTION
Brings in this change to ARM64 libs: https://github.com/mozilla/application-services/commit/26016b772e725689127a804218540641b5184891

@csadilek no other change is required right (to unzip logic, etc)? 