### PR TITLE
Closes #756: Add new BrowserToolbar text attributes

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.toolbar
 
 import android.content.Context
+import android.graphics.Typeface
 import android.support.annotation.DrawableRes
 import android.support.annotation.VisibleForTesting
 import android.util.AttributeSet
@@ -101,6 +102,46 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     /**
+     * Sets the colour of the text to be displayed when the URL of the toolbar is empty.
+     */
+    var hintColor: Int
+        get() = displayToolbar.urlView.currentHintTextColor
+        set(value) {
+            displayToolbar.urlView.setHintTextColor(value)
+            editToolbar.urlView.setHintTextColor(value)
+        }
+
+    /**
+     * Sets the colour of the text for the URL/search term displayed in the toolbar.
+     */
+    var textColor: Int
+        get() = displayToolbar.urlView.currentTextColor
+        set(value) {
+            displayToolbar.urlView.setTextColor(value)
+            editToolbar.urlView.setTextColor(value)
+        }
+
+    /**
+     * Sets the size of the text for the URL/search term displayed in the toolbar.
+     */
+    var textSize: Float
+        get() = displayToolbar.urlView.textSize
+        set(value) {
+            displayToolbar.urlView.textSize = value
+            editToolbar.urlView.textSize = value
+        }
+
+    /**
+     * Sets the typeface of the text for the URL/search term displayed in the toolbar.
+     */
+    var typeface: Typeface
+        get() = displayToolbar.urlView.typeface
+        set(value) {
+            displayToolbar.urlView.typeface = value
+            editToolbar.urlView.typeface = value
+        }
+
+    /**
      * Sets a listener to be invoked when focus of the URL input view (in edit mode) changed.
      */
     fun setOnEditFocusChangeListener(listener: (Boolean) -> Unit) {
@@ -145,6 +186,23 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     init {
+        context.obtainStyledAttributes(attrs, R.styleable.BrowserToolbar, defStyleAttr, 0).apply {
+            attrs?.let {
+                hintColor = getColor(
+                    R.styleable.BrowserToolbar_browserToolbarHintColor,
+                    hintColor
+                )
+                textColor = getColor(
+                    R.styleable.BrowserToolbar_browserToolbarTextColor,
+                    textColor
+                )
+                textSize = getDimension(
+                    R.styleable.BrowserToolbar_browserToolbarTextSize,
+                    textSize
+                ) / resources.displayMetrics.density
+            }
+            recycle()
+        }
         addView(displayToolbar)
         addView(editToolbar)
 

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<resources>
+  <declare-styleable name="BrowserToolbar">
+    <attr name="browserToolbarHintColor" format="color"/>
+    <attr name="browserToolbarTextColor" format="color"/>
+    <attr name="browserToolbarTextSize" format="dimension"/>
+  </declare-styleable>
+</resources>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.browser.toolbar
 
+import android.graphics.Color
+import android.graphics.Typeface
+import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import mozilla.components.browser.menu.BrowserMenuBuilder
@@ -15,6 +18,7 @@ import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -543,5 +547,70 @@ class BrowserToolbarTest {
         assertEquals(view.paddingTop, 20)
         assertEquals(view.paddingRight, 24)
         assertEquals(view.paddingBottom, 28)
+    }
+
+    @Test
+    fun `hintColor changes edit and display urlView`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        assertTrue(toolbar.displayToolbar.urlView.currentHintTextColor != Color.RED)
+        assertTrue(toolbar.editToolbar.urlView.currentHintTextColor != Color.RED)
+
+        toolbar.hintColor = Color.RED
+
+        assertEquals(Color.RED, toolbar.displayToolbar.urlView.currentHintTextColor)
+        assertEquals(Color.RED, toolbar.editToolbar.urlView.currentHintTextColor)
+    }
+
+    @Test
+    fun `textColor changes edit and display urlView`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        assertTrue(toolbar.displayToolbar.urlView.currentTextColor != Color.RED)
+        assertTrue(toolbar.editToolbar.urlView.currentTextColor != Color.RED)
+
+        toolbar.textColor = Color.RED
+
+        assertEquals(Color.RED, toolbar.displayToolbar.urlView.currentTextColor)
+        assertEquals(Color.RED, toolbar.editToolbar.urlView.currentTextColor)
+    }
+
+    @Test
+    fun `textSize changes edit and display urlView`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        assertTrue(toolbar.displayToolbar.urlView.textSize != 12f)
+        assertTrue(toolbar.editToolbar.urlView.textSize != 12f)
+
+        toolbar.textSize = 12f
+
+        assertEquals(12f, toolbar.displayToolbar.urlView.textSize)
+        assertEquals(12f, toolbar.editToolbar.urlView.textSize)
+    }
+
+    @Test
+    fun `typeface changes edit and display urlView`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        val typeface: Typeface = mock()
+
+        assertNotEquals(typeface, toolbar.editToolbar.urlView.typeface)
+        assertNotEquals(typeface, toolbar.displayToolbar.urlView.typeface)
+
+        toolbar.typeface = typeface
+
+        assertEquals(typeface, toolbar.displayToolbar.urlView.typeface)
+        assertEquals(typeface, toolbar.editToolbar.urlView.typeface)
+    }
+
+    @Test
+    fun `obtainAttributes called when attributes provided`() {
+        val application = spy(RuntimeEnvironment.application)
+        val attributeSet: AttributeSet = mock()
+
+        BrowserToolbar(application)
+        verify(application, never()).obtainStyledAttributes(attributeSet, R.styleable.BrowserToolbar, 0, 0)
+
+        BrowserToolbar(application, attributeSet)
+        verify(application).obtainStyledAttributes(attributeSet, R.styleable.BrowserToolbar, 0, 0)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,19 +17,36 @@ permalink: /changelog/
 * **browser-toolbar**:
   * Added new listener to get notified when the user is editing the URL:
   ```kotlin
-          toolbar.setOnEditListener(object : Toolbar.OnEditListener {
-            override fun onTextChanged(text: String) {
-              // Fired whenever the user changes the text in the address bar.
-            }
+  toolbar.setOnEditListener(object : Toolbar.OnEditListener {
+      override fun onTextChanged(text: String) {
+          // Fired whenever the user changes the text in the address bar.
+      }
 
-            override fun onStartEditing() {
-              // Fired when the toolbar switches to edit mode.
-            }
+      override fun onStartEditing() {
+          // Fired when the toolbar switches to edit mode.
+      }
 
-            override fun onStopEditing() {
-              // Fired when the toolbar switches back to display mode.
-            }
-        })
+      override fun onStopEditing() {
+          // Fired when the toolbar switches back to display mode.
+      }
+  })
+  ```
+  * Added new toolbar APIs:
+  ```kotlin
+  toolbar.textColor: Int = getColor(R.color.photonRed50)
+  toolbar.hintColor: Int = getColor(R.color.photonGreen50)
+  toolbar.textSize: Float = 12f
+  toolbar.typeface: Typeface = Typeface.createFromFile("fonts/foo.tff")
+  ```
+    These attributes are also available in XML (except for typeface):
+  ```xml
+  <mozilla.components.browser.toolbar.BrowserToolbar 
+    android:id="@+id/toolbar"
+    app:browserToolbarTextColor="#ff0000"
+    app:browserToolbarHintColor="#00ff00"
+    app:browserToolbarTextSize="12sp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"/>
   ```
   * [Api improvement](https://github.com/mozilla-mobile/android-components/issues/772) for more flexibility to create a `BrowserToolbar.Button`,
   and `BrowserToolbar.ToggleButton`, now you can provide a custom padding:


### PR DESCRIPTION
**Notes:**
- The typeface isn't accessible from XML.
- Writing a unit test for null attributes in the init block was more work that value so I omitted it.