### PR TITLE
Tweak errorpages L10n strings [ci skip]

### DIFF
--- a/components/browser/errorpages/src/main/res/values/strings.xml
+++ b/components/browser/errorpages/src/main/res/values/strings.xml
@@ -3,90 +3,32 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_connection_failure_title_alternative">Unable to connect</string>
-    <string name="mozac_browser_errorpages_connection_failure_message_alternative">
-    <![CDATA[
-      <ul>
-        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>
-        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>
-      </ul>
-    ]]>
-    </string>
-
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_host_lookup_title">Server not found</string>
-
-    <!-- In the example, the two URLs in markup do not need to be translated. -->
-    <string name="mozac_browser_errorpages_host_lookup_message"><![CDATA[
-      <ul>
-        <li>Check the address for typing errors such as
-          <strong>ww</strong>.example.com instead of
-          <strong>www</strong>.example.com</li>
-        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>
-      </ul>
-    ]]></string>
-
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_malformed_uri_title_alternative">The address isn’t valid</string>
-    <!-- This string contains markup. The URL should not be localized. -->
-    <string name="mozac_browser_errorpages_malformed_uri_message_alternative"><![CDATA[
-      <ul>
-        <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>
-        <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>
-      </ul>
-    ]]></string>
-
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_redirect_loop_title_alternative">The page isn’t redirecting properly</string>
-    <string name="mozac_browser_errorpages_redirect_loop_message_alternative"><![CDATA[
-      <ul>
-        <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>
-      </ul>
-    ]]></string>
-
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_unsupported_protocol_title">The address wasn’t understood</string>
-    <string name="mozac_browser_errorpages_unsupported_protocol_message"><![CDATA[
-      <ul>
-        <li>You might need to install other software to open this address.</li>
-      </ul>
-    ]]></string>
-
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_ssl_handshake_title">Secure connection failed</string>
-    <string name="mozac_browser_errorpages_ssl_handshake_message"><![CDATA[
-      <ul>
-        <li>This could be a problem with the server’s configuration, or it could be
-      someone trying to impersonate the server.</li>
-        <li>If you have connected to this server successfully in the past, the error may
-      be temporary, and you can try again later.</li>
-      </ul>
-    ]]></string>
-
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
     <string name="mozac_browser_errorpages_page_title">Problem loading page</string>
 
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">Try Again</string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">Cannot Complete Request</string>
+    <!-- The error message shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_message"><![CDATA[
       <p>Additional information about this problem or error is currently unavailable.</p>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of the error page shown when a website sends back unusual and incorrect credentials for an SSL certificate. -->
     <string name="mozac_browser_errorpages_security_ssl_title">Secure Connection Failed</string>
+    <!-- The error message shown when a website sends back unusual and incorrect credentials for an SSL certificate. -->
     <string name="mozac_browser_errorpages_security_ssl_message"><![CDATA[
-      <p>The page you are trying to view cannot be shown because the authenticity of the received data could not be verified.</p>
       <ul>
+        <li>The page you are trying to view cannot be shown because the authenticity of the received data could not be verified.</li>
         <li>Please contact the website owners to inform them of this problem.</li>
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of the error page shown when a website sends has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_title">Secure Connection Failed</string>
+    <!-- The error message shown when a website sends has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_message"><![CDATA[
       <ul>
         <li>This could be a problem with the server’s configuration, or it could be someone trying to impersonate the server.</li>
@@ -94,18 +36,20 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_net_interrupt_title">Data Transfer Interrupted</string>
+    <!-- The document title and heading of the error page shown when the user's network connection is interrupted while connecting to a website. -->
+    <string name="mozac_browser_errorpages_net_interrupt_title">The connection was interrupted</string>
+    <!-- The error message shown when the user's network connection is interrupted while connecting to a website. -->
     <string name="mozac_browser_errorpages_net_interrupt_message"><![CDATA[
       <p>The browser connected successfully, but the connection was interrupted while transferring information. Please try again.</p>
       <ul>
-        <li>Are you unable to browse other sites? Check the computer’s network connection.</li>
-        <li>Still having trouble? Consult your network administrator or Internet provider for assistance.</li>
+        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>
+        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_net_timeout_title">Network Timeout</string>
+    <!-- The document title and heading of the error page shown when a website takes too long to load. -->
+    <string name="mozac_browser_errorpages_net_timeout_title">The connection has timed out</string>
+    <!-- The error message shown when a website took long to load. -->
     <string name="mozac_browser_errorpages_net_timeout_message"><![CDATA[
       <p>The requested site did not respond to a connection request and the browser has stopped waiting for a reply.</p>
       <ul>
@@ -116,35 +60,37 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_connection_failure_title">Failed to Connect</string>
+    <!-- The document title and heading of the error page shown when a website could not be reached. -->
+    <string name="mozac_browser_errorpages_connection_failure_title">Unable to connect</string>
+    <!-- The error message shown when a website could not be reached. -->
     <string name="mozac_browser_errorpages_connection_failure_message"><![CDATA[
-      <p>Though the site seems valid, the browser was unable to establish a connection.</p>
       <ul>
-        <li>Could the site be temporarily unavailable? Try again later.</li>
-        <li>Are you unable to browse other sites? Check the computer’s network connection.</li>
-        <li>Is your computer or network protected by a firewall or proxy? Incorrect settings can interfere with Web browsing.</li>
+        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>
+        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_unknown_socket_type_title">Incorrect Response</string>
+    <!-- The document title and heading of the error page shown when a website responds in an unexpected way and the browser cannot continue. -->
+    <string name="mozac_browser_errorpages_unknown_socket_type_title">Unexpected response from server</string>
+    <!-- The error message shown when a website responds in an unexpected way and the browser cannot continue. -->
     <string name="mozac_browser_errorpages_unknown_socket_type_message"><![CDATA[
       <p>The site responded to the network request in an unexpected way and the browser cannot continue.</p>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_redirect_loop_title">Redirect Loop</string>
+    <!-- The document title and heading of the error page shown when the browser gets stuck in an infinite loop when loading a website. -->
+    <string name="mozac_browser_errorpages_redirect_loop_title">The page isn’t redirecting properly</string>
+    <!-- The error message shown when the browser gets stuck in an infinite loop when loading a website. -->
     <string name="mozac_browser_errorpages_redirect_loop_message"><![CDATA[
       <p>The browser has stopped trying to retrieve the requested item. The site is redirecting the request in a way that will never complete.</p>
       <ul>
         <li>Have you disabled or blocked cookies required by this site?</li>
-        <li><em>NOTE</em>: If accepting the site’s cookies does not resolve the problem, it is likely a server configuration issue and not your computer.</li>
+        <li>If accepting the site’s cookies does not resolve the problem, it is likely a server configuration issue and not your computer.</li>
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of the error page shown when a website cannot be loaded because the browser is in offline mode. -->
     <string name="mozac_browser_errorpages_offline_title">Offline Mode</string>
+    <!-- The error message shown when a website cannot be loaded because the browser is in offline mode. -->
     <string name="mozac_browser_errorpages_offline_message"><![CDATA[
       <p>The browser is operating in its offline mode and cannot connect to the requested item.</p>
       <ul>
@@ -153,28 +99,36 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_port_blocked_title">Port Restricted for Security Reasons</string>
+    <!-- The document title and heading of the error page shown when the browser prevents loading a website on a restricted port. -->
+    <string name="mozac_browser_errorpages_port_blocked_title">Port restricted for security reasons</string>
+    <!-- The error message shown when the browser prevents loading a website on a restricted port. -->
     <string name="mozac_browser_errorpages_port_blocked_message"><![CDATA[
       <p>The requested address specified a port (e.g., <q>mozilla.org:80</q> for port 80 on mozilla.org) normally used for purposes <em>other</em> than Web browsing. The browser has canceled the request for your protection and security.</p>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_net_reset_title">Connection Interrupted</string>
+    <!-- The document title and heading of the error page shown when the Internet connection is disrupted while loading a website. -->
+    <string name="mozac_browser_errorpages_net_reset_title">The connection was reset</string>
+    <!-- The error message shown when the Internet connection is disrupted while loading a website. -->
     <string name="mozac_browser_errorpages_net_reset_message"><![CDATA[
       <p>The network link was interrupted while negotiating a connection. Please try again.</p>
+      <ul>
+        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>
+        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>
+      </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of the error page shown when the browser refuses to load a type of file that is considered unsafe. -->
     <string name="mozac_browser_errorpages_unsafe_content_type_title">Unsafe File Type</string>
+    <!-- The error message shown when the browser refuses to load a type of file that is considered unsafe. -->
     <string name="mozac_browser_errorpages_unsafe_content_type_message"><![CDATA[
       <ul>
         <li>Please contact the website owners to inform them of this problem.</li>
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of the error page shown when a file cannot be loaded because of a detected data corruption. -->
     <string name="mozac_browser_errorpages_corrupted_content_title">Corrupted Content Error</string>
+    <!-- The error message shown when shown when a file cannot be loaded because of a detected data corruption. -->
     <string name="mozac_browser_errorpages_corrupted_content_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because an error in the data transmission was detected.</p>
       <ul>
@@ -182,7 +136,7 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_content_crashed_title">Content crashed</string>
     <string name="mozac_browser_errorpages_content_crashed_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because an error in the data transmission was detected.</p>
@@ -191,7 +145,7 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_invalid_content_encoding_title">Content Encoding Error</string>
     <string name="mozac_browser_errorpages_invalid_content_encoding_message"><![CDATA[
       <p>The page you are trying to view cannot be shown because it uses an invalid or unsupported form of compression.</p>
@@ -200,25 +154,35 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_unknown_host_title">Address Not Found</string>
     <!-- In the example, the two URLs in markup do not need to be translated. -->
     <string name="mozac_browser_errorpages_unknown_host_message"><![CDATA[
       <p>The browser could not find the host server for the provided address.</p>
       <ul>
-        <li>Did you make a mistake when typing the domain? (e.g., <q><strong>ww</strong>.mozilla.org</q> instead of <q><strong>www</strong>.mozilla.org</q>)</li><li>Are you certain this domain address exists? It’s registration may have expired.</li>
-        <li>Are you unable to browse other sites? Check your network connection and DNS server settings.</li>
-        <li>Is your computer or network protected by a firewall or proxy? Incorrect settings can interfere with Web browsing.</li>
+        <li>Check the address for typing errors such as
+          <strong>ww</strong>.example.com instead of
+          <strong>www</strong>.example.com.</li>
+        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_malformed_uri_title">Invalid Address</string>
     <string name="mozac_browser_errorpages_malformed_uri_message"><![CDATA[
       <p>The provided address is not in a recognized format. Please check the location bar for mistakes and try again.</p>
     ]]></string>
+    <!-- The document title and heading of an error page. -->
+    <string name="mozac_browser_errorpages_malformed_uri_title_alternative">The address isn’t valid</string>
+    <!-- This string contains markup. The URL should not be localized. -->
+    <string name="mozac_browser_errorpages_malformed_uri_message_alternative"><![CDATA[
+      <ul>
+        <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>
+        <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>
+      </ul>
+    ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_unknown_protocol_title">Unknown Protocol</string>
     <string name="mozac_browser_errorpages_unknown_protocol_message"><![CDATA[
       <p>The address specifies a protocol (e.g., <q>wxyz://</q>) the browser does not recognize, so the browser cannot properly connect to the site.</p>
@@ -228,7 +192,7 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_not_found_title">File Not Found</string>
     <string name="mozac_browser_errorpages_file_not_found_message"><![CDATA[
       <ul>
@@ -238,7 +202,7 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_file_access_denied_title">Access to the file was denied</string>
     <string name="mozac_browser_errorpages_file_access_denied_message"><![CDATA[
       <ul>
@@ -246,7 +210,7 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_proxy_connection_refused_title">Proxy Server Refused Connection</string>
     <string name="mozac_browser_errorpages_proxy_connection_refused_message"><![CDATA[
       <p>The browser is configured to use a proxy server, but the proxy refused a connection.</p>
@@ -257,7 +221,7 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_unknown_proxy_host_title">Proxy Server Not Found</string>
     <string name="mozac_browser_errorpages_unknown_proxy_host_message"><![CDATA[
       <p>The browser is configured to use a proxy server, but the proxy could not be found.</p>
@@ -268,32 +232,31 @@
       </ul>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_safe_browsing_malware_uri_title">Malware site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_browsing_malware_uri_message"><![CDATA[
       <p>The site at %1$s has been reported as an attack site and has been blocked based on your security preferences.</p>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_safe_browsing_unwanted_uri_title">Unwanted site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_browsing_unwanted_uri_message"><![CDATA[
       <p>The site at %1$s has been reported as serving unwanted software and has been blocked based on your security preferences.</p>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_safe_harmful_uri_title">Harmful site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_harmful_uri_message"><![CDATA[
       <p>The site at %1$s has been reported as a potentially harmful site and has been blocked based on your security preferences.</p>
     ]]></string>
 
-    <!-- The document title for an error page (i.e., the contents of the `<title>` tag). -->
+    <!-- The document title and heading of an error page. -->
     <string name="mozac_browser_errorpages_safe_phishing_uri_title">Deceptive site issue</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_phishing_uri_message"><![CDATA[
       <p>This web page at %1$s has been reported as a deceptive site and has been blocked based on your security preferences.</p>
     ]]></string>
-
 </resources>


### PR DESCRIPTION
This PR, a follow-up to PR #1071, contains changes to improve the localisation (L10n) comments, and several strings for the Error Pages.

I cross-referenced these against the strings defined in M-C, sorted the strings based on the order in which they are referenced in `ErrorPages.kt`, and removed unused strings (i.e., `_alternative` ones and a few others):

- https://dxr.mozilla.org/mozilla-central/source/mobile/locales/en-US/overrides/netError.dtd
- https://dxr.mozilla.org/mozilla-central/source/dom/locales/en-US/chrome/netError.dtd
- https://dxr.mozilla.org/mozilla-central/source/browser/locales/en-US/chrome/overrides/netError.dtd
- https://github.com/mozilla-mobile/android-components/blob/master/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
- https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/GeckoSession.NavigationDelegate.html#field.summary

r? @jonalmeida @Delphine @rbarker @caseyyee