### PR TITLE
Close #111: Fix potential static field leak in `TelemetryJobService`.

### DIFF
--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/TelemetryTest.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/TelemetryTest.java
@@ -8,7 +8,6 @@ import android.app.job.JobInfo;
 import android.app.job.JobParameters;
 import android.app.job.JobScheduler;
 import android.content.Context;
-import android.os.AsyncTask;
 import android.os.PersistableBundle;
 import android.preference.PreferenceManager;
 
@@ -563,9 +562,7 @@ public class TelemetryTest {
         final JobParameters parameters = mock(JobParameters.class);
         doReturn(bundle).when(parameters).getExtras();
 
-        AsyncTask task = mock(AsyncTask.class);
-
-        service.uploadPingsInBackground(task, parameters);
+        service.uploadPingsInBackground(parameters);
 
         verify(service).jobFinished(parameters, false);
     }

--- a/components/service/telemetry/src/test/java/org/mozilla/telemetry/TestUtils.java
+++ b/components/service/telemetry/src/test/java/org/mozilla/telemetry/TestUtils.java
@@ -5,13 +5,29 @@
 package org.mozilla.telemetry;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import org.mozilla.telemetry.schedule.jobscheduler.TelemetryJobService;
 
 public class TestUtils {
     /**
      * Wait for the internal executor service to execute all scheduled runnables.
      */
     public static void waitForExecutor(Telemetry telemetry) throws ExecutionException, InterruptedException {
-        telemetry.getExecutor().submit(new Runnable() {
+        waitForExecutor(telemetry.getExecutor());
+    }
+
+    /**
+     * Wait for the internal executor service to execute all scheduled runnables.
+     */
+    public static void waitForExecutor(TelemetryJobService jobService) throws ExecutionException, InterruptedException {
+        waitForExecutor(jobService.getExecutor());
+    }
+
+    /**
+     * Wait for runnable computation to complete.
+     */
+    private static void waitForExecutor(ExecutorService executor) throws ExecutionException, InterruptedException {
+        executor.submit(new Runnable() {
             @Override
             public void run() {
 


### PR DESCRIPTION
* Extract `UploadPingsTask` as a top-level class, so, the
class won't retain an implicit reference to the containing activity.
* Update tests related to `UploadPingsTask`, `TelemetryJobService` and
`Telemetry`

Close #111