### PR TITLE
Revert "Temporarily deactivate bintray publishing for 0.27.0 release"

### DIFF
--- a/automation/taskcluster/decision_task_release.py
+++ b/automation/taskcluster/decision_task_release.py
@@ -50,9 +50,8 @@ def generate_build_task(version):
     checkout = ("git fetch origin --tags && "
                 "git config advice.detachedHead false && "
                 "git checkout {}".format(version))
-    # TODO re-enable bintray once 0.27.0 is released
-    # bintray_publishing = (" && python automation/taskcluster/release/fetch-bintray-api-key.py"
-    #                       " && ./gradlew bintrayUpload --debug")
+    bintray_publishing = (" && python automation/taskcluster/release/fetch-bintray-api-key.py"
+                          " && ./gradlew bintrayUpload --debug")
 
     assemble_task = 'assembleRelease'
     scopes = [
@@ -66,9 +65,8 @@ def generate_build_task(version):
         command=(checkout +
                  ' && ./gradlew --no-daemon clean test detektCheck ktlint '
                  + assemble_task +
-                 ' docs uploadArchives zipMavenArtifacts'),
-                 # TODO re-enable bintray once 0.27.0 is released
-                 #bintray_publishing),
+                 ' docs uploadArchives zipMavenArtifacts' +
+                 bintray_publishing),
         features={
             "chainOfTrust": True
         },


### PR DESCRIPTION
This reverts commit cab3bdc002b472d9ff641f451d8c2cd80035b4d1.

Follows #1063 up 