### PR TITLE
Issue #1160: Glean: Expose library version as BuildConfig flag.

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -11,6 +11,8 @@ android {
     defaultConfig {
         minSdkVersion Config.minSdkVersion
         targetSdkVersion Config.targetSdkVersion
+
+        buildConfigField("String", "LIBRARY_VERSION", "\"" + Config.componentsVersion + "\"")
     }
 
     buildTypes {


### PR DESCRIPTION
This exposes a constant in the `BuildConfig` class that contains the version number of the library, e.g.:

```Kotlin
package mozilla.components.service.glean;

public final class BuildConfig {
  // ... everything else
  public static final String LIBRARY_VERSION = "0.29.0";
}

```