### PR TITLE
Fix browser-storage-memory config and update changelog

### DIFF
--- a/components/browser/storage-memory/build.gradle
+++ b/components/browser/storage-memory/build.gradle
@@ -34,10 +34,5 @@ dependencies {
     testImplementation project(':support-test')
 }
 
-archivesBaseName = "storage-memory"
-
 apply from: '../../../publish.gradle'
-ext.configurePublish(
-        'org.mozilla.components',
-        'storage-memory',
-        'In-memory implementation of concept-storage.')
+ext.configurePublish(Config.componentsGroupId, archivesBaseName, gradle.componentDescriptions[archivesBaseName])


### PR DESCRIPTION
@grigoryk This caused `browser-storage-memory` to not get published with the 0.29 release. Is it okay to wait for 0.30.0 or should we publish a dot release with it so that it can be used in the reference browser?