### PR TITLE
Closes #828: Fullscreen mode doesn't use entire screen.

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -297,12 +297,14 @@ class SystemEngineView @JvmOverloads constructor(
 
     internal fun addFullScreenView(view: View, callback: WebChromeClient.CustomViewCallback) {
         val webView = findViewWithTag<WebView>("mosac_system_engine_webview")
-        webView?.apply { this.visibility = View.GONE }
+        val layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
+        webView?.apply { this.visibility = View.INVISIBLE }
 
         fullScreenCallback = callback
 
         view.tag = "mosac_system_engine_fullscreen"
-        addView(view)
+        addView(view, layoutParams)
     }
 
     internal fun removeFullScreenView() {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -504,7 +504,7 @@ class SystemEngineViewTest {
         engineView.currentWebView.tag = "not_webview"
         engineView.currentWebView.webChromeClient.onShowCustomView(view, customViewCallback)
 
-        assertNotEquals(View.GONE, engineView.currentWebView.visibility)
+        assertNotEquals(View.INVISIBLE, engineView.currentWebView.visibility)
     }
 
     @Test
@@ -524,7 +524,7 @@ class SystemEngineViewTest {
 
         assertNotNull(engineView.fullScreenCallback)
         verify(engineView.fullScreenCallback, never())?.onCustomViewHidden()
-        assertEquals(View.GONE, engineView.currentWebView.visibility)
+        assertEquals(View.INVISIBLE, engineView.currentWebView.visibility)
 
         // When fullscreen view is available, but WebView isn't.
         engineView.findViewWithTag<View>("not_fullscreen").tag = "mosac_system_engine_fullscreen"
@@ -532,7 +532,7 @@ class SystemEngineViewTest {
 
         engineView.currentWebView.webChromeClient.onHideCustomView()
 
-        assertEquals(View.GONE, engineView.currentWebView.visibility)
+        assertEquals(View.INVISIBLE, engineView.currentWebView.visibility)
     }
 
     @Test


### PR DESCRIPTION
When we add the fullscreen view into the FrameLayout, we were taking the
original WebView and hiding it with View.GONE which doesn't take up any
layout space. View.INVISIBLE doesn't show the view, but continues to
use the space that it would if it did exist (drawing in the background).

For websites like YouTube and BBC.com/ideas, the video provided to us
was of a smaller size and resolution so it didn't take the fullscreen
and ended up shrinking to it's original size view size. 🤦