### PR TITLE
Use Pointer and not String in FxA FFI code.

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Error.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Error.kt
@@ -49,7 +49,7 @@ open class Error : Structure() {
      * Get the error message or null if there is none.
      */
     fun getMessage(): String? {
-        return this.message?.getString(0, "utf8")
+        return this.message?.getString(0, RustObject.RUST_STRING_ENCODING)
     }
 
     override fun getFieldOrder(): List<String> {

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/OAuthInfo.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/OAuthInfo.kt
@@ -17,9 +17,9 @@ class OAuthInfo internal constructor(raw: Raw) {
 
     @Suppress("VariableNaming")
     class Raw(p: Pointer) : Structure(p) {
-        @JvmField var access_token: String? = null
-        @JvmField var keys: String? = null
-        @JvmField var scope: String? = null
+        @JvmField var access_token: Pointer? = null
+        @JvmField var keys: Pointer? = null
+        @JvmField var scope: Pointer? = null
 
         init {
             read()
@@ -31,9 +31,9 @@ class OAuthInfo internal constructor(raw: Raw) {
     }
 
     init {
-        this.accessToken = raw.access_token
-        this.keys = raw.keys
-        this.scope = raw.scope
+        this.accessToken = raw.access_token?.getString(0, RustObject.RUST_STRING_ENCODING)
+        this.keys = raw.keys?.getString(0, RustObject.RUST_STRING_ENCODING)
+        this.scope = raw.scope?.getString(0, RustObject.RUST_STRING_ENCODING)
         FxaClient.INSTANCE.fxa_oauth_info_free(raw.pointer)
     }
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Profile.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Profile.kt
@@ -18,10 +18,10 @@ class Profile internal constructor(raw: Raw) {
 
     @Suppress("VariableNaming")
     class Raw(p: Pointer) : Structure(p) {
-        @JvmField var uid: String? = null
-        @JvmField var email: String? = null
-        @JvmField var avatar: String? = null
-        @JvmField var display_name: String? = null
+        @JvmField var uid: Pointer? = null
+        @JvmField var email: Pointer? = null
+        @JvmField var avatar: Pointer? = null
+        @JvmField var display_name: Pointer? = null
 
         init {
             read()
@@ -33,10 +33,10 @@ class Profile internal constructor(raw: Raw) {
     }
 
     init {
-        this.uid = raw.uid
-        this.email = raw.email
-        this.avatar = raw.avatar
-        this.displayName = raw.display_name
+        this.uid = raw.uid?.getString(0, RustObject.RUST_STRING_ENCODING)
+        this.email = raw.email?.getString(0, RustObject.RUST_STRING_ENCODING)
+        this.avatar = raw.avatar?.getString(0, RustObject.RUST_STRING_ENCODING)
+        this.displayName = raw.display_name?.getString(0, RustObject.RUST_STRING_ENCODING)
         FxaClient.INSTANCE.fxa_profile_free(raw.pointer)
     }
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/RustObject.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/RustObject.kt
@@ -41,12 +41,14 @@ abstract class RustObject<T> : Closeable {
     }
 
     companion object {
+        const val RUST_STRING_ENCODING = "utf8"
+
         fun getAndConsumeString(stringPtr: Pointer?): String? {
             if (stringPtr == null) {
                 return null
             }
             try {
-                return stringPtr.getString(0, "utf8")
+                return stringPtr.getString(0, RUST_STRING_ENCODING)
             } finally {
                 FxaClient.INSTANCE.fxa_str_free(stringPtr)
             }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/SyncKeys.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/SyncKeys.kt
@@ -16,8 +16,8 @@ class SyncKeys internal constructor(raw: Raw) {
 
     @Suppress("VariableNaming")
     class Raw(p: Pointer) : Structure(p) {
-        @JvmField var sync_key: String? = null
-        @JvmField var xcs: String? = null
+        @JvmField var sync_key: Pointer? = null
+        @JvmField var xcs: Pointer? = null
 
         init {
             read()
@@ -29,8 +29,8 @@ class SyncKeys internal constructor(raw: Raw) {
     }
 
     init {
-        this.syncKey = raw.sync_key
-        this.xcs = raw.xcs
+        this.syncKey = raw.sync_key?.getString(0, RustObject.RUST_STRING_ENCODING)
+        this.xcs = raw.xcs?.getString(0, RustObject.RUST_STRING_ENCODING)
         FxaClient.INSTANCE.fxa_sync_keys_free(raw.pointer)
     }
 }


### PR DESCRIPTION
Otherwise it seems like rust is getting (and freeing) strings that were allocated on the Java heap, which ... leads to problems (heap corruption of multiple heaps!)

This ensures rust gets only the strings it allocates.

I suspect there's a cleaner way to do the `if (a.b == null) null else a.b!!.c(stuff)` pattern in Kotlin, let me know and I can fix that.