### PR TITLE
Bug 1497809 - Implement a simple ping uploader

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation Deps.testing_junit
     testImplementation Deps.testing_robolectric
     testImplementation Deps.testing_mockito
+    testImplementation Deps.testing_mockwebserver
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.config
+
+import mozilla.components.service.glean.BuildConfig
+
+/**
+ * The Configuration class describes how to configure the Glean.
+ *
+ * @property serverEndpoint the server pings are sent to
+ * @property userAgent the user agent used when sending pings
+ * @property connectionTimeout the timeout, in milliseconds, to use when connecting to
+ *           the [serverEndpoint]
+ * @property readTimeout the timeout, in milliseconds, to use when connecting to
+ *           the [serverEndpoint]
+ */
+data class Configuration(
+    val serverEndpoint: String = "https://incoming.telemetry.mozilla.org",
+    val userAgent: String = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)",
+    val connectionTimeout: Int = 10000,
+    val readTimeout: Int = 30000
+)

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import android.support.annotation.VisibleForTesting
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.base.log.logger.Logger
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.MalformedURLException
+import java.net.URL
+
+/**
+ * A simple ping Uploader, which implements a "send once" policy, never
+ * storing or attempting to send the ping again.
+ */
+class HttpPingUploader(configuration: Configuration) : PingUploader {
+    private val config = configuration
+    private val logger = Logger("glean/HttpPingUploader")
+
+    /**
+     * Synchronously upload a ping to Mozilla servers.
+     * Note that the `X-Client-Type`: `Glean` and `X-Client-Version`: <SDK version>
+     * headers are added to the HTTP request in addition to the UserAgent. This allows
+     * us to easily handle pings coming from glean on the legacy Mozilla pipeline.
+     *
+     * @param path the URL path to append to the server address
+     * @param data the serialized text data to send
+     *
+     * @return true if the ping was correctly dealt with (sent successfully
+     *         or faced an unrecoverable error), false if there was a recoverable
+     *         error callers can deal with.
+     */
+    @Suppress("ReturnCount", "MagicNumber")
+    override fun upload(path: String, data: String): Boolean {
+        var connection: HttpURLConnection? = null
+        try {
+            connection = openConnection(config.serverEndpoint, path)
+            connection.requestMethod = "POST"
+            connection.connectTimeout = config.connectionTimeout
+            connection.readTimeout = config.readTimeout
+            connection.doOutput = true
+
+            connection.setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            connection.setRequestProperty("User-Agent", config.userAgent)
+            connection.setRequestProperty("Date", createDateHeaderValue())
+
+            // Add headers for supporting the legacy pipeline.
+            connection.setRequestProperty("X-Client-Type", "Glean")
+            connection.setRequestProperty("X-Client-Version", BuildConfig.LIBRARY_VERSION)
+
+            val responseCode = doUpload(connection, data)
+
+            logger.debug("Ping upload: $responseCode")
+
+            when (responseCode) {
+                in HttpURLConnection.HTTP_OK..(HttpURLConnection.HTTP_OK + 99) -> {
+                    // Known success errors (2xx):
+                    // 200 - OK. Request accepted into the pipeline.
+
+                    // We treat all success codes as successful upload even though we only expect 200.
+                    logger.debug("Ping successfully sent ($responseCode)")
+                    return true
+                }
+                in HttpURLConnection.HTTP_BAD_REQUEST..(HttpURLConnection.HTTP_BAD_REQUEST + 99) -> {
+                    // Known client (4xx) errors:
+                    // 404 - not found - POST/PUT to an unknown namespace
+                    // 405 - wrong request type (anything other than POST/PUT)
+                    // 411 - missing content-length header
+                    // 413 - request body too large (Note that if we have badly-behaved clients that
+                    //       retry on 4XX, we should send back 202 on body/path too long).
+                    // 414 - request path too long (See above)
+
+                    // Something our client did is not correct. It's unlikely that the client is going
+                    // to recover from this by re-trying again, so we just log and error and report a
+                    // successful upload to the service.
+                    logger.error("Server returned client error code: $responseCode")
+                    return true
+                }
+                else -> {
+                    // Known other errors:
+                    // 500 - internal error
+
+                    // For all other errors we log a warning an try again at a later time.
+                    logger.warn("Server returned response code: $responseCode")
+                    return false
+                }
+            }
+        } catch (e: MalformedURLException) {
+            // There's nothing we can do to recover from this here. So let's just log an error and
+            // notify the service that this job has been completed - even though we didn't upload
+            // anything to the server.
+            logger.error("Could not upload telemetry due to malformed URL", e)
+            return true
+        } catch (e: IOException) {
+            logger.warn("IOException while uploading ping", e)
+            return false
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    @Throws(IOException::class)
+    fun doUpload(connection: HttpURLConnection, data: String): Int {
+        connection.outputStream.bufferedWriter().use {
+            it.write(data)
+            it.flush()
+        }
+
+        return connection.responseCode
+    }
+
+    @VisibleForTesting @Throws(IOException::class)
+    fun openConnection(endpoint: String, path: String): HttpURLConnection {
+        return URL(endpoint + path).openConnection() as HttpURLConnection
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/PingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/PingUploader.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * The interface defining how to send pings.
+ */
+interface PingUploader {
+    fun upload(path: String, data: String): Boolean
+
+    fun createDateHeaderValue(): String {
+        val calendar = Calendar.getInstance()
+        val dateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
+        dateFormat.timeZone = TimeZone.getTimeZone("GMT")
+        return dateFormat.format(calendar.time)
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.config.Configuration
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import java.io.IOException
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.MalformedURLException
+
+@RunWith(RobolectricTestRunner::class)
+class HttpPingUploaderTest {
+    private val testPath: String = "/some/random/path/not/important"
+    private val testPing: String = "{ 'ping': 'test' }"
+    private val testDefaultConfig = Configuration().copy(
+        userAgent = "Glean/Test 25.0.2",
+        connectionTimeout = 3050,
+        readTimeout = 7050
+    )
+
+    @Test
+    fun `connection timeouts must be properly set`() {
+        val connection = mock<HttpURLConnection>(HttpURLConnection::class.java)
+
+        val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+
+        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+        doReturn(200).`when`(client).doUpload(connection, testPing)
+
+        client.upload(testPath, testPing)
+
+        verify<HttpURLConnection>(connection).readTimeout = 7050
+        verify<HttpURLConnection>(connection).connectTimeout = 3050
+        verify<HttpURLConnection>(connection, times(1)).disconnect()
+    }
+
+    @Test
+    fun `user-agent must be properly set`() {
+        val connection = mock(HttpURLConnection::class.java)
+
+        val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+
+        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+        doReturn(200).`when`(client).doUpload(connection, testPing)
+
+        client.upload(testPath, testPing)
+
+        verify(connection).setRequestProperty("User-Agent", testDefaultConfig.userAgent)
+        verify<HttpURLConnection>(connection, times(1)).disconnect()
+    }
+
+    @Test
+    fun `X-Client-* headers must be properly set`() {
+        val connection = mock(HttpURLConnection::class.java)
+
+        val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+
+        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+        doReturn(200).`when`(client).doUpload(connection, testPing)
+
+        client.upload(testPath, testPing)
+
+        verify(connection).setRequestProperty("X-Client-Type", "Glean")
+        verify(connection).setRequestProperty("X-Client-Version", BuildConfig.LIBRARY_VERSION)
+        verify<HttpURLConnection>(connection, times(1)).disconnect()
+    }
+
+    @Test
+    fun `upload() returns true for successful submissions (200)`() {
+        val connection = mock(HttpURLConnection::class.java)
+
+        doReturn(200).`when`(connection).responseCode
+        doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+
+        val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+
+        assertTrue(client.upload(testPath, testPing))
+        verify<HttpURLConnection>(connection, times(1)).disconnect()
+    }
+
+    @Test
+    fun `upload() returns false for server errors (5xx)`() {
+        for (responseCode in 500..527) {
+            val connection = mock(HttpURLConnection::class.java)
+
+            doReturn(responseCode).`when`(connection).responseCode
+            doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+
+            val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+            doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+
+            assertFalse(client.upload(testPath, testPing))
+            verify<HttpURLConnection>(connection, times(1)).disconnect()
+        }
+    }
+
+    @Test
+    fun `upload() returns true for successful submissions (2xx)`() {
+        for (responseCode in 200..226) {
+            val connection = mock(HttpURLConnection::class.java)
+
+            doReturn(responseCode).`when`(connection).responseCode
+            doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+
+            val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+            doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+
+            assertTrue(client.upload(testPath, testPing))
+            verify<HttpURLConnection>(connection, times(1)).disconnect()
+        }
+    }
+
+    @Test
+    fun `upload() returns true for failing submissions with broken requests (4xx)`() {
+        for (responseCode in 400..451) {
+            val connection = mock(HttpURLConnection::class.java)
+
+            doReturn(responseCode).`when`(connection).responseCode
+            doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+
+            val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+            doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+
+            assertTrue(client.upload(testPath, testPing))
+            verify<HttpURLConnection>(connection, times(1)).disconnect()
+        }
+    }
+
+    @Test
+    fun `upload() correctly uploads the ping data`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("OK"))
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://" + server.hostName + ":" + server.port
+        )
+
+        val client = HttpPingUploader(testConfig)
+        assertTrue(client.upload(testPath, testPing))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `upload() returns true on malformed URLs`() {
+        val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+        doThrow(MalformedURLException()).`when`(client).openConnection(anyString(), anyString())
+
+        // If the URL is malformed then there's nothing we can do to recover. Therefore this is treated
+        // like a successful upload.
+        assertTrue(client.upload("path", "ping"))
+    }
+
+    @Test
+    fun `upload() should return false when upload fails`() {
+        val stream = mock(OutputStream::class.java)
+        doThrow(IOException()).`when`(stream).write(any(ByteArray::class.java))
+
+        val connection = mock(HttpURLConnection::class.java)
+        doReturn(stream).`when`(connection).outputStream
+
+        val client = spy<HttpPingUploader>(HttpPingUploader(testDefaultConfig))
+        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+
+        // And IOException during upload is a failed upload that we should retry. The client should
+        // return false in this case.
+        assertFalse(client.upload("path", "ping"))
+        verify<HttpURLConnection>(connection, times(1)).disconnect()
+    }
+}


### PR DESCRIPTION
This implements a ping uploader that attempts to send a ping once and never again. This also implements the `Configuration` object and a `DefaultConfiguration` for glean.

Please note that this is a copy of the `HttpURLConnectionTelemetryClient.java` from `telemetry-android`, converted to Kotlin to have an uniform codebase.