### PR TITLE
Fix taskcluster 5.0.0 API breakage

### DIFF
--- a/automation/taskcluster/release/convert_group_and_artifact_ids.py
+++ b/automation/taskcluster/release/convert_group_and_artifact_ids.py
@@ -197,7 +197,7 @@ def convert_xml_element(element, conversion_dict):
 
 
 async def async_main(session, task_id):
-    asyncQueue = taskcluster.aio.Queue(session=session)
+    asyncQueue = taskcluster.aio.Queue(options={'rootUrl':'https://taskcluster.net'}, session=session)
     task_definition = await asyncQueue.task(task_id)
     upstream_zip_definitions = task_definition['payload']['upstreamZip']
 


### PR DESCRIPTION
https://tools.taskcluster.net/groups/OQDIpQDRRvCZbIeNvcNffQ/tasks/BjR2SjroQ66IxiUZ0BC6_A/runs/0/logs/public%2Flogs%2Flive_backing.log#L1587

`git grep` didn't return any other Queue() call in the same situation. The other already fill `baseUrl` which seems to work, based on the decision of the graph above