### PR TITLE
Introduced ktlint and detekt run on buildSrc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,12 @@ buildscript {
     }
 
     dependencies {
-        classpath Deps.tools_androidgradle
-        classpath Deps.tools_kotlingradle
-        classpath Deps.tools_dokka
+        classpath Dependencies.tools_androidgradle
+        classpath Dependencies.tools_kotlingradle
+        classpath Dependencies.tools_dokka
 
         // Publish.
-        classpath Deps.tools_mavengradle
+        classpath Dependencies.tools_mavengradle
     }
 }
 
@@ -168,7 +168,7 @@ task clean(type: Delete) {
 detekt {
     // The version number is duplicated, please refer to plugins block for more details
     version = "1.0.0.RC9.2"
-    input = files("$projectDir/components")
+    input = files("$projectDir/components", "$projectDir/buildSrc")
     config = files("$projectDir/config/detekt.yml")
     filters = ".*test.*,.*/resources/.*,.*/tmp/.*"
     baseline = file("$projectDir/config/detekt-baseline.xml")
@@ -193,7 +193,7 @@ task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
-    args "components/**/*.kt", "samples/**/*.kt", "!**/build"
+    args "components/**/*.kt" , "samples/**/*.kt", "!**/build", "buildSrc/**/*.kt"
 }
 
 task printModules {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,7 +34,8 @@ private object Versions {
 }
 
 // Synchronized dependencies used by (some) modules
-object Deps {
+@Suppress("MaxLineLength")
+object Dependencies {
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"

--- a/buildSrc/src/main/java/GVNightlyVersionVerifierPlugin.kt
+++ b/buildSrc/src/main/java/GVNightlyVersionVerifierPlugin.kt
@@ -16,7 +16,8 @@ open class GVNightlyVersionVerifierPlugin : Plugin<Project> {
 
     companion object {
         private const val GV_VERSION_PATH_FILE = "buildSrc/src/main/java/Gecko.kt"
-        private const val MAVEN_MOZILLA_GV_URL = "https://maven.mozilla.org/maven2/org/mozilla/geckoview/geckoview-nightly-armeabi-v7a/maven-metadata.xml"
+        private const val MAVEN_MOZILLA_GV_URL =
+            "https://maven.mozilla.org/maven2/org/mozilla/geckoview/geckoview-nightly-armeabi-v7a/maven-metadata.xml"
     }
 
     override fun apply(project: Project) {
@@ -29,6 +30,7 @@ open class GVNightlyVersionVerifierPlugin : Plugin<Project> {
         }
     }
 
+    @Suppress("TooGenericExceptionThrown")
     private fun updateGVNightlyVersion(project: Project) {
 
         val newVersion = getLastGeckoViewNightlyVersion(project)
@@ -60,9 +62,8 @@ open class GVNightlyVersionVerifierPlugin : Plugin<Project> {
         val file = File(path)
         var fileContent = file.readText()
         fileContent = fileContent.replace(Regex("nightly_version.*=.*"),
-                "nightly_version = \"$newVersion\"")
+            "nightly_version = \"$newVersion\"")
         file.writeText(fileContent)
         println("${file.name} file updated")
     }
-
 }

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -8,6 +8,7 @@ internal object GeckoVersions {
     const val release_version = "63.0.20181018182531"
 }
 
+@Suppress("MaxLineLength")
 object Gecko {
     const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
     const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"

--- a/buildSrc/src/main/java/GitHubClient.kt
+++ b/buildSrc/src/main/java/GitHubClient.kt
@@ -26,8 +26,8 @@ class GitHubClient(token: String) {
         return httpPOST(url, bodyJson, tokenHeader)
     }
 
-    private fun httpPOST(urlString: String, json: String,
-                         vararg headers: Pair<String, String>): Pair<Boolean, String> {
+    @Suppress("TooGenericExceptionCaught")
+    private fun httpPOST(urlString: String, json: String, vararg headers: Pair<String, String>): Pair<Boolean, String> {
         val url = URL(urlString)
         val http = url.openConnection() as HttpURLConnection
 
@@ -51,7 +51,6 @@ class GitHubClient(token: String) {
         } catch (e: Exception) {
             responseSuccessful = false
             http.errorStream.bufferedReader().readText()
-
         }
         return responseSuccessful to textResponse
     }

--- a/buildSrc/src/main/java/GitHubPlugin.kt
+++ b/buildSrc/src/main/java/GitHubPlugin.kt
@@ -36,7 +36,6 @@ open class GitHubPlugin : Plugin<Project> {
 
                 createPullRequest(title, body, branch, baseBranch, owner, repo, user)
             }
-
         }
 
         project.task("openIssue") {
@@ -52,15 +51,22 @@ open class GitHubPlugin : Plugin<Project> {
         }
     }
 
-    private fun createPullRequest(title: String, body: String, branchName: String,
-                                  baseBranch: String, owner: String,
-                                  repoName: String, user: String) {
+    @Suppress("TooGenericExceptionThrown", "LongParameterList")
+    private fun createPullRequest(
+        title: String,
+        body: String,
+        branchName: String,
+        baseBranch: String,
+        owner: String,
+        repoName: String,
+        user: String
+    ) {
         val bodyJson = ("{\n" +
-                "  \"title\": \" $title\",\n" +
-                "  \"body\": \"$body\",\n" +
-                "  \"head\": \"$user:$branchName\",\n" +
-                "  \"base\": \"$baseBranch\"\n" +
-                "}")
+            "  \"title\": \" $title\",\n" +
+            "  \"body\": \"$body\",\n" +
+            "  \"head\": \"$user:$branchName\",\n" +
+            "  \"base\": \"$baseBranch\"\n" +
+            "}")
 
         val result = client.createPullRequest(owner, repoName, bodyJson)
 
@@ -76,11 +82,12 @@ open class GitHubPlugin : Plugin<Project> {
         println(stringToPrint)
     }
 
+    @Suppress("TooGenericExceptionThrown")
     private fun createIssue(title: String, body: String, owner: String, repoName: String) {
         val bodyJson = ("{\n" +
-                "  \"title\": \"$title\",\n" +
-                "  \"body\": \"$body\"" +
-                "}")
+            "  \"title\": \"$title\",\n" +
+            "  \"body\": \"$body\"" +
+            "}")
 
         val result = client.createIssue(owner, repoName, bodyJson)
         val successFul = result.first

--- a/components/browser/awesomebar/build.gradle
+++ b/components/browser/awesomebar/build.gradle
@@ -29,17 +29,17 @@ android {
 dependencies {
     api project(':concept-awesomebar')
 
-    api Deps.support_recyclerview
-    implementation Deps.support_constraintlayout
+    api Dependencies.support_recyclerview
+    implementation Dependencies.support_constraintlayout
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 archivesBaseName = "browser-awesomebar"

--- a/components/browser/domains/build.gradle
+++ b/components/browser/domains/build.gradle
@@ -24,12 +24,12 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -32,12 +32,12 @@ dependencies {
     compileOnly Gecko.geckoview_beta_arm
     testImplementation Gecko.geckoview_beta_arm
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -39,12 +39,12 @@ dependencies {
     compileOnly Gecko.geckoview_nightly_arm
     testImplementation Gecko.geckoview_nightly_arm
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -32,12 +32,12 @@ dependencies {
     compileOnly Gecko.geckoview_release_arm
     testImplementation Gecko.geckoview_release_arm
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/browser/engine-servo/build.gradle
+++ b/components/browser/engine-servo/build.gradle
@@ -36,16 +36,16 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    implementation Deps.mozilla_servo
+    implementation Dependencies.mozilla_servo
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/engine-system/build.gradle
+++ b/components/browser/engine-system/build.gradle
@@ -31,14 +31,14 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/errorpages/build.gradle
+++ b/components/browser/errorpages/build.gradle
@@ -32,15 +32,15 @@ android {
 }
 
 dependencies {
-    implementation Deps.support_annotations
+    implementation Dependencies.support_annotations
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -24,15 +24,15 @@ android {
 dependencies {
     implementation project(':support-ktx')
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_recyclerview
-    implementation Deps.support_cardview
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_recyclerview
+    implementation Dependencies.support_cardview
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/search/build.gradle
+++ b/components/browser/search/build.gradle
@@ -35,12 +35,12 @@ android {
 dependencies {
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.support_customtabs
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.support_customtabs
 
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "utils".
@@ -35,9 +35,9 @@ dependencies {
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/storage-memory/build.gradle
+++ b/components/browser/storage-memory/build.gradle
@@ -25,12 +25,12 @@ dependencies {
     implementation project(':concept-storage')
     implementation project(':support-utils')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/browser/storage-sync/build.gradle
+++ b/components/browser/storage-sync/build.gradle
@@ -28,23 +28,23 @@ configurations {
 }
 
 dependencies {
-    jnaForTest Deps.jnaForTest
+    jnaForTest Dependencies.jnaForTest
 
-    api Deps.mozilla_places
+    api Dependencies.mozilla_places
 
     implementation project(':concept-storage')
     implementation project(':support-utils')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
-    implementation Deps.jna
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+    implementation Dependencies.jna
 
     testImplementation configurations.jnaForTest.dependencies
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/tabstray/build.gradle
+++ b/components/browser/tabstray/build.gradle
@@ -32,17 +32,17 @@ dependencies {
     implementation project(':ui-icons')
     implementation project(':ui-colors')
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_cardview
-    api Deps.support_recyclerview
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_cardview
+    api Dependencies.support_recyclerview
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -31,13 +31,14 @@ dependencies {
 
     implementation project(':support-ktx')
     api project(':support-base')
-    implementation Deps.support_appcompat
-    implementation Deps.kotlin_stdlib
+
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/concept/awesomebar/build.gradle
+++ b/components/concept/awesomebar/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation project(':support-base')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 }
 
 archivesBaseName = "concept-awesomebar"

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -22,18 +22,18 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.support_annotations
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.support_annotations
+    implementation Dependencies.kotlin_coroutines
 
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "base".
     api project(':support-base')
     api project(':browser-errorpages')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/concept/fetch/build.gradle
+++ b/components/concept/fetch/build.gradle
@@ -24,13 +24,13 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
-    testImplementation Deps.testing_mockwebserver
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_mockwebserver
 
     testImplementation project(':support-test')
 }

--- a/components/concept/storage/build.gradle
+++ b/components/concept/storage/build.gradle
@@ -22,17 +22,17 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.support_annotations
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.support_annotations
+    implementation Dependencies.kotlin_coroutines
 
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "base".
     api project(':support-base')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/concept/tabstray/build.gradle
+++ b/components/concept/tabstray/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':support-base')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 }
 
 apply from: '../../../publish.gradle'

--- a/components/concept/toolbar/build.gradle
+++ b/components/concept/toolbar/build.gradle
@@ -22,16 +22,16 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.support_annotations
-    implementation Deps.support_appcompat
+    implementation Dependencies.support_annotations
+    implementation Dependencies.support_appcompat
     api project(':support-base')
     implementation project(':support-ktx')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')
 }
 

--- a/components/feature/awesomebar/build.gradle
+++ b/components/feature/awesomebar/build.gradle
@@ -36,15 +36,16 @@ dependencies {
 
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
     testImplementation project(':browser-storage-memory')
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
-    testImplementation Deps.testing_mockwebserver
+
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_mockwebserver
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -22,15 +22,15 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.support_customtabs
+    implementation Dependencies.support_customtabs
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/downloads/build.gradle
+++ b/components/feature/downloads/build.gradle
@@ -27,11 +27,11 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':support-ktx')
     implementation project(':support-utils')
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')
     testImplementation project(':concept-engine')
 }

--- a/components/feature/intent/build.gradle
+++ b/components/feature/intent/build.gradle
@@ -30,15 +30,15 @@ dependencies {
     implementation project(':feature-session')
     implementation project(':support-utils')
     implementation project(':support-ktx')
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':browser-search')
     testImplementation project(':support-test')
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
-    testImplementation Deps.support_customtabs
-    testImplementation Deps.kotlin_coroutines
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.support_customtabs
+    testImplementation Dependencies.kotlin_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -26,11 +26,11 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':concept-engine')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -27,13 +27,13 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
-    testImplementation Deps.support_customtabs
+    testImplementation Dependencies.support_customtabs
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/storage/build.gradle
+++ b/components/feature/storage/build.gradle
@@ -26,12 +26,12 @@ dependencies {
     implementation project(':concept-storage')
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
 }

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -32,20 +32,20 @@ dependencies {
     implementation project(':ui-tabcounter')
     implementation project(':support-ktx')
 
-    implementation Deps.support_fragment
-    implementation Deps.support_recyclerview
+    implementation Dependencies.support_fragment
+    implementation Dependencies.support_recyclerview
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     // In tests we are constructing our own SessionManager instance which needs to know about an "engine".
     testImplementation project(':concept-engine')
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/toolbar/build.gradle
+++ b/components/feature/toolbar/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 }
 
 apply from: '../../../publish.gradle'

--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -25,24 +25,24 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_constraintlayout
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_constraintlayout
 
     implementation project(':support-base')
 
     // We only compile against Sentry and GeckoView. It's up to the app to add those dependencies if it wants to
     // send crash reports to Socorro (GV) or Sentry.
-    compileOnly Deps.thirdparty_sentry
+    compileOnly Dependencies.thirdparty_sentry
     compileOnly Gecko.geckoview_nightly_arm
-    testImplementation Deps.thirdparty_sentry
+    testImplementation Dependencies.thirdparty_sentry
 
     testImplementation project(':support-test')
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/lib/dataprotect/build.gradle
+++ b/components/lib/dataprotect/build.gradle
@@ -24,11 +24,11 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/lib/fetch-httpurlconnection/build.gradle
+++ b/components/lib/fetch-httpurlconnection/build.gradle
@@ -22,14 +22,14 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     implementation project(':concept-fetch')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
     testImplementation project(':tooling-fetch-tests')
 }

--- a/components/lib/fetch-okhttp/build.gradle
+++ b/components/lib/fetch-okhttp/build.gradle
@@ -22,16 +22,16 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.thirdparty_okhttp
+    implementation Dependencies.thirdparty_okhttp
 
     implementation project(':concept-fetch')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
     testImplementation project(':tooling-fetch-tests')
 }
 

--- a/components/lib/jexl/build.gradle
+++ b/components/lib/jexl/build.gradle
@@ -25,10 +25,10 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -45,19 +45,19 @@ configurations {
 }
 
 dependencies {
-    jnaForTest Deps.jnaForTest
+    jnaForTest Dependencies.jnaForTest
 
-    api Deps.mozilla_fxa
+    api Dependencies.mozilla_fxa
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.jna
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.jna
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation configurations.jnaForTest.dependencies
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/fretboard/build.gradle
+++ b/components/service/fretboard/build.gradle
@@ -22,19 +22,19 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
-    implementation Deps.arch_workmanager
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+    implementation Dependencies.arch_workmanager
 
     implementation project(':support-ktx')
     implementation project(':support-base')
 
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
-    testImplementation Deps.testing_mockwebserver
-    testImplementation Deps.kotlin_reflect
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.kotlin_reflect
 
     testImplementation project(':support-test')
 }

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -24,15 +24,15 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     implementation project(':support-base')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
-    testImplementation Deps.testing_mockwebserver
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_mockwebserver
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/sync-logins/build.gradle
+++ b/components/service/sync-logins/build.gradle
@@ -45,21 +45,21 @@ configurations {
 }
 
 dependencies {
-    jnaForTest Deps.jnaForTest
+    jnaForTest Dependencies.jnaForTest
 
-    api Deps.mozilla_sync_logins
+    api Dependencies.mozilla_sync_logins
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.jna
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.jna
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation configurations.jnaForTest.dependencies
 
-    testImplementation Deps.mozilla_sync_logins
+    testImplementation Dependencies.mozilla_sync_logins
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/telemetry/build.gradle
+++ b/components/service/telemetry/build.gradle
@@ -24,15 +24,15 @@ android {
 dependencies {
     implementation project(':support-base')
 
-    implementation Deps.support_annotations
+    implementation Dependencies.support_annotations
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 
-    testImplementation Deps.testing_mockwebserver
+    testImplementation Dependencies.testing_mockwebserver
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -25,16 +25,16 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
     // We expose the app-compat as API so that consumers get access to the Lifecycle classes automatically
-    api Deps.support_appcompat
+    api Dependencies.support_appcompat
 
     testImplementation project(':support-test')
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/ktx/build.gradle
+++ b/components/support/ktx/build.gradle
@@ -24,12 +24,14 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
-    implementation Deps.support_compat
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.support_compat
+
     implementation project(':support-base')
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -28,12 +28,12 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.testing_junit
-    implementation Deps.testing_mockito
-    implementation Deps.testing_robolectric
-    testImplementation Deps.support_compat
+    implementation Dependencies.testing_junit
+    implementation Dependencies.testing_mockito
+    implementation Dependencies.testing_robolectric
+    testImplementation Dependencies.support_compat
     testImplementation project(':support-ktx')
 }
 

--- a/components/support/utils/build.gradle
+++ b/components/support/utils/build.gradle
@@ -27,17 +27,17 @@ android {
 dependencies {
     implementation project(':support-base')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.support_annotations
-    implementation Deps.support_compat
+    implementation Dependencies.support_annotations
+    implementation Dependencies.support_compat
 
     // We expose the app-compat as API so that consumers get access to the Lifecycle classes automatically
-    api Deps.support_appcompat
+    api Dependencies.support_appcompat
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/tooling/fetch-tests/build.gradle
+++ b/components/tooling/fetch-tests/build.gradle
@@ -30,8 +30,8 @@ android {
 dependencies {
     implementation project(':concept-fetch')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.testing_mockwebserver
-    implementation Deps.testing_junit
+    implementation Dependencies.testing_mockwebserver
+    implementation Dependencies.testing_junit
 }

--- a/components/tooling/lint/build.gradle
+++ b/components/tooling/lint/build.gradle
@@ -9,11 +9,11 @@ targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  compileOnly Deps.tools_lintapi
-  compileOnly Deps.kotlin_stdlib
+  compileOnly Dependencies.tools_lintapi
+  compileOnly Dependencies.kotlin_stdlib
 
-  testImplementation Deps.tools_lint
-  testImplementation Deps.tools_linttests
+  testImplementation Dependencies.tools_lint
+  testImplementation Dependencies.tools_linttests
 }
 
 jar {

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -24,13 +24,13 @@ android {
 }
 
 dependencies {
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.support_appcompat
+    implementation Dependencies.support_appcompat
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/ui/progress/build.gradle
+++ b/components/ui/progress/build.gradle
@@ -24,13 +24,13 @@ android {
 dependencies {
     implementation project(':ui-colors')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    implementation Deps.support_appcompat
+    implementation Dependencies.support_appcompat
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/ui/tabcounter/build.gradle
+++ b/components/ui/tabcounter/build.gradle
@@ -24,11 +24,11 @@ android {
 dependencies {
     implementation project(':support-utils')
 
-    implementation Deps.kotlin_stdlib
+    implementation Dependencies.kotlin_stdlib
 
-    testImplementation Deps.testing_junit
-    testImplementation Deps.testing_robolectric
-    testImplementation Deps.testing_mockito
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -149,11 +149,12 @@ dependencies {
     geckoReleaseArmImplementation Gecko.geckoview_release_arm
     geckoReleaseX86Implementation Gecko.geckoview_release_x86
     geckoReleaseAarch64Implementation Gecko.geckoview_release_aarch64
-    implementation Deps.support_design
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.support_design
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_constraintlayout
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_constraintlayout
 }

--- a/samples/crash/build.gradle
+++ b/samples/crash/build.gradle
@@ -31,10 +31,10 @@ android {
 dependencies {
     implementation project(':lib-crash')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_design
-    implementation Deps.support_recyclerview
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_design
+    implementation Dependencies.support_recyclerview
 }

--- a/samples/dataprotect/build.gradle
+++ b/samples/dataprotect/build.gradle
@@ -28,9 +28,9 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':lib-dataprotect')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_recyclerview
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_recyclerview
 }

--- a/samples/firefox-accounts/build.gradle
+++ b/samples/firefox-accounts/build.gradle
@@ -38,14 +38,14 @@ android {
 dependencies {
     implementation project(':service-firefox-accounts')
 
-    implementation Deps.support_constraintlayout
+    implementation Dependencies.support_constraintlayout
     implementation ('me.dm7.barcodescanner:zxing:1.9.8') {
         exclude module: 'support-v4'
     }
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_customtabs
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_customtabs
 }

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -43,11 +43,11 @@ dependencies {
     implementation project(':service-glean')
     implementation project(':support-base')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_customtabs
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_customtabs
 }
 
 apply from: '../../components/service/glean/scripts/sdk_generator.gradle'

--- a/samples/sync-logins/build.gradle
+++ b/samples/sync-logins/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     implementation project(':service-firefox-accounts')
     implementation project(':service-sync-logins')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_customtabs
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_customtabs
 }

--- a/samples/toolbar/build.gradle
+++ b/samples/toolbar/build.gradle
@@ -38,9 +38,9 @@ dependencies {
 
     implementation project(':support-ktx')
 
-    implementation Deps.kotlin_stdlib
-    implementation Deps.kotlin_coroutines
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
-    implementation Deps.support_appcompat
-    implementation Deps.support_recyclerview
+    implementation Dependencies.support_appcompat
+    implementation Dependencies.support_recyclerview
 }


### PR DESCRIPTION
Closes https://github.com/mozilla-mobile/android-components/issues/976

This PR allows `ktlint` and `detekt` to run on BuildSrc. 
Some of these changes are subjective, so feedback would be welcome if we should do something in one way rather than another. I've stated my reasons for the way I did things in the comments.

This is done by including them in `build.gradle` and refactoring until both `ktlint` and `detekt` tests pass. 

To 🎩 ktlint run `gradle ktlint` [should build successfully]
To 🎩 detekt you will first have to change the input directory to ` input = "$projectDir/buildSrc" ` and then run `gradle detektcheck` [should build successfully]

```
detekt {
    // The version number is duplicated, please refer to plugins block for more details
    version = "1.0.0.RC7-3"
    profile("main") {
        input = "$projectDir/buildSrc"  
        config = "$projectDir/config/detekt.yml"
        filters = ".*test.*,.*/resources/.*,.*/tmp/.*"
        output = "$projectDir/build/reports/detekt"
        baseline = "$projectDir/config/detekt-baseline.xml"
    }
}
```

Note: [WIP] is due to the fact `detekt` does not take in multiple files, in should include both `components` and `buildSrc` trying to figure out how to get that working. 