### PR TITLE
[Glean] Enable 'user' persistence on supported metrics.

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
@@ -45,14 +45,6 @@ interface CommonMetricData {
             return false
         }
 
-        // TODO implement "user" metric lifetime. See bug 1499756.
-        // Metrics can be recorded with application or user lifetime. For now,
-        // we only support "application": metrics live as long as the application lives.
-        if (lifetime != Lifetime.Application) {
-            logger.error("The metric lifetime must be explicitly set.")
-            return false
-        }
-
         return true
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
@@ -60,6 +60,11 @@ data class EventMetricType(
             return
         }
 
+        if (lifetime != Lifetime.Ping) {
+            logger.warn("$category.$name can only have a Ping lifetime")
+            return
+        }
+
         // We don't need to check that the objectId is short, since that
         // has already been determined at build time for each of the valid objectId values.
         if (!objects.contains(objectId)) {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -59,6 +59,7 @@ data class StringMetricType(
             stores = getStorageNames(),
             category = category,
             name = name,
+            lifetime = lifetime,
             value = truncatedValue
         )
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
@@ -53,6 +53,7 @@ data class UuidMetricType(
                 stores = sendInPings,
                 category = category,
                 name = name,
+                lifetime = lifetime,
                 value = value
         )
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.glean.storages
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.os.SystemClock
 import android.support.annotation.VisibleForTesting
 import org.json.JSONArray
@@ -12,8 +14,15 @@ import org.json.JSONArray
  * This singleton handles the in-memory storage logic for events. It is meant to be used by
  * the Specific Events API and the ping assembling objects. No validation on the stored data
  * is performed at this point: validation must be performed by the Specific Events API.
+ *
+ * This class contains a reference to the Android application Context. While the IDE warns
+ * us that this could leak, the application context lives as long as the application and this
+ * object. For this reason, we should be safe to suppress the IDE warning.
  */
+@SuppressLint("StaticFieldLeak")
 internal object EventsStorageEngine : StorageEngine {
+    override lateinit var applicationContext: Context
+
     // Events recorded within the list should be reasonably sorted by timestamp, assuming
     // the sequence of calls to [record] has not been messed with. However, please only
     // trust the recorded timestamp values.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -182,22 +182,17 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
         @SuppressLint("CommitPrefEdits")
         val userPrefs: SharedPreferences.Editor? =
             if (lifetime == Lifetime.User) userLifetimeStorage.edit() else null
-        for (storeName in stores) {
-            val storeData = dataStores[lifetime.ordinal].getOrPut(storeName) { mutableMapOf() }
+        stores.forEach {
+            val storeData = dataStores[lifetime.ordinal].getOrPut(it) { mutableMapOf() }
             val entryName = "$category.$name"
             storeData[entryName] = value
             // Persist data with "user" lifetime
             if (lifetime == Lifetime.User) {
-                userPrefs?.putString("$storeName#$entryName", serializeSingleMetric(value))
+                userPrefs?.putString("$it#$entryName", serializeSingleMetric(value))
             }
         }
         userPrefs?.apply()
     }
 
-    @VisibleForTesting
-    internal open fun clearAllStores() {
-        for (store in dataStores) {
-            store.clear()
-        }
-    }
+    internal open fun clearAllStores() = dataStores.forEach { it.clear() }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -94,6 +94,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
 
         // Make sure data with "user" lifetime is loaded before getting the snapshot.
         // We still need to catch exceptions here, as `getAll()` might throw.
+        @Suppress("TooGenericExceptionCaught")
         try {
             userLifetimeStorage.all
         } catch (e: NullPointerException) {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -7,7 +7,6 @@ package mozilla.components.service.glean.storages
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
-import android.support.annotation.VisibleForTesting
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONObject

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.storages
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import android.support.annotation.VisibleForTesting
+import mozilla.components.service.glean.Lifetime
+import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONObject
+
+internal typealias GenericDataStorage<T> = MutableMap<String, T>
+internal typealias GenericStorageMap<T> = MutableMap<String, GenericDataStorage<T>>
+
+abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
+    override lateinit var applicationContext: Context
+
+    // Let derived class define a logger so that they can provide a proper name,
+    // useful when debugging weird behaviours.
+    abstract val logger: Logger
+
+    protected val userLifetimeStorage: SharedPreferences by lazy { deserializeUserLifetime() }
+
+    // Use a multi-level map to store the data for the different lifetimes and
+    // stores: Map[Lifetime, Map[StorageName, ScalarType]].
+    protected val dataStores: Map<String, GenericStorageMap<ScalarType>> =
+        Lifetime.values().associateBy(
+            { it.toString() },
+            { mutableMapOf<String, GenericDataStorage<ScalarType>>() }
+        )
+
+    /**
+     * Implementor's provided function to convert deserialized 'user' lifetime
+     * data to the destination ScalarType.
+     *
+     * @param value loaded from the storage as [Any]
+     *
+     * @return data as [ScalarType] or null if deserialization failed
+     */
+    abstract fun singleMetricDeserializer(value: Any?): ScalarType?
+
+    /**
+     * Deserialize the metrics with a lifetime = User that are on disk.
+     * This will be called the first time a metric is used or before a snapshot is
+     * taken.
+     *
+     * @return A [SharedPreferences] reference that will be used to inititialize [userLifetimeStorage]
+     */
+    @Suppress("TooGenericExceptionCaught")
+    open fun deserializeUserLifetime(): SharedPreferences {
+        val prefs =
+            applicationContext.getSharedPreferences(this.javaClass.simpleName, Context.MODE_PRIVATE)
+
+        return try {
+            for ((metricName, metricValue) in prefs.all.entries) {
+                if (!metricName.contains('#')) {
+                    continue
+                }
+
+                // Split the stored name in 2: we expect it to be in the format
+                // store#metric.name
+                val parts = metricName.split('#', limit = 2)
+                val storeData = dataStores[Lifetime.User.toString()]!!.getOrPut(parts[0]) { mutableMapOf() }
+                // Only set the stored value if we're able to deserialize the persisted data.
+                singleMetricDeserializer(metricValue)?.let {
+                    storeData[parts[1]] = it
+                }
+            }
+            prefs
+        } catch (e: NullPointerException) {
+            // If we fail to deserialize, we can log the problem but keep on going.
+            logger.error("Failed to deserialize UUIDs with 'user' lifetime")
+            prefs
+        }
+    }
+
+    /**
+     * Retrieves the [recorded metric data][ScalarType] for the provided
+     * store name.
+     *
+     * @param storeName the name of the desired store
+     * @param clearStore whether or not to clearStore the requested store
+     *
+     * @return the [ScalarType] recorded in the requested store
+     */
+    @Synchronized
+    fun getSnapshot(storeName: String, clearStore: Boolean): GenericDataStorage<ScalarType>? {
+        val allLifetimes: GenericDataStorage<ScalarType> = mutableMapOf()
+
+        // Make sure data with "user" lifetime is loaded before getting the snapshot.
+        userLifetimeStorage.all
+
+        // Get the metrics for all the supported lifetimes.
+        for ((_, store) in dataStores) {
+            store[storeName]?.let {
+                allLifetimes.putAll(it)
+            }
+        }
+
+        if (clearStore) {
+            // We only allow clearing metrics with the "ping" lifetime.
+            dataStores[Lifetime.Ping.toString()]!!.remove(storeName)
+        }
+
+        return if (allLifetimes.isNotEmpty()) allLifetimes else null
+    }
+
+    /**
+     * Get a snapshot of the stored data as a JSON object.
+     *
+     * @param storeName the name of the desired store
+     * @param clearStore whether or not to clearStore the requested store
+     *
+     * @return the [JSONObject] containing the recorded data.
+     */
+    override fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any? {
+        return getSnapshot(storeName, clearStore)?.let { dataMap ->
+            return JSONObject(dataMap)
+        }
+    }
+
+    /**
+     * Helper function for the derived classes. It can be used to record
+     * simple scalars to the internal storage.
+     */
+    protected fun recordScalar(
+        stores: List<String>,
+        category: String,
+        name: String,
+        lifetime: Lifetime,
+        value: ScalarType
+    ) {
+        checkNotNull(applicationContext) { "No recording can take place without an application context" }
+
+        // Record a copy of the uuid in all the needed stores.
+        @SuppressLint("CommitPrefEdits")
+        val userPrefs: SharedPreferences.Editor? =
+            if (lifetime == Lifetime.User) userLifetimeStorage.edit() else null
+        for (storeName in stores) {
+            val storeData = dataStores[lifetime.toString()]!!.getOrPut(storeName) { mutableMapOf() }
+            val entryName = "$category.$name"
+            storeData[entryName] = value
+            // Persist data with "user" lifetime
+            if (lifetime == Lifetime.User) {
+                userPrefs?.putString("$storeName#$entryName", value.toString())
+            }
+        }
+        userPrefs?.apply()
+    }
+
+    @VisibleForTesting
+    internal open fun clearAllStores() {
+        for ((_, store) in dataStores) {
+            store.clear()
+        }
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -95,7 +95,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
             // store#metric.name
             val (storeName, metricName) =
                 metricStoragePath.split('#', limit = 2)
-            if (storeName.length <= 1) {
+            if (storeName.isEmpty()) {
                 continue
             }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -69,7 +69,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
             prefs
         } catch (e: NullPointerException) {
             // If we fail to deserialize, we can log the problem but keep on going.
-            logger.error("Failed to deserialize UUIDs with 'user' lifetime")
+            logger.error("Failed to deserialize metric with 'user' lifetime")
             prefs
         }
     }
@@ -133,7 +133,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
     ) {
         checkNotNull(applicationContext) { "No recording can take place without an application context" }
 
-        // Record a copy of the uuid in all the needed stores.
+        // Record a copy of the metric in all the needed stores.
         @SuppressLint("CommitPrefEdits")
         val userPrefs: SharedPreferences.Editor? =
             if (lifetime == Lifetime.User) userLifetimeStorage.edit() else null

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngine.kt
@@ -4,11 +4,15 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
+
 /**
  * Base interface intended to be implemented by the different
  * storage engines
  */
 internal interface StorageEngine {
+    var applicationContext: Context
+
     /**
      * Get a snapshot of the stored data as a JSON object.
      *

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
 import org.json.JSONObject
 
 /**
@@ -16,8 +17,15 @@ internal class StorageEngineManager(
         "events" to EventsStorageEngine,
         "strings" to StringsStorageEngine,
         "uuids" to UuidsStorageEngine
-    )
+    ),
+    applicationContext: Context
 ) {
+    init {
+        for ((_, engine) in storageEngines) {
+            engine.applicationContext = applicationContext
+        }
+    }
+
     /**
      * Collect the recorded data for the requested storage.
      *

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -14,7 +14,8 @@ import org.json.JSONObject
 internal class StorageEngineManager(
     private val storageEngines: Map<String, StorageEngine> = mapOf(
         "events" to EventsStorageEngine,
-        "strings" to StringsStorageEngine
+        "strings" to StringsStorageEngine,
+        "uuids" to UuidsStorageEngine
     )
 ) {
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -24,7 +24,7 @@ open class StringsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/StringsStorageEngine")
 ) : GenericScalarStorageEngine<String>() {
 
-    override fun singleMetricDeserializer(value: Any?): String? {
+    override fun deserializeSingleMetric(value: Any?): String? {
         return value as? String
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.glean.storages
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.support.annotation.VisibleForTesting
 import org.json.JSONObject
 
@@ -11,8 +13,15 @@ import org.json.JSONObject
  * This singleton handles the in-memory storage logic for strings. It is meant to be used by
  * the Specific Strings API and the ping assembling objects. No validation on the stored data
  * is performed at this point: validation must be performed by the Specific Strings API.
+ *
+ * This class contains a reference to the Android application Context. While the IDE warns
+ * us that this could leak, the application context lives as long as the application and this
+ * object. For this reason, we should be safe to suppress the IDE warning.
  */
+@SuppressLint("StaticFieldLeak")
 internal object StringsStorageEngine : StorageEngine {
+    override lateinit var applicationContext: Context
+
     private val stringStores: MutableMap<String, MutableMap<String, String>> = mutableMapOf()
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -23,14 +23,7 @@ internal object StringsStorageEngine : StringsStorageEngineImplementation()
 open class StringsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/StringsStorageEngine")
 ) : GenericScalarStorageEngine<String>() {
-    /**
-     * Implementor's provided function to convert deserialized 'user' lifetime
-     * data to the destination ScalarType.
-     *
-     * @param value loaded from the storage as [Any?]
-     *
-     * @return data as [String?] or null if deserialization failed
-     */
+
     override fun singleMetricDeserializer(value: Any?): String? {
         return value as? String
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -27,9 +27,9 @@ open class StringsStorageEngineImplementation(
      * Implementor's provided function to convert deserialized 'user' lifetime
      * data to the destination ScalarType.
      *
-     * @param data loaded from the storage as [Any]
+     * @param value loaded from the storage as [Any?]
      *
-     * @return data as [ScalarType] or null if deserialization failed
+     * @return data as [String?] or null if deserialization failed
      */
     override fun singleMetricDeserializer(value: Any?): String? {
         return value as? String

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -7,13 +7,15 @@ package mozilla.components.service.glean.storages
 import java.util.UUID
 
 import android.support.annotation.VisibleForTesting
+import org.json.JSONObject
 
 /**
  * This singleton handles the in-memory storage logic for uuids. It is meant to be used by
  * the Specific UUID API and the ping assembling objects. No validation on the stored data
  * is performed at this point: validation must be performed by the Specific Uuids API.
  */
-internal object UuidsStorageEngine {
+internal object UuidsStorageEngine : StorageEngine  {
+
     private val uuidStores: MutableMap<String, MutableMap<String, UUID>> = mutableMapOf()
 
     /**
@@ -24,7 +26,7 @@ internal object UuidsStorageEngine {
      * @param name the name of the uuid
      * @param value the uuid value to record
      */
-    public fun record(
+    fun record(
         stores: List<String>,
         category: String,
         name: String,
@@ -40,7 +42,7 @@ internal object UuidsStorageEngine {
     }
 
     /**
-     * Retrieves the [recorded uuid data][Uuid] for the provided
+     * Retrieves the [recorded uuid data][UUID] for the provided
      * store name.
      *
      * @param storeName the name of the desired uuid store
@@ -49,12 +51,26 @@ internal object UuidsStorageEngine {
      * @return the uuids recorded in the requested store
      */
     @Synchronized
-    public fun getSnapshot(storeName: String, clearStore: Boolean): MutableMap<String, UUID>? {
+    fun getSnapshot(storeName: String, clearStore: Boolean): MutableMap<String, UUID>? {
         if (clearStore) {
             return uuidStores.remove(storeName)
         }
 
         return uuidStores.get(storeName)
+    }
+
+    /**
+     * Get a snapshot of the stored data as a JSON object.
+     *
+     * @param storeName the name of the desired store
+     * @param clearStore whether or not to clearStore the requested store
+     *
+     * @return the [JSONObject] containing the recorded data.
+     */
+    override fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any? {
+        return getSnapshot(storeName, clearStore)?.let { uuidMap ->
+            return JSONObject(uuidMap)
+        }
     }
 
     @VisibleForTesting

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -4,19 +4,47 @@
 
 package mozilla.components.service.glean.storages
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
 import java.util.UUID
 
 import android.support.annotation.VisibleForTesting
+import mozilla.components.service.glean.Lifetime
+import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONObject
+
+// Convenience aliases to make the code more readable.
+internal typealias UUIDStorage = MutableMap<String, UUID>
+internal typealias UUIDMap = MutableMap<String, UUIDStorage>
 
 /**
  * This singleton handles the in-memory storage logic for uuids. It is meant to be used by
  * the Specific UUID API and the ping assembling objects. No validation on the stored data
  * is performed at this point: validation must be performed by the Specific Uuids API.
+ *
+ * This class contains a reference to the Android application Context. While the IDE warns
+ * us that this could leak, the application context lives as long as the application and this
+ * object. For this reason, we should be safe to suppress the IDE warning.
  */
-internal object UuidsStorageEngine : StorageEngine  {
+@SuppressLint("StaticFieldLeak")
+internal object UuidsStorageEngine : UuidsStorageEngineImplementation()
 
-    private val uuidStores: MutableMap<String, MutableMap<String, UUID>> = mutableMapOf()
+/**
+ * This class implements the behaviour for UuidsStorageEngine. This is separate
+ * from the object to make it easier to test it.
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+open class UuidsStorageEngineImplementation : StorageEngine {
+    override lateinit var applicationContext: Context
+
+    private val userLifetimeStorage: SharedPreferences by lazy { deserializeUserLifetime() }
+    private val logger = Logger("glean/HttpPingUploader")
+
+    // Use a multi-level map to store the data for the different lifetimes and
+    // stores: Map[Lifetime, Map[StorageName, UUID]].
+    private val uuidStores: Map<String, UUIDMap> =
+        Lifetime.values().associateBy({ it.toString() }, { mutableMapOf<String, UUIDStorage>() })
 
     /**
      * Record a uuid in the desired stores.
@@ -26,19 +54,29 @@ internal object UuidsStorageEngine : StorageEngine  {
      * @param name the name of the uuid
      * @param value the uuid value to record
      */
+    @Synchronized
     fun record(
         stores: List<String>,
         category: String,
         name: String,
+        lifetime: Lifetime,
         value: UUID
     ) {
+        checkNotNull(applicationContext) { "No recording can take place without an application context" }
+
         // Record a copy of the uuid in all the needed stores.
-        synchronized(this) {
-            for (storeName in stores) {
-                val storeData = uuidStores.getOrPut(storeName) { mutableMapOf() }
-                storeData.put("$category.$name", value)
+        val userPrefs: SharedPreferences.Editor? =
+            if (lifetime == Lifetime.User) userLifetimeStorage.edit() else null
+        for (storeName in stores) {
+            val storeData = uuidStores[lifetime.toString()]!!.getOrPut(storeName) { mutableMapOf() }
+            val entryName = "$category.$name"
+            storeData[entryName] = value
+            // Persist data with "user" lifetime
+            if (lifetime == Lifetime.User) {
+                userPrefs?.putString("$storeName#$entryName", value.toString())
             }
         }
+        userPrefs?.apply()
     }
 
     /**
@@ -51,12 +89,25 @@ internal object UuidsStorageEngine : StorageEngine  {
      * @return the uuids recorded in the requested store
      */
     @Synchronized
-    fun getSnapshot(storeName: String, clearStore: Boolean): MutableMap<String, UUID>? {
-        if (clearStore) {
-            return uuidStores.remove(storeName)
+    fun getSnapshot(storeName: String, clearStore: Boolean): UUIDStorage? {
+        val allLifetimes: UUIDStorage = mutableMapOf()
+
+        // Make sure data with "user" lifetime is loaded before getting the snapshot.
+        userLifetimeStorage.all
+
+        // Get the metrics for all the supported lifetimes.
+        for ((_, store) in uuidStores) {
+            store[storeName]?.let {
+                allLifetimes.putAll(it)
+            }
         }
 
-        return uuidStores.get(storeName)
+        if (clearStore) {
+            // We only allow clearing metrics with the "ping" lifetime.
+            uuidStores[Lifetime.Ping.toString()]!!.remove(storeName)
+        }
+
+        return if (allLifetimes.isNotEmpty()) allLifetimes else null
     }
 
     /**
@@ -73,8 +124,41 @@ internal object UuidsStorageEngine : StorageEngine  {
         }
     }
 
+    /**
+     * Deserialize the metrics with a lifetime = User that are on disk.
+     * This will be called the first time a metric is used or before a snapshot is
+     * taken.
+     *
+     * @return A [SharedPreferences] reference that will be used to inititialize [userLifetimeStorage]
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun deserializeUserLifetime(): SharedPreferences {
+        val prefs =
+            applicationContext.getSharedPreferences(this.javaClass.simpleName, Context.MODE_PRIVATE)
+        return try {
+            for ((metricName, metricValue) in prefs.all.entries) {
+                if (metricValue !is String) {
+                    continue
+                }
+
+                // Split the stored name in 2: we expect it to be in the format
+                // store#metric.name
+                val parts = metricName.split('#', limit = 2)
+                val storeData = uuidStores[Lifetime.User.toString()]!!.getOrPut(parts[0]) { mutableMapOf() }
+                storeData[parts[1]] = UUID.fromString(metricValue)
+            }
+            prefs
+        } catch (e: NullPointerException) {
+            // If we fail to deserialize, we can log the problem but keep on going.
+            logger.error("Failed to deserialize UUIDs with 'user' lifetime")
+            prefs
+        }
+    }
+
     @VisibleForTesting
     internal fun clearAllStores() {
-        uuidStores.clear()
+        for ((_, store) in uuidStores) {
+            store.clear()
+        }
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -5,7 +5,6 @@
 package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
-import android.support.annotation.VisibleForTesting
 import java.util.UUID
 
 import mozilla.components.service.glean.Lifetime

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -5,18 +5,10 @@
 package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
-import android.content.Context
-import android.content.SharedPreferences
 import java.util.UUID
 
-import android.support.annotation.VisibleForTesting
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.support.base.log.logger.Logger
-import org.json.JSONObject
-
-// Convenience aliases to make the code more readable.
-internal typealias UUIDStorage = MutableMap<String, UUID>
-internal typealias UUIDMap = MutableMap<String, UUIDStorage>
 
 /**
  * This singleton handles the in-memory storage logic for uuids. It is meant to be used by
@@ -30,21 +22,13 @@ internal typealias UUIDMap = MutableMap<String, UUIDStorage>
 @SuppressLint("StaticFieldLeak")
 internal object UuidsStorageEngine : UuidsStorageEngineImplementation()
 
-/**
- * This class implements the behaviour for UuidsStorageEngine. This is separate
- * from the object to make it easier to test it.
- */
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-open class UuidsStorageEngineImplementation : StorageEngine {
-    override lateinit var applicationContext: Context
+open class UuidsStorageEngineImplementation(
+    override val logger: Logger = Logger("glean/UuidsStorageEngine")
+) : GenericScalarStorageEngine<UUID>() {
 
-    private val userLifetimeStorage: SharedPreferences by lazy { deserializeUserLifetime() }
-    private val logger = Logger("glean/HttpPingUploader")
-
-    // Use a multi-level map to store the data for the different lifetimes and
-    // stores: Map[Lifetime, Map[StorageName, UUID]].
-    private val uuidStores: Map<String, UUIDMap> =
-        Lifetime.values().associateBy({ it.toString() }, { mutableMapOf<String, UUIDStorage>() })
+    override fun singleMetricDeserializer(value: Any?): UUID? {
+        return if (value is String) UUID.fromString(value) else null
+    }
 
     /**
      * Record a uuid in the desired stores.
@@ -52,6 +36,7 @@ open class UuidsStorageEngineImplementation : StorageEngine {
      * @param stores the list of stores to record the uuid into
      * @param category the category of the uuid
      * @param name the name of the uuid
+     * @param lifetime the lifetime of the stored metric data
      * @param value the uuid value to record
      */
     @Synchronized
@@ -62,103 +47,6 @@ open class UuidsStorageEngineImplementation : StorageEngine {
         lifetime: Lifetime,
         value: UUID
     ) {
-        checkNotNull(applicationContext) { "No recording can take place without an application context" }
-
-        // Record a copy of the uuid in all the needed stores.
-        val userPrefs: SharedPreferences.Editor? =
-            if (lifetime == Lifetime.User) userLifetimeStorage.edit() else null
-        for (storeName in stores) {
-            val storeData = uuidStores[lifetime.toString()]!!.getOrPut(storeName) { mutableMapOf() }
-            val entryName = "$category.$name"
-            storeData[entryName] = value
-            // Persist data with "user" lifetime
-            if (lifetime == Lifetime.User) {
-                userPrefs?.putString("$storeName#$entryName", value.toString())
-            }
-        }
-        userPrefs?.apply()
-    }
-
-    /**
-     * Retrieves the [recorded uuid data][UUID] for the provided
-     * store name.
-     *
-     * @param storeName the name of the desired uuid store
-     * @param clearStore whether or not to clearStore the requested uuid store
-     *
-     * @return the uuids recorded in the requested store
-     */
-    @Synchronized
-    fun getSnapshot(storeName: String, clearStore: Boolean): UUIDStorage? {
-        val allLifetimes: UUIDStorage = mutableMapOf()
-
-        // Make sure data with "user" lifetime is loaded before getting the snapshot.
-        userLifetimeStorage.all
-
-        // Get the metrics for all the supported lifetimes.
-        for ((_, store) in uuidStores) {
-            store[storeName]?.let {
-                allLifetimes.putAll(it)
-            }
-        }
-
-        if (clearStore) {
-            // We only allow clearing metrics with the "ping" lifetime.
-            uuidStores[Lifetime.Ping.toString()]!!.remove(storeName)
-        }
-
-        return if (allLifetimes.isNotEmpty()) allLifetimes else null
-    }
-
-    /**
-     * Get a snapshot of the stored data as a JSON object.
-     *
-     * @param storeName the name of the desired store
-     * @param clearStore whether or not to clearStore the requested store
-     *
-     * @return the [JSONObject] containing the recorded data.
-     */
-    override fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any? {
-        return getSnapshot(storeName, clearStore)?.let { uuidMap ->
-            return JSONObject(uuidMap)
-        }
-    }
-
-    /**
-     * Deserialize the metrics with a lifetime = User that are on disk.
-     * This will be called the first time a metric is used or before a snapshot is
-     * taken.
-     *
-     * @return A [SharedPreferences] reference that will be used to inititialize [userLifetimeStorage]
-     */
-    @Suppress("TooGenericExceptionCaught")
-    private fun deserializeUserLifetime(): SharedPreferences {
-        val prefs =
-            applicationContext.getSharedPreferences(this.javaClass.simpleName, Context.MODE_PRIVATE)
-        return try {
-            for ((metricName, metricValue) in prefs.all.entries) {
-                if (metricValue !is String) {
-                    continue
-                }
-
-                // Split the stored name in 2: we expect it to be in the format
-                // store#metric.name
-                val parts = metricName.split('#', limit = 2)
-                val storeData = uuidStores[Lifetime.User.toString()]!!.getOrPut(parts[0]) { mutableMapOf() }
-                storeData[parts[1]] = UUID.fromString(metricValue)
-            }
-            prefs
-        } catch (e: NullPointerException) {
-            // If we fail to deserialize, we can log the problem but keep on going.
-            logger.error("Failed to deserialize UUIDs with 'user' lifetime")
-            prefs
-        }
-    }
-
-    @VisibleForTesting
-    internal fun clearAllStores() {
-        for ((_, store) in uuidStores) {
-            store.clear()
-        }
+        super.recordScalar(stores, category, name, lifetime, value)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
+import android.support.annotation.VisibleForTesting
 import java.util.UUID
 
 import mozilla.components.service.glean.Lifetime
@@ -27,7 +28,11 @@ open class UuidsStorageEngineImplementation(
 ) : GenericScalarStorageEngine<UUID>() {
 
     override fun singleMetricDeserializer(value: Any?): UUID? {
-        return if (value is String) UUID.fromString(value) else null
+        return try {
+            if (value is String) UUID.fromString(value) else null
+        } catch (e: IllegalArgumentException) {
+            null
+        }
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -26,7 +26,7 @@ open class UuidsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/UuidsStorageEngine")
 ) : GenericScalarStorageEngine<UUID>() {
 
-    override fun singleMetricDeserializer(value: Any?): UUID? {
+    override fun deserializeSingleMetric(value: Any?): UUID? {
         return try {
             if (value is String) UUID.fromString(value) else null
         } catch (e: IllegalArgumentException) {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -43,7 +43,7 @@ class EventMetricTypeTest {
         val click = EventMetricType(
             disabled = false,
             category = "ui",
-            lifetime = Lifetime.Application,
+            lifetime = Lifetime.Ping,
             name = "click",
             sendInPings = listOf("store1"),
             objects = listOf("buttonA", "buttonB")
@@ -74,7 +74,27 @@ class EventMetricTypeTest {
     }
 
     @Test
-    fun `events with no lifetime must not record data`() {
+    fun `events with non 'ping' lifetime must not be recorded`() {
+        val testEvent = EventMetricType(
+            disabled = false,
+            category = "ui",
+            lifetime = Lifetime.Application,
+            name = "testEvent",
+            sendInPings = listOf("store1"),
+            allowedExtraKeys = listOf("extra1", "extra2"),
+            objects = listOf("buttonA")
+        )
+
+        testEvent.record("buttonA",
+            extra = mapOf("unknownExtra" to "someValue", "extra1" to "test"))
+
+        // Check that nothing was recorded.
+        val snapshot = EventsStorageEngine.getSnapshot(storeName = "store1", clearStore = false)
+        assertNull("Events must not be recorded if they use unknown extra keys", snapshot)
+    }
+
+    @Test
+    fun `disabled events must not record data`() {
         // Define a 'click' event, which will be stored in "store1". It's disabled
         // so it should not record anything.
         val click = EventMetricType(
@@ -95,32 +115,11 @@ class EventMetricTypeTest {
     }
 
     @Test
-    fun `disabled events must not record data`() {
-        // Define a 'click' event, which will be stored in "store1". It's disabled
-        // so it should not record anything.
-        val click = EventMetricType(
-            disabled = true,
-            category = "ui",
-            lifetime = Lifetime.Application,
-            name = "click",
-            sendInPings = listOf("store1"),
-            objects = listOf("buttonA")
-        )
-
-        // Attempt to store the event.
-        click.record("buttonA")
-
-        // Check that nothing was recorded.
-        val snapshot = EventsStorageEngine.getSnapshot(storeName = "store1", clearStore = false)
-        assertNull("Events must not be recorded if they are disabled", snapshot)
-    }
-
-    @Test
     fun `'objectId' is in the object set`() {
         val click = EventMetricType(
             disabled = false,
             category = "ui",
-            lifetime = Lifetime.Application,
+            lifetime = Lifetime.Ping,
             name = "click",
             sendInPings = listOf("store1"),
             objects = listOf("object1")
@@ -138,7 +137,7 @@ class EventMetricTypeTest {
         val click = EventMetricType(
             disabled = false,
             category = "ui",
-            lifetime = Lifetime.Application,
+            lifetime = Lifetime.Ping,
             name = "click",
             sendInPings = listOf("store1"),
             objects = listOf("buttonA", "buttonB")
@@ -166,7 +165,7 @@ class EventMetricTypeTest {
         val testEvent = EventMetricType(
             disabled = false,
             category = "ui",
-            lifetime = Lifetime.Application,
+            lifetime = Lifetime.Ping,
             name = "testEvent",
             sendInPings = listOf("store1"),
             objects = listOf("buttonA")
@@ -185,7 +184,7 @@ class EventMetricTypeTest {
         val testEvent = EventMetricType(
             disabled = false,
             category = "ui",
-            lifetime = Lifetime.Application,
+            lifetime = Lifetime.Ping,
             name = "testEvent",
             sendInPings = listOf("store1"),
             allowedExtraKeys = listOf("extra1", "extra2"),
@@ -205,7 +204,7 @@ class EventMetricTypeTest {
         val testEvent = EventMetricType(
             disabled = false,
             category = "ui",
-            lifetime = Lifetime.Application,
+            lifetime = Lifetime.Ping,
             name = "testEvent",
             sendInPings = listOf("store1"),
             allowedExtraKeys = listOf("extra1", "truncatedExtra"),

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean
 
+import android.content.Context
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -12,12 +13,20 @@ import org.junit.Test
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class StringMetricTypeTest {
 
     @Before
     fun setUp() {
+        StringsStorageEngine.applicationContext = RuntimeEnvironment.application
+        // Clear the stored "user" preferences between tests.
+        RuntimeEnvironment.application
+            .getSharedPreferences(StringsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
         StringsStorageEngine.clearAllStores()
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean
 
+import android.content.Context
 import java.util.UUID
 
 import mozilla.components.service.glean.storages.UuidsStorageEngine
@@ -14,12 +15,20 @@ import org.junit.Test
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class UuidMetricTypeTest {
 
     @Before
     fun setUp() {
+        UuidsStorageEngine.applicationContext = RuntimeEnvironment.application
+        // Clear the stored "user" preferences between tests.
+        RuntimeEnvironment.application
+            .getSharedPreferences(UuidsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
         UuidsStorageEngine.clearAllStores()
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.ping
 
+import android.content.Context
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.storages.MockStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
@@ -16,17 +17,20 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
 @RunWith(RobolectricTestRunner::class)
 class PingMakerTest {
+    private val mockApplicationContext = mock(Context::class.java)
+
     @Test
     fun `"ping_info" must contain a non-empty start_time and end_time`() {
         val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
                 "engine2" to MockStorageEngine(JSONObject())
-            )))
+            ), applicationContext = mockApplicationContext))
 
         // Gather the data. We expect an empty ping with the "ping_info" information
         val data = maker.collect("test")
@@ -50,7 +54,7 @@ class PingMakerTest {
     fun `getPingInfo() must report all the required fields`() {
         val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
             "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
-        )))
+        ), applicationContext = mockApplicationContext))
 
         // Gather the data. We expect an empty ping with the "ping_info" information
         val data = maker.collect("test")
@@ -74,7 +78,7 @@ class PingMakerTest {
             "engine1" to MockStorageEngine(engine1Data),
             "engine2" to MockStorageEngine(engine2Data),
             "wontCollect" to MockStorageEngine(JSONObject(), "notThisPing")
-        )))
+        ), applicationContext = mockApplicationContext))
 
         // Gather the data. We expect an empty ping with the "ping_info" information
         val data = maker.collect("test")

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
@@ -27,7 +27,7 @@ class GenericScalarStorageEngineTest {
     private class MockScalarStorageEngine(
         override val logger: Logger = Logger("test")
     ) : GenericScalarStorageEngine<Int>() {
-        override fun singleMetricDeserializer(value: Any?): Int? {
+        override fun deserializeSingleMetric(value: Any?): Int? {
             if (value is String) {
                 return value.toIntOrNull()
             }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/MockStorageEngine.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/MockStorageEngine.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
 import org.junit.Assert
 
 /**
@@ -16,6 +17,8 @@ internal class MockStorageEngine(
     private val sampleJSON: Any,
     private val sampleStore: String = "test"
 ) : StorageEngine {
+    override lateinit var applicationContext: Context
+
     override fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any? {
         Assert.assertTrue(clearStore)
         return if (storeName == sampleStore) sampleJSON else null

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.service.glean.storages
 
-import android.content.Context
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
@@ -12,16 +11,14 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class StorageEngineManagerTest {
-    private val mockApplicationContext = Mockito.mock(Context::class.java)
-
     @Test
     fun `collect() must return an empty object for empty or unknown stores`() {
-        val manager = StorageEngineManager(applicationContext = mockApplicationContext)
+        val manager = StorageEngineManager(applicationContext = RuntimeEnvironment.application)
         val data = manager.collect("thisStoreNameDoesNotExist")
         assertNotNull(data)
         assertEquals("{}", data.toString())
@@ -32,7 +29,7 @@ class StorageEngineManagerTest {
         val manager = StorageEngineManager(storageEngines = mapOf(
             "engine1" to MockStorageEngine(JSONObject(mapOf("test" to "val"))),
             "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
-        ), applicationContext = mockApplicationContext)
+        ), applicationContext = RuntimeEnvironment.application)
 
         val data = manager.collect("test")
         assertEquals("{\"engine1\":{\"test\":\"val\"},\"engine2\":[\"a\",\"b\",\"c\"]}",

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
@@ -11,13 +12,16 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class StorageEngineManagerTest {
+    private val mockApplicationContext = Mockito.mock(Context::class.java)
+
     @Test
     fun `collect() must return an empty object for empty or unknown stores`() {
-        val manager = StorageEngineManager()
+        val manager = StorageEngineManager(applicationContext = mockApplicationContext)
         val data = manager.collect("thisStoreNameDoesNotExist")
         assertNotNull(data)
         assertEquals("{}", data.toString())
@@ -28,7 +32,7 @@ class StorageEngineManagerTest {
         val manager = StorageEngineManager(storageEngines = mapOf(
             "engine1" to MockStorageEngine(JSONObject(mapOf("test" to "val"))),
             "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
-        ))
+        ), applicationContext = mockApplicationContext)
 
         val data = manager.collect("test")
         assertEquals("{\"engine1\":{\"test\":\"val\"},\"engine2\":[\"a\",\"b\",\"c\"]}",

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -3,6 +3,7 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
 import mozilla.components.service.glean.Lifetime
 import org.junit.Before
 import org.junit.Test
@@ -10,12 +11,20 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class StringsStorageEngineTest {
 
     @Before
     fun setUp() {
+        StringsStorageEngine.applicationContext = RuntimeEnvironment.application
+        // Clear the stored "user" preferences between tests.
+        RuntimeEnvironment.application
+            .getSharedPreferences(StringsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
         StringsStorageEngine.clearAllStores()
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -3,6 +3,7 @@
 
 package mozilla.components.service.glean.storages
 
+import mozilla.components.service.glean.Lifetime
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
@@ -27,6 +28,7 @@ class StringsStorageEngineTest {
                 stores = storeNames,
                 category = "telemetry",
                 name = "string_metric",
+                lifetime = Lifetime.Ping,
                 value = "test_string_object"
         )
 
@@ -50,10 +52,11 @@ class StringsStorageEngineTest {
 
         // Record the string in the stores, without providing optional arguments.
         StringsStorageEngine.record(
-                stores = storeNames,
-                category = "telemetry",
-                name = "string_metric",
-                value = "test_string_value"
+            stores = storeNames,
+            category = "telemetry",
+            name = "string_metric",
+            lifetime = Lifetime.Ping,
+            value = "test_string_value"
         )
 
         // Get the snapshot from "store1" and clear it.
@@ -77,6 +80,7 @@ class StringsStorageEngineTest {
             stores = listOf("store1"),
             category = "telemetry",
             name = "string_metric",
+            lifetime = Lifetime.Ping,
             value = "test_string_value"
         )
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -58,7 +58,6 @@ class StringsStorageEngineTest {
         assertEquals("test", snapshot["telemetry.valid"])
     }
 
-
     @Test
     fun `setValue() properly sets the value in all stores`() {
         val storeNames = listOf("store1", "store2")

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -74,4 +74,26 @@ class UuidsStorageEngineTest {
             assertEquals(1, s!!.size)
         }
     }
+
+    @Test
+    fun `Uuids are serialized in the correct JSON format`() {
+        val testUUID = "ce2adeb8-843a-4232-87a5-a099ed1e7bb3"
+
+        // Record the string in the store, without providing optional arguments.
+        UuidsStorageEngine.record(
+            stores = listOf("store1"),
+            category = "telemetry",
+            name = "uuid_metric",
+            value = UUID.fromString(testUUID)
+        )
+
+        // Get the snapshot from "store1" and clear it.
+        val snapshot = UuidsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = true)
+        // Check that getting a new snapshot for "store1" returns an empty store.
+        assertNull("The engine must report 'null' on empty stores",
+            UuidsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = false))
+        // Check that this serializes to the expected JSON format.
+        assertEquals("{\"telemetry.uuid_metric\":\"$testUUID\"}",
+            snapshot.toString())
+    }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -3,20 +3,32 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
+import mozilla.components.service.glean.Lifetime
 import java.util.UUID
 
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class UuidsStorageEngineTest {
 
     @Before
     fun setUp() {
+        UuidsStorageEngine.applicationContext = RuntimeEnvironment.application
+        // Clear the stored "user" preferences between tests.
+        RuntimeEnvironment.application
+            .getSharedPreferences(UuidsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
         UuidsStorageEngine.clearAllStores()
     }
 
@@ -30,6 +42,7 @@ class UuidsStorageEngineTest {
                 stores = storeNames,
                 category = "telemetry",
                 name = "uuid_metric",
+                lifetime = Lifetime.Ping,
                 value = uuid
         )
 
@@ -58,6 +71,7 @@ class UuidsStorageEngineTest {
                 stores = storeNames,
                 category = "telemetry",
                 name = "uuid_metric",
+                lifetime = Lifetime.Ping,
                 value = uuid
         )
 
@@ -84,6 +98,7 @@ class UuidsStorageEngineTest {
             stores = listOf("store1"),
             category = "telemetry",
             name = "uuid_metric",
+            lifetime = Lifetime.Ping,
             value = UUID.fromString(testUUID)
         )
 
@@ -96,4 +111,87 @@ class UuidsStorageEngineTest {
         assertEquals("{\"telemetry.uuid_metric\":\"$testUUID\"}",
             snapshot.toString())
     }
+
+    @Test
+    fun `uuids with 'user' lifetime must be correctly persisted`() {
+        val sampleUUID = "decaffde-caff-d3ca-ffd3-caffd3caffd3"
+
+        val storageEngine = UuidsStorageEngineImplementation()
+        storageEngine.applicationContext = RuntimeEnvironment.application
+
+        storageEngine.record(
+            stores = listOf("some_store", "other_store"),
+            category = "telemetry",
+            name = "uuidMetric",
+            lifetime = Lifetime.User,
+            value = UUID.fromString(sampleUUID)
+        )
+
+        // Check that the persisted shared prefs contains the expected data.
+        val storedData = RuntimeEnvironment.application
+            .getSharedPreferences(storageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .all
+
+        assertEquals(2, storedData.size)
+        assertTrue(storedData.containsKey("some_store#telemetry.uuidMetric"))
+        assertTrue(storedData.containsKey("other_store#telemetry.uuidMetric"))
+        assertEquals(sampleUUID, storedData.getValue("some_store#telemetry.uuidMetric"))
+        assertEquals(sampleUUID, storedData.getValue("other_store#telemetry.uuidMetric"))
+    }
+
+    @Test
+    fun `uuids with 'user' lifetime must not be cleared when snapshotting`() {
+        val uuidUserLifetime = UUID.randomUUID()
+        val uuidPingLifetime = UUID.randomUUID()
+
+        val storageEngine = UuidsStorageEngineImplementation()
+        storageEngine.applicationContext = RuntimeEnvironment.application
+
+        // Record a value with User lifetime
+        storageEngine.record(
+            stores = listOf("store1"),
+            category = "telemetry",
+            name = "userUUID",
+            lifetime = Lifetime.User,
+            value = uuidUserLifetime
+        )
+
+        // Record a value with Ping lifetime
+        storageEngine.record(
+            stores = listOf("store1"),
+            category = "telemetry",
+            name = "pingUUID",
+            lifetime = Lifetime.Ping,
+            value = uuidPingLifetime
+        )
+
+        // Take a snapshot and clear the store: this snapshot must contain the data for
+        // both metrics.
+        val firstSnapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
+        assertEquals(2, firstSnapshot!!.size)
+        assertEquals(uuidUserLifetime, firstSnapshot["telemetry.userUUID"])
+        assertEquals(uuidPingLifetime, firstSnapshot["telemetry.pingUUID"])
+
+        // Take a new snapshot. The ping lifetime data should have been cleared and not be
+        // available anymore, data with 'user' lifetime must still be around.
+        val secondSnapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
+        assertEquals(1, secondSnapshot!!.size)
+        assertEquals(uuidUserLifetime, secondSnapshot["telemetry.userUUID"])
+        assertFalse(secondSnapshot.contains("telemetry.pingUUID"))
+    }
+
+    @Test
+    fun `uuids with 'user' lifetime must be correctly unpersisted before setting new values`() {}
+
+    @Test
+    fun `uuids with 'user' lifetime must be correctly unpersisted before taking snapshots`() {}
+
+    @Test
+    fun `corrupted 'user' lifetime store must not break snapshotting or accumulation`() {}
+
+    @Test
+    fun `snapshotting must only clear 'ping' lifetime`() {}
+
+    @Test
+    fun `uuids with 'application' lifetime must be cleared when the application is closed`() {}
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -15,11 +15,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -10,7 +10,6 @@ import java.util.UUID
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
@@ -138,60 +137,4 @@ class UuidsStorageEngineTest {
         assertEquals(sampleUUID, storedData.getValue("some_store#telemetry.uuidMetric"))
         assertEquals(sampleUUID, storedData.getValue("other_store#telemetry.uuidMetric"))
     }
-
-    @Test
-    fun `uuids with 'user' lifetime must not be cleared when snapshotting`() {
-        val uuidUserLifetime = UUID.randomUUID()
-        val uuidPingLifetime = UUID.randomUUID()
-
-        val storageEngine = UuidsStorageEngineImplementation()
-        storageEngine.applicationContext = RuntimeEnvironment.application
-
-        // Record a value with User lifetime
-        storageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "userUUID",
-            lifetime = Lifetime.User,
-            value = uuidUserLifetime
-        )
-
-        // Record a value with Ping lifetime
-        storageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "pingUUID",
-            lifetime = Lifetime.Ping,
-            value = uuidPingLifetime
-        )
-
-        // Take a snapshot and clear the store: this snapshot must contain the data for
-        // both metrics.
-        val firstSnapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
-        assertEquals(2, firstSnapshot!!.size)
-        assertEquals(uuidUserLifetime, firstSnapshot["telemetry.userUUID"])
-        assertEquals(uuidPingLifetime, firstSnapshot["telemetry.pingUUID"])
-
-        // Take a new snapshot. The ping lifetime data should have been cleared and not be
-        // available anymore, data with 'user' lifetime must still be around.
-        val secondSnapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
-        assertEquals(1, secondSnapshot!!.size)
-        assertEquals(uuidUserLifetime, secondSnapshot["telemetry.userUUID"])
-        assertFalse(secondSnapshot.contains("telemetry.pingUUID"))
-    }
-
-    @Test
-    fun `uuids with 'user' lifetime must be correctly unpersisted before setting new values`() {}
-
-    @Test
-    fun `uuids with 'user' lifetime must be correctly unpersisted before taking snapshots`() {}
-
-    @Test
-    fun `corrupted 'user' lifetime store must not break snapshotting or accumulation`() {}
-
-    @Test
-    fun `snapshotting must only clear 'ping' lifetime`() {}
-
-    @Test
-    fun `uuids with 'application' lifetime must be cleared when the application is closed`() {}
 }


### PR DESCRIPTION
This PR enables support for all the `Lifetime` values (`Ping`, `User` and `Application`) in the metrics. See the [spec](https://docs.google.com/document/d/186GI_2ljdqWqWTBk5P3QjHD3BwpMyd8kRayRAuz1-dk/edit#) for additional details.

**`Lifetime` tl;dr**

- the `Ping` lifetime will clear the value stored for the metric whenever a ping in which it is contained is collected;
- the `Application` lifetime will clear the value when the application is closed;
- the `User` lifetime will store the values to disk making them available again next time the application is started again (think of the `client_id`).

**Rationale**
The backend support for storing metrics with `User` lifetime is provided by the [SharedPreferences](https://developer.android.com/reference/android/content/SharedPreferences#getAll()). This requires us to have a valid `Context` from which to get the `SharedPreferences`, which is passed on to the API `StorageEngine`(s) by the `StorageEngineManager`.

The backing storage is loaded off the disk the first time we attempt to write a metric with `User` lifetime or when a snapshot is requested.