### PR TITLE
Closes #644: Clear Data (WebView only).

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -8,12 +8,12 @@ import android.annotation.SuppressLint
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.request.RequestInterceptor
-import mozilla.components.support.ktx.kotlin.isPhone
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
+import mozilla.components.support.ktx.kotlin.isPhone
 import org.mozilla.gecko.util.ThreadUtils
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
@@ -177,6 +177,13 @@ class GeckoEngineSession(
         if (reload) {
             geckoSession.reload()
         }
+    }
+
+    /**
+     * See [EngineSession.clearData]
+     */
+    override fun clearData() {
+        // API not available yet.
     }
 
     /**

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -29,6 +29,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
 import org.mozilla.gecko.util.BundleEventListener
 import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.gecko.util.ThreadUtils
@@ -698,5 +699,17 @@ class GeckoEngineSessionTest {
 
         engineSession.exitFullScreenMode()
         verify(geckoSession).exitFullScreen()
+    }
+
+    fun testClearData() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val engineSession = GeckoEngineSession(runtime)
+        val observer: EngineSession.Observer = mock()
+
+        engineSession.register(observer)
+
+        engineSession.clearData()
+
+        verifyZeroInteractions(observer)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -180,6 +180,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.clearData]
+     */
+    override fun clearData() {
+        // API not available yet.
+    }
+
+    /**
      * See [EngineSession.findAll]
      */
     override fun findAll(text: String) {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -29,6 +29,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
 import org.mozilla.gecko.util.BundleEventListener
 import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.gecko.util.ThreadUtils
@@ -698,5 +699,17 @@ class GeckoEngineSessionTest {
 
         engineSession.exitFullScreenMode()
         verify(geckoSession).exitFullScreen()
+    }
+
+    fun testClearData() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val engineSession = GeckoEngineSession(runtime)
+        val observer: EngineSession.Observer = mock()
+
+        engineSession.register(observer)
+
+        engineSession.clearData()
+
+        verifyZeroInteractions(observer)
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -165,6 +165,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.clearData]
+     */
+    override fun clearData() {
+        // API not available yet.
+    }
+
+    /**
      * See [EngineSession.findAll]
      */
     override fun findAll(text: String) {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -29,6 +29,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
 import org.mozilla.gecko.util.BundleEventListener
 import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.gecko.util.ThreadUtils
@@ -637,5 +638,18 @@ class GeckoEngineSessionTest {
 
         engineSession.exitFullScreenMode()
         verify(geckoSession).exitFullScreen()
+    }
+
+    @Test
+    fun testClearData() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val engineSession = GeckoEngineSession(runtime)
+        val observer: EngineSession.Observer = mock()
+
+        engineSession.register(observer)
+
+        engineSession.clearData()
+
+        verifyZeroInteractions(observer)
     }
 }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -1,10 +1,13 @@
 package mozilla.components.browser.engine.system
 
+import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
+import android.webkit.WebStorage
 import android.webkit.WebView
+import android.webkit.WebViewDatabase
 import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.browser.engine.system.matcher.UrlMatcher
 import mozilla.components.concept.engine.DefaultSettings
@@ -477,5 +480,35 @@ class SystemEngineSessionTest {
         `when`(engineSession.currentView()).thenReturn(webView)
         engineSession.clearFindMatches()
         verify(webView).clearMatches()
+    }
+
+    @Test
+    fun testClearDataMakingExpectedCalls() {
+        val engineSession = spy(SystemEngineSession::class.java)
+        val webView = mock(WebView::class.java)
+        val webStorage: WebStorage = mock()
+        val webViewDatabase: WebViewDatabase = mock()
+        val context: Context = RuntimeEnvironment.application
+
+        engineSession.clearData()
+        verify(webView, never()).clearFormData()
+        verify(webView, never()).clearHistory()
+        verify(webView, never()).clearMatches()
+        verify(webView, never()).clearSslPreferences()
+        verify(webView, never()).clearCache(true)
+
+        doReturn(webStorage).`when`(engineSession).webStorage()
+        doReturn(webViewDatabase).`when`(engineSession).webViewDatabase(context)
+        `when`(webView.context).thenReturn(context)
+        `when`(engineSession.currentView()).thenReturn(webView)
+
+        engineSession.clearData()
+        verify(webView).clearFormData()
+        verify(webView).clearHistory()
+        verify(webView).clearMatches()
+        verify(webView).clearSslPreferences()
+        verify(webView).clearCache(true)
+        verify(webStorage).deleteAllData()
+        verify(webViewDatabase).clearHttpAuthUsernamePassword()
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -34,6 +34,7 @@ class EngineObserverTest {
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
                 notifyObservers { onDesktopModeChange(enable) }
             }
+            override fun clearData() {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -83,6 +84,7 @@ class EngineObserverTest {
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
+            override fun clearData() {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -135,6 +137,7 @@ class EngineObserverTest {
 
             override fun loadUrl(url: String) {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
+            override fun clearData() {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -161,6 +161,11 @@ abstract class EngineSession(
     abstract fun toggleDesktopMode(enable: Boolean, reload: Boolean = false)
 
     /**
+     * Clears all user data sources available.
+     */
+    abstract fun clearData()
+
+    /**
      * Finds and highlights all occurrences of the provided String and highlights them asynchronously.
      *
      * @param text the String to search for

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.verifyZeroInteractions
 
 class EngineSessionTest {
     private val unknownHitResult = HitResult.UNKNOWN("file://foobar")
@@ -393,6 +394,17 @@ class EngineSessionTest {
         defaultObserver.onProgress(123)
         defaultObserver.onLoadingStateChange(true)
     }
+
+    @Test
+    fun `engine doesn't notify observers of clear data`() {
+        val session = spy(DummyEngineSession())
+        val observer = mock(EngineSession.Observer::class.java)
+        session.register(observer)
+
+        session.clearData()
+
+        verifyZeroInteractions(observer)
+    }
 }
 
 open class DummyEngineSession : EngineSession() {
@@ -418,6 +430,8 @@ open class DummyEngineSession : EngineSession() {
     override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
 
     override fun disableTrackingProtection() {}
+
+    override fun clearData() {}
 
     override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -106,6 +106,17 @@ class SessionUseCases(
         }
     }
 
+    class ClearDataUseCase internal constructor(
+        private val sessionManager: SessionManager
+    ) {
+        /**
+         * Clears all user data sources available.
+         */
+        fun invoke(session: Session = sessionManager.selectedSessionOrThrow) {
+            sessionManager.getOrCreateEngineSession(session).clearData()
+        }
+    }
+
     val loadUrl: LoadUrlUseCase by lazy { LoadUrlUseCase(sessionManager) }
     val loadData: LoadDataUseCase by lazy { LoadDataUseCase(sessionManager) }
     val reload: ReloadUrlUseCase by lazy { ReloadUrlUseCase(sessionManager) }
@@ -113,4 +124,5 @@ class SessionUseCases(
     val goBack: GoBackUseCase by lazy { GoBackUseCase(sessionManager) }
     val goForward: GoForwardUseCase by lazy { GoForwardUseCase(sessionManager) }
     val requestDesktopSite: RequestDesktopSiteUseCase by lazy { RequestDesktopSiteUseCase(sessionManager) }
+    val clearData: ClearDataUseCase by lazy { ClearDataUseCase(sessionManager) }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -10,9 +10,9 @@ import mozilla.components.concept.engine.EngineSession
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -101,5 +101,19 @@ class SessionUseCasesTest {
         `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.requestDesktopSite.invoke(true)
         verify(selectedEngineSession).toggleDesktopMode(true, true)
+    }
+
+    @Test
+    fun testClearData() {
+        val engineSession = mock(EngineSession::class.java)
+        val session = mock(Session::class.java)
+        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        useCases.clearData.invoke(session)
+        verify(engineSession).clearData()
+
+        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        useCases.clearData.invoke()
+        verify(selectedEngineSession).clearData()
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -78,6 +78,9 @@ class Components(private val applicationContext: Context) {
             SimpleBrowserMenuItem("Settings") {
                 Toast.makeText(applicationContext, "Settings", Toast.LENGTH_SHORT).show()
             },
+            SimpleBrowserMenuItem("Clear Data") {
+                sessionUseCases.clearData.invoke()
+            },
             SimpleBrowserMenuCheckbox("Request desktop site") { checked ->
                 sessionUseCases.requestDesktopSite.invoke(checked)
             }


### PR DESCRIPTION
This only includes the implementation for the SystemWebView that's based
off of what we currently do in Focus/Fire TV. Since this is needed for
those apps now, we can work with this implementation until GeckoView
provides us with a nicer API to do the equivalent for it. (Bug 1489669)

We also don't notify any observers since there isn't any
confirmation/information available that we can propagate to clients. 