### PR TITLE
Add Fretboard.getExperimentsMap()

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Fretboard.kt
@@ -106,6 +106,20 @@ class Fretboard(
     }
 
     /**
+     * Provides a map of active/inactive experiments
+     *
+     * @param context context
+     *
+     * @return map of experiments to A/B state
+     */
+    fun getExperimentsMap(context: Context): Map<String, Boolean> {
+        return experiments.associate {
+            it.name to
+                    isInExperiment(context, ExperimentDescriptor(it.name))
+        }
+    }
+
+    /**
      * Overrides a specified experiment asynchronously
      *
      * @param context context


### PR DESCRIPTION
I'm adding a method for the data team to identify both what experiments the client is aware of and whether they are active or inactive.