### PR TITLE
Update tooling-lint to Java 8..

### DIFF
--- a/components/tooling/lint/build.gradle
+++ b/components/tooling/lint/build.gradle
@@ -5,8 +5,8 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
-targetCompatibility = JavaVersion.VERSION_1_7
-sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   compileOnly Deps.tools_lintapi


### PR DESCRIPTION
Noticed that tooling-lint was the only module left that wasn't updated yet.