### PR TITLE
Issue #1109: Expose methods for switching between display/edit mode via toolbar concept component.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -250,7 +250,7 @@ class BrowserToolbar @JvmOverloads constructor(
     /**
      * Switches to URL editing mode.
      */
-    fun editMode() {
+    override fun editMode() {
         val urlValue = if (searchTerms.isEmpty()) url else searchTerms
         editToolbar.updateUrl(urlValue)
 
@@ -262,7 +262,7 @@ class BrowserToolbar @JvmOverloads constructor(
     /**
      * Switches to URL displaying mode.
      */
-    fun displayMode() {
+    override fun displayMode() {
         updateState(State.DISPLAY)
     }
 

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -16,6 +16,7 @@ import java.lang.ref.WeakReference
 /**
  * Interface to be implemented by components that provide browser toolbar functionality.
  */
+@Suppress("TooManyFunctions")
 interface Toolbar {
     /**
      * Sets/Gets the URL to be displayed on the toolbar.
@@ -79,6 +80,16 @@ interface Toolbar {
      * Registers the given listener to be invoked when the user edits the URL.
      */
     fun setOnEditListener(listener: OnEditListener)
+
+    /**
+     * Switches to URL displaying mode (from editing mode) if supported by the toolbar implementation.
+     */
+    fun displayMode()
+
+    /**
+     * Switches to URL editing mode (from displaying mode) if supported by the toolbar implementation.
+     */
+    fun editMode()
 
     /**
      * Listener to be invoked when the user edits the URL.


### PR DESCRIPTION
Another small piece for #1109. When selecting items from the awesombar we need to be able to automatically leave editing mode (from the feature component).