### PR TITLE
Bump mozilla_app_services to 0.6.0, and update FxA component to match

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,7 +26,7 @@ private object Versions {
 
     const val sentry = "1.7.10"
 
-    const val mozilla_app_services = "0.5.1"
+    const val mozilla_app_services = "0.6.0"
     const val servo = "0.0.1.20181017.aa95911"
 }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaClient.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaClient.kt
@@ -33,11 +33,6 @@ internal interface FxaClient : Library {
         }
     }
 
-    // This is ultra hacky and takes advantage of the zero-based error codes returned in Rust.
-    enum class ErrorCode {
-        NoError, Other, AuthenticationError, InternalPanic
-    }
-
     fun fxa_get_release_config(e: Error.ByReference): RawConfig
     fun fxa_get_custom_config(content_base: String, e: Error.ByReference): RawConfig
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaException.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaException.kt
@@ -10,11 +10,14 @@ open class FxaException(message: String) : Exception(message) {
     class Panic(msg: String) : FxaException(msg)
 
     companion object {
+        // These numbers come from `ffi::error_codes` in the fxa-client rust code.
+        const val CODE_UNAUTHORIZED: Int = 2
+        const val CODE_PANIC: Int = -1
         fun fromConsuming(e: Error): FxaException {
             val message = e.consumeMessage() ?: ""
             return when (e.code) {
-                FxaClient.ErrorCode.AuthenticationError.ordinal -> Unauthorized(message)
-                FxaClient.ErrorCode.InternalPanic.ordinal -> Panic(message)
+                CODE_UNAUTHORIZED -> Unauthorized(message)
+                CODE_PANIC -> Panic(message)
                 else -> Unspecified(message)
             }
         }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/RustObjectTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/RustObjectTest.kt
@@ -98,7 +98,7 @@ class RustObjectTest {
         latch = CountDownLatch(1)
         complete = false
 
-        RustObject.safeAsync { it.code = FxaClient.ErrorCode.AuthenticationError.ordinal }.then({
+        RustObject.safeAsync { it.code = FxaException.CODE_UNAUTHORIZED }.then({
             complete = true
             latch.countDown()
             FxaResult<Void>()
@@ -119,17 +119,17 @@ class RustObjectTest {
         assertTrue(RustObject.safeSync { true })
 
         try {
-            RustObject.safeSync { it.code = FxaClient.ErrorCode.AuthenticationError.ordinal }
+            RustObject.safeSync { it.code = FxaException.CODE_UNAUTHORIZED }
             fail("Should have thrown FxaException.Unauthorized")
         } catch (e: FxaException.Unauthorized) { }
 
         try {
-            RustObject.safeSync { it.code = FxaClient.ErrorCode.InternalPanic.ordinal }
+            RustObject.safeSync { it.code = FxaException.CODE_PANIC }
             fail("Should have thrown FxaException.Panic")
         } catch (e: FxaException.Panic) { }
 
         try {
-            RustObject.safeSync { it.code = FxaClient.ErrorCode.Other.ordinal }
+            RustObject.safeSync { it.code = 100 } // Number not used by FxaException
             fail("Should have thrown FxaException.Unspecified")
         } catch (e: FxaException.Unspecified) { }
     }


### PR DESCRIPTION
We changed some things about how errors are handled internally, which required becoming consistent about which value is used for the panic error code (-1 everywhere now).

This also changes how the `FxaException` implemented `fromConsuming` because IMO it's much better to be explicit about what the error code values are (and also one of them is -1, which isn't a valid enum index, so it wouldn't have worked for that one anymore anyway).