### PR TITLE
Closes #755: Replace Toolbar Actions from resouces to Drawables.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.toolbar
 
 import android.content.Context
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.support.annotation.DrawableRes
 import android.support.annotation.VisibleForTesting
 import android.util.AttributeSet
@@ -366,7 +367,7 @@ class BrowserToolbar @JvmOverloads constructor(
     /**
      * An action button to be added to the toolbar.
      *
-     * @param imageResource The drawable to be shown.
+     * @param imageDrawable The drawable to be shown.
      * @param contentDescription The content description to use.
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
      * @param background A custom (stateful) background drawable resource to be used.
@@ -374,17 +375,18 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param listener Callback that will be invoked whenever the button is pressed
      */
     open class Button(
-        imageResource: Int,
+        imageDrawable: Drawable,
         contentDescription: String,
         visible: () -> Boolean = { true },
-        @DrawableRes background: Int? = null,
-        private val padding: Padding = defaultActionPadding,
+        @DrawableRes background: Int = 0,
+        val padding: Padding = DEFAULT_PADDING,
         listener: () -> Unit
-    ) : Toolbar.ActionButton(imageResource, contentDescription, visible, background, listener = listener) {
+    ) : Toolbar.ActionButton(imageDrawable, contentDescription, visible, background, padding, listener) {
+
         override fun createView(parent: ViewGroup): View {
-            val view = super.createView(parent)
-            view.setPadding(padding)
-            return view
+            return super.createView(parent).apply {
+                setPadding(padding)
+            }
         }
     }
 
@@ -392,8 +394,8 @@ class BrowserToolbar @JvmOverloads constructor(
      * An action button with two states, selected and unselected. When the button is pressed, the
      * state changes automatically.
      *
-     * @param imageResource The drawable to be shown if the button is in unselected state.
-     * @param imageResourceSelected The drawable to be shown if the button is in selected state.
+     * @param image The drawable to be shown if the button is in unselected state.
+     * @param imageSelected The drawable to be shown if the button is in selected state.
      * @param contentDescription The content description to use if the button is in unselected state.
      * @param contentDescriptionSelected The content description to use if the button is in selected state.
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
@@ -403,25 +405,27 @@ class BrowserToolbar @JvmOverloads constructor(
      * @param listener Callback that will be invoked whenever the checked state changes.
      */
     open class ToggleButton(
-        @DrawableRes imageResource: Int,
-        @DrawableRes imageResourceSelected: Int,
+        image: Drawable,
+        imageSelected: Drawable,
         contentDescription: String,
         contentDescriptionSelected: String,
         visible: () -> Boolean = { true },
         selected: Boolean = false,
-        @DrawableRes background: Int? = null,
-        private val padding: Padding = defaultActionPadding,
+        @DrawableRes background: Int = 0,
+        val padding: Padding = DEFAULT_PADDING,
         listener: (Boolean) -> Unit
     ) : Toolbar.ActionToggleButton(
-        imageResource,
-        imageResourceSelected,
+        image,
+        imageSelected,
         contentDescription,
         contentDescriptionSelected,
         visible,
         selected,
         background,
-        listener = listener
+        padding,
+        listener
     ) {
+
         override fun createView(parent: ViewGroup): View {
             return super.createView(parent).apply {
                 setPadding(padding)
@@ -430,9 +434,9 @@ class BrowserToolbar @JvmOverloads constructor(
     }
 
     companion object {
-        internal const val ACTION_PADDING_DP = 16
-        private val defaultActionPadding =
-            Padding(ACTION_PADDING_DP, ACTION_PADDING_DP, ACTION_PADDING_DP, ACTION_PADDING_DP)
         private const val DEFAULT_TOOLBAR_HEIGHT_DP = 56
+        internal const val ACTION_PADDING_DP = 16
+        internal val DEFAULT_PADDING =
+            Padding(ACTION_PADDING_DP, ACTION_PADDING_DP, ACTION_PADDING_DP, ACTION_PADDING_DP)
     }
 }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.android.Padding
+import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -269,7 +270,7 @@ class BrowserToolbarTest {
 
         toolbar.displayToolbar = displayToolbar
 
-        val action = BrowserToolbar.Button(0, "Hello") {
+        val action = BrowserToolbar.Button(mock(), "Hello") {
             // Do nothing
         }
 
@@ -286,7 +287,7 @@ class BrowserToolbarTest {
 
         toolbar.displayToolbar = displayToolbar
 
-        val action = BrowserToolbar.Button(0, "World") {
+        val action = BrowserToolbar.Button(mock(), "World") {
             // Do nothing
         }
 
@@ -323,7 +324,7 @@ class BrowserToolbarTest {
         val displayToolbar = mock(DisplayToolbar::class.java)
         toolbar.displayToolbar = displayToolbar
 
-        val action = BrowserToolbar.Button(0, "Back") {
+        val action = BrowserToolbar.Button(mock(), "Back") {
             // Do nothing
         }
 
@@ -480,7 +481,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `BrowserToolbar Button must set padding`() {
-        var button = BrowserToolbar.Button(0, "imageResource", visible = { true }) {}
+        var button = BrowserToolbar.Button(mock(), "imageResource", visible = { true }) {}
         val linearLayout = LinearLayout(RuntimeEnvironment.application)
         var view = button.createView(linearLayout)
         val padding = Padding(0, 0, 0, 0)
@@ -488,20 +489,20 @@ class BrowserToolbarTest {
         assertEquals(view.paddingTop, ACTION_PADDING_DP)
         assertEquals(view.paddingRight, ACTION_PADDING_DP)
         assertEquals(view.paddingBottom, ACTION_PADDING_DP)
-        button = BrowserToolbar.Button(0, "imageResource", padding = padding.copy(left = 16)) {}
+        button = BrowserToolbar.Button(mock(), "imageResource", padding = padding.copy(left = 16)) {}
         view = button.createView(linearLayout)
         assertEquals(view.paddingLeft, 16)
-        button = BrowserToolbar.Button(0, "imageResource", padding = padding.copy(top = 16)) {}
+        button = BrowserToolbar.Button(mock(), "imageResource", padding = padding.copy(top = 16)) {}
         view = button.createView(linearLayout)
         assertEquals(view.paddingTop, 16)
-        button = BrowserToolbar.Button(0, "imageResource", padding = padding.copy(right = 16)) {}
+        button = BrowserToolbar.Button(mock(), "imageResource", padding = padding.copy(right = 16)) {}
         view = button.createView(linearLayout)
         assertEquals(view.paddingRight, 16)
-        button = BrowserToolbar.Button(0, "imageResource", padding = padding.copy(bottom = 16)) {}
+        button = BrowserToolbar.Button(mock(), "imageResource", padding = padding.copy(bottom = 16)) {}
         view = button.createView(linearLayout)
         assertEquals(view.paddingBottom, 16)
         button = BrowserToolbar.Button(
-            0, "imageResource",
+            mock(), "imageResource",
             padding = Padding(16, 20, 24, 28)
         ) {}
         view = button.createView(linearLayout)
@@ -515,8 +516,8 @@ class BrowserToolbarTest {
     @Test
     fun `BrowserToolbar ToggleButton must set padding`() {
         var button = BrowserToolbar.ToggleButton(
-            0,
-            0,
+            mock(),
+            mock(),
             "imageResource",
             "",
             visible = { true },
@@ -525,15 +526,14 @@ class BrowserToolbarTest {
         ) {}
         val linearLayout = LinearLayout(RuntimeEnvironment.application)
         var view = button.createView(linearLayout)
-        val padding = Padding(0, 0, 0, 0)
         assertEquals(view.paddingLeft, ACTION_PADDING_DP)
         assertEquals(view.paddingTop, ACTION_PADDING_DP)
         assertEquals(view.paddingRight, ACTION_PADDING_DP)
         assertEquals(view.paddingBottom, ACTION_PADDING_DP)
 
         button = BrowserToolbar.ToggleButton(
-            0,
-            0,
+            mock(),
+            mock(),
             "imageResource",
             "",
             visible = { true },
@@ -547,6 +547,32 @@ class BrowserToolbarTest {
         assertEquals(view.paddingTop, 20)
         assertEquals(view.paddingRight, 24)
         assertEquals(view.paddingBottom, 28)
+
+        button = BrowserToolbar.ToggleButton(
+            mock(),
+            mock(),
+            "imageResource",
+            "",
+            selected = false,
+            background = 0
+        ) {}
+
+        assertTrue(button.visible())
+    }
+
+    @Test
+    fun `hint changes edit and display urlView`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+
+        assertNull(toolbar.displayToolbar.urlView.hint)
+        assertNull(toolbar.editToolbar.urlView.hint)
+
+        toolbar.hint = "hint"
+
+        assertEquals("hint", toolbar.displayToolbar.urlView.hint)
+        assertEquals("hint", toolbar.editToolbar.urlView.hint)
+
+        assertEquals(toolbar.displayToolbar.urlView.hint.toString(), toolbar.hint)
     }
 
     @Test
@@ -600,6 +626,8 @@ class BrowserToolbarTest {
 
         assertEquals(typeface, toolbar.displayToolbar.urlView.typeface)
         assertEquals(typeface, toolbar.editToolbar.urlView.typeface)
+
+        assertEquals(toolbar.displayToolbar.urlView.typeface, toolbar.typeface)
     }
 
     @Test
@@ -612,5 +640,82 @@ class BrowserToolbarTest {
 
         BrowserToolbar(application, attributeSet)
         verify(application).obtainStyledAttributes(attributeSet, R.styleable.BrowserToolbar, 0, 0)
+    }
+
+    @Test
+    fun `displaySiteSecurityIcon getter and setter`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        assertEquals(toolbar.displayToolbar.iconView.isVisible(), toolbar.displaySiteSecurityIcon)
+
+        toolbar.displaySiteSecurityIcon = false
+        assertEquals(View.GONE, toolbar.displayToolbar.iconView.visibility)
+
+        toolbar.displaySiteSecurityIcon = true
+        assertEquals(View.VISIBLE, toolbar.displayToolbar.iconView.visibility)
+    }
+
+    @Test
+    fun `urlBoxView getter`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        assertEquals(toolbar.displayToolbar.urlBoxView, toolbar.urlBoxView)
+    }
+
+    @Test
+    fun `browserActionMargin getter`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        assertEquals(toolbar.displayToolbar.browserActionMargin, toolbar.browserActionMargin)
+    }
+
+    @Test
+    fun `urlBoxMargin getter`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        assertEquals(toolbar.displayToolbar.urlBoxMargin, toolbar.urlBoxMargin)
+    }
+
+    @Test
+    fun `onUrlClicked getter`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        assertEquals(toolbar.displayToolbar.onUrlClicked, toolbar.onUrlClicked)
+    }
+
+    @Test
+    fun `setUrlTextPadding applies padding to urlView`() {
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        toolbar.setUrlTextPadding(5, 5, 5, 5)
+        assertEquals(5, toolbar.displayToolbar.urlView.paddingLeft)
+        assertEquals(5, toolbar.displayToolbar.urlView.paddingTop)
+        assertEquals(5, toolbar.displayToolbar.urlView.paddingRight)
+        assertEquals(5, toolbar.displayToolbar.urlView.paddingBottom)
+    }
+
+    @Test
+    fun `Button constructor with drawable`() {
+        val buttonDefault = BrowserToolbar.Button(mock(), "imageDrawable") {}
+
+        assertEquals(true, buttonDefault.visible())
+        assertEquals(BrowserToolbar.DEFAULT_PADDING, buttonDefault.padding)
+        assertEquals("imageDrawable", buttonDefault.contentDescription)
+
+        val button = BrowserToolbar.Button(mock(), "imageDrawable", visible = { false }) {}
+
+        assertEquals(false, button.visible())
+    }
+
+    @Test
+    fun `ToggleButton constructor with drawable`() {
+        val buttonDefault =
+            BrowserToolbar.ToggleButton(mock(), mock(), "imageDrawable", "imageSelectedDrawable") {}
+
+        assertEquals(true, buttonDefault.visible())
+        assertEquals(BrowserToolbar.DEFAULT_PADDING, buttonDefault.padding)
+
+        val button = BrowserToolbar.ToggleButton(
+            mock(),
+            mock(),
+            "imageDrawable",
+            "imageSelectedDrawable",
+            visible = { false }) {}
+
+        assertEquals(false, button.visible())
     }
 }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.ktx.android.view.forEach
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -163,7 +164,7 @@ class DisplayToolbarTest {
 
         assertNull(extractActionView(displayToolbar, contentDescription))
 
-        val action = BrowserToolbar.Button(0, contentDescription) {}
+        val action = BrowserToolbar.Button(mock(), contentDescription) {}
         displayToolbar.addBrowserAction(action)
 
         val view = extractActionView(displayToolbar, contentDescription)
@@ -175,7 +176,7 @@ class DisplayToolbarTest {
     fun `clicking browser action view triggers listener of action`() {
         var callbackExecuted = false
 
-        val action = BrowserToolbar.Button(0, "Button") {
+        val action = BrowserToolbar.Button(mock(), "Button") {
             callbackExecuted = true
         }
 
@@ -198,7 +199,7 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        val action = BrowserToolbar.Button(0, "action") {}
+        val action = BrowserToolbar.Button(mock(), "action") {}
         displayToolbar.addBrowserAction(action)
 
         val widthSpec = View.MeasureSpec.makeMeasureSpec(1024, View.MeasureSpec.EXACTLY)
@@ -219,7 +220,7 @@ class DisplayToolbarTest {
 
         assertNull(extractActionView(displayToolbar, "Reader Mode"))
 
-        val action = BrowserToolbar.Button(0, "Reader Mode") {}
+        val action = BrowserToolbar.Button(mock(), "Reader Mode") {}
         displayToolbar.addPageAction(action)
 
         assertNotNull(extractActionView(displayToolbar, "Reader Mode"))
@@ -229,7 +230,7 @@ class DisplayToolbarTest {
     fun `clicking a page action view will execute the listener of the action`() {
         var listenerExecuted = false
 
-        val action = BrowserToolbar.Button(0, "Reload") {
+        val action = BrowserToolbar.Button(mock(), "Reload") {
             listenerExecuted = true
         }
 
@@ -248,7 +249,7 @@ class DisplayToolbarTest {
 
     @Test
     fun `views for page actions will have a square shape`() {
-        val action = BrowserToolbar.Button(0, "Open app") {}
+        val action = BrowserToolbar.Button(mock(), "Open app") {}
 
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
@@ -273,8 +274,8 @@ class DisplayToolbarTest {
         assertNull(extractActionView(displayToolbar, "Back"))
         assertNull(extractActionView(displayToolbar, "Forward"))
 
-        displayToolbar.addNavigationAction(BrowserToolbar.Button(0, "Back") {})
-        displayToolbar.addNavigationAction(BrowserToolbar.Button(0, "Forward") {})
+        displayToolbar.addNavigationAction(BrowserToolbar.Button(mock(), "Back") {})
+        displayToolbar.addNavigationAction(BrowserToolbar.Button(mock(), "Forward") {})
 
         assertNotNull(extractActionView(displayToolbar, "Back"))
         assertNotNull(extractActionView(displayToolbar, "Forward"))
@@ -286,7 +287,7 @@ class DisplayToolbarTest {
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
         var listenerExecuted = false
-        val action = BrowserToolbar.Button(0, "Back") {
+        val action = BrowserToolbar.Button(mock(), "Back") {
             listenerExecuted = true
         }
 
@@ -306,7 +307,7 @@ class DisplayToolbarTest {
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
         displayToolbar.addNavigationAction(
-                BrowserToolbar.Button(0, "Back") {})
+            BrowserToolbar.Button(mock(), "Back") {})
 
         val widthSpec = View.MeasureSpec.makeMeasureSpec(1024, View.MeasureSpec.EXACTLY)
         val heightSpec = View.MeasureSpec.makeMeasureSpec(56, View.MeasureSpec.EXACTLY)
@@ -327,7 +328,7 @@ class DisplayToolbarTest {
         var shouldActionBeDisplayed = true
 
         val action = BrowserToolbar.Button(
-            0,
+            mock(),
             "Back",
             visible = { shouldActionBeDisplayed }
         ) { /* Do nothing */ }
@@ -352,7 +353,7 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        val action = spy(BrowserToolbar.Button(0, "Reload") {})
+        val action = spy(BrowserToolbar.Button(mock(), "Reload") {})
 
         displayToolbar.addPageAction(action)
 
@@ -370,9 +371,9 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        val visibleAction = BrowserToolbar.Button(0, "Reload") {}
+        val visibleAction = BrowserToolbar.Button(mock(), "Reload") {}
         val invisibleAction = BrowserToolbar.Button(
-            0,
+            mock(),
             "Reader Mode",
             visible = { false }) {}
 
@@ -388,9 +389,9 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        val visibleAction = BrowserToolbar.Button(0, "Tabs") {}
+        val visibleAction = BrowserToolbar.Button(mock(), "Tabs") {}
         val invisibleAction = BrowserToolbar.Button(
-                0,
+            mock(),
                 "Settings",
                 visible = { false }) {}
 
@@ -406,9 +407,9 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        val visibleAction = BrowserToolbar.Button(0, "Forward") {}
+        val visibleAction = BrowserToolbar.Button(mock(), "Forward") {}
         val invisibleAction = BrowserToolbar.Button(
-                0,
+            mock(),
                 "Back",
                 visible = { false }) {}
 
@@ -424,8 +425,8 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        val normalAction = BrowserToolbar.Button(0, "Forward") {}
-        val backAction = object : BrowserToolbar.Button(0, "Back", listener = {}) {
+        val normalAction = BrowserToolbar.Button(mock(), "Forward") {}
+        val backAction = object : BrowserToolbar.Button(mock(), "Back", listener = {}) {
             override fun createView(parent: ViewGroup): View {
                 return super.createView(parent).apply {
                     minimumWidth = 500
@@ -474,8 +475,8 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        displayToolbar.addPageAction(BrowserToolbar.Button(0, "Reload") {})
-        displayToolbar.addPageAction(BrowserToolbar.Button(0, "Reader Mode") {})
+        displayToolbar.addPageAction(BrowserToolbar.Button(mock(), "Reload") {})
+        displayToolbar.addPageAction(BrowserToolbar.Button(mock(), "Reader Mode") {})
 
         val view = TextView(RuntimeEnvironment.application)
         displayToolbar.urlBoxView = view
@@ -500,8 +501,8 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
 
-        displayToolbar.addPageAction(BrowserToolbar.Button(0, "Reload") {})
-        displayToolbar.addPageAction(BrowserToolbar.Button(0, "Reader Mode") {})
+        displayToolbar.addPageAction(BrowserToolbar.Button(mock(), "Reload") {})
+        displayToolbar.addPageAction(BrowserToolbar.Button(mock(), "Reader Mode") {})
 
         val view = TextView(RuntimeEnvironment.application)
         displayToolbar.urlBoxView = view

--- a/components/concept/toolbar/build.gradle
+++ b/components/concept/toolbar/build.gradle
@@ -28,8 +28,11 @@ dependencies {
     implementation Deps.support_appcompat
     api project(':support-base')
     implementation project(':support-ktx')
+
     testImplementation Deps.testing_junit
     testImplementation Deps.testing_robolectric
+    testImplementation Deps.testing_mockito
+    testImplementation project(':support-test')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.toolbar
 
+import android.graphics.drawable.Drawable
 import android.support.annotation.DrawableRes
 import android.support.v7.widget.AppCompatImageButton
 import android.support.v7.widget.AppCompatImageView
@@ -128,32 +129,33 @@ interface Toolbar {
     /**
      * An action button to be added to the toolbar.
      *
-     * @param imageResource The drawable to be shown.
+     * @param imageDrawable The drawable to be shown.
      * @param contentDescription The content description to use.
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
-     * @param background A custom (stateful) background drawable resource to be used.
      * @param padding A optional custom padding.
      * @param listener Callback that will be invoked whenever the button is pressed
      */
     open class ActionButton(
-        @DrawableRes private val imageResource: Int,
-        private val contentDescription: String,
+        val imageDrawable: Drawable? = null,
+        val contentDescription: String,
         override val visible: () -> Boolean = { true },
-        @DrawableRes private val background: Int? = null,
+        private val background: Int = 0,
         private val padding: Padding? = null,
         private val listener: () -> Unit
     ) : Action {
+
         override fun createView(parent: ViewGroup): View = AppCompatImageButton(parent.context).also { imageButton ->
-            imageButton.setImageResource(imageResource)
+            imageButton.setImageDrawable(imageDrawable)
             imageButton.contentDescription = contentDescription
             imageButton.setOnClickListener { listener.invoke() }
 
-            if (background == null) {
+            if (background == 0) {
                 val outValue = TypedValue()
                 parent.context.theme.resolveAttribute(
-                        android.R.attr.selectableItemBackgroundBorderless,
-                        outValue,
-                        true)
+                    android.R.attr.selectableItemBackgroundBorderless,
+                    outValue,
+                    true
+                )
                 imageButton.setBackgroundResource(outValue.resourceId)
             } else {
                 imageButton.setBackgroundResource(background)
@@ -168,26 +170,25 @@ interface Toolbar {
      * An action button with two states, selected and unselected. When the button is pressed, the
      * state changes automatically.
      *
-     * @param imageResource The drawable to be shown if the button is in unselected state.
-     * @param imageResourceSelected The drawable to be shown if the button is in selected state.
+     * @param imageDrawable The drawable to be shown if the button is in unselected state.
+     * @param imageSelectedDrawable The  drawable to be shown if the button is in selected state.
      * @param contentDescription The content description to use if the button is in unselected state.
      * @param contentDescriptionSelected The content description to use if the button is in selected state.
      * @param visible Lambda that returns true or false to indicate whether this button should be shown.
      * @param selected Sets whether this button should be selected initially.
-     * @param background A custom (stateful) background drawable resource to be used.
      * @param padding A optional custom padding.
      * @param listener Callback that will be invoked whenever the checked state changes.
      */
     open class ActionToggleButton(
-        @DrawableRes private val imageResource: Int,
-        @DrawableRes private val imageResourceSelected: Int,
+        internal val imageDrawable: Drawable,
+        internal val imageSelectedDrawable: Drawable,
         private val contentDescription: String,
         private val contentDescriptionSelected: String,
         override val visible: () -> Boolean = { true },
         private var selected: Boolean = false,
-        @DrawableRes private val background: Int? = null,
+        @DrawableRes private val background: Int = 0,
         private val padding: Padding? = null,
-        private val listener: (Boolean) -> Unit = {}
+        private val listener: (Boolean) -> Unit
     ) : Action {
         private var view: WeakReference<ImageButton>? = null
 
@@ -199,7 +200,7 @@ interface Toolbar {
 
             updateViewState()
 
-            if (background == null) {
+            if (background == 0) {
                 val outValue = TypedValue()
                 parent.context.theme.resolveAttribute(
                         android.R.attr.selectableItemBackgroundBorderless,
@@ -252,10 +253,10 @@ interface Toolbar {
                 it.isSelected = selected
 
                 if (selected) {
-                    it.setImageResource(imageResourceSelected)
+                    it.setImageDrawable(imageSelectedDrawable)
                     it.contentDescription = contentDescriptionSelected
                 } else {
-                    it.setImageResource(imageResource)
+                    it.setImageDrawable(imageDrawable)
                     it.contentDescription = contentDescription
                 }
             }
@@ -285,30 +286,29 @@ interface Toolbar {
     /**
      * An action that just shows a static, non-clickable image.
      *
-     * @param imageResource The drawable to be shown.
+     * @param imageDrawable The drawable to be shown.
      * @param contentDescription Optional content description to be used. If no content description
      *                           is provided then this view will be treated as not important for
      *                           accessibility.
      * @param padding A optional custom padding.
      */
     open class ActionImage(
-        @DrawableRes private val imageResource: Int,
+        private val imageDrawable: Drawable,
         private val contentDescription: String? = null,
         private val padding: Padding? = null
     ) : Action {
-        override fun createView(parent: ViewGroup): View = AppCompatImageView(parent.context).also {
-            val drawable = parent.context.resources.getDrawable(imageResource, parent.context.theme)
-            it.minimumWidth = drawable.intrinsicWidth
 
-            it.setImageDrawable(drawable)
+        override fun createView(parent: ViewGroup): View = AppCompatImageView(parent.context).also { image ->
+            image.minimumWidth = imageDrawable.intrinsicWidth
+            image.setImageDrawable(imageDrawable)
 
-            it.contentDescription = contentDescription
-            it.importantForAccessibility = if (contentDescription.isNullOrEmpty()) {
+            image.contentDescription = contentDescription
+            image.importantForAccessibility = if (contentDescription.isNullOrEmpty()) {
                 View.IMPORTANT_FOR_ACCESSIBILITY_NO
             } else {
                 View.IMPORTANT_FOR_ACCESSIBILITY_AUTO
             }
-            padding?.let { pd -> it.setPadding(pd) }
+            padding?.let { pd -> image.setPadding(pd) }
         }
 
         override fun bind(view: View) = Unit

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
@@ -6,7 +6,9 @@ package mozilla.components.concept.toolbar
 
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -16,8 +18,8 @@ import org.robolectric.RuntimeEnvironment
 class ActionButtonTest {
 
     @Test
-    fun `Toolbar ActionButton must set padding`() {
-        var button = Toolbar.ActionButton(0, "imageResource") {}
+    fun `set padding`() {
+        var button = Toolbar.ActionButton(mock(), "imageResource") {}
         val linearLayout = LinearLayout(RuntimeEnvironment.application)
         var view = button.createView(linearLayout)
 
@@ -27,7 +29,7 @@ class ActionButtonTest {
         assertEquals(view.paddingBottom, 0)
 
         button = Toolbar.ActionButton(
-            0, "imageResource",
+            mock(), "imageResource",
             padding = Padding(16, 20, 24, 28)
         ) {}
 
@@ -37,5 +39,18 @@ class ActionButtonTest {
         assertEquals(view.paddingTop, 20)
         assertEquals(view.paddingRight, 24)
         assertEquals(view.paddingBottom, 28)
+    }
+
+    @Test
+    fun `constructor with drawables`() {
+        val visibilityListener = { false }
+        val button = Toolbar.ActionButton(mock(), "image", visibilityListener, 0, null) { }
+        assertNotNull(button.imageDrawable)
+        assertEquals("image", button.contentDescription)
+        assertEquals(visibilityListener, button.visible)
+        assertEquals(Unit, button.bind(mock()))
+
+        val buttonVisibility = Toolbar.ActionButton(mock(), "image") {}
+        assertEquals(true, buttonVisibility.visible())
     }
 }

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionImageTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionImageTest.kt
@@ -1,0 +1,86 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.concept.toolbar
+
+import android.graphics.drawable.Drawable
+import android.view.View
+import android.view.ViewGroup
+import mozilla.components.support.base.android.Padding
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ActionImageTest {
+
+    @Test
+    fun `setting minimumWidth`() {
+        val drawable: Drawable = mock()
+        val image = Toolbar.ActionImage(drawable)
+        val emptyImage = Toolbar.ActionImage(mock())
+
+        val viewGroup: ViewGroup = mock()
+        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(drawable.intrinsicWidth).thenReturn(5)
+
+        val emptyImageView = emptyImage.createView(viewGroup)
+        assertEquals(0, emptyImageView.minimumWidth)
+
+        val imageView = image.createView(viewGroup)
+        assertTrue(imageView.minimumWidth != 0)
+    }
+
+    @Test
+    fun `accessibility description provided`() {
+        val image = Toolbar.ActionImage(mock())
+        var imageAccessible = Toolbar.ActionImage(mock(), "image")
+        val viewGroup: ViewGroup = mock()
+        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+
+        val imageView = image.createView(viewGroup)
+        assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_NO, imageView.importantForAccessibility)
+
+        var imageViewAccessible = imageAccessible.createView(viewGroup)
+        assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO, imageViewAccessible.importantForAccessibility)
+
+        imageAccessible = Toolbar.ActionImage(mock(), "")
+        imageViewAccessible = imageAccessible.createView(viewGroup)
+        assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_NO, imageViewAccessible.importantForAccessibility)
+    }
+
+    @Test
+    fun `bind is not implemented`() {
+        val button = Toolbar.ActionImage(mock())
+        assertEquals(Unit, button.bind(mock()))
+    }
+
+    @Test
+    fun `padding is set`() {
+        var image = Toolbar.ActionImage(mock())
+        val viewGroup: ViewGroup = mock()
+        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        var view = image.createView(viewGroup)
+
+        assertEquals(view.paddingLeft, 0)
+        assertEquals(view.paddingTop, 0)
+        assertEquals(view.paddingRight, 0)
+        assertEquals(view.paddingBottom, 0)
+
+        image = Toolbar.ActionImage(mock(), padding = Padding(16, 20, 24, 28))
+
+        view = image.createView(viewGroup)
+        assertEquals(view.paddingLeft, 16)
+        assertEquals(view.paddingTop, 20)
+        assertEquals(view.paddingRight, 24)
+        assertEquals(view.paddingBottom, 28)
+    }
+}

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionSpaceTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionSpaceTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.toolbar
 
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,5 +36,11 @@ class ActionSpaceTest {
         assertEquals(view.paddingTop, 20)
         assertEquals(view.paddingRight, 24)
         assertEquals(view.paddingBottom, 28)
+    }
+
+    @Test
+    fun `bind is not implemented`() {
+        val button = Toolbar.ActionSpace(0)
+        assertEquals(Unit, button.bind(mock()))
     }
 }

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionToggleButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionToggleButtonTest.kt
@@ -7,8 +7,10 @@ package mozilla.components.concept.toolbar
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,7 +22,8 @@ import java.util.UUID
 class ActionToggleButtonTest {
     @Test
     fun `clicking view will toggle state`() {
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {}
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {}
         val view = button.createView(FrameLayout(RuntimeEnvironment.application))
 
         assertFalse(button.isSelected())
@@ -38,9 +41,10 @@ class ActionToggleButtonTest {
     fun `clicking view will invoke listener`() {
         var listenerInvoked = false
 
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
-            listenerInvoked = true
-        }
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
+                listenerInvoked = true
+            }
 
         val view = button.createView(FrameLayout(RuntimeEnvironment.application))
 
@@ -55,9 +59,10 @@ class ActionToggleButtonTest {
     fun `toggle will invoke listener`() {
         var listenerInvoked = false
 
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
-            listenerInvoked = true
-        }
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
+                listenerInvoked = true
+            }
 
         assertFalse(listenerInvoked)
 
@@ -70,9 +75,10 @@ class ActionToggleButtonTest {
     fun `toggle will not invoke listener if notifyListener is set to false`() {
         var listenerInvoked = false
 
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
-            listenerInvoked = true
-        }
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
+                listenerInvoked = true
+            }
 
         assertFalse(listenerInvoked)
 
@@ -85,9 +91,10 @@ class ActionToggleButtonTest {
     fun `setSelected will invoke listener`() {
         var listenerInvoked = false
 
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
-            listenerInvoked = true
-        }
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
+                listenerInvoked = true
+            }
 
         assertFalse(button.isSelected())
         assertFalse(listenerInvoked)
@@ -101,9 +108,10 @@ class ActionToggleButtonTest {
     fun `setSelected will not invoke listener if value has not changed`() {
         var listenerInvoked = false
 
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
-            listenerInvoked = true
-        }
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
+                listenerInvoked = true
+            }
 
         assertFalse(button.isSelected())
         assertFalse(listenerInvoked)
@@ -117,9 +125,10 @@ class ActionToggleButtonTest {
     fun `setSelected will not invoke listener if notifyListener is set to false`() {
         var listenerInvoked = false
 
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
-            listenerInvoked = true
-        }
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {
+                listenerInvoked = true
+            }
 
         assertFalse(button.isSelected())
         assertFalse(listenerInvoked)
@@ -131,7 +140,8 @@ class ActionToggleButtonTest {
 
     @Test
     fun `isSelected will always return correct state`() {
-        val button = Toolbar.ActionToggleButton(0, 0, UUID.randomUUID().toString(), UUID.randomUUID().toString()) {}
+        val button =
+            Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {}
         assertFalse(button.isSelected())
 
         button.toggle()
@@ -156,7 +166,7 @@ class ActionToggleButtonTest {
 
     @Test
     fun `Toolbar ActionToggleButton must set padding`() {
-        var button = Toolbar.ActionToggleButton(0, 0, "imageResource", "") {}
+        var button = Toolbar.ActionToggleButton(mock(), mock(), "imageResource", "") {}
         val linearLayout = LinearLayout(RuntimeEnvironment.application)
         var view = button.createView(linearLayout)
         val padding = Padding(16, 20, 24, 28)
@@ -166,10 +176,7 @@ class ActionToggleButtonTest {
         assertEquals(view.paddingRight, 0)
         assertEquals(view.paddingBottom, 0)
 
-        button = Toolbar.ActionToggleButton(
-            0, 0, "imageResource", "",
-            padding = padding
-        ) {}
+        button = Toolbar.ActionToggleButton(mock(), mock(), "imageResource", "", padding = padding) {}
 
         view = button.createView(linearLayout)
         view.paddingLeft
@@ -177,5 +184,29 @@ class ActionToggleButtonTest {
         assertEquals(view.paddingTop, 20)
         assertEquals(view.paddingRight, 24)
         assertEquals(view.paddingBottom, 28)
+    }
+
+    @Test
+    fun `default constructor with drawables`() {
+        var selectedValue = false
+        val visibility = { true }
+        val button = Toolbar.ActionToggleButton(mock(), mock(), "image", "selected", visible = visibility) { value ->
+            selectedValue = value
+        }
+        assertEquals(true, button.visible())
+        assertNotNull(button.imageDrawable)
+        assertNotNull(button.imageSelectedDrawable)
+        assertEquals(visibility, button.visible)
+        button.setSelected(true)
+        assertTrue(selectedValue)
+
+        val buttonVisibility = Toolbar.ActionToggleButton(mock(), mock(), "image", "selected", background = 0) { }
+        assertTrue(buttonVisibility.visible())
+    }
+
+    @Test
+    fun `bind is not implemented`() {
+        val button = Toolbar.ActionToggleButton(mock(), mock(), "image", "imageSelected") {}
+        assertEquals(Unit, button.bind(mock()))
     }
 }

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/SampleToolbarHelpers.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/SampleToolbarHelpers.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Canvas
 import android.graphics.drawable.ClipDrawable
-import android.support.annotation.DrawableRes
+import android.graphics.drawable.Drawable
 import android.support.v7.widget.RecyclerView
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -135,15 +135,15 @@ class UrlBoxProgressView(
  * <code>isLoading</code> lambda.
  */
 class ReloadPageAction(
-    @DrawableRes private val reloadImageResource: Int,
+    private val reloadImage: Drawable,
     private val reloadContentDescription: String,
-    private val stopImageResource: Int,
+    private val stopImage: Drawable,
     private val stopContentDescription: String,
     private val isLoading: () -> Boolean,
-    background: Int? = null,
+    background: Int = 0,
     listener: () -> Unit
 ) : BrowserToolbar.Button(
-    reloadImageResource,
+    reloadImage,
     reloadContentDescription,
     listener = listener,
     background = background
@@ -157,10 +157,10 @@ class ReloadPageAction(
         val button = view as ImageButton
 
         if (loading) {
-            button.setImageResource(stopImageResource)
+            button.setImageDrawable(stopImage)
             button.contentDescription = stopContentDescription
         } else {
-            button.setImageResource(reloadImageResource)
+            button.setImageDrawable(reloadImage)
             button.contentDescription = reloadContentDescription
         }
     }

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -4,7 +4,9 @@
 
 package org.mozilla.samples.toolbar
 
+import android.content.res.Resources
 import android.os.Bundle
+import android.support.annotation.DrawableRes
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
@@ -56,7 +58,11 @@ class ToolbarActivity : AppCompatActivity() {
             view?.let {
                 val result = autoCompleteProvider.autocomplete(value)
                 view.applyAutocompleteResult(
-                        InlineAutocompleteEditText.AutocompleteResult(result.text, result.source, result.size, { result.url }))
+                    InlineAutocompleteEditText.AutocompleteResult(
+                        result.text,
+                        result.source,
+                        result.size
+                    ) { result.url })
             }
         }
     }
@@ -93,16 +99,18 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val back = BrowserToolbar.Button(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_back,
-            "Back") {
+            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_back),
+            "Back"
+        ) {
             simulateReload()
         }
 
         toolbar.addNavigationAction(back)
 
         val forward = BrowserToolbar.Button(
-                mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
-                "Forward") {
+            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_forward),
+            "Forward"
+        ) {
             simulateReload()
         }
 
@@ -113,7 +121,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val reload = BrowserToolbar.Button(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh),
             "Reload") {
             simulateReload()
         }
@@ -246,7 +254,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val grid = BrowserToolbar.Button(
-                mozilla.components.ui.icons.R.drawable.mozac_ic_grid,
+            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_grid),
                 "Grid",
                 background = R.drawable.button_background) {
             // Do nothing
@@ -255,7 +263,7 @@ class ToolbarActivity : AppCompatActivity() {
         toolbar.addNavigationAction(grid)
 
         val back = BrowserToolbar.Button(
-                mozilla.components.ui.icons.R.drawable.mozac_ic_back,
+            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_back),
                 "Back",
                 visible = ::canGoBack,
                 background = R.drawable.button_background) {
@@ -267,7 +275,7 @@ class ToolbarActivity : AppCompatActivity() {
         toolbar.addNavigationAction(back)
 
         val forward = BrowserToolbar.Button(
-                mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
+            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_forward),
                 "Forward",
                 visible = ::canGoForward,
                 background = R.drawable.button_background) {
@@ -283,9 +291,9 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val reload = ReloadPageAction(
-            reloadImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+            reloadImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh),
             reloadContentDescription = "Reload",
-            stopImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
+            stopImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_stop),
             stopContentDescription = "Stop",
             isLoading = { loading },
             background = R.drawable.pageaction_background
@@ -300,8 +308,8 @@ class ToolbarActivity : AppCompatActivity() {
         toolbar.addPageAction(reload)
 
         val pin = BrowserToolbar.ToggleButton(
-            imageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_pin,
-            imageResourceSelected = mozilla.components.ui.icons.R.drawable.mozac_ic_pin_filled,
+            image = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_pin),
+            imageSelected = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_pin),
             contentDescription = "Pin",
             contentDescriptionSelected = "Unpin",
             background = R.drawable.toggle_background) {
@@ -311,8 +319,8 @@ class ToolbarActivity : AppCompatActivity() {
         toolbar.addBrowserAction(pin)
 
         val turbo = BrowserToolbar.ToggleButton(
-            imageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_rocket,
-            imageResourceSelected = mozilla.components.ui.icons.R.drawable.mozac_ic_rocket_filled,
+            image = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_rocket),
+            imageSelected = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_rocket_filled),
             contentDescription = "Turbo: Off",
             contentDescriptionSelected = "Turbo: On",
             background = R.drawable.toggle_background) {
@@ -329,7 +337,7 @@ class ToolbarActivity : AppCompatActivity() {
 
         toolbar.addBrowserAction(space)
 
-        val brand = Toolbar.ActionImage(R.drawable.brand)
+        val brand = Toolbar.ActionImage(resources.getThemedDrawable(R.drawable.brand))
 
         toolbar.addBrowserAction(brand)
 
@@ -422,4 +430,6 @@ class ToolbarActivity : AppCompatActivity() {
         // Update toolbar buttons to reflect loading state
         toolbar.invalidateActions()
     }
+
+    private fun Resources.getThemedDrawable(@DrawableRes resId: Int) = getDrawable(resId, theme)
 }


### PR DESCRIPTION
To be more versatile, we've added a secondary constructor to `BrowserToolbar.Button` and `BrowserToolbar.ToggleButton`.

```kotlin
// Before
BrowserToolbar.Button(R.drawable.image, "image description") {
  // perform an action on click.
}

// Now
val imageDrawable: Drawable = Drawable()
BrowserToolbar.Button(imageDrawable, "image description") {
  // perform an action on click.
}
```

```kotlin
// Before
BrowserToolbar.ToggleButton(
  R.drawable.image, 
  R.drawable.image_selected, 
  "image description", 
  "image selected description") {
  // perform an action on click.
}

// Now
val imageDrawable: Drawable = Drawable()
val imageSelectedDrawable: Drawable = Drawable()
BrowserToolbar.ToggleButton(
  imageDrawable, 
  imageSelectedDrawable, 
  "image description", 
  "image selected description") {
  // perform an action on click.
}
```

(These commits will be squashed before merging)