### PR TITLE
Issue #681: Add empty "glean" component shell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ _Components and libraries to interact with backend services._
 
 * ⚪ [**Fretboard**](components/service/fretboard/README.md) - An Android framework for segmenting users in order to run A/B tests and roll out features gradually.
 
+* 🔴 [**Glean**](components/service/glean/README.md) - A client-side telemetry SDK for collecting metrics and sending them to Mozilla's telemetry service (eventually replacing [service-telemetry](components/service/telemetry/README.md)).
+
 * 🔵 [**Telemetry**](components/service/telemetry/README.md) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 
 ## Support

--- a/automation/taskcluster/artifacts.yml
+++ b/automation/taskcluster/artifacts.yml
@@ -98,6 +98,11 @@
           name: browser-domains
           old_artifact_id: domains
           new_group_id: org.mozilla.components
+        public/build/service.glean.maven.zip:
+          path: /build/android-components/components/service/glean/build/target.maven.zip
+          name: service-glean
+          old_artifact_id: service-glean
+          new_group_id: org.mozilla.components
         public/build/service.telemetry.maven.zip:
           path: /build/android-components/components/service/telemetry/build/target.maven.zip
           name: service-telemetry

--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Service > Glean
+
+A client-side telemetry SDK for collecting metrics and sending them to Mozilla's telemetry service (eventually replacing [service-telemetry](../telemetry/README.md)).
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md)):
+
+```Groovy
+implementation "org.mozilla.components:service-glean:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion Config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
+
+    implementation project(':support-base')
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+}
+
+archivesBaseName = "service-glean"
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.components',
+        'service-glean',
+        'A client-side telemetry SDK for collecting metrics and sending them to Mozilla\'s telemetry service')

--- a/components/service/glean/proguard-rules.pro
+++ b/components/service/glean/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/service/glean/src/main/AndroidManifest.xml
+++ b/components/service/glean/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.service.glean" />

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Placeholder.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Placeholder.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+class Placeholder

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/PlaceholderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/PlaceholderTest.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+class PlaceholderTest

--- a/components/service/glean/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/service/glean/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/settings.gradle
+++ b/settings.gradle
@@ -109,6 +109,9 @@ project(':service-sync-logins').projectDir = new File('components/service/sync-l
 include ':service-fretboard'
 project(':service-fretboard').projectDir = new File('components/service/fretboard')
 
+include ':service-glean'
+project(':service-glean').projectDir = new File('components/service/glean')
+
 include ':service-telemetry'
 project(':service-telemetry').projectDir = new File('components/service/telemetry')
 


### PR DESCRIPTION
The team decided to use the name "glean" for the new telemetry SDK (as "telemetry" is already used). This empty shell gives them something to start landing code that will automatically be picked up by our tools.