### PR TITLE
Closes #260: In "Icons" readme, provide sample images of included icons

### DIFF
--- a/docs/assets/js/icon-js.js
+++ b/docs/assets/js/icon-js.js
@@ -1,0 +1,100 @@
+let icons = {};
+let needed = 0;
+let got = 0;
+
+/**
+ * @param html {String} HTML representing a single element
+ * @return {Element}
+ */
+function htmlToElement(html) {
+    let template = document.createElement('template');
+    html = html.trim(); // Never return a text node of whitespace as the result
+    template.innerHTML = html;
+    //firstChild may be a comment so we must use firstElementChild to avoid picking it
+    return template.content.firstElementChild;
+}
+
+/**
+ * Converts an Android Vector Drawable to a standard SVG by striping off or renaming some elements
+ *
+ * @param s {String} String of an Android Vector Drawable
+ * @returns {String} The same string but in the standard SVG representation
+ */
+function androidSVGtoNormalSVG(s) {
+    s = s.replace(/<\?xml version="1\.0" encoding="utf-8"\?>/g, '');
+    s = s.replace(/<vector xmlns:android="http:\/\/schemas.android.com\/apk\/res\/android"/g, '<svg xmlns="http://www.w3.org/2000/svg"');
+    s = s.replace(/<\/vector>/g, '</svg>');
+    s = s.replace(/android:(height|width)="(\d+)dp"/g, '');
+    s = s.replace(/android:viewportHeight="(\d+\.?\d+)"/g, 'height="$1"');
+    s = s.replace(/android:viewportWidth="(\d+\.?\d+)"/g, 'width="$1"');
+    s = s.replace(/android:fillColor=/g, 'fill=');
+    s = s.replace(/android:pathData=/g, 'd=');
+    //s = s.replace(/android:/g, '');
+    return s;
+}
+
+function addToTable(name, svg) {
+    let table = document.querySelector("#preview_table > tbody");
+    let row = htmlToElement("<tr></tr>");
+    row.appendChild(htmlToElement("<td>" + name + "</td>"));
+    let td = htmlToElement("<td></td>");
+    td.appendChild(svg);
+    row.appendChild(td);
+    table.appendChild(row);
+}
+
+function addSingleItemToTable(str) {
+    let table = document.querySelector("#preview_table > tbody");
+    table.append(htmlToElement("<tr><td colspan='2'>" + str + "</td></tr>"))
+}
+
+function getFile(iconName, downloadUrl) {
+    let request = new XMLHttpRequest();
+    request.open('GET', downloadUrl, true);
+    request.onreadystatechange = function () {
+        if (request.readyState === 4 && request.status === 200) {
+            got++;
+            let androidXmlText = request.responseText;
+            androidXmlText = androidSVGtoNormalSVG(androidXmlText);
+            icons[iconName] = androidXmlText;
+        } else if (request.readyState === 4) {
+            //Request completed with an error
+            got++;
+            icons[iconName] = "<span>Error during download</span>";
+        }
+        if (got == needed) {
+            document.querySelector("#preview_table > tbody").innerHTML = "";
+            for (let el in icons) {
+                addToTable(el, htmlToElement(icons[el]));
+            }
+        }
+    };
+    request.send(null);
+}
+
+// This function recovers all icons inside the drawable folder via github API
+(function getIcons() {
+    let request = new XMLHttpRequest();
+    request.open("GET", "https://api.github.com/repos/mozilla-mobile/android-components/contents/components/ui/icons/src/main/res/drawable", true);
+    //Explicit request of the V3 version of the API
+    request.setRequestHeader("Accept", "application/vnd.github.v3+json");
+    request.onreadystatechange = function () {
+        if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+            let response = JSON.parse(request.response);
+            if (response.message) {
+                //Something went wrong
+                console.error(response.message);
+                addSingleItemToTable("Error: " + response.message);
+                return;
+            }
+            needed = response.length;
+            addSingleItemToTable("Loading");
+            for (let i = 0; i < response.length; i++) {
+                let iconName = response[i]['name'].substr(0, response[i]['name'].length - 4);
+                icons[iconName] = null;
+                getFile(iconName, response[i]['download_url']);
+            }
+        }
+    };
+    request.send(null);
+})();

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,7 +43,7 @@ Independent, small visual UI elements to use in applications.
 * [ui-autocomplete](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/autocomplete) - A user interface element for entering and modifying text with the ability to inline autocomplete.
 * [ui-colors](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/colors) - The standard set of [colors](https://design.firefox.com/photon/visuals/color.html) used in the [Photon Design System](https://design.firefox.com/photon/welcome.html) for Firefox products.
 * [ui-fonts](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/fonts) - The standard set of fonts used by Mozilla Android products.
-* [ui-icons](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/icons) - Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/welcome.html).
+* [ui-icons]({{ site.baseurl }}/components/ui/icons) - Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/welcome.html).
 * [ui-progress](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/progress) - An animated progress bar following the [Photon Design System](https://design.firefox.com/photon/welcome.html)..
 * [ui-tabcounter](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/tabcounter) - A button that shows the current tab count and can animate state changes.
 

--- a/docs/ui/icons.md
+++ b/docs/ui/icons.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: UI icons
+permalink: /components/ui/icons
+---
+
+Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/welcome.html).
+<style>
+    #preview_table {
+        text-align: center;
+    }
+
+    #preview_table td:nth-child(2) {
+        background: darkgray;
+    }
+</style>
+<table id="preview_table">
+    <thead>
+    <tr>
+        <th>Icon name</th>
+        <th>Preview</th>
+    </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+
+<script src="{{"/assets/js/icon-js.js" | relative_url }}"></script>
+
+
+## More
+
+[List of all components in the android-components repository](https://github.com/mozilla-mobile/android-components/blob/master/README.md)


### PR DESCRIPTION
I wrote a simple script that fetch all the Android Vector Drawable files inside the drawable folder, makes a simple conversion to transform them in regular svg (that browsers can render) and then displays them inside a table.
Files are retrieved via GitHub API, so everything should stay in sync when adding future icons or after making changes.
The API is limited with max 60 requests per hour per IP, but the script only makes one.
Android SVG to standard SVG conversion is made via regex, by striping off/renaming elements.

Everything is working, but probably needs some improvements.

I made a first version, then a second one with Promise.
I don't know which one is better.
The other problem is that in ```docs/ui/icons.md``` i wrote some css style and HTML tags directly inside the page.
Let me know what I should change

Preview: https://santimar.github.io/android-components/components/ui/icons

Closes: #260 