### PR TITLE
Added required uri parameter to createErrorPage.

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -16,6 +16,7 @@ object ErrorPages {
     fun createErrorPage(
         context: Context,
         errorType: ErrorType,
+        uri: String? = null,
         @RawRes htmlResource: Int = R.raw.error_pages,
         @RawRes cssResource: Int = R.raw.error_style
     ): String {
@@ -29,7 +30,7 @@ object ErrorPages {
             .replace("%pageTitle%", context.getString(R.string.errorpage_title))
             .replace("%button%", context.getString(R.string.errorpage_refresh))
             .replace("%messageShort%", context.getString(errorType.titleRes))
-            .replace("%messageLong%", context.getString(errorType.messageRes))
+            .replace("%messageLong%", context.getString(errorType.messageRes, uri))
             .replace("%css%", css)
     }
 }

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -9,6 +9,7 @@ package mozilla.components.browser.errorpages
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.nullable
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
@@ -28,6 +29,7 @@ class ErrorPagesTest {
         Assert.assertFalse(errorPage.contains("%messageShort%"))
         Assert.assertFalse(errorPage.contains("%messageLong%"))
         Assert.assertFalse(errorPage.contains("%css%"))
-        verify(context, times(4)).getString(anyInt())
+        verify(context, times(3)).getString(anyInt())
+        verify(context, times(1)).getString(anyInt(), nullable(String::class.java))
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
@@ -23,6 +23,6 @@ class SampleRequestInterceptor(val context: Context) : RequestInterceptor {
         errorType: ErrorType,
         uri: String?
     ): RequestInterceptor.ErrorResponse? {
-        return RequestInterceptor.ErrorResponse(ErrorPages.createErrorPage(context, errorType))
+        return RequestInterceptor.ErrorResponse(ErrorPages.createErrorPage(context, errorType, uri))
     }
 }


### PR DESCRIPTION
Some error pages like [Safe Browsing](https://testsafebrowsing.appspot.com/) error pages require a URI parameter.