### PR TITLE
Issue #1181: Update deprecated coroutines for FxA

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -5,6 +5,8 @@
 package mozilla.components.service.fxa
 
 import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
 import org.mozilla.fxaclient.internal.Config as InternalConfig
 
@@ -23,7 +25,7 @@ class Config internal constructor(internal val inner: InternalConfig) : AutoClos
          * Set up endpoints used in the production Firefox Accounts instance.
          */
         fun release(): Deferred<Config> {
-            return async {
+            return GlobalScope.async(Dispatchers.IO) {
                 Config(InternalConfig.release())
             }
         }
@@ -34,7 +36,7 @@ class Config internal constructor(internal val inner: InternalConfig) : AutoClos
          * @param content_base Hostname of the FxA auth service provider
          */
         fun custom(content_base: String): Deferred<Config> {
-            return async {
+            return GlobalScope.async(Dispatchers.IO) {
                 Config(InternalConfig.custom(content_base))
             }
         }

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -13,22 +13,30 @@ import android.view.View
 import android.content.Intent
 import android.widget.CheckBox
 import android.widget.TextView
+import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.android.UI
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.runBlocking
 import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.FxaException
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.Profile
+import kotlin.coroutines.experimental.CoroutineContext
 
-open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener {
+open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener, CoroutineScope {
 
     private lateinit var whenAccount: Deferred<FirefoxAccount>
     private var scopesWithoutKeys: Array<String> = arrayOf("profile")
     private var scopesWithKeys: Array<String> = arrayOf("profile", "https://identity.mozilla.com/apps/oldsync")
     private var scopes: Array<String> = scopesWithoutKeys
     private var wantsKeys: Boolean = false
+
+    private lateinit var job: Job
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main + job
 
     companion object {
         const val CLIENT_ID = "12cc4070a481bc73"
@@ -42,14 +50,13 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        job = Job()
 
         whenAccount = async {
             val acct = getAuthenticatedAccount()
             if (acct != null) {
                 val profile = acct.getProfile(true).await()
-                launch(UI) {
-                    displayProfile(profile)
-                }
+                displayProfile(profile)
                 acct
             } else {
                 val pairingUrl = intent.extras?.getString("pairingUrl")
@@ -57,9 +64,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
                     Config.custom(CONFIG_URL_PAIRING).await().use { config ->
                         val acct = FirefoxAccount(config, CLIENT_ID, REDIRECT_URL)
                         val url = acct.beginPairingFlow(pairingUrl, scopes).await()
-                        launch(UI) {
-                            openWebView(url)
-                        }
+                        openWebView(url)
                         acct
                     }
                 } else {
@@ -73,14 +78,14 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
         findViewById<View>(R.id.buttonCustomTabs).setOnClickListener {
             launch {
                 val url = whenAccount.await().beginOAuthFlow(scopes, wantsKeys).await()
-                launch(UI) { openTab(url) }
+                openTab(url)
             }
         }
 
         findViewById<View>(R.id.buttonWebView).setOnClickListener {
             launch {
                 val url = whenAccount.await().beginOAuthFlow(scopes, wantsKeys).await()
-                launch(UI) { openWebView(url) }
+                openWebView(url)
             }
         }
 
@@ -103,9 +108,8 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
 
     override fun onDestroy() {
         super.onDestroy()
-        if (this::whenAccount.isInitialized) {
-            launch { whenAccount.await().close() }
-        }
+        runBlocking { whenAccount.await().close() }
+        job.cancel()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -126,11 +130,11 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
         supportFragmentManager?.popBackStack()
     }
 
-    private suspend fun getAuthenticatedAccount(): FirefoxAccount? {
+    private fun getAuthenticatedAccount(): FirefoxAccount? {
         val savedJSON = getSharedPreferences(FXA_STATE_PREFS_KEY, Context.MODE_PRIVATE).getString(FXA_STATE_KEY, "")
         return savedJSON?.let {
             try {
-                FirefoxAccount.fromJSONString(it).await()
+                FirefoxAccount.fromJSONString(it)
             } catch (e: FxaException) {
                 null
             }
@@ -160,9 +164,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
             val account = whenAccount.await()
             account.completeOAuthFlow(code, state).await()
             val profile = account.getProfile().await()
-            runOnUiThread {
-                displayProfile(profile)
-            }
+            displayProfile(profile)
             account.toJSONString().let {
                 getSharedPreferences(FXA_STATE_PREFS_KEY, Context.MODE_PRIVATE)
                         .edit().putString(FXA_STATE_KEY, it).apply()


### PR DESCRIPTION
This brings in coroutine scopes and makes sure we call cancel on the corresponding "Job" when the activity is destroyed and/or the FirefoxAccount/Config are closed.

With @thomcc's changes plus these refactorings, things look much cleaner than before, imo. `onCreate` is still somewhat convoluted, but I think it's best to clean this up when we attempt to build the higher level API. This is mainly caused by `onCreate` handling 3 different use cases in one async block.

Thanks @pocmo @thomcc for talking through the scope->context->dispatcher->job coroutine fun :)