### PR TITLE
Provide extension via MIME type if none exists

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -125,10 +125,10 @@ object DownloadUtils {
                 val lastDotIndex = filename.lastIndexOf('.')
                 val typeFromExt = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
                         filename.substring(lastDotIndex + 1))
-                if (typeFromExt != null && !typeFromExt.equals(mimeType, ignoreCase = true)) {
+                if (typeFromExt == null || !typeFromExt.equals(mimeType, ignoreCase = true)) {
                     extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
                     if (extension != null) {
-                        extension = "" + extension
+                        extension = "." + extension
                     }
                 }
             }

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -4,10 +4,13 @@
 
 package mozilla.components.support.utils
 
+import android.webkit.MimeTypeMap
+
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 
 private val CONTENT_DISPOSITION_TYPES = listOf("attachment", "inline")
 
@@ -65,5 +68,13 @@ class DownloadUtilsTest {
         assertUrl("downloadfile.bin", "http://example.com/filename/")
         assertUrl("filename.jpg", "http://example.com/filename.jpg")
         assertUrl("filename.jpg", "http://example.com/foo/bar/filename.jpg")
+    }
+
+    @Test
+    fun testGuessFileName_mimeType() {
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("jpg", "image/jpeg")
+
+        assertEquals("file.jpg", DownloadUtils.guessFileName(null, "http://example.com/file.jpg", "image/jpeg"))
+        assertEquals("file.jpg", DownloadUtils.guessFileName(null, "http://example.com/file.bin", "image/jpeg"))
     }
 }


### PR DESCRIPTION
Previously `guessFileName` only replaced the extension with the MIME
type if the file name had an extension which mapped onto a valid but
different MIME type.  Suggested by:

https://issuetracker.google.com/issues/37053711

Also fix missing dot in extension, copying a fix from Android `URLUtil`.

References mozilla-mobile/focus-android#3462.