### PR TITLE
Issue #1109: browser-toolbar: Add listener for observing edit mode changes.

### DIFF
--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation Deps.support_appcompat
     implementation Deps.kotlin_stdlib
 
+    testImplementation project(':support-test')
     testImplementation Deps.testing_junit
     testImplementation Deps.testing_robolectric
     testImplementation Deps.testing_mockito

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -44,7 +44,6 @@ class BrowserToolbar @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : ViewGroup(context, attrs, defStyleAttr), Toolbar {
-
     // displayToolbar and editToolbar are only visible internally and mutable so that we can mock
     // them in tests.
     @VisibleForTesting internal var displayToolbar = DisplayToolbar(context, this)
@@ -106,6 +105,10 @@ class BrowserToolbar @JvmOverloads constructor(
         editToolbar.urlView.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             listener.invoke(hasFocus)
         }
+    }
+
+    override fun setOnEditListener(listener: Toolbar.OnEditListener) {
+        editToolbar.editListener = listener
     }
 
     /**
@@ -281,8 +284,14 @@ class BrowserToolbar @JvmOverloads constructor(
         this.state = state
 
         val (show, hide) = when (state) {
-            State.DISPLAY -> Pair(displayToolbar, editToolbar)
-            State.EDIT -> Pair(editToolbar, displayToolbar)
+            State.DISPLAY -> {
+                editToolbar.editListener?.onStopEditing()
+                Pair(displayToolbar, editToolbar)
+            }
+            State.EDIT -> {
+                editToolbar.editListener?.onStartEditing()
+                Pair(editToolbar, displayToolbar)
+            }
         }
 
         show.visibility = View.VISIBLE

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -14,6 +14,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
+import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.ktx.android.content.res.pxToDp
 import mozilla.components.support.ktx.android.view.showKeyboard
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
@@ -48,6 +49,9 @@ class EditToolbar(
         setSelectAllOnFocus(true)
 
         setOnCommitListener { toolbar.onUrlEntered(text.toString()) }
+        setOnTextChangeListener { text, _ ->
+            editListener?.onTextChanged(text)
+        }
     }
 
     private val cancelView = ImageView(context).apply {
@@ -60,6 +64,8 @@ class EditToolbar(
             toolbar.displayMode()
         }
     }
+
+    internal var editListener: Toolbar.OnEditListener? = null
 
     init {
         addView(urlView)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -8,6 +8,8 @@ import android.view.View
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.browser.toolbar.edit.EditToolbar
+import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -417,5 +419,53 @@ class BrowserToolbarTest {
 
             verify(it).layout(50, 20, 940, 185)
         }
+    }
+
+    @Test
+    fun `editListener is set on EditToolbar`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        assertNull(toolbar.editToolbar.editListener)
+
+        val listener: Toolbar.OnEditListener = mock()
+        toolbar.setOnEditListener(listener)
+
+        assertEquals(listener, toolbar.editToolbar.editListener)
+    }
+
+    @Test
+    fun `editListener is invoked when switching between modes`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        val listener: Toolbar.OnEditListener = mock()
+        toolbar.setOnEditListener(listener)
+
+        toolbar.editMode()
+
+        verify(listener).onStartEditing()
+        verifyNoMoreInteractions(listener)
+
+        toolbar.displayMode()
+
+        verify(listener).onStopEditing()
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `editListener is invoked when text changes`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        val listener: Toolbar.OnEditListener = mock()
+        toolbar.setOnEditListener(listener)
+
+        toolbar.editToolbar.urlView.onAttachedToWindow()
+
+        toolbar.editMode()
+
+        toolbar.editToolbar.urlView.setText("Hello")
+        toolbar.editToolbar.urlView.setText("Hello World")
+
+        verify(listener).onStartEditing()
+        verify(listener).onTextChanged("Hello")
+        verify(listener).onTextChanged("Hello World")
     }
 }

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -76,6 +76,31 @@ interface Toolbar {
     fun asView(): View = this as View
 
     /**
+     * Registers the given listener to be invoked when the user edits the URL.
+     */
+    fun setOnEditListener(listener: OnEditListener)
+
+    /**
+     * Listener to be invoked when the user edits the URL.
+     */
+    interface OnEditListener {
+        /**
+         * Fired when the toolbar switches to edit mode.
+         */
+        fun onStartEditing() = Unit
+
+        /**
+         * Fired when the toolbar switches back to display mode.
+         */
+        fun onStopEditing() = Unit
+
+        /**
+         * Fired whenever the user changes the text in the address bar.
+         */
+        fun onTextChanged(text: String) = Unit
+    }
+
+    /**
      * Generic interface for actions to be added to the toolbar.
      */
     interface Action {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,23 @@ permalink: /changelog/
   * Android (SDK: 27, Support Libraries: 27.1.1)
   * Kotlin (Stdlib: 1.2.61, Coroutines: 0.23.4)
   * GeckoView (Nightly: **65.0.20181023100123** 🔺, Beta: **64.0.20181022150107** 🔺, Release: **63.0.20181018182531** 🔺)
+* **browser-toolbar**:
+  * Added new listener to get notified when the user is editing the URL:
+  ```kotlin
+          toolbar.setOnEditListener(object : Toolbar.OnEditListener {
+            override fun onTextChanged(text: String) {
+              // Fired whenever the user changes the text in the address bar.
+            }
+
+            override fun onStartEditing() {
+              // Fired when the toolbar switches to edit mode.
+            }
+
+            override fun onStopEditing() {
+              // Fired when the toolbar switches back to display mode.
+            }
+        })
+  ```
 * **lib-jexl**
   * New component for for evaluating Javascript Expression Language (JEXL) expressions. This implementation is based on [Mozjexl](https://github.com/mozilla/mozjexl) used at Mozilla, specifically as a part of SHIELD and Normandy. In a future version of Fretboard JEXL will allow more complex rules for experiments. For more see [documentation](https://github.com/mozilla-mobile/android-components/blob/master/components/lib/jexl/README.md).
 


### PR DESCRIPTION
A small piece for #1109 that can land earlier: To implement an independent awesomebar component we need to be able to hook into the toolbar whenever it switches to edit mode and the text changes.