### PR TITLE
Peg the version of glean_parser installed.

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -11,7 +11,7 @@ envs {
     pipInstallOptions = "--trusted-host pypi.python.org --no-cache-dir"
 
     // Setup a miniconda environment.
-    conda "Miniconda3", "Miniconda3-latest", "64", ["glean_parser"]
+    conda "Miniconda3", "Miniconda3-latest", "64", ["glean_parser==0.3.1"]
 }
 
 // Setup the python environment before the build starts.


### PR DESCRIPTION
I'm expecting to introduce a number of backward-incompatible changes in glean_parser, and rather than breaking everyone's android-components builds in the process, I though it best to peg the version and bump it up in individual PRs as we move along...