### PR TITLE
Issue #719: Fretboard: Deprecate Experiments.id usage...

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
@@ -13,6 +13,7 @@ data class Experiment(
     /**
      * Unique identifier of the experiment
      */
+    @Deprecated("This is an internal ID used by Kinto. Public access will be removed soon.")
     val id: String,
     /**
      * Human-readable name of the experiment


### PR DESCRIPTION
Closes #719.

Deprecating access to this in 0.22 and making it `internal` in 0.24.