### PR TITLE
Request a key-bearing scope in FxA sample app.

### DIFF
--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -25,7 +25,9 @@ import mozilla.components.service.fxa.Profile
 open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener {
 
     private lateinit var whenAccount: Deferred<FirefoxAccount>
-    private var scopes: Array<String> = arrayOf("profile")
+    private var scopesWithoutKeys: Array<String> = arrayOf("profile")
+    private var scopesWithKeys: Array<String> = arrayOf("profile", "https://identity.mozilla.com/apps/oldsync")
+    private var scopes: Array<String> = scopesWithoutKeys
     private var wantsKeys: Boolean = false
 
     companion object {
@@ -95,6 +97,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
 
         findViewById<CheckBox>(R.id.checkboxKeys).setOnCheckedChangeListener { _, isChecked ->
             wantsKeys = isChecked
+            scopes = if (isChecked) scopesWithKeys else scopesWithoutKeys
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/android-components/issues/1225

If you attempt to fetch keys via the FxA OAuth flow, but you don't request any scopes that actually *have* keys, then FxA bails out because something has probably gone very wrong in your app.  This updates the FxA sample app to request a key-bearing scope when the "wants keys" option is checked.