### PR TITLE
Closes #876: Lifecycle bound observers should pause/resume.

### DIFF
--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -256,7 +256,7 @@ private class MockedTabsTray : TabsTray {
 
     override fun register(observer: TabsTray.Observer) {}
 
-    override fun register(observer: TabsTray.Observer, owner: LifecycleOwner) {}
+    override fun register(observer: TabsTray.Observer, owner: LifecycleOwner, autoPause: Boolean) {}
 
     override fun register(observer: TabsTray.Observer, view: View) {}
 
@@ -267,4 +267,8 @@ private class MockedTabsTray : TabsTray {
     override fun notifyObservers(block: TabsTray.Observer.() -> Unit) {}
 
     override fun <R> wrapConsumers(block: TabsTray.Observer.(R) -> Boolean): List<(R) -> Boolean> = emptyList()
+
+    override fun pauseObserver(observer: TabsTray.Observer) {}
+
+    override fun resumeObserver(observer: TabsTray.Observer) {}
 }

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
@@ -18,6 +18,8 @@ import android.view.View
 interface Observable<T> {
     /**
      * Registers an observer to get notified about changes.
+     *
+     * @param observer the observer to register.
      */
     fun register(observer: T)
 
@@ -26,18 +28,28 @@ interface Observable<T> {
      *
      * The observer will automatically unsubscribe if the lifecycle of the provided LifecycleOwner
      * becomes DESTROYED.
+     *
+     * @param observer the observer to register.
+     * @param owner the lifecycle owner the provided observer is bound to.
+     * @param autoPause whether or not the observer should automatically be
+     * paused/resumed with the bound lifecycle.
      */
-    fun register(observer: T, owner: LifecycleOwner)
+    fun register(observer: T, owner: LifecycleOwner, autoPause: Boolean = false)
 
     /**
      * Registers an observer to get notified about changes.
      *
      * The observer will automatically unsubscribe if the provided view gets detached.
+     *
+     * @param observer the observer to register.
+     * @param view the view the provided observer is bound to.
      */
     fun register(observer: T, view: View)
 
     /**
      * Unregisters an observer.
+     *
+     * @param observer the observer to unregister.
      */
     fun unregister(observer: T)
 
@@ -47,9 +59,28 @@ interface Observable<T> {
     fun unregisterObservers()
 
     /**
-     * Notify all registered observers about a change.
+     * Notifies all registered observers about a change.
+     *
+     * @param block the notification (method on the observer to be invoked).
      */
     fun notifyObservers(block: T.() -> Unit)
+
+    /**
+     * Pauses the provided observer. No notifications will be sent to this
+     * observer until [resumeObserver] is called.
+     *
+     * @param observer the observer to pause.
+     */
+    fun pauseObserver(observer: T)
+
+    /**
+     * Resumes the provided observer. Notifications sent since it
+     * was last paused (see [pauseObserver]]) are lost and will not be
+     * re-delivered.
+     *
+     * @param observer the observer to resume.
+     */
+    fun resumeObserver(observer: T)
 
     /**
      * Returns a list of lambdas wrapping a consuming method of an observer.

--- a/components/support/base/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/support/base/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)


### PR DESCRIPTION
First stab at this which pauses/resumes observers. When an observer is resumed only the last value/notification is sent to get it up-to-date. I want to do more testing but putting it up for review / discussion. 