### PR TITLE
[ci skip] Delete components/service/firefox-accounts/.gitignore. (Fixes #859)

### DIFF
--- a/components/service/firefox-accounts/.gitignore
+++ b/components/service/firefox-accounts/.gitignore
@@ -1,3 +1,0 @@
-
-# Ignore JNI libs downloaded as dependencies
-src/main/jniLibs/**/*.so


### PR DESCRIPTION
This is follow-up to https://github.com/mozilla-mobile/android-components/pull/818.