### PR TITLE
Closes #1056: Add error page string resource namespacing. [ci skip]

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -27,8 +27,8 @@ object ErrorPages {
         return context.resources.openRawResource(htmlResource)
             .bufferedReader()
             .use { it.readText() }
-            .replace("%pageTitle%", context.getString(R.string.error_page_title))
-            .replace("%button%", context.getString(R.string.error_page_refresh))
+            .replace("%pageTitle%", context.getString(R.string.mozac_browser_errorpages_page_title))
+            .replace("%button%", context.getString(R.string.mozac_browser_errorpages_page_refresh))
             .replace("%messageShort%", context.getString(errorType.titleRes))
             .replace("%messageLong%", context.getString(errorType.messageRes, uri))
             .replace("%css%", css)
@@ -43,107 +43,107 @@ enum class ErrorType(
     @StringRes val messageRes: Int
 ) {
     UNKNOWN(
-        R.string.error_generic_title,
-        R.string.error_generic_message
+        R.string.mozac_browser_errorpages_generic_title,
+        R.string.mozac_browser_errorpages_generic_message
     ),
     ERROR_SECURITY_SSL(
-        R.string.error_security_ssl_title,
-        R.string.error_security_ssl_message
+        R.string.mozac_browser_errorpages_security_ssl_title,
+        R.string.mozac_browser_errorpages_security_ssl_message
     ),
     ERROR_SECURITY_BAD_CERT(
-        R.string.error_security_bad_cert_title,
-        R.string.error_security_bad_cert_message
+        R.string.mozac_browser_errorpages_security_bad_cert_title,
+        R.string.mozac_browser_errorpages_security_bad_cert_message
     ),
     ERROR_NET_INTERRUPT(
-        R.string.error_net_interrupt_title,
-        R.string.error_net_interrupt_message
+        R.string.mozac_browser_errorpages_net_interrupt_title,
+        R.string.mozac_browser_errorpages_net_interrupt_message
     ),
     ERROR_NET_TIMEOUT(
-        R.string.error_net_timeout_title,
-        R.string.error_net_timeout_message
+        R.string.mozac_browser_errorpages_net_timeout_title,
+        R.string.mozac_browser_errorpages_net_timeout_message
     ),
     ERROR_CONNECTION_REFUSED(
-        R.string.error_connection_failure_title,
-        R.string.error_connection_failure_message
+        R.string.mozac_browser_errorpages_connection_failure_title,
+        R.string.mozac_browser_errorpages_connection_failure_message
     ),
     ERROR_UNKNOWN_SOCKET_TYPE(
-        R.string.error_unknown_socket_type_title,
-        R.string.error_unknown_socket_type_message
+        R.string.mozac_browser_errorpages_unknown_socket_type_title,
+        R.string.mozac_browser_errorpages_unknown_socket_type_message
     ),
     ERROR_REDIRECT_LOOP(
-        R.string.error_redirect_loop_title,
-        R.string.error_redirect_loop_message
+        R.string.mozac_browser_errorpages_redirect_loop_title,
+        R.string.mozac_browser_errorpages_redirect_loop_message
     ),
     ERROR_OFFLINE(
-        R.string.error_offline_title,
-        R.string.error_offline_message
+        R.string.mozac_browser_errorpages_offline_title,
+        R.string.mozac_browser_errorpages_offline_message
     ),
     ERROR_PORT_BLOCKED(
-        R.string.error_port_blocked_title,
-        R.string.error_port_blocked_message
+        R.string.mozac_browser_errorpages_port_blocked_title,
+        R.string.mozac_browser_errorpages_port_blocked_message
     ),
     ERROR_NET_RESET(
-        R.string.error_net_reset_title,
-        R.string.error_net_reset_message
+        R.string.mozac_browser_errorpages_net_reset_title,
+        R.string.mozac_browser_errorpages_net_reset_message
     ),
     ERROR_UNSAFE_CONTENT_TYPE(
-        R.string.error_unsafe_content_type_title,
-        R.string.error_unsafe_content_type_message
+        R.string.mozac_browser_errorpages_unsafe_content_type_title,
+        R.string.mozac_browser_errorpages_unsafe_content_type_message
     ),
     ERROR_CORRUPTED_CONTENT(
-        R.string.error_corrupted_content_title,
-        R.string.error_corrupted_content_message
+        R.string.mozac_browser_errorpages_corrupted_content_title,
+        R.string.mozac_browser_errorpages_corrupted_content_message
     ),
     ERROR_CONTENT_CRASHED(
-        R.string.error_content_crashed_title,
-        R.string.error_content_crashed_message
+        R.string.mozac_browser_errorpages_content_crashed_title,
+        R.string.mozac_browser_errorpages_content_crashed_message
     ),
     ERROR_INVALID_CONTENT_ENCODING(
-        R.string.error_invalid_content_encoding_title,
-        R.string.error_invalid_content_encoding_message
+        R.string.mozac_browser_errorpages_invalid_content_encoding_title,
+        R.string.mozac_browser_errorpages_invalid_content_encoding_message
     ),
     ERROR_UNKNOWN_HOST(
-        R.string.error_unknown_host_title,
-        R.string.error_unknown_host_message
+        R.string.mozac_browser_errorpages_unknown_host_title,
+        R.string.mozac_browser_errorpages_unknown_host_message
     ),
     ERROR_MALFORMED_URI(
-        R.string.error_malformed_uri_title,
-        R.string.error_malformed_uri_message
+        R.string.mozac_browser_errorpages_malformed_uri_title,
+        R.string.mozac_browser_errorpages_malformed_uri_message
     ),
     ERROR_UNKNOWN_PROTOCOL(
-        R.string.error_unknown_protocol_title,
-        R.string.error_unknown_protocol_message
+        R.string.mozac_browser_errorpages_unknown_protocol_title,
+        R.string.mozac_browser_errorpages_unknown_protocol_message
     ),
     ERROR_FILE_NOT_FOUND(
-        R.string.error_file_not_found_title,
-        R.string.error_file_not_found_message
+        R.string.mozac_browser_errorpages_file_not_found_title,
+        R.string.mozac_browser_errorpages_file_not_found_message
     ),
     ERROR_FILE_ACCESS_DENIED(
-        R.string.error_file_access_denied_title,
-        R.string.error_file_access_denied_message
+        R.string.mozac_browser_errorpages_file_access_denied_title,
+        R.string.mozac_browser_errorpages_file_access_denied_message
     ),
     ERROR_PROXY_CONNECTION_REFUSED(
-        R.string.error_proxy_connection_refused_title,
-        R.string.error_proxy_connection_refused_message
+        R.string.mozac_browser_errorpages_proxy_connection_refused_title,
+        R.string.mozac_browser_errorpages_proxy_connection_refused_message
     ),
     ERROR_UNKNOWN_PROXY_HOST(
-        R.string.error_unknown_proxy_host_title,
-        R.string.error_unknown_proxy_host_message
+        R.string.mozac_browser_errorpages_unknown_proxy_host_title,
+        R.string.mozac_browser_errorpages_unknown_proxy_host_message
     ),
     ERROR_SAFEBROWSING_MALWARE_URI(
-        R.string.error_safe_browsing_malware_uri_title,
-        R.string.error_safe_browsing_malware_uri_message
+        R.string.mozac_browser_errorpages_safe_browsing_malware_uri_title,
+        R.string.mozac_browser_errorpages_safe_browsing_malware_uri_message
     ),
     ERROR_SAFEBROWSING_UNWANTED_URI(
-        R.string.error_safe_browsing_unwanted_uri_title,
-        R.string.error_safe_browsing_unwanted_uri_message
+        R.string.mozac_browser_errorpages_safe_browsing_unwanted_uri_title,
+        R.string.mozac_browser_errorpages_safe_browsing_unwanted_uri_message
     ),
     ERROR_SAFEBROWSING_HARMFUL_URI(
-        R.string.error_safe_harmful_uri_title,
-        R.string.error_safe_harmful_uri_message
+        R.string.mozac_browser_errorpages_safe_harmful_uri_title,
+        R.string.mozac_browser_errorpages_safe_harmful_uri_message
     ),
     ERROR_SAFEBROWSING_PHISHING_URI(
-        R.string.error_safe_phishing_uri_title,
-        R.string.error_safe_phishing_uri_message
+        R.string.mozac_browser_errorpages_safe_phishing_uri_title,
+        R.string.mozac_browser_errorpages_safe_phishing_uri_message
     )
 }

--- a/components/browser/errorpages/src/main/res/values/strings.xml
+++ b/components/browser/errorpages/src/main/res/values/strings.xml
@@ -4,8 +4,8 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_connection_failure_title_alternative">Unable to connect</string>
-    <string name="error_connection_failure_message_alternative">
+    <string name="mozac_browser_errorpages_connection_failure_title_alternative">Unable to connect</string>
+    <string name="mozac_browser_errorpages_connection_failure_message_alternative">
     <![CDATA[
       <ul>
         <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>
@@ -15,10 +15,10 @@
     </string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_host_lookup_title">Server not found</string>
+    <string name="mozac_browser_errorpages_host_lookup_title">Server not found</string>
 
     <!-- In the example, the two URLs in markup do not need to be translated. -->
-    <string name="error_host_lookup_message"><![CDATA[
+    <string name="mozac_browser_errorpages_host_lookup_message"><![CDATA[
       <ul>
         <li>Check the address for typing errors such as
           <strong>ww</strong>.example.com instead of
@@ -28,9 +28,9 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_malformed_uri_title_alternative">The address isn’t valid</string>
+    <string name="mozac_browser_errorpages_malformed_uri_title_alternative">The address isn’t valid</string>
     <!-- This string contains markup. The URL should not be localized. -->
-    <string name="error_malformed_uri_message_alternative"><![CDATA[
+    <string name="mozac_browser_errorpages_malformed_uri_message_alternative"><![CDATA[
       <ul>
         <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>
         <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>
@@ -38,24 +38,24 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_redirect_loop_title_alternative">The page isn’t redirecting properly</string>
-    <string name="error_redirect_loop_message_alternative"><![CDATA[
+    <string name="mozac_browser_errorpages_redirect_loop_title_alternative">The page isn’t redirecting properly</string>
+    <string name="mozac_browser_errorpages_redirect_loop_message_alternative"><![CDATA[
       <ul>
         <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>
       </ul>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_unsupported_protocol_title">The address wasn’t understood</string>
-    <string name="error_unsupported_protocol_message"><![CDATA[
+    <string name="mozac_browser_errorpages_unsupported_protocol_title">The address wasn’t understood</string>
+    <string name="mozac_browser_errorpages_unsupported_protocol_message"><![CDATA[
       <ul>
         <li>You might need to install other software to open this address.</li>
       </ul>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_ssl_handshake_title">Secure connection failed</string>
-    <string name="error_ssl_handshake_message"><![CDATA[
+    <string name="mozac_browser_errorpages_ssl_handshake_title">Secure connection failed</string>
+    <string name="mozac_browser_errorpages_ssl_handshake_message"><![CDATA[
       <ul>
         <li>This could be a problem with the server’s configuration, or it could be
       someone trying to impersonate the server.</li>
@@ -65,20 +65,20 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_page_title">Problem loading page</string>
+    <string name="mozac_browser_errorpages_page_title">Problem loading page</string>
 
     <!-- The button that appears at the bottom of an error page. -->
-    <string name="error_page_refresh">Try Again</string>
+    <string name="mozac_browser_errorpages_page_refresh">Try Again</string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_generic_title">Cannot Complete Request</string>
-    <string name="error_generic_message"><![CDATA[
+    <string name="mozac_browser_errorpages_generic_title">Cannot Complete Request</string>
+    <string name="mozac_browser_errorpages_generic_message"><![CDATA[
       <p>Additional information about this problem or error is currently unavailable.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_security_ssl_title">Secure Connection Failed</string>
-    <string name="error_security_ssl_message"><![CDATA[
+    <string name="mozac_browser_errorpages_security_ssl_title">Secure Connection Failed</string>
+    <string name="mozac_browser_errorpages_security_ssl_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because the authenticity of the received data could not be verified.</p>
       <ul>
         <li>Please contact the website owners to inform them of this problem.</li>
@@ -86,8 +86,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_security_bad_cert_title">Secure Connection Failed</string>
-    <string name="error_security_bad_cert_message"><![CDATA[
+    <string name="mozac_browser_errorpages_security_bad_cert_title">Secure Connection Failed</string>
+    <string name="mozac_browser_errorpages_security_bad_cert_message"><![CDATA[
       <ul>
         <li>This could be a problem with the server’s configuration, or it could be someone trying to impersonate the server.</li>
         <li>If you have connected to this server successfully in the past, the error may be temporary, and you can try again later.</li>
@@ -95,8 +95,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_net_interrupt_title">Data Transfer Interrupted</string>
-    <string name="error_net_interrupt_message"><![CDATA[
+    <string name="mozac_browser_errorpages_net_interrupt_title">Data Transfer Interrupted</string>
+    <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[
       <p>The browser connected successfully, but the connection was interrupted while transferring information. Please try again.</p>
       <ul>
         <li>Are you unable to browse other sites? Check the computer’s network connection.</li>
@@ -105,8 +105,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_net_timeout_title">Network Timeout</string>
-    <string name="error_net_timeout_message"><![CDATA[
+    <string name="mozac_browser_errorpages_net_timeout_title">Network Timeout</string>
+    <string name="mozac_browser_errorpages_net_timeout_message"><![CDATA[
       <p>The requested site did not respond to a connection request and the browser has stopped waiting for a reply.</p>
       <ul>
         <li>Could the server be experiencing high demand or a temporary outage? Try again later.</li>
@@ -117,8 +117,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_connection_failure_title">Failed to Connect</string>
-    <string name="error_connection_failure_message"><![CDATA[
+    <string name="mozac_browser_errorpages_connection_failure_title">Failed to Connect</string>
+    <string name="mozac_browser_errorpages_connection_failure_message"><![CDATA[
       <p>Though the site seems valid, the browser was unable to establish a connection.</p>
       <ul>
         <li>Could the site be temporarily unavailable? Try again later.</li>
@@ -128,14 +128,14 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_unknown_socket_type_title">Incorrect Response</string>
-    <string name="error_unknown_socket_type_message"><![CDATA[
+    <string name="mozac_browser_errorpages_unknown_socket_type_title">Incorrect Response</string>
+    <string name="mozac_browser_errorpages_unknown_socket_type_message"><![CDATA[
       <p>The site responded to the network request in an unexpected way and the browser cannot continue.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_redirect_loop_title">Redirect Loop</string>
-    <string name="error_redirect_loop_message"><![CDATA[
+    <string name="mozac_browser_errorpages_redirect_loop_title">Redirect Loop</string>
+    <string name="mozac_browser_errorpages_redirect_loop_message"><![CDATA[
       <p>The browser has stopped trying to retrieve the requested item. The site is redirecting the request in a way that will never complete.</p>
       <ul>
         <li>Have you disabled or blocked cookies required by this site?</li>
@@ -144,8 +144,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_offline_title">Offline Mode</string>
-    <string name="error_offline_message"><![CDATA[
+    <string name="mozac_browser_errorpages_offline_title">Offline Mode</string>
+    <string name="mozac_browser_errorpages_offline_message"><![CDATA[
       <p>The browser is operating in its offline mode and cannot connect to the requested item.</p>
       <ul>
         <li>Is the computer connected to an active network?</li>
@@ -154,28 +154,28 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_port_blocked_title">Port Restricted for Security Reasons</string>
-    <string name="error_port_blocked_message"><![CDATA[
+    <string name="mozac_browser_errorpages_port_blocked_title">Port Restricted for Security Reasons</string>
+    <string name="mozac_browser_errorpages_port_blocked_message"><![CDATA[
       <p>The requested address specified a port (e.g., <q>mozilla.org:80</q> for port 80 on mozilla.org) normally used for purposes <em>other</em> than Web browsing. The browser has canceled the request for your protection and security.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_net_reset_title">Connection Interrupted</string>
-    <string name="error_net_reset_message"><![CDATA[
+    <string name="mozac_browser_errorpages_net_reset_title">Connection Interrupted</string>
+    <string name="mozac_browser_errorpages_net_reset_message"><![CDATA[
       <p>The network link was interrupted while negotiating a connection. Please try again.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_unsafe_content_type_title">Unsafe File Type</string>
-    <string name="error_unsafe_content_type_message"><![CDATA[
+    <string name="mozac_browser_errorpages_unsafe_content_type_title">Unsafe File Type</string>
+    <string name="mozac_browser_errorpages_unsafe_content_type_message"><![CDATA[
       <ul>
         <li>Please contact the website owners to inform them of this problem.</li>
       </ul>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_corrupted_content_title">Corrupted Content Error</string>
-    <string name="error_corrupted_content_message"><![CDATA[
+    <string name="mozac_browser_errorpages_corrupted_content_title">Corrupted Content Error</string>
+    <string name="mozac_browser_errorpages_corrupted_content_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because an error in the data transmission was detected.</p>
       <ul>
         <li>Please contact the website owners to inform them of this problem.</li>
@@ -183,8 +183,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_content_crashed_title">Content crashed</string>
-    <string name="error_content_crashed_message"><![CDATA[
+    <string name="mozac_browser_errorpages_content_crashed_title">Content crashed</string>
+    <string name="mozac_browser_errorpages_content_crashed_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because an error in the data transmission was detected.</p>
       <ul>
         <li>Please contact the website owners to inform them of this problem.</li>
@@ -192,8 +192,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_invalid_content_encoding_title">Content Encoding Error</string>
-    <string name="error_invalid_content_encoding_message"><![CDATA[
+    <string name="mozac_browser_errorpages_invalid_content_encoding_title">Content Encoding Error</string>
+    <string name="mozac_browser_errorpages_invalid_content_encoding_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because it uses an invalid or unsupported form of compression.</p>
       <ul>
         <li>Please contact the website owners to inform them of this problem.</li>
@@ -201,9 +201,9 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_unknown_host_title">Address Not Found</string>
+    <string name="mozac_browser_errorpages_unknown_host_title">Address Not Found</string>
     <!-- In the example, the two URLs in markup do not need to be translated. -->
-    <string name="error_unknown_host_message"><![CDATA[
+    <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[
       <p>The browser could not find the host server for the provided address.</p>
       <ul>
         <li>Did you make a mistake when typing the domain? (e.g., <q><strong>ww</strong>.mozilla.org</q> instead of <q><strong>www</strong>.mozilla.org</q>)</li><li>Are you certain this domain address exists? It’s registration may have expired.</li>
@@ -213,14 +213,14 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_malformed_uri_title">Invalid Address</string>
-    <string name="error_malformed_uri_message"><![CDATA[
+    <string name="mozac_browser_errorpages_malformed_uri_title">Invalid Address</string>
+    <string name="mozac_browser_errorpages_malformed_uri_message"><![CDATA[
       <p>The provided address is not in a recognized format. Please check the location bar for mistakes and try again.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_unknown_protocol_title">Unknown Protocol</string>
-    <string name="error_unknown_protocol_message"><![CDATA[
+    <string name="mozac_browser_errorpages_unknown_protocol_title">Unknown Protocol</string>
+    <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[
       <p>The address specifies a protocol (e.g., <q>wxyz://</q>) the browser does not recognize, so the browser cannot properly connect to the site.</p>
       <ul>
         <li>Are you trying to access multimedia or other non-text services? Check the site for extra requirements.</li>
@@ -229,8 +229,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_file_not_found_title">File Not Found</string>
-    <string name="error_file_not_found_message"><![CDATA[
+    <string name="mozac_browser_errorpages_file_not_found_title">File Not Found</string>
+    <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[
       <ul>
         <li>Could the item have been renamed, removed, or relocated?</li>
         <li>Is there a spelling, capitalization, or other typographical error in the address?</li>
@@ -239,16 +239,16 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_file_access_denied_title">Access to the file was denied</string>
-    <string name="error_file_access_denied_message"><![CDATA[
+    <string name="mozac_browser_errorpages_file_access_denied_title">Access to the file was denied</string>
+    <string name="mozac_browser_errorpages_file_access_denied_message"><![CDATA[
       <ul>
         <li>It may have been removed, moved, or file permissions may be preventing access.</li>
       </ul>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_proxy_connection_refused_title">Proxy Server Refused Connection</string>
-    <string name="error_proxy_connection_refused_message"><![CDATA[
+    <string name="mozac_browser_errorpages_proxy_connection_refused_title">Proxy Server Refused Connection</string>
+    <string name="mozac_browser_errorpages_proxy_connection_refused_message"><![CDATA[
       <p>The browser is configured to use a proxy server, but the proxy refused a connection.</p>
       <ul>
         <li>Is the browser’s proxy configuration correct? Check the settings and try again.</li>
@@ -258,8 +258,8 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_unknown_proxy_host_title">Proxy Server Not Found</string>
-    <string name="error_unknown_proxy_host_message"><![CDATA[
+    <string name="mozac_browser_errorpages_unknown_proxy_host_title">Proxy Server Not Found</string>
+    <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[
       <p>The browser is configured to use a proxy server, but the proxy could not be found.</p>
       <ul>
         <li>Is the browser’s proxy configuration correct? Check the settings and try again.</li>
@@ -269,30 +269,30 @@
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_safe_browsing_malware_uri_title">Malware site issue</string>
+    <string name="mozac_browser_errorpages_safe_browsing_malware_uri_title">Malware site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
-    <string name="error_safe_browsing_malware_uri_message"><![CDATA[
+    <string name="mozac_browser_errorpages_safe_browsing_malware_uri_message"><![CDATA[
       <p>The site at %1$s has been reported as an attack site and has been blocked based on your security preferences.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_safe_browsing_unwanted_uri_title">Unwanted site issue</string>
+    <string name="mozac_browser_errorpages_safe_browsing_unwanted_uri_title">Unwanted site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
-    <string name="error_safe_browsing_unwanted_uri_message"><![CDATA[
+    <string name="mozac_browser_errorpages_safe_browsing_unwanted_uri_message"><![CDATA[
       <p>The site at %1$s has been reported as serving unwanted software and has been blocked based on your security preferences.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_safe_harmful_uri_title">Harmful site issue</string>
+    <string name="mozac_browser_errorpages_safe_harmful_uri_title">Harmful site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
-    <string name="error_safe_harmful_uri_message"><![CDATA[
+    <string name="mozac_browser_errorpages_safe_harmful_uri_message"><![CDATA[
       <p>The site at %1$s has been reported as a potentially harmful site and has been blocked based on your security preferences.</p>
     ]]></string>
 
     <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="error_safe_phishing_uri_title">Deceptive site issue</string>
+    <string name="mozac_browser_errorpages_safe_phishing_uri_title">Deceptive site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
-    <string name="error_safe_phishing_uri_message"><![CDATA[
+    <string name="mozac_browser_errorpages_safe_phishing_uri_message"><![CDATA[
       <p>This web page at %1$s has been reported as a deceptive site and has been blocked based on your security preferences.</p>
     ]]></string>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ Release date: TBD
   * `Download.fileName` cannot be `null` anymore. All engine implementations are guaranteed to return a proposed file name for Downloads now.
 * **browser-engine-servo**
   * Added a new experimental *Engine* implementation based on the [Servo Browser Engine](https://servo.org/).
+* **browser-errorpages**
+  * Added translation annotations to our error page strings. Translated strings will follow in a future release.
 * **service-glean**
   * A new client-side telemetry SDK for collecting metrics and sending them to Mozilla's telemetry service. This component is going to eventually replace `service-telemetry`. The SDK is currently in development and the component is not ready to be used yet.
 * **lib-jexl**:


### PR DESCRIPTION
All `error_*` string resources now use `mozac_browser_errorpages_` instead.

Based on #1071 and will be rebased once it is merged (awaiting L10N check off).

cc: @Pike