### PR TITLE
Closes #286: Process Share Intents (ACTION_SEND)

### DIFF
--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':concept-engine')
     implementation project(':support-utils')
+    implementation project(':support-ktx')
 
     implementation Deps.kotlin_stdlib
 

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -44,6 +44,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
 
         <service

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/Components.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionIntentProcessor
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.session.TextSearchHandler
 import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.samples.browser.request.SampleRequestInterceptor
@@ -54,7 +55,19 @@ class Components(private val applicationContext: Context) {
     }
 
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
-    val sessionIntentProcessor by lazy { SessionIntentProcessor(sessionUseCases, sessionManager) }
+    val sessionIntentProcessor by lazy {
+        SessionIntentProcessor(
+            sessionUseCases, sessionManager,
+            textSearchHandler = textSearchHandler
+        )
+    }
+
+    private val textSearchHandler by lazy {
+        val handler: TextSearchHandler = { searchTerm, session ->
+            searchUseCases.defaultSearch.invoke(searchTerm, session)
+        }
+        handler
+    }
 
     // Search
     private val searchEngineManager by lazy {


### PR DESCRIPTION
Closes #286: Process Share Intents (ACTION_SEND)

*Handling action ACTION_SEND on SessionIntentProcessor
    if the intent contains additional text, do the following
     If the text is a URL then we load it,
     Otherwise we trigger a search.

* Adding support-ktx module to feature-session module
    implementation project(':support-ktx')
    
* Updating the sample-browser