### PR TITLE
Closes #688: Extend engine settings for WebView

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -40,7 +40,7 @@ class GeckoEngine(
     /**
      * See [Engine.settings]
      */
-    override val settings: Settings = object : Settings {
+    override val settings: Settings = object : Settings() {
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -39,7 +39,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override val settings: Settings = object : Settings {
+    override val settings: Settings = object : Settings() {
         override var requestInterceptor: RequestInterceptor? = null
     }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -40,7 +40,7 @@ class GeckoEngine(
     /**
      * See [Engine.settings]
      */
-    override val settings: Settings = object : Settings {
+    override val settings: Settings = object : Settings() {
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -39,7 +39,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override val settings: Settings = object : Settings {
+    override val settings: Settings = object : Settings() {
         override var requestInterceptor: RequestInterceptor? = null
     }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -40,7 +40,7 @@ class GeckoEngine(
     /**
      * See [Engine.settings]
      */
-    override val settings: Settings = object : Settings {
+    override val settings: Settings = object : Settings() {
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -38,7 +38,7 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.settings]
      */
-    override val settings: Settings = object : Settings {
+    override val settings: Settings = object : Settings() {
         override var requestInterceptor: RequestInterceptor? = null
     }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -252,11 +252,16 @@ class SystemEngineSessionTest {
     @Test
     fun testInitSettings() {
         val engineSession = spy(SystemEngineSession())
+        val webViewSettings = mock(WebSettings::class.java)
+        `when`(webViewSettings.displayZoomControls).thenReturn(true)
+        `when`(webViewSettings.allowContentAccess).thenReturn(true)
+        `when`(webViewSettings.allowFileAccess).thenReturn(true)
+
         val webView = mock(WebView::class.java)
         `when`(webView.context).thenReturn(RuntimeEnvironment.application)
-        val webViewSettings = mock(WebSettings::class.java)
-        `when`(webViewSettings.javaScriptEnabled).thenReturn(false)
         `when`(webView.settings).thenReturn(webViewSettings)
+        `when`(webView.isVerticalScrollBarEnabled).thenReturn(true)
+        `when`(webView.isHorizontalScrollBarEnabled).thenReturn(true)
 
         try {
             engineSession.initSettings()
@@ -265,6 +270,7 @@ class SystemEngineSessionTest {
 
         `when`(engineSession.currentView()).thenReturn(webView)
         engineSession.initSettings()
+
         assertFalse(engineSession.settings.javascriptEnabled)
         engineSession.settings.javascriptEnabled = true
         verify(webViewSettings).javaScriptEnabled = true
@@ -272,6 +278,50 @@ class SystemEngineSessionTest {
         assertFalse(engineSession.settings.domStorageEnabled)
         engineSession.settings.domStorageEnabled = true
         verify(webViewSettings).domStorageEnabled = true
+
+        assertNull(engineSession.settings.userAgentString)
+        engineSession.settings.userAgentString = "userAgent"
+        verify(webViewSettings).userAgentString = "userAgent"
+
+        assertFalse(engineSession.settings.mediaPlaybackRequiresUserGesture)
+        engineSession.settings.mediaPlaybackRequiresUserGesture = false
+        verify(webViewSettings).mediaPlaybackRequiresUserGesture = false
+
+        assertFalse(engineSession.settings.javaScriptCanOpenWindowsAutomatically)
+        engineSession.settings.javaScriptCanOpenWindowsAutomatically = true
+        verify(webViewSettings).javaScriptCanOpenWindowsAutomatically = true
+
+        assertTrue(engineSession.settings.displayZoomControls)
+        engineSession.settings.javaScriptCanOpenWindowsAutomatically = false
+        verify(webViewSettings).javaScriptCanOpenWindowsAutomatically = false
+
+        assertFalse(engineSession.settings.loadWithOverviewMode)
+        engineSession.settings.loadWithOverviewMode = true
+        verify(webViewSettings).loadWithOverviewMode = true
+
+        assertTrue(engineSession.settings.allowContentAccess)
+        engineSession.settings.allowContentAccess = false
+        verify(webViewSettings).allowContentAccess = false
+
+        assertTrue(engineSession.settings.allowFileAccess)
+        engineSession.settings.allowFileAccess = false
+        verify(webViewSettings).allowFileAccess = false
+
+        assertFalse(engineSession.settings.allowUniversalAccessFromFileURLs)
+        engineSession.settings.allowUniversalAccessFromFileURLs = true
+        verify(webViewSettings).allowUniversalAccessFromFileURLs = true
+
+        assertFalse(engineSession.settings.allowFileAccessFromFileURLs)
+        engineSession.settings.allowFileAccessFromFileURLs = true
+        verify(webViewSettings).allowFileAccessFromFileURLs = true
+
+        assertTrue(engineSession.settings.verticalScrollBarEnabled)
+        engineSession.settings.verticalScrollBarEnabled = false
+        verify(webView).isVerticalScrollBarEnabled = false
+
+        assertTrue(engineSession.settings.horizontalScrollBarEnabled)
+        engineSession.settings.horizontalScrollBarEnabled = false
+        verify(webView).isHorizontalScrollBarEnabled = false
 
         assertTrue(engineSession.webFontsEnabled)
         assertTrue(engineSession.settings.webFontsEnabled)
@@ -285,6 +335,13 @@ class SystemEngineSessionTest {
 
         engineSession.settings.trackingProtectionPolicy = null
         verify(engineSession).disableTrackingProtection()
+
+        verify(webViewSettings).setAppCacheEnabled(false)
+        verify(webViewSettings).setGeolocationEnabled(false)
+        verify(webViewSettings).databaseEnabled = false
+        verify(webViewSettings).savePassword = false
+        verify(webViewSettings).saveFormData = false
+        verify(webViewSettings).builtInZoomControls = true
     }
 
     @Test
@@ -293,7 +350,12 @@ class SystemEngineSessionTest {
                 javascriptEnabled = false,
                 domStorageEnabled = false,
                 webFontsEnabled = false,
-                trackingProtectionPolicy = EngineSession.TrackingProtectionPolicy.all())
+                trackingProtectionPolicy = EngineSession.TrackingProtectionPolicy.all(),
+                userAgentString = "userAgent",
+                mediaPlaybackRequiresUserGesture = false,
+                javaScriptCanOpenWindowsAutomatically = true,
+                displayZoomControls = false,
+                loadWithOverviewMode = true)
         val engineSession = spy(SystemEngineSession(defaultSettings))
         val webView = mock(WebView::class.java)
         `when`(webView.context).thenReturn(RuntimeEnvironment.application)
@@ -305,6 +367,11 @@ class SystemEngineSessionTest {
         engineSession.initSettings()
         verify(webViewSettings).domStorageEnabled = false
         verify(webViewSettings).javaScriptEnabled = false
+        verify(webViewSettings).userAgentString = "userAgent"
+        verify(webViewSettings).mediaPlaybackRequiresUserGesture = false
+        verify(webViewSettings).javaScriptCanOpenWindowsAutomatically = true
+        verify(webViewSettings).displayZoomControls = false
+        verify(webViewSettings).loadWithOverviewMode = true
         verify(engineSession).enableTrackingProtection(EngineSession.TrackingProtectionPolicy.all())
         assertFalse(engineSession.webFontsEnabled)
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -6,47 +6,97 @@ package mozilla.components.concept.engine
 
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.request.RequestInterceptor
+import kotlin.reflect.KProperty
 
 /**
  * Holds settings of an engine or session. Concrete engine
  * implementations define how these settings are applied i.e.
  * whether a setting is applied on an engine or session instance.
  */
-interface Settings {
+@Suppress("UnnecessaryAbstractClass")
+abstract class Settings {
     /**
      * Setting to control whether or not JavaScript is enabled.
      */
-    var javascriptEnabled: Boolean
-        get() = throw UnsupportedSettingException()
-        set(_) = throw UnsupportedSettingException()
+    open var javascriptEnabled: Boolean by UnsupportedSetting()
 
     /**
      * Setting to control whether or not DOM Storage is enabled.
      */
-    var domStorageEnabled: Boolean
-        get() = throw UnsupportedSettingException()
-        set(_) = throw UnsupportedSettingException()
+    open var domStorageEnabled: Boolean by UnsupportedSetting()
 
     /**
      * Setting to control whether or not Web fonts are enabled.
      */
-    var webFontsEnabled: Boolean
-        get() = throw UnsupportedSettingException()
-        set(_) = throw UnsupportedSettingException()
+    open var webFontsEnabled: Boolean by UnsupportedSetting()
 
     /**
      * Setting to control tracking protection.
      */
-    var trackingProtectionPolicy: TrackingProtectionPolicy?
-        get() = throw UnsupportedSettingException()
-        set(_) = throw UnsupportedSettingException()
+    open var trackingProtectionPolicy: TrackingProtectionPolicy? by UnsupportedSetting()
 
     /**
      * Setting to intercept and override requests.
      */
-    var requestInterceptor: RequestInterceptor?
-        get() = throw UnsupportedSettingException()
-        set(_) = throw UnsupportedSettingException()
+    open var requestInterceptor: RequestInterceptor? by UnsupportedSetting()
+
+    /**
+     * Setting to control the user agent string.
+     */
+    open var userAgentString: String? by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not a user gesture is required to play media.
+     */
+    open var mediaPlaybackRequiresUserGesture: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not window.open can be called from JavaScript.
+     */
+    open var javaScriptCanOpenWindowsAutomatically: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not zoom controls should be displayed.
+     */
+    open var displayZoomControls: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not the engine zooms out the content to fit on screen by width.
+     */
+    open var loadWithOverviewMode: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not file access is allowed.
+     */
+    open var allowFileAccess: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not JavaScript running in the context of a file scheme URL
+     * should be allowed to access content from other file scheme URLs.
+     */
+    open var allowFileAccessFromFileURLs: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not JavaScript running in the context of a file scheme URL
+     * should be allowed to access content from any origin.
+     */
+    open var allowUniversalAccessFromFileURLs: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not the engine is allowed to load content from a content
+     * provider installed in the system.
+     */
+    open var allowContentAccess: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not vertical scrolling is enabled.
+     */
+    open var verticalScrollBarEnabled: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not horizontal scrolling is enabled.
+     */
+    open var horizontalScrollBarEnabled: Boolean by UnsupportedSetting()
 }
 
 /**
@@ -56,11 +106,32 @@ data class DefaultSettings(
     override var javascriptEnabled: Boolean = true,
     override var domStorageEnabled: Boolean = true,
     override var webFontsEnabled: Boolean = true,
+    override var mediaPlaybackRequiresUserGesture: Boolean = true,
     override var trackingProtectionPolicy: TrackingProtectionPolicy? = null,
-    override var requestInterceptor: RequestInterceptor? = null
-) : Settings
+    override var requestInterceptor: RequestInterceptor? = null,
+    override var userAgentString: String? = null,
+    override var javaScriptCanOpenWindowsAutomatically: Boolean = false,
+    override var displayZoomControls: Boolean = true,
+    override var loadWithOverviewMode: Boolean = false,
+    override var allowFileAccess: Boolean = true,
+    override var allowFileAccessFromFileURLs: Boolean = false,
+    override var allowUniversalAccessFromFileURLs: Boolean = false,
+    override var allowContentAccess: Boolean = true,
+    override var verticalScrollBarEnabled: Boolean = true,
+    override var horizontalScrollBarEnabled: Boolean = true
+) : Settings()
+
+class UnsupportedSetting<T> {
+    operator fun getValue(thisRef: Any?, prop: KProperty<*>): T {
+        throw UnsupportedSettingException("Setting ${prop.name} is not supported by this engine!")
+    }
+
+    operator fun setValue(thisRef: Any?, prop: KProperty<*>, value: T) {
+        throw UnsupportedSettingException("Setting ${prop.name} is not supported by this engine!")
+    }
+}
 
 /**
  * Exception thrown by default if a setting is not supported by an engine or session.
  */
-class UnsupportedSettingException : RuntimeException("Setting not supported by this engine")
+class UnsupportedSettingException(message: String = "Setting not supported by this engine") : RuntimeException(message)

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -18,7 +18,7 @@ class SettingsTest {
 
     @Test
     fun testSettingsThrowByDefault() {
-        val settings = object : Settings { }
+        val settings = object : Settings() { }
 
         expectUnsupportedSettingException(
             { settings.javascriptEnabled },
@@ -30,7 +30,29 @@ class SettingsTest {
             { settings.trackingProtectionPolicy },
             { settings.trackingProtectionPolicy = TrackingProtectionPolicy.all() },
             { settings.requestInterceptor },
-            { settings.requestInterceptor = null }
+            { settings.requestInterceptor = null },
+            { settings.userAgentString },
+            { settings.userAgentString = null },
+            { settings.mediaPlaybackRequiresUserGesture },
+            { settings.mediaPlaybackRequiresUserGesture = false },
+            { settings.javaScriptCanOpenWindowsAutomatically },
+            { settings.javaScriptCanOpenWindowsAutomatically = false },
+            { settings.displayZoomControls },
+            { settings.displayZoomControls = false },
+            { settings.loadWithOverviewMode },
+            { settings.loadWithOverviewMode = false },
+            { settings.allowFileAccess },
+            { settings.allowFileAccess = false },
+            { settings.allowContentAccess },
+            { settings.allowContentAccess = false },
+            { settings.allowFileAccessFromFileURLs },
+            { settings.allowFileAccessFromFileURLs = false },
+            { settings.allowUniversalAccessFromFileURLs },
+            { settings.allowUniversalAccessFromFileURLs = false },
+            { settings.verticalScrollBarEnabled },
+            { settings.verticalScrollBarEnabled = false },
+            { settings.horizontalScrollBarEnabled },
+            { settings.horizontalScrollBarEnabled = false }
         )
     }
 
@@ -47,20 +69,53 @@ class SettingsTest {
         assertTrue(settings.javascriptEnabled)
         assertNull(settings.trackingProtectionPolicy)
         assertNull(settings.requestInterceptor)
+        assertNull(settings.userAgentString)
+        assertTrue(settings.mediaPlaybackRequiresUserGesture)
+        assertFalse(settings.javaScriptCanOpenWindowsAutomatically)
+        assertTrue(settings.displayZoomControls)
+        assertFalse(settings.loadWithOverviewMode)
+        assertTrue(settings.allowContentAccess)
+        assertTrue(settings.allowFileAccess)
+        assertFalse(settings.allowFileAccessFromFileURLs)
+        assertFalse(settings.allowUniversalAccessFromFileURLs)
+        assertTrue(settings.verticalScrollBarEnabled)
+        assertTrue(settings.horizontalScrollBarEnabled)
 
         val interceptor: RequestInterceptor = mock()
 
-        val trackingProtectionSettings = DefaultSettings(
+        val defaultSettings = DefaultSettings(
             javascriptEnabled = false,
             domStorageEnabled = false,
             webFontsEnabled = false,
             trackingProtectionPolicy = TrackingProtectionPolicy.all(),
-            requestInterceptor = interceptor)
+            requestInterceptor = interceptor,
+            userAgentString = "userAgent",
+            mediaPlaybackRequiresUserGesture = false,
+            javaScriptCanOpenWindowsAutomatically = true,
+            displayZoomControls = false,
+            loadWithOverviewMode = true,
+            allowContentAccess = false,
+            allowFileAccess = false,
+            allowFileAccessFromFileURLs = true,
+            allowUniversalAccessFromFileURLs = true,
+            verticalScrollBarEnabled = false,
+            horizontalScrollBarEnabled = false)
 
-        assertFalse(trackingProtectionSettings.domStorageEnabled)
-        assertFalse(trackingProtectionSettings.javascriptEnabled)
-        assertFalse(trackingProtectionSettings.webFontsEnabled)
-        assertEquals(TrackingProtectionPolicy.all(), trackingProtectionSettings.trackingProtectionPolicy)
-        assertEquals(interceptor, trackingProtectionSettings.requestInterceptor)
+        assertFalse(defaultSettings.domStorageEnabled)
+        assertFalse(defaultSettings.javascriptEnabled)
+        assertFalse(defaultSettings.webFontsEnabled)
+        assertEquals(TrackingProtectionPolicy.all(), defaultSettings.trackingProtectionPolicy)
+        assertEquals(interceptor, defaultSettings.requestInterceptor)
+        assertEquals("userAgent", defaultSettings.userAgentString)
+        assertFalse(defaultSettings.mediaPlaybackRequiresUserGesture)
+        assertTrue(defaultSettings.javaScriptCanOpenWindowsAutomatically)
+        assertFalse(defaultSettings.displayZoomControls)
+        assertTrue(defaultSettings.loadWithOverviewMode)
+        assertFalse(defaultSettings.allowContentAccess)
+        assertFalse(defaultSettings.allowFileAccess)
+        assertTrue(defaultSettings.allowFileAccessFromFileURLs)
+        assertTrue(defaultSettings.allowUniversalAccessFromFileURLs)
+        assertFalse(defaultSettings.verticalScrollBarEnabled)
+        assertFalse(defaultSettings.horizontalScrollBarEnabled)
     }
 }


### PR DESCRIPTION
This now brings in all required settings for WebView (used in FireTV and Focus). This is a little fancier than it needs to be (using property delegates) but I really wanted to avoid code duplication where possible.

From the issue:
>Some of those we may want to add as default settings on WebView for all apps by default. Others we may want to expose via our Settings object.

I made this decision based on:
Can the setting be toggled and both states be supported with the current functionality then make it a setting otherwise a default.