### PR TITLE
Closes Issue: 701: Not exposed desktop mode in browser session

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -160,7 +160,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override fun setDesktopMode(enable: Boolean, reload: Boolean) {
+    override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         // no-op (requires v63+)
     }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -160,7 +160,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override fun setDesktopMode(enable: Boolean, reload: Boolean) {
+    override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         val currentMode = geckoSession.settings.getInt(GeckoSessionSettings.USER_AGENT_MODE)
         val newMode = if (enable) {
             GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
@@ -170,7 +170,7 @@ class GeckoEngineSession(
 
         if (newMode != currentMode) {
             geckoSession.settings.setInt(GeckoSessionSettings.USER_AGENT_MODE, newMode)
-            notifyObservers { onDesktopModeEnabled(enable) }
+            notifyObservers { onDesktopModeChange(enable) }
         }
 
         if (reload) {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -571,22 +571,22 @@ class GeckoEngineSessionTest {
 
         var desktopModeEnabled = false
         engineSession.register(object : EngineSession.Observer {
-            override fun onDesktopModeEnabled(enabled: Boolean) {
+            override fun onDesktopModeChange(enabled: Boolean) {
                 desktopModeEnabled = true
             }
         })
-        engineSession.setDesktopMode(true)
+        engineSession.toggleDesktopMode(true)
         assertTrue(desktopModeEnabled)
 
         desktopModeEnabled = false
-        engineSession.setDesktopMode(true)
+        engineSession.toggleDesktopMode(true)
         assertFalse(desktopModeEnabled)
 
         engineSession.geckoSession.settings.setInt(GeckoSessionSettings.USER_AGENT_MODE, GeckoSessionSettings.USER_AGENT_MODE_DESKTOP)
-        engineSession.setDesktopMode(true)
+        engineSession.toggleDesktopMode(true)
         assertFalse(desktopModeEnabled)
 
-        engineSession.setDesktopMode(false)
+        engineSession.toggleDesktopMode(false)
         assertTrue(desktopModeEnabled)
     }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -153,7 +153,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override fun setDesktopMode(enable: Boolean, reload: Boolean) {
+    override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         // no-op (requires v63+)
     }
 

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -203,9 +203,9 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
     }
 
     /**
-     * See [EngineSession.setDesktopMode]
+     * See [EngineSession.toggleDesktopMode]
      */
-    override fun setDesktopMode(enable: Boolean, reload: Boolean) {
+    override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         currentView()?.let { view ->
             val webSettings = view.settings
             webSettings.userAgentString = toggleDesktopUA(webSettings.userAgentString, enable)

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -374,7 +374,7 @@ class SystemEngineSessionTest {
         val webView = mock(WebView::class.java)
         val webViewSettings = mock(WebSettings::class.java)
 
-        engineSession.setDesktopMode(true)
+        engineSession.toggleDesktopMode(true)
         verify(engineSession).currentView()
         verify(webView, never()).settings
 
@@ -382,14 +382,14 @@ class SystemEngineSessionTest {
         `when`(webView.settings).thenReturn(webViewSettings)
         `when`(webViewSettings.userAgentString).thenReturn(userAgentMobile)
 
-        engineSession.setDesktopMode(true)
+        engineSession.toggleDesktopMode(true)
         verify(webViewSettings).useWideViewPort = true
         verify(engineSession).toggleDesktopUA(userAgentMobile, true)
 
-        engineSession.setDesktopMode(true)
+        engineSession.toggleDesktopMode(true)
         verify(webView, never()).reload()
 
-        engineSession.setDesktopMode(true, true)
+        engineSession.toggleDesktopMode(true, true)
         verify(webView).reload()
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -47,6 +47,7 @@ class Session(
         fun onTrackerBlocked(session: Session, blocked: String, all: List<String>) = Unit
         fun onLongPress(session: Session, hitResult: HitResult): Boolean = false
         fun onFindResult(session: Session, result: FindResult) = Unit
+        fun onDesktopModeChanged(session: Session, enabled: Boolean) = Unit
     }
 
     /**
@@ -225,6 +226,15 @@ class Session(
     var hitResult: Consumable<HitResult> by Delegates.vetoable(Consumable.empty()) { _, _, result ->
         val consumers = wrapConsumers<HitResult> { onLongPress(this@Session, it) }
         !result.consumeBy(consumers)
+    }
+
+    /**
+     * Desktop Mode state, true if the desktop mode is requested, otherwise false.
+     */
+    var desktopMode: Boolean by Delegates.observable(false) { _, old, new ->
+        notifyObservers(old, new) {
+            onDesktopModeChanged(this@Session, new)
+        }
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -77,4 +77,8 @@ internal class EngineObserver(val session: Session) : EngineSession.Observer {
         val download = Download(url, fileName, contentType, contentLength, userAgent, Environment.DIRECTORY_DOWNLOADS)
         session.download = Consumable.from(download)
     }
+
+    override fun onDesktopModeChange(enabled: Boolean) {
+        session.desktopMode = enabled
+    }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -492,4 +492,18 @@ class SessionTest {
         session.findResults = emptyList()
         verifyNoMoreInteractions(observer)
     }
+
+    @Test
+    fun `observer is notified when desktop mode is set`() {
+        val observer = mock(Session.Observer::class.java)
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.desktopMode = true
+
+        verify(observer).onDesktopModeChanged(
+                eq(session),
+                eq(true))
+        assertTrue(session.desktopMode)
+    }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -31,7 +31,11 @@ class EngineObserverTest {
             override fun restoreState(state: Map<String, Any>) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
-            override fun setDesktopMode(enable: Boolean, reload: Boolean) {}
+            override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
+                notifyObservers {
+                    onDesktopModeChange(enable)
+                }
+            }
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -55,12 +59,14 @@ class EngineObserverTest {
         engineSession.register(EngineObserver(session))
 
         engineSession.loadUrl("http://mozilla.org")
+        engineSession.toggleDesktopMode(true)
         Assert.assertEquals("http://mozilla.org", session.url)
         Assert.assertEquals("", session.searchTerms)
         Assert.assertEquals(100, session.progress)
         Assert.assertEquals(true, session.loading)
         Assert.assertEquals(true, session.canGoForward)
         Assert.assertEquals(true, session.canGoBack)
+        Assert.assertEquals(true, session.desktopMode)
     }
 
     @Test
@@ -77,7 +83,7 @@ class EngineObserverTest {
             override fun restoreState(state: Map<String, Any>) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
-            override fun setDesktopMode(enable: Boolean, reload: Boolean) {}
+            override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -122,7 +128,7 @@ class EngineObserverTest {
                 notifyObservers { onTrackerBlockingEnabledChange(false) }
             }
 
-            override fun setDesktopMode(enable: Boolean, reload: Boolean) {}
+            override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
             override fun saveState(): Map<String, Any> {
                 return emptyMap()
             }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -30,7 +30,7 @@ abstract class EngineSession(
         fun onTrackerBlockingEnabledChange(enabled: Boolean) = Unit
         fun onTrackerBlocked(url: String) = Unit
         fun onLongPress(hitResult: HitResult) = Unit
-        fun onDesktopModeEnabled(enabled: Boolean) = Unit
+        fun onDesktopModeChange(enabled: Boolean) = Unit
         fun onFind(text: String) = Unit
         fun onFindResult(activeMatchOrdinal: Int, numberOfMatches: Int, isDoneCounting: Boolean) = Unit
 
@@ -157,7 +157,7 @@ abstract class EngineSession(
     /**
      * Enables/disables Desktop Mode with an optional ability to reload the session right after.
      */
-    abstract fun setDesktopMode(enable: Boolean, reload: Boolean = false)
+    abstract fun toggleDesktopMode(enable: Boolean, reload: Boolean = false)
 
     /**
      * Finds and highlights all occurrences of the provided String and highlights them asynchronously.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -33,7 +33,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(true) }
         session.notifyInternalObservers { onTrackerBlocked("tracker") }
         session.notifyInternalObservers { onLongPress(unknownHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(true) }
+        session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
 
@@ -46,7 +46,7 @@ class EngineSessionTest {
         verify(observer).onTrackerBlockingEnabledChange(true)
         verify(observer).onTrackerBlocked("tracker")
         verify(observer).onLongPress(unknownHitResult)
-        verify(observer).onDesktopModeEnabled(true)
+        verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
         verifyNoMoreInteractions(observer)
@@ -66,7 +66,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(true) }
         session.notifyInternalObservers { onTrackerBlocked("tracker") }
         session.notifyInternalObservers { onLongPress(unknownHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(true) }
+        session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
 
@@ -79,7 +79,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlocked("tracker2") }
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(false) }
         session.notifyInternalObservers { onLongPress(otherHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(false) }
+        session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search2") }
         session.notifyInternalObservers { onFindResult(0, 1, false) }
 
@@ -90,7 +90,7 @@ class EngineSessionTest {
         verify(observer).onTrackerBlockingEnabledChange(true)
         verify(observer).onTrackerBlocked("tracker")
         verify(observer).onLongPress(unknownHitResult)
-        verify(observer).onDesktopModeEnabled(true)
+        verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
@@ -100,7 +100,7 @@ class EngineSessionTest {
         verify(observer, never()).onTrackerBlockingEnabledChange(false)
         verify(observer, never()).onTrackerBlocked("tracker2")
         verify(observer, never()).onLongPress(otherHitResult)
-        verify(observer, never()).onDesktopModeEnabled(false)
+        verify(observer, never()).onDesktopModeChange(false)
         verify(observer, never()).onFind("search2")
         verify(observer, never()).onFindResult(0, 1, false)
         verifyNoMoreInteractions(observer)
@@ -122,7 +122,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(true) }
         session.notifyInternalObservers { onTrackerBlocked("tracker") }
         session.notifyInternalObservers { onLongPress(unknownHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(true) }
+        session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
 
@@ -135,7 +135,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlocked("tracker2") }
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(false) }
         session.notifyInternalObservers { onLongPress(otherHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(false) }
+        session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search2") }
         session.notifyInternalObservers { onFindResult(0, 1, false) }
 
@@ -146,7 +146,7 @@ class EngineSessionTest {
         verify(observer).onTrackerBlockingEnabledChange(true)
         verify(observer).onTrackerBlocked("tracker")
         verify(observer).onLongPress(unknownHitResult)
-        verify(observer).onDesktopModeEnabled(true)
+        verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
@@ -156,7 +156,7 @@ class EngineSessionTest {
         verify(observer, never()).onTrackerBlockingEnabledChange(false)
         verify(observer, never()).onTrackerBlocked("tracker2")
         verify(observer, never()).onLongPress(otherHitResult)
-        verify(observer, never()).onDesktopModeEnabled(false)
+        verify(observer, never()).onDesktopModeChange(false)
         verify(observer, never()).onFind("search2")
         verify(observer, never()).onFindResult(0, 1, false)
         verify(otherObserver, never()).onLocationChange("https://www.firefox.com")
@@ -166,7 +166,7 @@ class EngineSessionTest {
         verify(otherObserver, never()).onTrackerBlockingEnabledChange(false)
         verify(otherObserver, never()).onTrackerBlocked("tracker2")
         verify(otherObserver, never()).onLongPress(otherHitResult)
-        verify(otherObserver, never()).onDesktopModeEnabled(false)
+        verify(otherObserver, never()).onDesktopModeChange(false)
         verify(otherObserver, never()).onFind("search2")
         verify(otherObserver, never()).onFindResult(0, 1, false)
     }
@@ -185,7 +185,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(true) }
         session.notifyInternalObservers { onTrackerBlocked("tracker") }
         session.notifyInternalObservers { onLongPress(unknownHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(true) }
+        session.notifyInternalObservers { onDesktopModeChange(true) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
 
@@ -198,7 +198,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlocked("tracker2") }
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(false) }
         session.notifyInternalObservers { onLongPress(otherHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(false) }
+        session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search2") }
         session.notifyInternalObservers { onFindResult(0, 1, false) }
 
@@ -209,7 +209,7 @@ class EngineSessionTest {
         verify(observer).onTrackerBlockingEnabledChange(true)
         verify(observer).onTrackerBlocked("tracker")
         verify(observer).onLongPress(unknownHitResult)
-        verify(observer).onDesktopModeEnabled(true)
+        verify(observer).onDesktopModeChange(true)
         verify(observer).onFind("search")
         verify(observer).onFindResult(0, 1, true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
@@ -219,7 +219,7 @@ class EngineSessionTest {
         verify(observer, never()).onTrackerBlockingEnabledChange(false)
         verify(observer, never()).onTrackerBlocked("tracker2")
         verify(observer, never()).onLongPress(otherHitResult)
-        verify(observer, never()).onDesktopModeEnabled(false)
+        verify(observer, never()).onDesktopModeChange(false)
         verify(observer, never()).onFind("search2")
         verify(observer, never()).onFindResult(0, 1, false)
         verifyNoMoreInteractions(observer)
@@ -241,7 +241,7 @@ class EngineSessionTest {
         otherSession.notifyInternalObservers { onTrackerBlockingEnabledChange(true) }
         otherSession.notifyInternalObservers { onTrackerBlocked("tracker") }
         otherSession.notifyInternalObservers { onLongPress(unknownHitResult) }
-        otherSession.notifyInternalObservers { onDesktopModeEnabled(true) }
+        otherSession.notifyInternalObservers { onDesktopModeChange(true) }
         otherSession.notifyInternalObservers { onFind("search") }
         otherSession.notifyInternalObservers { onFindResult(0, 1, true) }
         verify(observer, never()).onLocationChange("https://www.mozilla.org")
@@ -251,7 +251,7 @@ class EngineSessionTest {
         verify(observer, never()).onTrackerBlockingEnabledChange(true)
         verify(observer, never()).onTrackerBlocked("tracker")
         verify(observer, never()).onLongPress(unknownHitResult)
-        verify(observer, never()).onDesktopModeEnabled(true)
+        verify(observer, never()).onDesktopModeChange(true)
         verify(observer, never()).onFind("search")
         verify(observer, never()).onFindResult(0, 1, true)
 
@@ -262,7 +262,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onTrackerBlockingEnabledChange(true) }
         session.notifyInternalObservers { onTrackerBlocked("tracker") }
         session.notifyInternalObservers { onLongPress(unknownHitResult) }
-        session.notifyInternalObservers { onDesktopModeEnabled(false) }
+        session.notifyInternalObservers { onDesktopModeChange(false) }
         session.notifyInternalObservers { onFind("search") }
         session.notifyInternalObservers { onFindResult(0, 1, true) }
         verify(observer, times(1)).onLocationChange("https://www.mozilla.org")
@@ -272,7 +272,7 @@ class EngineSessionTest {
         verify(observer, times(1)).onTrackerBlockingEnabledChange(true)
         verify(observer, times(1)).onTrackerBlocked("tracker")
         verify(observer, times(1)).onLongPress(unknownHitResult)
-        verify(observer, times(1)).onDesktopModeEnabled(false)
+        verify(observer, times(1)).onDesktopModeChange(false)
         verify(observer, times(1)).onFind("search")
         verify(observer, times(1)).onFindResult(0, 1, true)
         verifyNoMoreInteractions(observer)
@@ -363,7 +363,7 @@ class EngineSessionTest {
         defaultObserver.onLocationChange("")
         defaultObserver.onLongPress(HitResult.UNKNOWN(""))
         defaultObserver.onExternalResource("")
-        defaultObserver.onDesktopModeEnabled(true)
+        defaultObserver.onDesktopModeChange(true)
         defaultObserver.onSecurityChange(true)
         defaultObserver.onTrackerBlocked("")
         defaultObserver.onTrackerBlockingEnabledChange(true)
@@ -400,7 +400,7 @@ open class DummyEngineSession : EngineSession() {
 
     override fun disableTrackingProtection() {}
 
-    override fun setDesktopMode(enable: Boolean, reload: Boolean) {}
+    override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
 
     override fun findAll(text: String) {}
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -95,14 +95,14 @@ class SessionUseCases(
         }
     }
 
-    class RequestDesktopSite internal constructor(
+    class RequestDesktopSiteUseCase internal constructor(
         private val sessionManager: SessionManager
     ) {
         /**
          * Request the desktop version of the current session and reloads the page.
          */
         fun invoke(enable: Boolean, session: Session = sessionManager.selectedSessionOrThrow) {
-            sessionManager.getOrCreateEngineSession(session).setDesktopMode(enable, true)
+            sessionManager.getOrCreateEngineSession(session).toggleDesktopMode(enable, true)
         }
     }
 
@@ -112,5 +112,5 @@ class SessionUseCases(
     val stopLoading: StopLoadingUseCase by lazy { StopLoadingUseCase(sessionManager) }
     val goBack: GoBackUseCase by lazy { GoBackUseCase(sessionManager) }
     val goForward: GoForwardUseCase by lazy { GoForwardUseCase(sessionManager) }
-    val requestDesktopSite: RequestDesktopSite by lazy { RequestDesktopSite(sessionManager) }
+    val requestDesktopSite: RequestDesktopSiteUseCase by lazy { RequestDesktopSiteUseCase(sessionManager) }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -96,10 +96,10 @@ class SessionUseCasesTest {
         `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.requestDesktopSite.invoke(true, session)
-        verify(engineSession).setDesktopMode(true, true)
+        verify(engineSession).toggleDesktopMode(true, true)
 
         `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.requestDesktopSite.invoke(true)
-        verify(selectedEngineSession).setDesktopMode(true, true)
+        verify(selectedEngineSession).toggleDesktopMode(true, true)
     }
 }


### PR DESCRIPTION
Closes #701: Exposing browser-session Desktop mode.

* Adding desktopMode property to Session

* Adding onDesktopModeEnabled in Session

* Renaming RequestDesktopSite to RequestDesktopSiteUseCase to follow
  the convention

* Implementing onDesktopModeEnabled in EngineObserver

* I kept the function name setDesktopMode instead of changing it to
  desktopMode, to follow the existed convention (all function are verbs)
  and because it denotes the action of changing the value
