### PR TITLE
Setup CODEOWNERS for glean library.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,5 +20,5 @@
 *    @mozilla-mobile/act
 
 # Glean telemetry library
-components/service/glean/*    @Dexterp37 @mdboom @georgf
+/components/service/glean/    @Dexterp37 @mdboom @georgf
 


### PR DESCRIPTION
The previous pattern only matched files direclty under the glean folder. This now matches everything in this path of the repository.