### PR TITLE
[ci skip] Closes Issue #922 - Update READMEs to point to maven.mozilla.org and use new artifact names. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ The following diagram does not contain all available components. See [Components
 * ⚪ **Preview** - This component is almost/partially ready and can be tested in products.
 * 🔵 **Production ready** - Used by shipping products.
 
+Our artifacts live in [maven.mozilla.org](https://maven.mozilla.org/maven2) remember to add it in your root ```build.gradle``` file:
+```groovy
+repositories {
+  maven {
+   url "https://maven.mozilla.org/maven2"
+  }
+}
+```
+
 ## Browser
 
 High-level components for building browser(-like) apps.
@@ -100,7 +109,7 @@ High-level components for building browser(-like) apps.
 
 * 🔴 [**Engine-Gecko-Beta**](components/browser/engine-gecko-beta/README.md) - *Engine* implementation based on [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView) (Beta channel).
 
-* 🔴 [**Engine-Gecko-Nightly**](components/browser/engine-gecko/README.md) - *Engine* implementation based on [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView) (Nightly channel).
+* 🔴 [**Engine-Gecko-Nightly**](components/browser/engine-gecko-nightly/README.md) - *Engine* implementation based on [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView) (Nightly channel).
 
 * ⚪ [**Engine-System**](components/browser/engine-system/README.md) - *Engine* implementation based on the system's WebView.
 

--- a/components/browser/domains/README.md
+++ b/components/browser/domains/README.md
@@ -9,7 +9,7 @@ Localized and customizable domain lists for auto-completion in browsers.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:domains:{latest-version}
+implementation "org.mozilla.components:browser-domains:{latest-version}"
 ```
 
 ## License

--- a/components/browser/engine-gecko-beta/README.md
+++ b/components/browser/engine-gecko-beta/README.md
@@ -11,7 +11,7 @@ See [concept-engine](../../concept/engine/README.md) for a documentation of the 
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:engine-gecko-beta:{latest-version}
+implementation "org.mozilla.components:browser-engine-gecko-beta:{latest-version}"
 ```
 
 ### Initializing

--- a/components/browser/engine-gecko-nightly/README.md
+++ b/components/browser/engine-gecko-nightly/README.md
@@ -9,7 +9,7 @@
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:engine-gecko:{latest-version}
+implementation "org.mozilla.components:browser-engine-gecko-nightly:{latest-version}"
 ```
 
 ## License

--- a/components/browser/engine-gecko/README.md
+++ b/components/browser/engine-gecko/README.md
@@ -11,7 +11,7 @@ See [concept-engine](../../concept/engine/README.md) for a documentation of the 
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:engine-gecko-nightly:{latest-version}
+implementation "org.mozilla.components:browser-engine-gecko:{latest-version}"
 ```
 
 ### Initializing

--- a/components/browser/engine-system/README.md
+++ b/components/browser/engine-system/README.md
@@ -11,7 +11,7 @@ See [concept-engine](../../concept/engine/README.md) for a documentation of the 
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:engine-system:{latest-version}
+implementation "org.mozilla.components:browser-engine-system:{latest-version}"
 ```
 
 ### Initializing

--- a/components/browser/errorpages/README.md
+++ b/components/browser/errorpages/README.md
@@ -9,7 +9,7 @@ Responsive browser error pages for Android apps.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:errorpages:{latest-version}
+implementation "org.mozilla.components:browser-errorpages:{latest-version}"
 ```
 
 ## License

--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -9,7 +9,7 @@ A generic menu with customizable items primarily for browser toolbars.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:menu:{latest-version}
+implementation "org.mozilla.components:browser-menu:{latest-version}"
 ```
 
 ## License

--- a/components/browser/search/README.md
+++ b/components/browser/search/README.md
@@ -9,7 +9,7 @@ Search plugins and companion code to load, parse and use them.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:search:{latest-version}
+implementation "org.mozilla.components:browser-search:{latest-version}"
 ```
 
 ## License

--- a/components/browser/session/README.md
+++ b/components/browser/session/README.md
@@ -9,7 +9,7 @@ This component provides a generic representation of a browser [Session](#session
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:session:{latest-version}
+implementation "org.mozilla.components:browser-session:{latest-version}"
 ```
 
 ### Session

--- a/components/browser/tabstray/README.md
+++ b/components/browser/tabstray/README.md
@@ -9,7 +9,7 @@ A customizable tabs tray for browsers.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:tabstray:{latest-version}
+implementation "org.mozilla.components:browser-tabstray:{latest-version}"
 ```
 
 ## License

--- a/components/browser/toolbar/README.md
+++ b/components/browser/toolbar/README.md
@@ -9,7 +9,7 @@ A customizable toolbar for browsers.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:toolbar:{latest-version}
+implementation "org.mozilla.components:browser-toolbar:{latest-version}"
 ```
 
 ## License

--- a/components/concept/engine/README.md
+++ b/components/concept/engine/README.md
@@ -17,7 +17,7 @@ Other components and apps only referencing `concept-engine` makes it possible to
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:engine:{latest-version}
+implementation "org.mozilla.components:concept-engine:{latest-version}"
 ```
 
 ### Integration

--- a/components/concept/tabstray/README.md
+++ b/components/concept/tabstray/README.md
@@ -9,7 +9,7 @@ Abstract definition of a tabs tray component.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:abstract-tabstray:{latest-version}
+implementation "org.mozilla.components:concept-tabstray:{latest-version}"
 ```
 
 ## License

--- a/components/concept/toolbar/README.md
+++ b/components/concept/toolbar/README.md
@@ -9,7 +9,7 @@ Abstract definition of a browser toolbar component.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:abstract-toolbar:{latest-version}
+implementation "org.mozilla.components:concept-toolbar:{latest-version}"
 ```
 
 ## License

--- a/components/feature/intent/README.md
+++ b/components/feature/intent/README.md
@@ -9,7 +9,7 @@ A component that provides intent processing functionality by combining various o
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:feature-intent:{latest-version}
+implementation "org.mozilla.components:feature-intent:{latest-version}"
 ```
 
 ## License

--- a/components/feature/search/README.md
+++ b/components/feature/search/README.md
@@ -9,7 +9,7 @@ A component that connects an (concept) engine implementation with the browser se
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:feature-search:{latest-version}
+implementation "org.mozilla.components:feature-search:{latest-version}"
 ```
 
 ## License

--- a/components/feature/session/README.md
+++ b/components/feature/session/README.md
@@ -9,7 +9,7 @@ A component that connects an (concept) engine implementation with the browser se
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:feature-session:{latest-version}
+implementation "org.mozilla.components:feature-session:{latest-version}"
 ```
 
 ## License

--- a/components/feature/tabs/README.md
+++ b/components/feature/tabs/README.md
@@ -9,7 +9,7 @@ A component that connects a trabs tray implementation with the session and toolb
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:feature-tabs:{latest-version}
+implementation "org.mozilla.components:feature-tabs:{latest-version}"
 ```
 
 ## License

--- a/components/feature/toolbar/README.md
+++ b/components/feature/toolbar/README.md
@@ -9,7 +9,7 @@ A component that connects a (concept) toolbar implementation with the browser se
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:feature-toolbar:{latest-version}
+implementation "org.mozilla.components:feature-toolbar:{latest-version}"
 ```
 
 ## License

--- a/components/lib/dataprotect/README.md
+++ b/components/lib/dataprotect/README.md
@@ -9,7 +9,7 @@ A component using AndroidKeyStore to protect user data.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:dataprotect:{latest-version}
+implementation "org.mozilla.components:lib-dataprotect:{latest-version}"
 ```
 
 ## License

--- a/components/service/firefox-accounts/README.md
+++ b/components/service/firefox-accounts/README.md
@@ -20,7 +20,7 @@ for help with integrating this component into your application.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:fxa:{latest-version}
+implementation "org.mozilla.components:service-firefox-accounts:{latest-version}"
 ```
 
 ### Start coding

--- a/components/service/fretboard/README.md
+++ b/components/service/fretboard/README.md
@@ -9,7 +9,7 @@ An Android framework for segmenting users in order to run A/B tests and rollout 
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:fretboard:{latest-version}"
+implementation "org.mozilla.components:service-fretboard:{latest-version}"
 ```
 
 ### Creating Fretboard instance

--- a/components/service/sync-logins/README.md
+++ b/components/service/sync-logins/README.md
@@ -15,7 +15,7 @@ The **Firefox Sync - Logins Component** provides a way for Android applications 
 Use gradle to download the library from JCenter:
 
 ```
-implementation "org.mozilla.components:sync-logins:{latest-version}
+implementation "org.mozilla.components:service-sync-logins:{latest-version}"
 ```
 
 You will also need the Firefox Accounts component to be able to obtain the keys to decrypt the Logins data:

--- a/components/service/telemetry/README.md
+++ b/components/service/telemetry/README.md
@@ -13,7 +13,7 @@ The goal of this library is to provide a generic set of components to support a 
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:telemetry:{latest-version}
+implementation "org.mozilla.components:service-telemetry:{latest-version}"
 ```
 
 

--- a/components/support/base/README.md
+++ b/components/support/base/README.md
@@ -11,7 +11,7 @@ Usually this component never needs to be added to application projects manually.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:base:{latest-version}
+implementation "org.mozilla.components:support-base:{latest-version}"
 ```
 
 ### Logging

--- a/components/support/ktx/README.md
+++ b/components/support/ktx/README.md
@@ -9,7 +9,7 @@ A set of Kotlin extensions on top of the Android framework and Kotlin standard l
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:ktx:{latest-version}
+implementation "org.mozilla.components:support-ktx:{latest-version}"
 ```
 
 ## License

--- a/components/support/test/README.md
+++ b/components/support/test/README.md
@@ -9,7 +9,7 @@ A collection of helpers for testing components.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:test:{latest-version}
+implementation "org.mozilla.components:support-test:{latest-version}"
 ```
 
 ## License

--- a/components/support/utils/README.md
+++ b/components/support/utils/README.md
@@ -9,7 +9,7 @@ Generic utility classes to be shared between projects.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:utils:{latest-version}
+implementation "org.mozilla.components:support-utils:{latest-version}"
 ```
 
 ## License

--- a/components/ui/autocomplete/README.md
+++ b/components/ui/autocomplete/README.md
@@ -9,7 +9,7 @@ A set of components to provide autocomplete functionality.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:autocomplete:{latest-version}
+implementation "org.mozilla.components:ui-autocomplete:{latest-version}"
 ```
 
 ## License

--- a/components/ui/colors/README.md
+++ b/components/ui/colors/README.md
@@ -9,7 +9,7 @@ The standard set of [Photon](https://design.firefox.com/photon/) colors.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.photon:colors:{latest-version}
+implementation "org.mozilla.photon:ui-colors:{latest-version}"
 ```
 
 ## License

--- a/components/ui/fonts/README.md
+++ b/components/ui/fonts/README.md
@@ -9,7 +9,7 @@ The standard set of fonts used by Mozilla Android products.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.photon:fonts:{latest-version}
+implementation "org.mozilla.photon:ui-fonts:{latest-version}"
 ```
 
 ## License

--- a/components/ui/icons/README.md
+++ b/components/ui/icons/README.md
@@ -9,7 +9,7 @@ A collection of often used browser icons.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.photon:icons:{latest-version}
+implementation "org.mozilla.photon:ui-icons:{latest-version}"
 ```
 
 ## License

--- a/components/ui/progress/README.md
+++ b/components/ui/progress/README.md
@@ -9,7 +9,7 @@ An animated progress bar following the Photon Design System.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.photon:progress:{latest-version}
+implementation "org.mozilla.photon:ui-progress:{latest-version}"
 ```
 
 ## License

--- a/components/ui/tabcounter/README.md
+++ b/components/ui/tabcounter/README.md
@@ -9,7 +9,7 @@ A button that shows the current tab count and can animate state changes.
 Use gradle to download the library from JCenter:
 
 ```Groovy
-implementation "org.mozilla.components:tabcounter:{latest-version}
+implementation "org.mozilla.components:ui-tabcounter:{latest-version}"
 ```
 
 ## License


### PR DESCRIPTION
Fixes issue #922 to Update READMEs to point to ```maven.mozilla.org``` and use new artifact names.