### PR TITLE
Closes #865: Add ErrorResult for RequestInterceptor.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -231,6 +231,7 @@ class GeckoEngineSession(
     /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
+    @Suppress("ComplexMethod")
     private fun createNavigationDelegate() = object : GeckoSession.NavigationDelegate {
 
         override fun onLocationChange(session: GeckoSession?, url: String) {
@@ -282,7 +283,9 @@ class GeckoEngineSession(
                 this@GeckoEngineSession,
                 error,
                 uri
-            )
+            )?.apply {
+                return GeckoResult.fromValue(data)
+            }
             return GeckoResult.fromValue(null)
         }
     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -231,6 +231,7 @@ class GeckoEngineSession(
     /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
+    @Suppress("ComplexMethod")
     private fun createNavigationDelegate() = object : GeckoSession.NavigationDelegate {
         override fun onLocationChange(session: GeckoSession?, url: String) {
             // Ignore initial load of about:blank (see https://github.com/mozilla-mobile/android-components/issues/403)
@@ -281,7 +282,9 @@ class GeckoEngineSession(
                 this@GeckoEngineSession,
                 error,
                 uri
-            )
+            )?.apply {
+                return GeckoResult.fromValue(data)
+            }
             return GeckoResult.fromValue(null)
         }
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
@@ -20,6 +20,16 @@ interface RequestInterceptor {
     )
 
     /**
+     * An alternative response for an error request.
+     */
+    data class ErrorResponse(
+        val data: String,
+        val url: String? = null,
+        val mimeType: String = "text/html",
+        val encoding: String = "UTF-8"
+    )
+
+    /**
      * A request to open an URI. This is called before each page load to allow custom behavior implementation.
      *
      * @param session The engine session that initiated the callback.
@@ -34,6 +44,8 @@ interface RequestInterceptor {
      * @param session The engine session that initiated the callback.
      * @param errorCode The error code that was provided by the engine related to the type of error caused.
      * @param uri The uri that resulted in the error.
+     * @return An ErrorResponse object containing alternative content if the request caused an error.
+     *         <code>null</code> otherwise.
      */
-    fun onErrorRequest(session: EngineSession, errorCode: Int, uri: String?) = Unit
+    fun onErrorRequest(session: EngineSession, errorCode: Int, uri: String?): ErrorResponse? = null
 }


### PR DESCRIPTION
If we want to load an error page, we can return it to the interceptor,
along with a custom URL to show on the screen.

Tests for the GeckoView implementation will follow up. This change
should unblock SystemEngine clients for now.