### PR TITLE
Updates the requirement for GV Crash reporting

### DIFF
--- a/components/lib/crash/README.md
+++ b/components/lib/crash/README.md
@@ -172,7 +172,7 @@ crashReporter.submitReport(crash)
 
 ### Sending GeckoView crash reports
 
-⚠️ Note: For sending GeckoView crash reports GeckoView **63.0** or higher is required!
+⚠️ Note: For sending GeckoView crash reports GeckoView **64.0** or higher is required!
 
 Register `CrashHandlerService` as crash handler for GeckoView:
 


### PR DESCRIPTION
This API isn't available in 63. So it now requires 64