### PR TITLE
Issue #1011: Fretboard: ValuesProvider.getCountry(): MissingResourceException

### DIFF
--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ValuesProvider.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ValuesProvider.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.fretboard
 import android.content.Context
 import android.os.Build
 import java.util.Locale
+import java.util.MissingResourceException
 
 /**
  * Class used to provide
@@ -19,7 +20,11 @@ open class ValuesProvider {
      * @return user's language as a three-letter abbreviation
      */
     open fun getLanguage(context: Context): String {
-        return Locale.getDefault().isO3Language
+        return try {
+            Locale.getDefault().isO3Language
+        } catch (e: MissingResourceException) {
+            Locale.getDefault().language
+        }
     }
 
     /**
@@ -73,7 +78,11 @@ open class ValuesProvider {
      * @return user's country, as a three-letter abbreviation
      */
     open fun getCountry(context: Context): String {
-        return Locale.getDefault().isO3Country
+        return try {
+            Locale.getDefault().isO3Country
+        } catch (e: MissingResourceException) {
+            Locale.getDefault().country
+        }
     }
 
     /**

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ValuesProviderTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ValuesProviderTest.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.robolectric.RobolectricTestRunner
+import java.util.Locale
+import java.util.MissingResourceException
+
+@RunWith(RobolectricTestRunner::class)
+class ValuesProviderTest {
+    @Test
+    fun `get language has three letter code`() {
+        Locale.setDefault(Locale("en", "US"))
+        assertEquals("eng", ValuesProvider().getLanguage(mock(Context::class.java)))
+    }
+
+    @Test
+    fun `get language doesn't have three letter code`() {
+        val locale = spy(Locale.getDefault())
+        `when`(locale.isO3Language).thenThrow(MissingResourceException("", "", ""))
+        `when`(locale.language).thenReturn("language")
+        Locale.setDefault(locale)
+        assertEquals("language", ValuesProvider().getLanguage(mock(Context::class.java)))
+    }
+
+    @Test
+    fun `get country has three letter code`() {
+        Locale.setDefault(Locale("en", "US"))
+        assertEquals("USA", ValuesProvider().getCountry(mock(Context::class.java)))
+    }
+
+    @Test
+    fun `get country doesn't have three letter code`() {
+        Locale.setDefault(Locale("cnr", "CS"))
+        assertEquals("CS", ValuesProvider().getCountry(mock(Context::class.java)))
+    }
+}


### PR DESCRIPTION
The `Locale` class [documentation](https://developer.android.com/reference/java/util/Locale.html#getISO3Country()) says the `getISO3Country` method throws a `MissingResourceException` if the three-letter country abbreviation is not available for a `Locale`.

What this pull request does is in this case it returns the result of calling `getCountry`, which could return a 2 letter country code or an empty string (but not throw an exception). It seems more reasonable to me to do this rather than, for example, simply return an empty string in that case.

This pull request also does the same for the language, since it's the same problem.

Closes #1011