### PR TITLE
Closes #1128: browser-engine-system: Automatically grant playing protected media (EME APIs).

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -17,20 +17,21 @@ import android.util.AttributeSet
 import android.view.View
 import android.webkit.CookieManager
 import android.webkit.DownloadListener
+import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import android.webkit.WebViewClient
-import android.webkit.ValueCallback
 import android.webkit.WebView.HitTestResult.EMAIL_TYPE
 import android.webkit.WebView.HitTestResult.GEO_TYPE
 import android.webkit.WebView.HitTestResult.IMAGE_TYPE
 import android.webkit.WebView.HitTestResult.PHONE_TYPE
 import android.webkit.WebView.HitTestResult.SRC_ANCHOR_TYPE
 import android.webkit.WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE
+import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import mozilla.components.browser.engine.system.matcher.UrlMatcher
 import mozilla.components.browser.errorpages.ErrorType
@@ -247,6 +248,7 @@ class SystemEngineView @JvmOverloads constructor(
 
     private fun isLowOnMemory() = testLowMemory || (context?.isOSOnLowMemory() == true)
 
+    @Suppress("ComplexMethod")
     private fun createWebChromeClient() = object : WebChromeClient() {
         override fun getVisitedHistory(callback: ValueCallback<Array<String>>) {
             // TODO private browsing not supported for SystemEngine
@@ -283,6 +285,16 @@ class SystemEngineView @JvmOverloads constructor(
         override fun onHideCustomView() {
             removeFullScreenView()
             session?.internalNotifyObservers { onFullScreenChange(false) }
+        }
+
+        override fun onPermissionRequest(request: PermissionRequest) {
+            if (request.resources.contains(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)) {
+                // For now we automatically grant playing protected media (EME APIs).
+                // See https://github.com/mozilla-mobile/android-components/issues/1128
+                request.grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+            } else {
+                super.onPermissionRequest(request)
+            }
         }
     }
 


### PR DESCRIPTION
This is a workaround for Firefox for Fire TV to play DRM content automatically.

Eventually we want to implement this API in a way that the app (or another component) can
handle those requests. See: https://github.com/mozilla-mobile/android-components/issues/1157