### PR TITLE
Beginnings of concept-storage and friends (Closes #1089)

### DIFF
--- a/automation/taskcluster/artifacts.yml
+++ b/automation/taskcluster/artifacts.yml
@@ -25,6 +25,9 @@
         public/build/concept.engine.maven.zip:
           path: /build/android-components/components/concept/engine/build/target.maven.zip
           name: concept-engine
+        public/build/concept.storage.maven.zip:
+          path: /build/android-components/components/concept/storage/build/target.maven.zip
+          name: concept-storage
         public/build/concept.toolbar.maven.zip:
           path: /build/android-components/components/concept/toolbar/build/target.maven.zip
           name: concept-toolbar

--- a/automation/taskcluster/artifacts.yml
+++ b/automation/taskcluster/artifacts.yml
@@ -91,6 +91,9 @@
         public/build/feature.session.maven.zip:
           path: /build/android-components/components/feature/session/build/target.maven.zip
           name: feature-session
+        public/build/feature.storage.maven.zip:
+          path: /build/android-components/components/feature/storage/build/target.maven.zip
+          name: feature-storage
         public/build/feature.toolbar.maven.zip:
           path: /build/android-components/components/feature/toolbar/build/target.maven.zip
           name: feature-toolbar

--- a/automation/taskcluster/artifacts.yml
+++ b/automation/taskcluster/artifacts.yml
@@ -67,6 +67,9 @@
         public/build/browser.search.maven.zip:
           path: /build/android-components/components/browser/search/build/target.maven.zip
           name: browser-search
+        public/build/browser.storage-memory.maven.zip:
+          path: /build/android-components/components/browser/storage-memory/build/target.maven.zip
+          name: browser-storage-memory
         public/build/browser.domains.maven.zip:
           path: /build/android-components/components/browser/domains/build/target.maven.zip
           name: browser-domains

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -21,7 +22,6 @@ class GeckoEngine(
     private val defaultSettings: Settings? = null,
     private val runtime: GeckoRuntime = GeckoRuntime.getDefault(context)
 ) : Engine {
-
     /**
      * Creates a new Gecko-based EngineView.
      */
@@ -61,6 +61,10 @@ class GeckoEngine(
         override var remoteDebuggingEnabled: Boolean
             get() = runtime.settings.remoteDebuggingEnabled
             set(value) { runtime.settings.remoteDebuggingEnabled = value }
+
+        override var historyTrackingDelegate: HistoryTrackingDelegate?
+            get() = defaultSettings?.historyTrackingDelegate
+            set(value) { defaultSettings?.historyTrackingDelegate = value }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -58,6 +58,7 @@ class GeckoEngineSession(
     init {
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
+        defaultSettings?.historyTrackingDelegate?.let { settings.historyTrackingDelegate = it }
 
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -61,6 +62,10 @@ class GeckoEngine(
         override var remoteDebuggingEnabled: Boolean
             get() = runtime.settings.remoteDebuggingEnabled
             set(value) { runtime.settings.remoteDebuggingEnabled = value }
+
+        override var historyTrackingDelegate: HistoryTrackingDelegate?
+            get() = defaultSettings?.historyTrackingDelegate
+            set(value) { defaultSettings?.historyTrackingDelegate = value }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -58,6 +58,7 @@ class GeckoEngineSession(
     init {
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
+        defaultSettings?.historyTrackingDelegate?.let { settings.historyTrackingDelegate = it }
 
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -61,6 +62,10 @@ class GeckoEngine(
         override var remoteDebuggingEnabled: Boolean
             get() = runtime.settings.remoteDebuggingEnabled
             set(value) { runtime.settings.remoteDebuggingEnabled = value }
+
+        override var historyTrackingDelegate: HistoryTrackingDelegate?
+            get() = defaultSettings?.historyTrackingDelegate
+            set(value) { defaultSettings?.historyTrackingDelegate = value }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -15,6 +15,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 
 /**
  * WebView-based implementation of the Engine interface.
@@ -72,6 +73,12 @@ class SystemEngine(
             get() = defaultSettings.trackingProtectionPolicy
             set(value) {
                 defaultSettings.trackingProtectionPolicy = value
+            }
+
+        override var historyTrackingDelegate: HistoryTrackingDelegate?
+            get() = defaultSettings.historyTrackingDelegate
+            set(value) {
+                defaultSettings.historyTrackingDelegate = value
             }
     }.apply {
         this.remoteDebuggingEnabled = defaultSettings.remoteDebuggingEnabled

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -257,7 +257,7 @@ class SystemEngineViewTest {
 
         val engineView = SystemEngineView(RuntimeEnvironment.application)
         val historyDelegate = object : HistoryTrackingDelegate {
-            override fun onVisited(uri: String, isReload: Boolean?, privateMode: Boolean) {
+            override fun onVisited(uri: String, isReload: Boolean, privateMode: Boolean) {
                 fail()
             }
 

--- a/components/browser/storage-memory/README.md
+++ b/components/browser/storage-memory/README.md
@@ -1,0 +1,17 @@
+# [Android Components](../../../README.md) > Browser > Memory Storage
+
+An in-memory implementation of `concept-storage`. Data is not persisted to disk, and does not survive a restart. Not suitable for syncing.
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:browser-storage-memory:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/storage-memory/build.gradle
+++ b/components/browser/storage-memory/build.gradle
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion Config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':concept-storage')
+
+    implementation Deps.kotlin_stdlib
+    implementation Deps.kotlin_coroutines
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+
+    testImplementation project(':support-test')
+}
+
+archivesBaseName = "storage-memory"
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.components',
+        'storage-memory',
+        'In-memory implementation of concept-storage.')

--- a/components/browser/storage-memory/proguard-rules.pro
+++ b/components/browser/storage-memory/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/browser/storage-memory/src/main/AndroidManifest.xml
+++ b/components/browser/storage-memory/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.browser.storage.memory" />

--- a/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
+++ b/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.memory
+
+import android.support.annotation.VisibleForTesting
+import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.concept.storage.PageObservation
+import mozilla.components.concept.storage.VisitType
+
+data class Visit(val timestamp: Long, val type: VisitType)
+
+/**
+ * An in-memory implementation of [mozilla.components.concept.storage.HistoryStorage].
+ */
+class InMemoryHistoryStorage : HistoryStorage {
+    @VisibleForTesting
+    internal val pages: LinkedHashMap<String, MutableList<Visit>> = linkedMapOf()
+    @VisibleForTesting
+    internal val pageMeta: HashMap<String, PageObservation> = hashMapOf()
+
+    override fun recordVisit(uri: String, visitType: VisitType) {
+        val now = System.currentTimeMillis()
+
+        synchronized(pages) {
+            if (!pages.containsKey(uri)) {
+                pages[uri] = mutableListOf(Visit(now, visitType))
+            } else {
+                pages[uri]!!.add(Visit(now, visitType))
+            }
+        }
+    }
+
+    override fun recordObservation(uri: String, observation: PageObservation) {
+        synchronized(pageMeta) {
+            pageMeta[uri] = observation
+        }
+    }
+
+    override fun getVisited(uris: List<String>, callback: (List<Boolean>) -> Unit) {
+        callback(synchronized(pages) {
+            uris.map {
+                if (pages[it] != null && pages[it]!!.size > 0) {
+                    return@map true
+                }
+                return@map false
+            }
+        })
+    }
+
+    override fun getVisited(callback: (List<String>) -> Unit) {
+        callback(synchronized(pages) {
+            (pages.keys.toList())
+        })
+    }
+}

--- a/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
+++ b/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.memory
+
+import mozilla.components.concept.storage.PageObservation
+import mozilla.components.concept.storage.VisitType
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.reset
+
+class InMemoryHistoryStorageTest {
+    @Test
+    fun `store can be used to track visit information`() {
+        val history = InMemoryHistoryStorage()
+
+        assertEquals(0, history.pages.size)
+
+        history.recordVisit("http://www.mozilla.org", VisitType.LINK)
+        assertEquals(1, history.pages.size)
+        assertEquals(1, history.pages["http://www.mozilla.org"]!!.size)
+        assertEquals(VisitType.LINK, history.pages["http://www.mozilla.org"]!![0].type)
+
+        // Reloads are recorded.
+        history.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
+        assertEquals(1, history.pages.size)
+        assertEquals(2, history.pages["http://www.mozilla.org"]!!.size)
+        assertEquals(VisitType.LINK, history.pages["http://www.mozilla.org"]!![0].type)
+        assertEquals(VisitType.RELOAD, history.pages["http://www.mozilla.org"]!![1].type)
+
+        // Visits for multiple pages are tracked.
+        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+        assertEquals(2, history.pages.size)
+        assertEquals(2, history.pages["http://www.mozilla.org"]!!.size)
+        assertEquals(VisitType.LINK, history.pages["http://www.mozilla.org"]!![0].type)
+        assertEquals(VisitType.RELOAD, history.pages["http://www.mozilla.org"]!![1].type)
+        assertEquals(1, history.pages["http://www.firefox.com"]!!.size)
+        assertEquals(VisitType.LINK, history.pages["http://www.firefox.com"]!![0].type)
+    }
+
+    @Test
+    fun `store can be used to record and retrieve history via webview-style callbacks`() {
+        val history = InMemoryHistoryStorage()
+
+        val callback = mock<(List<String>) -> Unit>()
+
+        // Empty.
+        history.getVisited(callback)
+        verify(callback).invoke(listOf())
+        reset(callback)
+        history.getVisited(callback)
+        verify(callback).invoke(listOf())
+        reset(callback)
+
+        // Regular visits are tracked.
+        history.recordVisit("https://www.mozilla.org", VisitType.LINK)
+        history.getVisited(callback)
+        verify(callback).invoke(listOf("https://www.mozilla.org"))
+        reset(callback)
+
+        // Multiple visits can be tracked, results ordered by "URL's first seen first".
+        history.recordVisit("https://www.firefox.com", VisitType.LINK)
+        history.getVisited(callback)
+        verify(callback).invoke(listOf("https://www.mozilla.org", "https://www.firefox.com"))
+        reset(callback)
+
+        // Visits marked as reloads can be tracked.
+        history.recordVisit("https://www.firefox.com", VisitType.RELOAD)
+        history.getVisited(callback)
+        verify(callback).invoke(listOf("https://www.mozilla.org", "https://www.firefox.com"))
+        reset(callback)
+
+        // Visited urls are certainly a set.
+        history.recordVisit("https://www.firefox.com", VisitType.LINK)
+        history.recordVisit("https://www.mozilla.org", VisitType.LINK)
+        history.recordVisit("https://www.wikipedia.org", VisitType.LINK)
+        history.getVisited(callback)
+        verify(callback).invoke(listOf("https://www.mozilla.org", "https://www.firefox.com", "https://www.wikipedia.org"))
+    }
+
+    @Test
+    fun `store can be used to record and retrieve history via gecko-style callbacks`() {
+        val history = InMemoryHistoryStorage()
+
+        // Empty.
+        val callback = mock<(List<Boolean>) -> Unit>()
+
+        history.getVisited(listOf(), callback)
+        verify(callback).invoke(listOf())
+        reset(callback)
+
+        // Regular visits are tracked
+        history.recordVisit("https://www.mozilla.org", VisitType.LINK)
+        history.getVisited(listOf("https://www.mozilla.org"), callback)
+        verify(callback).invoke(listOf(true))
+        reset(callback)
+
+        // Duplicate requests are handled.
+        history.getVisited(listOf("https://www.mozilla.org", "https://www.mozilla.org"), callback)
+        verify(callback).invoke(listOf(true, true))
+        reset(callback)
+
+        // Visit map is returned in correct order.
+        history.getVisited(listOf("https://www.mozilla.org", "https://www.unknown.com"), callback)
+        verify(callback).invoke(listOf(true, false))
+        reset(callback)
+
+        history.getVisited(listOf("https://www.unknown.com", "https://www.mozilla.org"), callback)
+        verify(callback).invoke(listOf(false, true))
+        reset(callback)
+
+        // Multiple visits can be tracked. Reloads can be tracked.
+        history.recordVisit("https://www.firefox.com", VisitType.LINK)
+        history.recordVisit("https://www.mozilla.org", VisitType.RELOAD)
+        history.recordVisit("https://www.wikipedia.org", VisitType.LINK)
+        history.getVisited(listOf("https://www.firefox.com", "https://www.wikipedia.org", "https://www.unknown.com", "https://www.mozilla.org"), callback)
+        verify(callback).invoke(listOf(true, true, false, true))
+    }
+
+    @Test
+    fun `store can be used to track page meta information - title changes`() {
+        val history = InMemoryHistoryStorage()
+        assertEquals(0, history.pageMeta.size)
+
+        // Title changes are recorded.
+        history.recordObservation("https://www.wikipedia.org", PageObservation("Wikipedia"))
+        assertEquals(1, history.pageMeta.size)
+        assertEquals(PageObservation("Wikipedia"), history.pageMeta["https://www.wikipedia.org"])
+
+        history.recordObservation("https://www.wikipedia.org", PageObservation("Википедия"))
+        assertEquals(1, history.pageMeta.size)
+        assertEquals(PageObservation("Википедия"), history.pageMeta["https://www.wikipedia.org"])
+
+        // Titles for different pages are recorded.
+        history.recordObservation("https://www.firefox.com", PageObservation("Firefox"))
+        history.recordObservation("https://www.mozilla.org", PageObservation("Мозилла"))
+        assertEquals(3, history.pageMeta.size)
+        assertEquals(PageObservation("Википедия"), history.pageMeta["https://www.wikipedia.org"])
+        assertEquals(PageObservation("Firefox"), history.pageMeta["https://www.firefox.com"])
+        assertEquals(PageObservation("Мозилла"), history.pageMeta["https://www.mozilla.org"])
+    }
+}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
@@ -15,7 +15,7 @@ interface HistoryTrackingDelegate {
     /**
      * A URI visit happened that an engine considers worthy of being recorded in browser's history.
      */
-    fun onVisited(uri: String, isReload: Boolean? = false, privateMode: Boolean)
+    fun onVisited(uri: String, isReload: Boolean = false, privateMode: Boolean)
 
     /**
      * Title changed for a given URI.

--- a/components/concept/storage/README.md
+++ b/components/concept/storage/README.md
@@ -1,0 +1,27 @@
+# [Android Components](../../../README.md) > Concept > Storage
+
+The `concept-storage` component contains interfaces and abstract classes that describe a "core data" storage layer.
+
+This abstraction makes it possible to build components that work independently of the storage layer being used.
+
+Currently an [in-memory storage implementation](../../browser/storage-memory) is available.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:concept-storage:{latest-version}"
+```
+
+### Integration
+
+One way to interact with a `concept-storage` component is via [feature-storage](../../features/storage/README.md), which provides "glue" implementations that make use of storage. For example, a `features.storage.HistoryTrackingFeature` allows a `concept.engine.Engine` to keep track of visits and page meta information.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/concept/storage/build.gradle
+++ b/components/concept/storage/build.gradle
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion Config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Deps.kotlin_stdlib
+    implementation Deps.support_annotations
+
+    // We expose this as API because we are using Observable in our public API and do not want every
+    // consumer to have to manually import "base".
+    api project(':support-base')
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+
+    testImplementation project(':support-test')
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(Config.componentsGroupId, archivesBaseName, gradle.componentDescriptions[archivesBaseName])

--- a/components/concept/storage/proguard-rules.pro
+++ b/components/concept/storage/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/concept/storage/src/main/AndroidManifest.xml
+++ b/components/concept/storage/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.concept.storage" />

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.storage
+
+/**
+ * An interface which defines read/write methods for history data.
+ */
+interface HistoryStorage {
+    /**
+     * Records a visit to a page.
+     * @param uri of the page which was visited.
+     * @param visitType type of the visit, see [VisitType].
+     */
+    fun recordVisit(uri: String, visitType: VisitType)
+
+    /**
+     * Records an observation about a page.
+     * @param uri of the page for which to record an observation.
+     * @param observation a [PageObservation] which encapsulates meta data observed about the page.
+     */
+    fun recordObservation(uri: String, observation: PageObservation)
+
+    /**
+     * Maps a list of page URIs to a list of booleans indicating if each URI was visited.
+     * @param uris a list of page URIs about which "visited" information is being requested.
+     * @param callback will be invoked with a list of booleans indicating visited status of each
+     * corresponding page URI from [uris].
+     */
+    fun getVisited(uris: List<String>, callback: (List<Boolean>) -> Unit)
+
+    /**
+     * Retrieves a list of all visited pages.
+     * @param callback will be invoked with a list of all visited page URIs.
+     */
+    fun getVisited(callback: (List<String>) -> Unit)
+}
+
+data class PageObservation(val title: String?)
+
+/**
+ * Visit type constants as defined by Desktop Firefox.
+ */
+@SuppressWarnings("MagicNumber")
+enum class VisitType(val type: Int) {
+    // User followed a link.
+    LINK(1),
+    // User typed a URL or selected it from the UI (autocomplete results, etc).
+    TYPED(2),
+    RELOAD(9)
+}

--- a/components/feature/storage/README.md
+++ b/components/feature/storage/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Feature > Storage
+
+A component that connects an (concept) engine implementation with a concept storage implementation.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-storage:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/storage/build.gradle
+++ b/components/feature/storage/build.gradle
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion Config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':concept-engine')
+    implementation project(':concept-storage')
+    implementation project(':support-ktx')
+
+    implementation Deps.kotlin_stdlib
+
+    testImplementation Deps.testing_junit
+    testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+
+    testImplementation project(':support-test')
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(Config.componentsGroupId, archivesBaseName, gradle.componentDescriptions[archivesBaseName])

--- a/components/feature/storage/proguard-rules.pro
+++ b/components/feature/storage/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/storage/src/main/AndroidManifest.xml
+++ b/components/feature/storage/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.storage" />

--- a/components/feature/storage/src/main/java/mozilla/components/feature/storage/HistoryTrackingFeature.kt
+++ b/components/feature/storage/src/main/java/mozilla/components/feature/storage/HistoryTrackingFeature.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.storage
+
+import android.support.annotation.VisibleForTesting
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.concept.storage.PageObservation
+import mozilla.components.concept.storage.VisitType
+
+/**
+ * Feature implementation for connecting an engine implementation with a history storage implementation
+ * in order to enable engine to track history.
+ */
+class HistoryTrackingFeature(engine: Engine, historyStorage: HistoryStorage) {
+    init {
+        engine.settings.historyTrackingDelegate = HistoryDelegate(historyStorage)
+    }
+}
+
+@VisibleForTesting
+internal class HistoryDelegate(private val historyStorage: HistoryStorage) : HistoryTrackingDelegate {
+    override fun onVisited(uri: String, isReload: Boolean, privateMode: Boolean) {
+        if (privateMode) {
+            return
+        }
+        val visitType = when (isReload) {
+            true -> VisitType.RELOAD
+            false -> VisitType.LINK
+        }
+        historyStorage.recordVisit(uri, visitType)
+    }
+
+    override fun onTitleChanged(uri: String, title: String, privateMode: Boolean) {
+        if (privateMode) {
+            return
+        }
+        historyStorage.recordObservation(uri, PageObservation(title = title))
+    }
+
+    override fun getVisited(uris: List<String>, callback: (List<Boolean>) -> Unit, privateMode: Boolean) {
+        if (privateMode) {
+            callback(List(uris.size) { false })
+            return
+        }
+        historyStorage.getVisited(uris, callback)
+    }
+
+    override fun getVisited(callback: (List<String>) -> Unit, privateMode: Boolean) {
+        if (privateMode) {
+            callback(listOf())
+            return
+        }
+        historyStorage.getVisited(callback)
+    }
+}

--- a/components/feature/storage/src/test/java/mozilla/components/feature/storage/HistoryTrackingFeatureTest.kt
+++ b/components/feature/storage/src/test/java/mozilla/components/feature/storage/HistoryTrackingFeatureTest.kt
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.storage
+
+import mozilla.components.concept.engine.DefaultSettings
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.concept.storage.PageObservation
+import mozilla.components.concept.storage.VisitType
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.never
+
+class HistoryTrackingFeatureTest {
+    @Test
+    fun `feature sets a history delegate on the engine`() {
+        val engine: Engine = mock()
+        val settings = DefaultSettings()
+        `when`(engine.settings).thenReturn(settings)
+
+        assertNull(settings.historyTrackingDelegate)
+        HistoryTrackingFeature(engine, mock())
+        assertNotNull(settings.historyTrackingDelegate)
+    }
+
+    @Test
+    fun `history delegate doesn't interact with storage in private mode`() {
+        val storage: HistoryStorage = mock()
+        val delegate = HistoryDelegate(storage)
+
+        delegate.onVisited("http://www.mozilla.org", false, true)
+        verify(storage, never()).recordVisit(any(), any())
+
+        delegate.onTitleChanged("http://www.mozilla.org", "Mozilla", true)
+        verify(storage, never()).recordObservation(any(), any())
+
+        val systemCallback = mock<(List<String>) -> Unit>()
+        delegate.getVisited(systemCallback, true)
+        verify(systemCallback).invoke(listOf())
+        verify(storage, never()).getVisited(systemCallback)
+
+        val geckoCallback = mock<(List<Boolean>) -> Unit>()
+        delegate.getVisited(listOf("http://www.mozilla.com"), geckoCallback, true)
+        verify(geckoCallback).invoke(listOf(false))
+        verify(storage, never()).getVisited(listOf("http://www.mozilla.com"), geckoCallback)
+
+        delegate.getVisited(listOf("http://www.mozilla.com", "http://www.firefox.com"), geckoCallback, true)
+        verify(geckoCallback).invoke(listOf(false, false))
+        verify(storage, never()).getVisited(listOf("http://www.mozilla.com", "http://www.firefox.com"), geckoCallback)
+    }
+
+    @Test
+    fun `history delegate passes through onVisited calls`() {
+        val storage: HistoryStorage = mock()
+        val delegate = HistoryDelegate(storage)
+
+        delegate.onVisited("http://www.mozilla.org", false, false)
+        verify(storage).recordVisit("http://www.mozilla.org", VisitType.LINK)
+
+        delegate.onVisited("http://www.firefox.com", true, false)
+        verify(storage).recordVisit("http://www.firefox.com", VisitType.RELOAD)
+    }
+
+    @Test
+    fun `history delegate passes through onTitleChanged calls`() {
+        val storage: HistoryStorage = mock()
+        val delegate = HistoryDelegate(storage)
+
+        delegate.onTitleChanged("http://www.mozilla.org", "Mozilla", false)
+        verify(storage).recordObservation("http://www.mozilla.org", PageObservation("Mozilla"))
+    }
+
+    @Test
+    fun `history delegate passes through getVisited calls`() {
+        val storage: HistoryStorage = mock()
+        val delegate = HistoryDelegate(storage)
+
+        val systemCallback = mock<(List<String>) -> Unit>()
+        delegate.getVisited(systemCallback, false)
+        verify(storage).getVisited(systemCallback)
+
+        val geckoCallback = mock<(List<Boolean>) -> Unit>()
+        delegate.getVisited(listOf("http://www.mozilla.org", "http://www.firefox.com"), geckoCallback, false)
+        verify(storage).getVisited(listOf("http://www.mozilla.org", "http://www.firefox.com"), geckoCallback)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,8 +84,24 @@ permalink: /changelog/
             }
          }
   ```
+* **concept-storage**:
+  * Added a new concept for describing an interface for storing browser data. First iteration includes a description of `HistoryStorage`.
+* **browser-storage-memory**:
+  * Added an in-memory implementation of `concept-storage`.
+* **feature-storage**:
+  * Added a first iteration of `feature-storage`, which includes `HistoryTrackingFeature` that ties together `concept-storage` and `concept-engine` and allows engines to track history visits and page meta information. It does so by implementing `HistoryTrackingDelegate` defined by `concept-engine`.
+  Before adding a first session to the engine, initialize the history tracking feature:
+  ```kotlin
+  val historyTrackingFeature = HistoryTrackingFeature(
+    components.engine,
+    components.historyStorage
+  )
+  ```
+  Once the feature has been initialized, history will be tracked for all subsequently added sessions.
+* **sample-browser**:
+  * Updated the sample browser to track browsing history using an in-memory history storage implementation (how much is actually tracked in practice depends on which engine is being used. As of this release, only `SystemEngine` provides a full set of necessary APIs).
 * **lib-jexl**
-  * New component for for evaluating Javascript Expression Language (JEXL) expressions. This implementation is based on [Mozjexl](https://github.com/mozilla/mozjexl) used at Mozilla, specifically as a part of SHIELD and Normandy. In a future version of Fretboard JEXL will allow more complex rules for experiments. For more see [documentation](https://github.com/mozilla-mobile/android-components/blob/master/components/lib/jexl/README.md).
+  * New component for evaluating Javascript Expression Language (JEXL) expressions. This implementation is based on [Mozjexl](https://github.com/mozilla/mozjexl) used at Mozilla, specifically as a part of SHIELD and Normandy. In a future version of Fretboard JEXL will allow more complex rules for experiments. For more see [documentation](https://github.com/mozilla-mobile/android-components/blob/master/components/lib/jexl/README.md).
 
 # 0.28.0
 

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     implementation project(':concept-engine')
     implementation project(':concept-tabstray')
     implementation project(':concept-toolbar')
+    implementation project(':concept-storage')
 
     implementation project(':browser-engine-system')
 
@@ -117,10 +118,12 @@ dependencies {
     implementation project(':browser-tabstray')
     implementation project(':browser-toolbar')
     implementation project(':browser-menu')
+    implementation project(':browser-storage-memory')
 
     implementation project(':feature-intent')
     implementation project(':feature-search')
     implementation project(':feature-session')
+    implementation project(':feature-storage')
     implementation project(':feature-toolbar')
     implementation project(':feature-tabs')
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -15,6 +15,7 @@ import kotlinx.android.synthetic.main.fragment_browser.*
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.SimpleDownloadDialogFragment.DownloadDialogListener
 import mozilla.components.feature.session.SessionFeature
+import mozilla.components.feature.storage.HistoryTrackingFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.support.ktx.android.content.isPermissionGranted
@@ -25,6 +26,7 @@ class BrowserFragment : Fragment(), BackHandler, DownloadDialogListener {
     private lateinit var toolbarFeature: ToolbarFeature
     private lateinit var tabsToolbarFeature: TabsToolbarFeature
     private lateinit var downloadsFeature: DownloadsFeature
+    private lateinit var historyTrackingFeature: HistoryTrackingFeature
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_browser, container, false)
@@ -36,6 +38,11 @@ class BrowserFragment : Fragment(), BackHandler, DownloadDialogListener {
         toolbar.setMenuBuilder(components.menuBuilder)
 
         val sessionId = arguments?.getString(SESSION_ID)
+
+        historyTrackingFeature = HistoryTrackingFeature(
+                components.engine,
+                components.historyStorage
+        )
 
         sessionFeature = SessionFeature(
                 components.sessionManager,

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.DefaultSessionStorage
+import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.intent.IntentProcessor
@@ -33,6 +34,9 @@ open class DefaultComponents(private val applicationContext: Context) {
         )
         SystemEngine(applicationContext, settings)
     }
+
+    // Storage
+    val historyStorage by lazy { InMemoryHistoryStorage() }
 
     // Session
     val sessionStorage by lazy { DefaultSessionStorage(applicationContext) }

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ setupProject(':concept-awesomebar', 'components/concept/awesomebar', 'An abstrac
 setupProject(':concept-toolbar', 'components/concept/toolbar', 'An abstract definition of a toolbar component.')
 setupProject(':concept-tabstray', 'components/concept/tabstray', 'An abstract definition of a tabs tray component.')
 setupProject(':concept-engine', 'components/concept/engine', 'An abstract layer hiding the actual browser engine implementation.')
+setupProject(':concept-storage', 'components/concept/storage', 'An abstract definition of a browser storage layer.')
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Features

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,7 @@ setupProject(':browser-errorpages', 'components/browser/errorpages', 'Responsive
 setupProject(':browser-menu', 'components/browser/menu', 'A customizable menu for browsers.')
 setupProject(':browser-search', 'components/browser/search', 'Search plugins and companion code to load, parse and use them.')
 setupProject(':browser-session', 'components/browser/session', 'An abstract layer hiding the actual browser engine implementation.')
+setupProject(':browser-storage-memory', 'components/browser/storage-memory', 'A memory-backed implementation of core data storage.')
 setupProject(':browser-tabstray', 'components/browser/tabstray', 'A tabs tray component for browsers.')
 setupProject(':browser-toolbar', 'components/browser/toolbar', 'A customizable toolbar for browsers.')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,7 @@ setupProject(':concept-storage', 'components/concept/storage', 'An abstract defi
 setupProject(':feature-intent', 'components/feature/intent', 'Combining various feature components for intent processing.')
 setupProject(':feature-search', 'components/feature/search', 'Feature implementation connecting an engine implementation with the search module.')
 setupProject(':feature-session', 'components/feature/session', 'Feature implementation connecting an engine implementation with the session module.')
+setupProject(':feature-storage', 'components/feature/storage', 'Feature implementation connecting a storage implementation with various consumers (like an engine implementation).')
 setupProject(':feature-tabs', 'components/feature/tabs', 'Feature implementation connecting a tabs tray implementation with the session and toolbar modules.')
 setupProject(':feature-toolbar', 'components/feature/toolbar', 'Feature implementation connecting a toolbar implementation with the session module.')
 setupProject(':feature-downloads', 'components/feature/downloads', 'Feature implementation for apps that want to use Android downloads manager.')


### PR DESCRIPTION
This patch provides an in-memory implementation of HistoryTrackingDelegate
which may be used in conjunction with `concept-engine` to enable link colouring
and basic page meta tracking. (link colouring currently works with SystemEngine, and should work with GeckoView once its HistoryDelegate support is in place - see https://bugzilla.mozilla.org/show_bug.cgi?id=1494713).

Implementation lives within a `core-storage-local` component. "Local" is used to
denote that this component is intended for various non-syncable implementations storage
implementations. I intend for #905 to also live within this component.