### PR TITLE
Closes #1182: Crash reporter prompt: Persist checkbox state

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/prompt/CrashReporterActivity.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/prompt/CrashReporterActivity.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.lib.crash.prompt
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
@@ -17,12 +18,17 @@ import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.R
 
+private const val PREFERENCE_KEY_SEND_REPORT = "sendCrashReport"
+
 /**
  * Activity showing the crash reporter prompt asking the user for confirmation before submitting a crash report.
  */
 class CrashReporterActivity : AppCompatActivity() {
     private val crashReporter: CrashReporter by lazy { CrashReporter.requireInstance }
     private val crash: Crash by lazy { Crash.fromIntent(intent) }
+    private val sharedPreferences by lazy {
+        getSharedPreferences("mozac_lib_crash_settings", Context.MODE_PRIVATE)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(crashReporter.promptConfiguration.theme)
@@ -40,6 +46,9 @@ class CrashReporterActivity : AppCompatActivity() {
 
         titleView.text = getString(R.string.mozac_lib_crash_dialog_title, appName)
         sendCheckbox.text = getString(R.string.mozac_lib_crash_dialog_checkbox, organizationName)
+
+        sendCheckbox.isChecked = sharedPreferences.getBoolean(PREFERENCE_KEY_SEND_REPORT, true)
+
         restartButton.apply {
             text = getString(R.string.mozac_lib_crash_dialog_button_restart, appName)
             setOnClickListener { restart() }
@@ -72,6 +81,8 @@ class CrashReporterActivity : AppCompatActivity() {
     }
 
     private fun sendCrashReportIfNeeded(then: () -> Unit) {
+        sharedPreferences.edit().putBoolean(PREFERENCE_KEY_SEND_REPORT, sendCheckbox.isChecked).apply()
+
         if (!sendCheckbox.isChecked) {
             then()
             return

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 permalink: /changelog/
 ---
 
-# 0.32.0-SNAPSHOT (In Devvelopment)
+# 0.32.0-SNAPSHOT (In Development)
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.31.0...v0.32.0),
 [Milestone](https://github.com/mozilla-mobile/android-components/milestone/34?closed=1),
@@ -14,6 +14,9 @@ permalink: /changelog/
   * Android (SDK: 27, Support Libraries: 27.1.1)
   * Kotlin (Stdlib: 1.3.0, Coroutines: 1.0.1)
   * GeckoView (Nightly: 65.0.20181107100135, Beta: 64.0.20181022150107, Release: 63.0.20181018182531)
+
+* **lib-crash**
+  * The state of the "Send crash report" checkbox is now getting saved and restored once the dialog is shown again. 
 
 # 0.31.0
 


### PR DESCRIPTION
Modified the file CrashResporterActivity.kt. The value of the send checkbox will be stored in a shared preference.