### PR TITLE
Closes #728: Invoke onNavigationStateChange sooner..

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -122,7 +122,6 @@ class SystemEngineView @JvmOverloads constructor(
                 session?.internalNotifyObservers {
                     onLocationChange(it)
                     onLoadingStateChange(false)
-                    onNavigationStateChange(webView.canGoBack(), webView.canGoForward())
                     onSecurityChange(cert != null, cert?.let { URI(url).host }, cert?.issuedBy?.oName)
                 }
             }
@@ -182,7 +181,10 @@ class SystemEngineView @JvmOverloads constructor(
         }
 
         override fun onReceivedTitle(view: WebView, title: String?) {
-            session?.internalNotifyObservers { onTitleChange(title ?: "") }
+            session?.internalNotifyObservers {
+                onTitleChange(title ?: "")
+                onNavigationStateChange(view.canGoBack(), view.canGoForward())
+            }
         }
 
         override fun onShowCustomView(view: View, callback: CustomViewCallback) {


### PR DESCRIPTION
We're only waiting until the page is fully loaded until we call
onNavigationStateChange, which causes the UI components to seem slow.

Now, we make the call when we receive a title from the SystemEngine.