### PR TITLE
Closes: #735: Adding jacoco.exec and similar files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ l10n-repo/
 # OS X
 .DS_Store
 
+# jacoco.exec
+jacoco.exec


### PR DESCRIPTION
Closes: #735