### PR TITLE
Kick of 0.28.0 sprint (version, changelog) + re-active servo

### DIFF
--- a/automation/taskcluster/artifacts.yml
+++ b/automation/taskcluster/artifacts.yml
@@ -58,11 +58,11 @@
           name: browser-engine-gecko-nightly
           old_artifact_id: engine-gecko-nightly
           new_group_id: org.mozilla.components
-        # public/build/browser.engine-servo.maven.zip:
-        #   path: /build/android-components/components/browser/engine-servo/build/target.maven.zip
-        #   name: browser-engine-servo
-        #   old_artifact_id: browser-engine-servo
-        #   new_group_id: org.mozilla.components
+        public/build/browser.engine-servo.maven.zip:
+          path: /build/android-components/components/browser/engine-servo/build/target.maven.zip
+          name: browser-engine-servo
+          old_artifact_id: browser-engine-servo
+          new_group_id: org.mozilla.components
         public/build/browser.engine-system.maven.zip:
           path: /build/android-components/components/browser/engine-system/build/target.maven.zip
           name: browser-engine-system

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,10 @@ allprojects {
         maven {
             url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.revision.${geckoRelease['revision']}.mobile.android-aarch64-opt/artifacts/public/android/maven"
         }
+
+        maven {
+            url "https://download.servo.org/nightly/maven"
+        }
     }
 }
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -7,7 +7,7 @@ object Config {
 
     // This version number should follow semantic versioning (MAJOR.MINOR.PATCH).
     // See https://semver.org/
-    const val componentsVersion = "0.27.0"
+    const val componentsVersion = "0.28.0"
 
     // Synchronized build configuration for all modules
     const val compileSdkVersion = 27

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,6 +27,7 @@ private object Versions {
     const val sentry = "1.7.10"
 
     const val mozilla_app_services = "0.5.1"
+    const val servo = "0.0.1.20181017.aa95911"
 }
 
 // Synchronized dependencies used by (some) modules
@@ -63,6 +64,7 @@ object Deps {
 
     const val mozilla_fxa = "org.mozilla.fxa_client:fxa_client:${Versions.mozilla_app_services}"
     const val mozilla_sync_logins = "org.mozilla.sync15:logins:${Versions.mozilla_app_services}"
+    const val mozilla_servo = "org.mozilla.servoview:servoview-armv7:${Versions.servo}"
 
     const val thirdparty_sentry = "io.sentry:sentry-android:${Versions.sentry}"
 

--- a/components/browser/engine-servo/build.gradle
+++ b/components/browser/engine-servo/build.gradle
@@ -31,18 +31,12 @@ android {
     }
 }
 
-repositories {
-    flatDir {
-        dirs 'libs'
-    }
-}
-
 dependencies {
     implementation project(':concept-engine')
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    implementation(name: 'servo-2018-10-08', ext: 'aar')
+    implementation Deps.mozilla_servo
 
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,20 @@ title: Changelog
 permalink: /changelog/
 ---
 
+# 0.28.0-SNAPSHOT (In Development)
+
+Release date: TBD
+
+* [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.27.0...master),
+[Milestone](https://github.com/mozilla-mobile/android-components/milestone/30?closed=1),
+
+* **browser-engine**
+ * `Download.fileName` cannot be `null` anymore. All engine implementations are guaranteed to return a proposed file name for Downloads now.
+* **browser-engine-servo**
+ * Added a new experimental *Engine* implementation based on the [Servo Browser Engine](https://servo.org/).
+* **service-glean**
+ * A new client-side telemetry SDK for collecting metrics and sending them to Mozilla's telemetry service. This component is going to eventually replace `service-telemetry`. The SDK is currently in development and the component is not ready to be used yet.
+
 # 0.27.0
 
 Release date: 2018-10-16

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -91,12 +91,6 @@ android {
     }
 }
 
-repositories {
-    flatDir {
-        dirs project(':browser-engine-servo').file('libs')
-    }
-}
-
 configurations {
     geckoNightlyArmImplementation {}
     geckoNightlyX86Implementation {}


### PR DESCRIPTION
This PR ended up containing multiple things. But separating them for the PR doesn't seem to be worth it. There are separate commits though!

* Modify the servo component to use the maven repository and with that re-active publishing of the component.
* Setting the version to 0.28.0 and adding changelog entries for the things that already landed.