### PR TITLE
Closes #962: Add reusable functionality for observing selected session

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session
+
+import android.support.annotation.CallSuper
+
+/**
+ * This class is a combination of [Session.Observer] and
+ * [SessionManager.Observer]. It provides functionality to observe changes to a
+ * specified or selected session, and can automatically take care of switching
+ * over the observer in case a different session gets selected (see
+ * [observeFixed] and [observeSelected]).
+ *
+ * @property activeSession the currently observed session
+ * @property sessionManager the application's session manager
+ */
+abstract class SelectionAwareSessionObserver(
+    private val sessionManager: SessionManager
+) : SessionManager.Observer, Session.Observer {
+
+    protected open var activeSession: Session? = null
+
+    /**
+     * Starts observing changes to the specified session.
+     *
+     * @param session the session to observe.
+     */
+    fun observeFixed(session: Session) {
+        activeSession = session
+        session.register(this)
+    }
+
+    /**
+     * Starts observing changes to the selected session (see
+     * [SessionManager.selectedSession]). If a different session is selected
+     * the observer will automatically be switched over and only notified of
+     * changes to the newly selected session.
+     */
+    fun observeSelected() {
+        activeSession = sessionManager.selectedSession
+        sessionManager.register(this)
+        activeSession?.register(this)
+    }
+
+    /**
+     * Stops the observer.
+     */
+    fun stop() {
+        sessionManager.unregister(this)
+        activeSession?.unregister(this)
+    }
+
+    @CallSuper
+    override fun onSessionSelected(session: Session) {
+        activeSession?.unregister(this)
+        activeSession = session
+        session.register(this)
+    }
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session
+
+import android.graphics.Bitmap
+import mozilla.components.concept.engine.HitResult
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+class SelectionAwareSessionObserverTest {
+    private lateinit var sessionManager: SessionManager
+    private lateinit var session1: Session
+    private lateinit var session2: Session
+    private lateinit var observer: MockObserver
+
+    @Before
+    fun setup() {
+        sessionManager = SessionManager(engine = mock())
+        session1 = Session("https://mozilla.org")
+        session2 = Session("https://getpocket.com")
+        observer = MockObserver(sessionManager)
+    }
+
+    @Test
+    fun `observe specific session`() {
+        observer.observeFixed(session1)
+        assertEquals(session1, observer.activeSession)
+
+        session1.url = "changed"
+        assertEquals("changed", observer.observedUrl)
+    }
+
+    @Test
+    fun `observe selected session`() {
+        sessionManager.add(session1, selected = true)
+        observer.observeSelected()
+        assertEquals(session1, observer.activeSession)
+
+        session1.url = "changed"
+        assertEquals("changed", observer.observedUrl)
+    }
+
+    @Test
+    fun `observe selected session on empty session manager`() {
+        observer.observeSelected()
+        assertNull(observer.activeSession)
+
+        sessionManager.add(session1)
+        assertEquals(session1, observer.activeSession)
+
+        session1.url = "changed"
+        assertEquals("changed", observer.observedUrl)
+    }
+
+    @Test
+    fun `observer handles session selection change`() {
+        sessionManager.add(session1, selected = true)
+        sessionManager.add(session2)
+
+        observer.observeSelected()
+        assertEquals(session1, observer.activeSession)
+
+        sessionManager.select(session2)
+        assertEquals(session2, observer.activeSession)
+    }
+
+    @Test
+    fun `observer notified of changes to selected session only`() {
+        sessionManager.add(session1, selected = true)
+        sessionManager.add(session2)
+
+        observer.observeSelected()
+
+        session1.url = "changed1"
+        session2.url = "changed2"
+        assertEquals("changed1", observer.observedUrl)
+
+        session1.url = "http://mozilla.org"
+        session2.url = "http://getpocket.org"
+
+        sessionManager.select(session2)
+        session2.url = "changed2"
+        session1.url = "changed1"
+        assertEquals("changed2", observer.observedUrl)
+    }
+
+    @Test
+    fun `observer not notified after stop was called`() {
+        sessionManager.add(session1, selected = true)
+        sessionManager.add(session2)
+
+        observer.observeSelected()
+        assertEquals(session1, observer.activeSession)
+
+        observer.stop()
+        sessionManager.select(session2)
+        assertEquals(session1, observer.activeSession)
+
+        session1.url = "changed1"
+        assertEquals("", observer.observedUrl)
+    }
+
+    @Test
+    fun `stop has no effect if observe was never called`() {
+        assertNull(observer.activeSession)
+        observer.stop()
+        assertNull(observer.activeSession)
+    }
+
+    @Test
+    fun `observer has default methods`() {
+        val session = Session("")
+        val observer = object : SelectionAwareSessionObserver(sessionManager) { }
+        observer.onUrlChanged(session, "")
+        observer.onTitleChanged(session, "")
+        observer.onProgress(session, 0)
+        observer.onLoadingStateChanged(session, true)
+        observer.onNavigationStateChanged(session, true, true)
+        observer.onSearch(session, "")
+        observer.onSecurityChanged(session, Session.SecurityInfo())
+        observer.onCustomTabConfigChanged(session, null)
+        observer.onDownload(session, Mockito.mock(Download::class.java))
+        observer.onTrackerBlockingEnabledChanged(session, true)
+        observer.onTrackerBlocked(session, "", emptyList())
+        observer.onLongPress(session, Mockito.mock(HitResult::class.java))
+        observer.onFindResult(session, Mockito.mock(Session.FindResult::class.java))
+        observer.onDesktopModeChanged(session, true)
+        observer.onFullScreenChanged(session, true)
+        observer.onThumbnailChanged(session, Mockito.spy(Bitmap::class.java))
+        observer.onSessionRemoved(session)
+        observer.onAllSessionsRemoved()
+    }
+
+    class MockObserver(sessionManager: SessionManager) : SelectionAwareSessionObserver(sessionManager) {
+        public override var activeSession: Session?
+            get() = super.activeSession
+            set(value) { super.activeSession = value }
+
+        var observedUrl: String = ""
+
+        override fun onUrlChanged(session: Session, url: String) {
+            observedUrl = url
+        }
+    }
+}


### PR DESCRIPTION
This provides a reusable solution for consumers to observe the currently selected session, even if it changes. I went with a simple approach:

We already have both `Session.Observer` and `SessionManager.Observer` in our `browser-session` component. We can hide these from consumers and alternatively let them implement the new `SessionObserver`. The consumer can then decide whether they want to observe a single session or always observe the selected session. Both cases are needed in our `ToolbarPresenter` to support CustomTabs

This cleaned up the `ToolbarPresenter` and also seems to work well for the download feature under development in #1009 .

The reason I went with an interface instead of an (abstract) class is to not limit the possible consumers (e.g. a consumer could already by a subclass and still need this functionality).

