### PR TITLE
Issue #1094: Use JEXL in fretboard

### DIFF
--- a/components/service/fretboard/build.gradle
+++ b/components/service/fretboard/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     implementation project(':support-ktx')
     implementation project(':support-base')
+    implementation project(':lib-jexl')
 
 
     testImplementation Deps.testing_junit

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/Experiment.kt
@@ -76,7 +76,11 @@ data class Experiment(
         /**
          * Required app release channel (alpha, beta, ...), as a regex
          */
-        val releaseChannel: String? = null
+        val releaseChannel: String? = null,
+        /**
+         * Activation condition as a JEXL expression
+         */
+        val jexl: String? = null
     )
 
     data class Bucket(

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/JSONExperimentParser.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/JSONExperimentParser.kt
@@ -36,7 +36,8 @@ class JSONExperimentParser {
                 matchObject.tryGetString(MANUFACTURER_KEY),
                 matchObject.tryGetString(DEVICE_KEY),
                 matchObject.tryGetString(COUNTRY_KEY),
-                matchObject.tryGetString(RELEASE_CHANNEL_KEY))
+                matchObject.tryGetString(RELEASE_CHANNEL_KEY),
+                matchObject.tryGetString(JEXL_KEY))
         } else null
         val bucket = if (bucketsObject != null) {
             Experiment.Bucket(bucketsObject.tryGetInt(MAX_KEY), bucketsObject.tryGetInt(MIN_KEY))
@@ -87,6 +88,7 @@ class JSONExperimentParser {
         matchObject.putIfNotNull(REGIONS_KEY, experiment.match?.regions?.let { JSONArray(it) })
         matchObject.putIfNotNull(RELEASE_CHANNEL_KEY, experiment.match?.releaseChannel)
         matchObject.putIfNotNull(VERSION_KEY, experiment.match?.version)
+        matchObject.putIfNotNull(JEXL_KEY, experiment.match?.jexl)
         return matchObject
     }
 
@@ -139,5 +141,6 @@ class JSONExperimentParser {
         private const val LAST_MODIFIED_KEY = "last_modified"
         private const val SCHEMA_KEY = "schema"
         private const val PAYLOAD_KEY = "values"
+        private const val JEXL_KEY = "jexl"
     }
 }

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/JexlExtensions.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/JexlExtensions.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import mozilla.components.lib.jexl.evaluator.JexlContext
+import mozilla.components.lib.jexl.ext.toJexl
+
+fun ValuesProvider.toJexlContext(context: Context): JexlContext {
+    return JexlContext(
+        "language" to getLanguage(context).toJexl(),
+        "appId" to getAppId(context).toJexl(),
+        "version" to getVersion(context).toJexl(),
+        "manufacturer" to getManufacturer(context).toJexl(),
+        "device" to getDevice(context).toJexl(),
+        "country" to getCountry(context).toJexl(),
+        "clientId" to getClientId(context).toJexl()
+    ).apply {
+        getRegion(context)?.let { set("region", it.toJexl()) }
+        getReleaseChannel(context)?.let { set("releaseChannel", it.toJexl()) }
+        addCustomValuesToJexlContext(values, this)
+    }
+}
+
+private fun addCustomValuesToJexlContext(values: Map<String, Any>, jexlContext: JexlContext) {
+    values.forEach {
+        val value = it.value
+        when (value) {
+            is String -> jexlContext.set(it.key, value.toJexl())
+            is Int -> jexlContext.set(it.key, value.toJexl())
+            is Double -> jexlContext.set(it.key, value.toJexl())
+            is Float -> jexlContext.set(it.key, value.toJexl())
+            is Boolean -> jexlContext.set(it.key, value.toJexl())
+        }
+    }
+}

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ValuesProvider.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/ValuesProvider.kt
@@ -14,6 +14,12 @@ import java.util.MissingResourceException
  * custom filter values
  */
 open class ValuesProvider {
+
+    private val valuesMap: MutableMap<String, Any> = mutableMapOf()
+
+    val values: Map<String, Any>
+        get() = valuesMap.toMap()
+
     /**
      * Provides the user's language
      *
@@ -99,5 +105,9 @@ open class ValuesProvider {
      */
     open fun getClientId(context: Context): String {
         return DeviceUuidFactory(context).uuid
+    }
+
+    fun putValue(key: String, value: Any) {
+        valuesMap[key] = value
     }
 }

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/JexlExtensionsTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/JexlExtensionsTest.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fretboard
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class JexlExtensionsTest {
+    @Test
+    fun `generated jexl context is valid`() {
+        val provider = object : ValuesProvider() {
+            override fun getRegion(context: Context): String? {
+                return "UK"
+            }
+
+            override fun getReleaseChannel(context: Context): String? {
+                return "alpha"
+            }
+        }
+        provider.putValue("test-key", "test-value")
+        provider.putValue("second-key", "second-value")
+        val jexlContext = provider.toJexlContext(mockContext())
+        assertEquals("eng", jexlContext.get("language").toString())
+        assertEquals("test.appId", jexlContext.get("appId").toString())
+        assertEquals("test.version", jexlContext.get("version").toString())
+        assertEquals("unknown", jexlContext.get("manufacturer").toString())
+        assertEquals("robolectric", jexlContext.get("device").toString())
+        assertEquals("USA", jexlContext.get("country").toString())
+        assertEquals("UK", jexlContext.get("region").toString())
+        assertEquals("alpha", jexlContext.get("releaseChannel").toString())
+        assertNotNull("clientId", jexlContext.get("clientId").toString())
+        assertEquals("test-value", jexlContext.get("test-key").toString())
+        assertEquals("second-value", jexlContext.get("second-key").toString())
+    }
+
+    private fun mockContext(): Context {
+        val context = mock(Context::class.java)
+        `when`(context.packageName).thenReturn("test.appId")
+        val sharedPreferences = mock(SharedPreferences::class.java)
+        `when`(sharedPreferences.getBoolean(ArgumentMatchers.eq("testexperiment"), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
+        `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
+        val editor = mock(SharedPreferences.Editor::class.java)
+        `when`(editor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(editor)
+        `when`(sharedPreferences.edit()).thenReturn(editor)
+        val packageManager = mock(PackageManager::class.java)
+        val packageInfo = PackageInfo()
+        packageInfo.versionName = "test.version"
+        `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+        return context
+    }
+}

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ValuesProviderTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ValuesProviderTest.kt
@@ -43,4 +43,15 @@ class ValuesProviderTest {
         Locale.setDefault(Locale("cnr", "CS"))
         assertEquals("CS", ValuesProvider().getCountry(mock(Context::class.java)))
     }
+
+    @Test
+    fun `custom values`() {
+        val provider = ValuesProvider()
+        provider.putValue("first", 1)
+        provider.putValue("second", "other")
+        val values = provider.values
+        assertEquals(2, values.size)
+        assertEquals(1, values["first"])
+        assertEquals("other", values["second"])
+    }
 }


### PR DESCRIPTION
This pull request adds a field `jexl` to the `Experiment.Matcher` class which contains a JEXL expression to be evaluated. The experiment will only be enabled if that expression evaluates to true, along with the rest of matchers

Closes #1094