### PR TITLE
Close #1064: add Parent id to Session

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -32,6 +32,12 @@ class Session(
     internal val engineSessionHolder = EngineSessionHolder()
 
     /**
+     * Id of parent session, usually refer to the session which created this one. The clue to indicate if this session
+     * is terminated, which target we should go back.
+     */
+    internal var parentId: String? = null
+
+    /**
      * Interface to be implemented by classes that want to observe a session.
      */
     interface Observer {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -72,7 +72,21 @@ class SessionManager(
     /**
      * Adds the provided session.
      */
-    fun add(session: Session, selected: Boolean = false, engineSession: EngineSession? = null) = synchronized(values) {
+    fun add(
+        session: Session,
+        selected: Boolean = false,
+        engineSession: EngineSession? = null,
+        parent: Session? = null
+    ) = synchronized(values) {
+
+        parent?.let {
+            if (!values.contains(it)) {
+                throw IllegalArgumentException("The parent does not exist")
+            }
+
+            session.parentId = parent.id
+        }
+
         values.add(session)
 
         engineSession?.let { link(session, it) }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -65,6 +65,34 @@ class SessionManagerTest {
     }
 
     @Test
+    fun `session can be added by specifying parent`() {
+        val manager = SessionManager(mock())
+        val session1 = Session("https://www.mozilla.org")
+        val session2 = Session("https://www.firefox.com")
+        val session3 = Session("https://wiki.mozilla.org")
+        val session4 = Session("https://github.com/mozilla-mobile/android-components")
+
+        manager.add(session1)
+        manager.add(session2)
+        manager.add(session3, parent = session1)
+        manager.add(session4, parent = session2)
+
+        assertNull(manager.sessions[0].parentId)
+        assertNull(manager.sessions[1].parentId)
+        assertEquals(session1.id, manager.sessions[2].parentId)
+        assertEquals(session2.id, manager.sessions[3].parentId)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `session manager throws exception if parent is not in session manager`() {
+        val parent = Session("https://www.mozilla.org")
+        val session = Session("https://www.firefox.com")
+
+        val manager = SessionManager(mock())
+        manager.add(session, parent = parent)
+    }
+
+    @Test
     fun `session can be selected`() {
         val session1 = Session("http://www.mozilla.org")
         val session2 = Session("http://www.firefox.com")

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
@@ -148,7 +148,7 @@ class IntentProcessorTest {
         `when`(intent.dataString).thenReturn("http://mozilla.org")
 
         handler.process(intent)
-        verify(sessionManager).add(anySession(), eq(false), eq(null))
+        verify(sessionManager).add(anySession(), eq(false), eq(null), eq(null))
         verify(engineSession).loadUrl("http://mozilla.org")
 
         val customTabSession = sessionManager.all[0]


### PR DESCRIPTION
When creating new session from an existing session, we need to the
relationship between two sessions. For example, to click a href link in
web-page to open new tab.

This commit add parent id to Session. If a session is added without
parent, it will be append to tail of sessions. Otherwise it will sit
next to parent.