### PR TITLE
Issue #3306: Make blocking setOverride calls in service-fretboard.

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ExperimentEvaluator.kt
@@ -4,7 +4,9 @@
 
 package mozilla.components.service.fretboard
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Looper
 import android.text.TextUtils
 import java.util.zip.CRC32
 
@@ -14,6 +16,7 @@ import java.util.zip.CRC32
  *
  * @property valuesProvider provider for the device's values
  */
+@Suppress("TooManyFunctions")
 internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = ValuesProvider()) {
     /**
      * Determines if a specific experiment should be enabled or not for the device
@@ -95,7 +98,7 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
     }
 
     /**
-     * Overrides a specified experiment
+     * Overrides a specified experiment asynchronously
      *
      * @param context context
      * @param descriptor descriptor of the experiment
@@ -109,7 +112,23 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
     }
 
     /**
-     * Clears an override for a specified experiment
+     * Overrides a specified experiment as a blocking operation
+     *
+     * @param context context
+     * @param descriptor descriptor of the experiment
+     * @param active overridden value for the experiment, true to activate it, false to deactivate
+     */
+    @SuppressLint("ApplySharedPref")
+    fun setOverrideNow(context: Context, descriptor: ExperimentDescriptor, active: Boolean) {
+        require(Looper.myLooper() != Looper.getMainLooper()) { "This cannot be used on the main thread" }
+        context.getSharedPreferences(OVERRIDES_PREF_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean(descriptor.name, active)
+                .commit()
+    }
+
+    /**
+     * Clears an override for a specified experiment asynchronously
      *
      * @param context context
      * @param descriptor descriptor of the experiment
@@ -122,7 +141,22 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
     }
 
     /**
-     * Clears all experiment overrides
+     * Clears an override for a specified experiment as a blocking operation
+     *
+     * @param context context
+     * @param descriptor descriptor of the experiment
+     */
+    @SuppressLint("ApplySharedPref")
+    fun clearOverrideNow(context: Context, descriptor: ExperimentDescriptor) {
+        require(Looper.myLooper() != Looper.getMainLooper()) { "This cannot be used on the main thread" }
+        context.getSharedPreferences(OVERRIDES_PREF_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .remove(descriptor.name)
+                .commit()
+    }
+
+    /**
+     * Clears all experiment overrides asynchronously
      *
      * @param context context
      */
@@ -131,6 +165,20 @@ internal class ExperimentEvaluator(private val valuesProvider: ValuesProvider = 
             .edit()
             .clear()
             .apply()
+    }
+
+    /**
+     * Clears all experiment overrides as a blocking operation
+     *
+     * @param context context
+     */
+    @SuppressLint("ApplySharedPref")
+    fun clearAllOverridesNow(context: Context) {
+        require(Looper.myLooper() != Looper.getMainLooper()) { "This cannot be used on the main thread" }
+        context.getSharedPreferences(OVERRIDES_PREF_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .clear()
+                .commit()
     }
 
     companion object {

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -14,6 +14,7 @@ import mozilla.components.support.base.log.logger.Logger
  * @property storage experiment local storage mechanism
  * @param valuesProvider provider for the device's values
  */
+@Suppress("TooManyFunctions")
 class Fretboard(
     private val source: ExperimentSource,
     private val storage: ExperimentStorage,
@@ -105,7 +106,7 @@ class Fretboard(
     }
 
     /**
-     * Overrides a specified experiment
+     * Overrides a specified experiment asynchronously
      *
      * @param context context
      * @param descriptor descriptor of the experiment
@@ -116,7 +117,19 @@ class Fretboard(
     }
 
     /**
-     * Clears an override for a specified experiment
+     * Overrides a specified experiment as a blocking operation
+     *
+     * @exception IllegalArgumentException when called from the main thread
+     * @param context context
+     * @param descriptor descriptor of the experiment
+     * @param active overridden value for the experiment, true to activate it, false to deactivate
+     */
+    fun setOverrideNow(context: Context, descriptor: ExperimentDescriptor, active: Boolean) {
+        evaluator.setOverrideNow(context, descriptor, active)
+    }
+
+    /**
+     * Clears an override for a specified experiment asynchronously
      *
      * @param context context
      * @param descriptor descriptor of the experiment
@@ -126,12 +139,34 @@ class Fretboard(
     }
 
     /**
-     * Clears all experiment overrides
+     * Clears an override for a specified experiment as a blocking operation
+     *
+     *
+     * @exception IllegalArgumentException when called from the main thread
+     * @param context context
+     * @param descriptor descriptor of the experiment
+     */
+    fun clearOverrideNow(context: Context, descriptor: ExperimentDescriptor) {
+        evaluator.clearOverrideNow(context, descriptor)
+    }
+
+    /**
+     * Clears all experiment overrides asynchronously
      *
      * @param context context
      */
     fun clearAllOverrides(context: Context) {
         evaluator.clearAllOverrides(context)
+    }
+
+    /**
+     * Clears all experiment overrides as a blocking operation
+     *
+     * @exception IllegalArgumentException when called from the main thread
+     * @param context context
+     */
+    fun clearAllOverridesNow(context: Context) {
+        evaluator.clearAllOverridesNow(context)
     }
 
     companion object {

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
@@ -8,6 +8,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.support.test.any
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -318,6 +320,14 @@ class FretboardTest {
         verify(prefsEditor).putBoolean("first-name", false)
         fretboard.setOverride(context, ExperimentDescriptor("first-name"), true)
         verify(prefsEditor).putBoolean("first-name", true)
+
+        runBlocking(CommonPool) {
+            assertTrue(fretboard.isInExperiment(context, ExperimentDescriptor("first-name")))
+            fretboard.setOverrideNow(context, ExperimentDescriptor("first-name"), false)
+            verify(prefsEditor, times(2)).putBoolean("first-name", false)
+            fretboard.setOverrideNow(context, ExperimentDescriptor("first-name"), true)
+            verify(prefsEditor, times(2)).putBoolean("first-name", true)
+        }
     }
 
     @Test
@@ -357,6 +367,12 @@ class FretboardTest {
         fretboard.setOverride(context, ExperimentDescriptor("first-name"), false)
         fretboard.clearOverride(context, ExperimentDescriptor("first-name"))
         verify(prefsEditor).remove("first-name")
+
+        runBlocking(CommonPool) {
+            fretboard.setOverrideNow(context, ExperimentDescriptor("first-name"), false)
+            fretboard.clearOverrideNow(context, ExperimentDescriptor("first-name"))
+            verify(prefsEditor, times(2)).remove("first-name")
+        }
     }
 
     @Test
@@ -396,6 +412,12 @@ class FretboardTest {
         fretboard.setOverride(context, ExperimentDescriptor("first-name"), false)
         fretboard.clearAllOverrides(context)
         verify(prefsEditor).clear()
+
+        runBlocking(CommonPool) {
+            fretboard.setOverrideNow(context, ExperimentDescriptor("first-name"), false)
+            fretboard.clearAllOverridesNow(context)
+            verify(prefsEditor, times(2)).clear()
+        }
     }
 
     @Test


### PR DESCRIPTION
Added blocking setOverrideNow() and clearOverrideNow() calls to prevent race conditions when the operations must complete before the next line of code. These are not to be called from the main thread. Part of a solution to mozilla-mobile/focus-android#3306.