### PR TITLE
[glean]  Bug 1497808 - Create the PingMaker to collect data and assemble pings.

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
@@ -35,7 +35,11 @@ interface CommonMetricData {
     val name: String
     val sendInPings: List<String>
 
-    public fun shouldRecord(logger: Logger): Boolean {
+    companion object {
+        internal const val DEFAULT_STORAGE_NAME = "default"
+    }
+
+    fun shouldRecord(logger: Logger): Boolean {
         // Silently drop recording for disabled events.
         if (disabled) {
             return false
@@ -50,5 +54,26 @@ interface CommonMetricData {
         }
 
         return true
+    }
+
+    /**
+     * Defines the names of the storages the metric defaults to when
+     * "default" is used as the destination storage.
+     * Note that every metric type will need to implement this.
+     */
+    fun defaultStorageDestinations(): List<String>
+
+    /**
+     * Get the list of storage names the metric will record to. This
+     * automatically expands [DEFAULT_STORAGE_NAME] to the list of default
+     * storages for the metric.
+     */
+    fun getStorageNames(): List<String> {
+        if (DEFAULT_STORAGE_NAME !in sendInPings) {
+            return sendInPings
+        }
+
+        val filteredNames = sendInPings.filter { it != DEFAULT_STORAGE_NAME }
+        return filteredNames + defaultStorageDestinations()
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
@@ -30,6 +30,11 @@ data class EventMetricType(
     val objects: List<String>,
     val allowedExtraKeys: List<String>? = null
 ) : CommonMetricData {
+
+    override fun defaultStorageDestinations(): List<String> {
+        return listOf("events")
+    }
+
     private val logger = Logger("glean/EventMetricType")
 
     companion object {
@@ -95,7 +100,7 @@ data class EventMetricType(
 
         // Delegate storing the event to the storage engine.
         EventsStorageEngine.record(
-            stores = sendInPings,
+            stores = getStorageNames(),
             category = category,
             name = name,
             objectId = objectId,

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Placeholder.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Placeholder.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package mozilla.components.service.glean
-
-class Placeholder

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -23,6 +23,11 @@ data class StringMetricType(
     override val name: String,
     override val sendInPings: List<String>
 ) : CommonMetricData {
+
+    override fun defaultStorageDestinations(): List<String> {
+        return listOf("metrics")
+    }
+
     private val logger = Logger("glean/StringMetricType")
 
     companion object {
@@ -53,7 +58,7 @@ data class StringMetricType(
 
         // Delegate storing the string to the storage engine.
         StringsStorageEngine.record(
-            stores = sendInPings,
+            stores = getStorageNames(),
             category = category,
             name = name,
             value = truncatedValue

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
@@ -24,6 +24,11 @@ data class UuidMetricType(
     override val name: String,
     override val sendInPings: List<String>
 ) : CommonMetricData {
+
+    override fun defaultStorageDestinations(): List<String> {
+        return listOf("metrics")
+    }
+
     private val logger = Logger("glean/UuidMetricType")
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.ping
+
+import android.support.annotation.VisibleForTesting
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.storages.StorageEngineManager
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+internal class PingMaker(
+    private val storageManager: StorageEngineManager
+) {
+    private val pingStartTimes: MutableMap<String, String> = mutableMapOf()
+    private val objectStartTime = getISOTimeString()
+
+    /**
+     * Generate an ISO8601 compliant time string for the current time.
+     *
+     * @return a string containing the date and time.
+     */
+    private fun getISOTimeString(): String {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX", Locale.US)
+        return dateFormat.format(Date())
+    }
+
+    /**
+     * Return the object containing the "ping_info" section of a ping.
+     *
+     * @param pingName the name of the ping to be sent
+     * @return a [JSONObject] containing the "ping_info" data
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun getPingInfo(pingName: String): JSONObject {
+        // TODO this section is still missing app_build, client_id, seq and experiments.
+        // These fields will be added by bug 1497894 when 1499756 and 1501318 land.
+        val pingInfo = JSONObject()
+        pingInfo.put("ping_type", pingName)
+        pingInfo.put("telemetry_sdk_build", BuildConfig.LIBRARY_VERSION)
+
+        // This needs to be a bit more involved for start-end times. "start_time" is
+        // the time the ping was generated the last time. If not available, we use the
+        // date the object was initialized.
+        val startTime = if (pingName in pingStartTimes) pingStartTimes[pingName] else objectStartTime
+        pingInfo.put("start_time", startTime)
+        val endTime = getISOTimeString()
+        pingInfo.put("end_time", endTime)
+        // Update the start time with the current time.
+        pingStartTimes[pingName] = endTime
+        return pingInfo
+    }
+
+    /**
+     * Collects the relevant data and assembles the requested ping.
+     *
+     * @param storage the name of the storage containing the data for the ping.
+     *        This usually matches with the name of the ping
+     * @return a string holding the data for the ping.
+     */
+    fun collect(storage: String): String {
+        val jsonPing = JSONObject()
+
+        // Assemble the JSON ping.
+        jsonPing.put("ping_info", getPingInfo(storage))
+        jsonPing.put("metrics", storageManager.collect(storage))
+
+        return jsonPing.toString()
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngine.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.storages
+
+/**
+ * Base interface intended to be implemented by the different
+ * storage engines
+ */
+internal interface StorageEngine {
+    /**
+     * Get a snapshot of the stored data as a JSON object.
+     *
+     * @param storeName the name of the desired store
+     * @param clearStore whether or not to clearStore the requested store
+     *
+     * @return the JSON object containing the recorded data. This could be either
+     *         a [JSONObject] or a [JSONArray]. Unfortunately, the only common
+     *         ancestor is [Object], so we need to return [Any].
+     */
+    fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any?
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.storages
+
+import org.json.JSONObject
+
+/**
+ * This singleton is the one interface to all the available storage engines:
+ * it provides a convenient way to collect the data stored in a particular store
+ * and serialize it
+ */
+internal class StorageEngineManager(
+    private val storageEngines: Map<String, StorageEngine> = mapOf(
+        "events" to EventsStorageEngine,
+        "strings" to StringsStorageEngine
+    )
+) {
+    /**
+     * Collect the recorded data for the requested storage.
+     *
+     * @param storeName the name of the storage of interest
+     * @return a [JSONObject] containing the data collected from all the
+     *         storage engines.
+     */
+    fun collect(storeName: String): JSONObject {
+        val jsonPing = JSONObject()
+
+        for ((sectionName, engine) in storageEngines) {
+            val engineData = engine.getSnapshotAsJSON(storeName, clearStore = true)
+            jsonPing.put(sectionName, engineData)
+        }
+
+        return jsonPing
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -5,13 +5,14 @@
 package mozilla.components.service.glean.storages
 
 import android.support.annotation.VisibleForTesting
+import org.json.JSONObject
 
 /**
  * This singleton handles the in-memory storage logic for strings. It is meant to be used by
  * the Specific Strings API and the ping assembling objects. No validation on the stored data
  * is performed at this point: validation must be performed by the Specific Strings API.
  */
-internal object StringsStorageEngine {
+internal object StringsStorageEngine : StorageEngine {
     private val stringStores: MutableMap<String, MutableMap<String, String>> = mutableMapOf()
 
     /**
@@ -53,6 +54,20 @@ internal object StringsStorageEngine {
         }
 
         return stringStores.get(storeName)
+    }
+
+    /**
+     * Get a snapshot of the stored data as a JSON object.
+     *
+     * @param storeName the name of the desired store
+     * @param clearStore whether or not to clearStore the requested store
+     *
+     * @return the [JSONObject] containing the recorded data.
+     */
+    override fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any? {
+        return getSnapshot(storeName, clearStore)?.let { stringMap ->
+            return JSONObject(stringMap)
+        }
     }
 
     @VisibleForTesting

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/CommonMetricDataTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/CommonMetricDataTest.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The following is a test-only specific metric type used
+ * to test the "default" data storage translation.
+ */
+data class TestOnlyMetricType(
+    override val disabled: Boolean,
+    override val category: String,
+    override val lifetime: Lifetime,
+    override val name: String,
+    override val sendInPings: List<String>
+) : CommonMetricData {
+
+    override fun defaultStorageDestinations(): List<String> {
+        return listOf("translated_default")
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class CommonMetricDataTest {
+    @Test
+    fun `getStorageNames() should correctly translate "default"`() {
+        val testData = TestOnlyMetricType(
+            disabled = false,
+            category = "glean_test",
+            lifetime = Lifetime.Ping,
+            name = "test",
+            sendInPings = listOf(CommonMetricData.DEFAULT_STORAGE_NAME, "other_test_ping"))
+
+        assertEquals(testData.getStorageNames(), listOf("other_test_ping", "translated_default"))
+    }
+
+    @Test
+    fun `getStorageNames() should pass-through if no "default" is present`() {
+        val testData = TestOnlyMetricType(
+            disabled = false,
+            category = "glean_test",
+            lifetime = Lifetime.Ping,
+            name = "test",
+            sendInPings = listOf("other_test_ping", "additional_storage"))
+
+        assertEquals(testData.getStorageNames(), listOf("other_test_ping", "additional_storage"))
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -24,6 +24,20 @@ class EventMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'click' event, which will be stored in "store1"
+        val click = EventMetricType(
+            disabled = false,
+            category = "ui",
+            lifetime = Lifetime.Ping,
+            name = "click",
+            sendInPings = listOf("store1"),
+            objects = listOf("buttonA", "buttonB")
+        )
+        assertEquals(listOf("events"), click.defaultStorageDestinations())
+    }
+
+    @Test
     fun `The API records to its storage engine`() {
         // Define a 'click' event, which will be stored in "store1"
         val click = EventMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/PlaceholderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/PlaceholderTest.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package mozilla.components.service.glean
-
-class PlaceholderTest

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
@@ -22,6 +22,19 @@ class StringMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'stringMetric' string metric, which will be stored in "store1"
+        val stringMetric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "string_metric",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("metrics"), stringMetric.defaultStorageDestinations())
+    }
+
+    @Test
     fun `The API saves to its storage engine`() {
         // Define a 'stringMetric' string metric, which will be stored in "store1"
         val stringMetric = StringMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.ping
+
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.storages.MockStorageEngine
+import mozilla.components.service.glean.storages.StorageEngineManager
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+@RunWith(RobolectricTestRunner::class)
+class PingMakerTest {
+    @Test
+    fun `"ping_info" must contain a non-empty start_time and end_time`() {
+        val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
+                "engine2" to MockStorageEngine(JSONObject())
+            )))
+
+        // Gather the data. We expect an empty ping with the "ping_info" information
+        val data = maker.collect("test")
+        assertTrue("We expect a non-empty JSON blob", "{}" != data)
+
+        // Parse the data so that we can easily check the other fields
+        val jsonData = JSONObject(data)
+        val pingInfo = jsonData["ping_info"] as JSONObject
+        assertNotNull(pingInfo)
+
+        // "start_time" and "end_time" must be valid ISO8601 dates. DateTimeFormatter would
+        // throw otherwise.
+        DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(pingInfo.getString("start_time"))
+        DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(pingInfo.getString("end_time"))
+        OffsetDateTime.parse(pingInfo.getString("start_time"))
+        assertTrue(OffsetDateTime.parse(pingInfo.getString("start_time"))
+            >= OffsetDateTime.parse(pingInfo.getString("end_time")))
+    }
+
+    @Test
+    fun `getPingInfo() must report all the required fields`() {
+        val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
+            "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
+        )))
+
+        // Gather the data. We expect an empty ping with the "ping_info" information
+        val data = maker.collect("test")
+        assertTrue("We expect a non-empty JSON blob", "{}" != data)
+
+        // Parse the data so that we can easily check the other fields
+        val jsonData = JSONObject(data)
+        val pingInfo = jsonData["ping_info"] as JSONObject
+
+        assertEquals("test", pingInfo.getString("ping_type"))
+        assertEquals(BuildConfig.LIBRARY_VERSION, pingInfo.getString("telemetry_sdk_build"))
+        assertTrue(pingInfo.has("start_time"))
+        assertTrue(pingInfo.has("end_time"))
+    }
+
+    @Test
+    fun `collect() must report a valid ping with the data from the engines`() {
+        val engine1Data = JSONArray(listOf("1", "2", "3"))
+        val engine2Data = JSONArray(listOf("a", "b", "c"))
+        val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
+            "engine1" to MockStorageEngine(engine1Data),
+            "engine2" to MockStorageEngine(engine2Data),
+            "wontCollect" to MockStorageEngine(JSONObject(), "notThisPing")
+        )))
+
+        // Gather the data. We expect an empty ping with the "ping_info" information
+        val data = maker.collect("test")
+        assertTrue("We expect a non-empty JSON blob", "{}" != data)
+
+        // Parse the data so that we can easily check the other fields
+        val jsonData = JSONObject(data)
+        val metricsData = jsonData.getJSONObject("metrics")
+        assertEquals(engine1Data, metricsData.getJSONArray("engine1"))
+        assertEquals(engine2Data, metricsData.getJSONArray("engine2"))
+        assertFalse(metricsData.has("wontCollect"))
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -134,4 +134,24 @@ class EventsStorageEngineTest {
                     s.first().extra)
         }
     }
+
+    @Test
+    fun `Events are serialized in the correct JSON format`() {
+        // Record the event in the store, without providing optional arguments.
+        EventsStorageEngine.record(
+            stores = listOf("store1"),
+            category = "telemetry",
+            name = "test_event_clear",
+            objectId = "test_event_object"
+        )
+
+        // Get the snapshot from "store1" and clear it.
+        val snapshot = EventsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = true)
+        // Check that getting a new snapshot for "store1" returns an empty store.
+        assertNull("The engine must report 'null' on empty stores",
+            EventsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = false))
+        // Check that this serializes to the expected JSON format.
+        assertEquals("[[0,\"telemetry\",\"test_event_clear\",\"test_event_object\",null,null]]",
+            snapshot.toString())
+    }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/MockStorageEngine.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/MockStorageEngine.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.storages
+
+import org.junit.Assert
+
+/**
+ * A mock storage engine. This merely returns some sample
+ * data as a JSONObject or JSONArray.
+ */
+internal class MockStorageEngine(
+    // The following needs to be Any as we expect to
+    // return both JSONObject and JSONArray
+    private val sampleJSON: Any,
+    private val sampleStore: String = "test"
+) : StorageEngine {
+    override fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any? {
+        Assert.assertTrue(clearStore)
+        return if (storeName == sampleStore) sampleJSON else null
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.storages
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StorageEngineManagerTest {
+    @Test
+    fun `collect() must return an empty object for empty or unknown stores`() {
+        val manager = StorageEngineManager()
+        val data = manager.collect("thisStoreNameDoesNotExist")
+        assertNotNull(data)
+        assertEquals("{}", data.toString())
+    }
+
+    @Test
+    fun `collect() must report data from all the stores`() {
+        val manager = StorageEngineManager(storageEngines = mapOf(
+            "engine1" to MockStorageEngine(JSONObject(mapOf("test" to "val"))),
+            "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
+        ))
+
+        val data = manager.collect("test")
+        assertEquals("{\"engine1\":{\"test\":\"val\"},\"engine2\":[\"a\",\"b\",\"c\"]}",
+            data.toString())
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -69,4 +69,24 @@ class StringsStorageEngineTest {
             assertEquals(1, s!!.size)
         }
     }
+
+    @Test
+    fun `Strings are serialized in the correct JSON format`() {
+        // Record the string in the store, without providing optional arguments.
+        StringsStorageEngine.record(
+            stores = listOf("store1"),
+            category = "telemetry",
+            name = "string_metric",
+            value = "test_string_value"
+        )
+
+        // Get the snapshot from "store1" and clear it.
+        val snapshot = StringsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = true)
+        // Check that getting a new snapshot for "store1" returns an empty store.
+        assertNull("The engine must report 'null' on empty stores",
+            StringsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = false))
+        // Check that this serializes to the expected JSON format.
+        assertEquals("{\"telemetry.string_metric\":\"test_string_value\"}",
+            snapshot.toString())
+    }
 }

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -41,6 +41,7 @@ android {
 
 dependencies {
     implementation project(':service-glean')
+    implementation project(':support-base')
 
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -7,12 +7,16 @@ package org.mozilla.samples.glean
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.View
+import mozilla.components.support.base.log.Log
+import mozilla.components.support.base.log.sink.AndroidLogSink
 
 open class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        Log.addSink(AndroidLogSink())
 
         GleanMetrics.Basic.os.set("Android")
         GleanMetrics.Basic.clientId.generateAndSet()


### PR DESCRIPTION
This adds the PingMaker and slightly refactors the storage engines to have implement the same interface, which is useful for handling the ping generation. Additionally, this stubs out the "ping_info" section
that must be send with every ping. Even though a better solution would have been for the fields of that section to dogfood our field types, some of them are not planned for the MVP (e.g. DateTime), so I'm manually handling this.