### PR TITLE
Closes #1191: Use escaped apostrophe in CDATA strings [ci skip]

### DIFF
--- a/components/browser/errorpages/src/main/res/raw/error_pages.html
+++ b/components/browser/errorpages/src/main/res/raw/error_pages.html
@@ -5,6 +5,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <html xmlns="http://www.w3.org/1999/xhtml">
+    <meta charset="UTF-8">
     <head>
         <meta name="viewport" content="width=device-width; user-scalable=false;" />
         <title>%pageTitle%</title>


### PR DESCRIPTION
In CDATA strings, you need to escape the apostrophe so that it renders
correctly. Currently, it shows some garbald text when the page is
rendered.