### PR TITLE
Closes #923: SystemEngineSession.exitFullScreenMode() is a no-op...

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -297,7 +297,7 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
      * See [EngineSession.exitFullScreenMode]
      */
     override fun exitFullScreenMode() {
-        // no-op
+        view?.get()?.fullScreenCallback?.onCustomViewHidden()
     }
 
     override fun captureThumbnail(): Bitmap? {

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -332,7 +332,6 @@ class SystemEngineView @JvmOverloads constructor(
         val view = findViewWithTag<View>("mosac_system_engine_fullscreen")
         val webView = findViewWithTag<WebView>("mosac_system_engine_webview")
         view?.let {
-            fullScreenCallback?.onCustomViewHidden()
             webView?.apply { this.visibility = View.VISIBLE }
             removeView(view)
         }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Bundle
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebStorage
@@ -643,5 +644,17 @@ class SystemEngineSessionTest {
 
         `when`(webView.drawingCache).thenReturn(ShadowBitmap.createBitmap(10, 10, Bitmap.Config.RGB_565))
         assertNotNull(engineSession.captureThumbnail())
+    }
+
+    @Test
+    fun testExitFullscreenModeWithWebViewAndCallBack() {
+        val engineSession = SystemEngineSession()
+        val engineView = SystemEngineView(RuntimeEnvironment.application)
+        val customViewCallback = mock(WebChromeClient.CustomViewCallback::class.java)
+
+        engineView.render(engineSession)
+        engineView.fullScreenCallback = customViewCallback
+        engineSession.exitFullScreenMode()
+        verify(customViewCallback).onCustomViewHidden()
     }
 }


### PR DESCRIPTION
This was an error where we weren't calling the WebView's fullscreen view
callback in the EngineSession#exitFullScreenMode.