### PR TITLE
Closes #1113: Session/EngineSession link is not thread-safe

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineSessionHolder.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineSessionHolder.kt
@@ -7,6 +7,6 @@ package mozilla.components.browser.session.engine
 import mozilla.components.concept.engine.EngineSession
 
 internal class EngineSessionHolder {
-    var engineSession: EngineSession? = null
-    var engineObserver: EngineObserver? = null
+    @Volatile var engineSession: EngineSession? = null
+    @Volatile var engineObserver: EngineObserver? = null
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineSessionHolderTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineSessionHolderTest.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.engine
+
+import junit.framework.Assert.assertTrue
+import mozilla.components.concept.engine.EngineSession
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class EngineSessionHolderTest {
+
+    @Test
+    fun `engine session holder changes are visible across threads`() {
+        val engineSessionHolder = EngineSessionHolder()
+        var countDownLatch = CountDownLatch(1)
+
+        val executor = Executors.newScheduledThreadPool(2)
+
+        executor.submit {
+            engineSessionHolder.engineObserver = mock(EngineObserver::class.java)
+            engineSessionHolder.engineSession = mock(EngineSession::class.java)
+        }
+
+        executor.submit {
+            while (engineSessionHolder.engineObserver == null || engineSessionHolder.engineSession == null) { }
+            countDownLatch.countDown()
+        }
+
+        // Setting a timeout in case this test fails in the future. As long as
+        // the engine session holder fields are volatile, await will return
+        // true immediately, otherwise false after the timeout expired.
+        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS))
+    }
+}


### PR DESCRIPTION
Looking at the problem I ran into (described in the issue), we really just need to make sure that the established link between session and engine session is visible across threads. So, I believe this solution is good enough.