### PR TITLE
Closes #911 - ui-autocomplete: Do not restart input method in deleteS…

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -468,18 +468,6 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                     // If we have autocomplete text, the cursor is at the boundary between
                     // regular and autocomplete text. So regardless of which direction we
                     // are deleting, we should delete the autocomplete text first.
-                    // Make the IME aware that we interrupted the deleteSurroundingText call,
-                    // by restarting the IME.
-                    post {
-                        // On some devices this method can lead to race conditions (see Javadoc on
-                        // [InputConnection#deleteSurroundingText], and in at least one case this
-                        // caused our soft keyboard to desynchronize from its backing EditText.
-                        //
-                        // It is not known exactly how this method interacts with platform code
-                        // to create problems, but posting has resolved the reported issue.
-                        val imm = ctx.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                        imm.restartInput(this@InlineAutocompleteEditText)
-                    }
                     return false
                 }
                 return super.deleteSurroundingText(beforeLength, afterLength)

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -28,7 +28,6 @@ import org.robolectric.annotation.Config
 
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.Companion.AUTOCOMPLETE_SPAN
-import org.mockito.ArgumentMatchers.any
 
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class)

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -324,17 +324,6 @@ class InlineAutocompleteEditTextTest {
     }
 
     @Test
-    fun testPostIsCalledWhenAutocompletedTextIsDeleted() {
-        val et = spy(InlineAutocompleteEditText(context, attributes))
-        val icw = et.onCreateInputConnection(mock(EditorInfo::class.java))
-
-        et.setText("text")
-        et.applyAutocompleteResult(AutocompleteResult("text completed", "source", 1))
-        icw?.deleteSurroundingText(0, 1)
-        verify(et).post(any<Runnable>())
-    }
-
-    @Test
     fun testRemoveAutocompleteOnComposing() {
         val et = InlineAutocompleteEditText(context, attributes)
         val ic = et.onCreateInputConnection(mock(EditorInfo::class.java))


### PR DESCRIPTION
…urroundingText.

This fix is speculative. There seems to be theoretical reason we need
to restart the input method and I think it's creating a race condition
that causes the keyboard to stop working on some devices. In practice,
removing this call fixes the bug but otherwise doesn't seem to make a
difference in autocomplete behavior on device or in the emulator.