### PR TITLE
Closes #1106: Enhance RequestInterceptor to load alternative URL

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
 import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
@@ -259,7 +260,10 @@ class GeckoEngineSession(
                 this@GeckoEngineSession,
                 request.uri
             )?.apply {
-                loadData(data, mimeType, encoding)
+                when (this) {
+                    is InterceptionResponse.Content -> loadData(data, mimeType, encoding)
+                    is InterceptionResponse.Url -> loadUrl(url)
+                }
             }
 
             return GeckoResult.fromValue(if (response != null) AllowOrDeny.DENY else AllowOrDeny.ALLOW)

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -481,13 +481,13 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun settingRequestInterceptor() {
+    fun settingInterceptorToProvideAlternativeContent() {
         var interceptorCalledWithUri: String? = null
 
         val interceptor = object : RequestInterceptor {
             override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
-                return RequestInterceptor.InterceptionResponse("<h1>Hello World</h1>")
+                return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
             }
         }
 
@@ -499,8 +499,31 @@ class GeckoEngineSessionTest {
         engineSession.geckoSession.navigationDelegate.onLoadRequest(
             engineSession.geckoSession, mockLoadRequest("sample:about"))
 
-        assertEquals("sample:about", interceptorCalledWithUri!!)
+        assertEquals("sample:about", interceptorCalledWithUri)
         verify(engineSession.geckoSession).loadString("<h1>Hello World</h1>", "text/html")
+    }
+
+    @Test
+    fun settingInterceptorToProvideAlternativeUrl() {
+        var interceptorCalledWithUri: String? = null
+
+        val interceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+                interceptorCalledWithUri = uri
+                return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
+            }
+        }
+
+        val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
+
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+        engineSession.geckoSession = spy(engineSession.geckoSession)
+
+        engineSession.geckoSession.navigationDelegate.onLoadRequest(
+                engineSession.geckoSession, mockLoadRequest("sample:about"))
+
+        assertEquals("sample:about", interceptorCalledWithUri)
+        verify(engineSession.geckoSession).loadUri("https://mozilla.org")
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
 import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
@@ -259,7 +260,10 @@ class GeckoEngineSession(
                 this@GeckoEngineSession,
                 request.uri
             )?.apply {
-                loadData(data, mimeType, encoding)
+                when (this) {
+                    is InterceptionResponse.Content -> loadData(data, mimeType, encoding)
+                    is InterceptionResponse.Url -> loadUrl(url)
+                }
             }
 
             return GeckoResult.fromValue(if (response != null) AllowOrDeny.DENY else AllowOrDeny.ALLOW)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -481,13 +481,13 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun settingRequestInterceptor() {
+    fun settingInterceptorToProvideAlternativeContent() {
         var interceptorCalledWithUri: String? = null
 
         val interceptor = object : RequestInterceptor {
             override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
-                return RequestInterceptor.InterceptionResponse("<h1>Hello World</h1>")
+                return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
             }
         }
 
@@ -497,10 +497,33 @@ class GeckoEngineSessionTest {
         engineSession.geckoSession = spy(engineSession.geckoSession)
 
         engineSession.geckoSession.navigationDelegate.onLoadRequest(
-            engineSession.geckoSession, mockLoadRequest("sample:about"))
+                engineSession.geckoSession, mockLoadRequest("sample:about"))
 
-        assertEquals("sample:about", interceptorCalledWithUri!!)
+        assertEquals("sample:about", interceptorCalledWithUri)
         verify(engineSession.geckoSession).loadString("<h1>Hello World</h1>", "text/html")
+    }
+
+    @Test
+    fun settingInterceptorToProvideAlternativeUrl() {
+        var interceptorCalledWithUri: String? = null
+
+        val interceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+                interceptorCalledWithUri = uri
+                return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
+            }
+        }
+
+        val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
+
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+        engineSession.geckoSession = spy(engineSession.geckoSession)
+
+        engineSession.geckoSession.navigationDelegate.onLoadRequest(
+                engineSession.geckoSession, mockLoadRequest("sample:about"))
+
+        assertEquals("sample:about", interceptorCalledWithUri)
+        verify(engineSession.geckoSession).loadUri("https://mozilla.org")
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -15,6 +15,7 @@ import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.support.ktx.android.util.Base64
+import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
@@ -262,7 +263,10 @@ class GeckoEngineSession(
                 this@GeckoEngineSession,
                 uri
             )?.apply {
-                loadData(data, mimeType, encoding)
+                when (this) {
+                    is InterceptionResponse.Content -> loadData(data, mimeType, encoding)
+                    is InterceptionResponse.Url -> loadUrl(url)
+                }
             }
 
             return GeckoResult.fromValue(response != null)

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -481,13 +481,13 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun settingRequestInterceptor() {
+    fun settingInterceptorToProvideAlternativeContent() {
         var interceptorCalledWithUri: String? = null
 
         val interceptor = object : RequestInterceptor {
             override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
-                return RequestInterceptor.InterceptionResponse("<h1>Hello World</h1>")
+                return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
             }
         }
 
@@ -499,8 +499,31 @@ class GeckoEngineSessionTest {
         engineSession.geckoSession.navigationDelegate.onLoadRequest(
                 engineSession.geckoSession, "sample:about", 0, 0)
 
-        assertEquals("sample:about", interceptorCalledWithUri!!)
+        assertEquals("sample:about", interceptorCalledWithUri)
         verify(engineSession.geckoSession).loadString("<h1>Hello World</h1>", "text/html")
+    }
+
+    @Test
+    fun settingInterceptorToProvideAlternativeUrl() {
+        var interceptorCalledWithUri: String? = null
+
+        val interceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+                interceptorCalledWithUri = uri
+                return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
+            }
+        }
+
+        val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
+
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+        engineSession.geckoSession = spy(engineSession.geckoSession)
+
+        engineSession.geckoSession.navigationDelegate.onLoadRequest(
+                engineSession.geckoSession, "sample:about", 0, 0)
+
+        assertEquals("sample:about", interceptorCalledWithUri)
+        verify(engineSession.geckoSession).loadUri("https://mozilla.org")
     }
 
     @Test

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
@@ -14,11 +14,15 @@ interface RequestInterceptor {
     /**
      * An alternative response for an intercepted request.
      */
-    data class InterceptionResponse(
-        val data: String,
-        val mimeType: String = "text/html",
-        val encoding: String = "UTF-8"
-    )
+    sealed class InterceptionResponse {
+        data class Content(
+            val data: String,
+            val mimeType: String = "text/html",
+            val encoding: String = "UTF-8"
+        ) : InterceptionResponse()
+
+        data class Url(val url: String) : InterceptionResponse()
+    }
 
     /**
      * An alternative response for an error request.
@@ -31,11 +35,13 @@ interface RequestInterceptor {
     )
 
     /**
-     * A request to open an URI. This is called before each page load to allow custom behavior implementation.
+     * A request to open an URI. This is called before each page load to allow
+     * providing custom behavior.
      *
      * @param session The engine session that initiated the callback.
-     * @return An InterceptionResponse object containing alternative content if the request should be intercepted.
-     *         <code>null</code> otherwise.
+     * @return An [InterceptionResponse] object containing alternative content
+     * or an alternative URL. Null if the original request should continue to
+     * be loaded.
      */
     fun onLoadRequest(session: EngineSession, uri: String): InterceptionResponse? = null
 
@@ -43,10 +49,11 @@ interface RequestInterceptor {
      * A request that the engine wasn't able to handle that resulted in an error.
      *
      * @param session The engine session that initiated the callback.
-     * @param errorType The error that was provided by the engine related to the type of error caused.
+     * @param errorType The error that was provided by the engine related to the
+     * type of error caused.
      * @param uri The uri that resulted in the error.
-     * @return An ErrorResponse object containing alternative content if the request caused an error.
-     *         <code>null</code> otherwise.
+     * @return An [ErrorResponse] object containing content to display for the
+     * provided error type.
      */
     fun onErrorRequest(session: EngineSession, errorType: ErrorType, uri: String?): ErrorResponse? = null
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/request/RequestInterceptorTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/request/RequestInterceptorTest.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.request
+
+import mozilla.components.browser.errorpages.ErrorType
+import mozilla.components.concept.engine.EngineSession
+import org.junit.Test
+import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.engine.request.RequestInterceptor.ErrorResponse
+import org.junit.Assert.assertEquals
+import org.mockito.Mockito.mock
+
+class RequestInterceptorTest {
+
+    @Test
+    fun `match interception response`() {
+        val urlResponse = InterceptionResponse.Url("https://mozilla.org")
+        val contentReponse = InterceptionResponse.Content("data")
+
+        var url: String = when (urlResponse) {
+            is InterceptionResponse.Url -> urlResponse.url
+            else -> ""
+        }
+        var content: Triple<String, String, String> = when (contentReponse) {
+            is InterceptionResponse.Content ->
+                Triple(contentReponse.data, contentReponse.encoding, contentReponse.mimeType)
+            else -> Triple("", "", "")
+        }
+
+        assertEquals("https://mozilla.org", url)
+        assertEquals(Triple("data", "UTF-8", "text/html"), content)
+    }
+
+    @Test
+    fun `error response has default values`() {
+        val errorResponse = ErrorResponse("data")
+        assertEquals("data", errorResponse.data)
+        assertEquals("text/html", errorResponse.mimeType)
+        assertEquals("UTF-8", errorResponse.encoding)
+        assertEquals(null, errorResponse.url)
+    }
+
+    @Test
+    fun `interceptor has default methods`() {
+        val engineSession = mock(EngineSession::class.java)
+        val interceptor = object : RequestInterceptor { }
+        interceptor.onLoadRequest(engineSession, "url")
+        interceptor.onErrorRequest(engineSession, ErrorType.ERROR_UNKNOWN_SOCKET_TYPE, null)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,29 @@ permalink: /changelog/
             }
         })
   ```
+* **concept-engine**, **browser-engine-system**, **browser-engine-gecko(-beta/nightly)**
+  * `RequestInterceptor` was enhanced to support loading an alternative URL.  
+  :warning: **This is a breaking change for the `RequestInterceptor` method signature!**
+  ```kotlin
+          // To provide alternative content the new InterceptionResponse.Content type needs to be used
+          requestInterceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): InterceptionResponse? {
+                return when (uri) {
+                    "sample:about" -> InterceptionResponse.Content("<h1>I am the sample browser</h1>")
+                    else -> null
+                }
+            }
+          }
+          // To provide an alternative URL the new InterceptionResponse.Url type needs to be used
+          requestInterceptor = object : RequestInterceptor {
+            override fun onLoadRequest(session: EngineSession, uri: String): InterceptionResponse? {
+               return when (uri) {
+                    "sample:about" -> InterceptionResponse.Url("sample:aboutNew")
+                    else -> null
+               }
+            }
+         }
+  ```
 * **lib-jexl**
   * New component for for evaluating Javascript Expression Language (JEXL) expressions. This implementation is based on [Mozjexl](https://github.com/mozilla/mozjexl) used at Mozilla, specifically as a part of SHIELD and Normandy. In a future version of Fretboard JEXL will allow more complex rules for experiments. For more see [documentation](https://github.com/mozilla-mobile/android-components/blob/master/components/lib/jexl/README.md).
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
@@ -9,11 +9,13 @@ import mozilla.components.browser.errorpages.ErrorPages
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.engine.request.RequestInterceptor.ErrorResponse
 
 class SampleRequestInterceptor(val context: Context) : RequestInterceptor {
-    override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+    override fun onLoadRequest(session: EngineSession, uri: String): InterceptionResponse? {
         return when (uri) {
-            "sample:about" -> RequestInterceptor.InterceptionResponse("<h1>I am the sample browser</h1>")
+            "sample:about" -> InterceptionResponse.Content("<h1>I am the sample browser</h1>")
             else -> null
         }
     }
@@ -22,7 +24,7 @@ class SampleRequestInterceptor(val context: Context) : RequestInterceptor {
         session: EngineSession,
         errorType: ErrorType,
         uri: String?
-    ): RequestInterceptor.ErrorResponse? {
-        return RequestInterceptor.ErrorResponse(ErrorPages.createErrorPage(context, errorType, uri))
+    ): ErrorResponse? {
+        return ErrorResponse(ErrorPages.createErrorPage(context, errorType, uri))
     }
 }


### PR DESCRIPTION
Turned `InterceptionResponse` into a sealed class. Adding just a `url` field would have allowed for incorrect API usage i.e. one could've provided both a `url` and `data` which wouldn't make sense.

This is a breaking API change, but it's minimal: 
```Kotlin
return InterceptionResponse("data") 
```
becomes
```Kotlin
return InterceptionResponse.Content("data")
```

I will add this to the changelog if we decide to land this.