### PR TITLE
[glean] Make glean code more idiomatic

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
@@ -59,9 +59,9 @@ interface CommonMetricData {
     /**
      * Defines the names of the storages the metric defaults to when
      * "default" is used as the destination storage.
-     * Note that every metric type will need to implement this.
+     * Note that every metric type will need to override this.
      */
-    fun defaultStorageDestinations(): List<String>
+    val defaultStorageDestinations: List<String>
 
     /**
      * Get the list of storage names the metric will record to. This
@@ -74,6 +74,6 @@ interface CommonMetricData {
         }
 
         val filteredNames = sendInPings.filter { it != DEFAULT_STORAGE_NAME }
-        return filteredNames + defaultStorageDestinations()
+        return filteredNames + defaultStorageDestinations
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
@@ -31,9 +31,7 @@ data class EventMetricType(
     val allowedExtraKeys: List<String>? = null
 ) : CommonMetricData {
 
-    override fun defaultStorageDestinations(): List<String> {
-        return listOf("events")
-    }
+    override val defaultStorageDestinations: List<String> = listOf("events")
 
     private val logger = Logger("glean/EventMetricType")
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -24,9 +24,7 @@ data class StringMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
-    override fun defaultStorageDestinations(): List<String> {
-        return listOf("metrics")
-    }
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
 
     private val logger = Logger("glean/StringMetricType")
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
@@ -25,9 +25,7 @@ data class UuidMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
-    override fun defaultStorageDestinations(): List<String> {
-        return listOf("metrics")
-    }
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
 
     private val logger = Logger("glean/UuidMetricType")
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -23,7 +23,7 @@ internal object StringsStorageEngine : StorageEngine {
      * @param name the name of the string
      * @param value the string value to record
      */
-    public fun record(
+    fun record(
         stores: List<String>,
         category: String,
         name: String,
@@ -48,7 +48,7 @@ internal object StringsStorageEngine : StorageEngine {
      * @return the strings recorded in the requested store
      */
     @Synchronized
-    public fun getSnapshot(storeName: String, clearStore: Boolean): MutableMap<String, String>? {
+    fun getSnapshot(storeName: String, clearStore: Boolean): MutableMap<String, String>? {
         if (clearStore) {
             return stringStores.remove(storeName)
         }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/CommonMetricDataTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/CommonMetricDataTest.kt
@@ -22,9 +22,7 @@ data class TestOnlyMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
-    override fun defaultStorageDestinations(): List<String> {
-        return listOf("translated_default")
-    }
+    override val defaultStorageDestinations: List<String> = listOf("translated_default")
 }
 
 @RunWith(RobolectricTestRunner::class)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -34,7 +34,7 @@ class EventMetricTypeTest {
             sendInPings = listOf("store1"),
             objects = listOf("buttonA", "buttonB")
         )
-        assertEquals(listOf("events"), click.defaultStorageDestinations())
+        assertEquals(listOf("events"), click.defaultStorageDestinations)
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
@@ -31,7 +31,7 @@ class StringMetricTypeTest {
             name = "string_metric",
             sendInPings = listOf("store1")
         )
-        assertEquals(listOf("metrics"), stringMetric.defaultStorageDestinations())
+        assertEquals(listOf("metrics"), stringMetric.defaultStorageDestinations)
     }
 
     @Test


### PR DESCRIPTION
In #1224 it was suggested to morph getters into val(s). This PR takes care of that and removes the "public" visibility from some methods of the StringStorageEngine.