### PR TITLE
Closes #1252: Webfont blocking is controlled by both policy and setting.

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -407,8 +407,7 @@ class SystemEngineView @JvmOverloads constructor(
                 UrlMatcher.ADVERTISING to TrackingProtectionPolicy.AD,
                 UrlMatcher.ANALYTICS to TrackingProtectionPolicy.ANALYTICS,
                 UrlMatcher.CONTENT to TrackingProtectionPolicy.CONTENT,
-                UrlMatcher.SOCIAL to TrackingProtectionPolicy.SOCIAL,
-                UrlMatcher.WEBFONTS to TrackingProtectionPolicy.WEBFONTS
+                UrlMatcher.SOCIAL to TrackingProtectionPolicy.SOCIAL
         )
 
         @Synchronized

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/matcher/UrlMatcher.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/matcher/UrlMatcher.kt
@@ -23,7 +23,6 @@ class UrlMatcher {
     private val whiteList: WhiteList?
     private val previouslyMatched = HashSet<String>()
     private val previouslyUnmatched = HashSet<String>()
-    private var blockWebfonts = true
 
     constructor(patterns: Array<String>) {
         categories = HashMap()
@@ -66,11 +65,6 @@ class UrlMatcher {
     }
 
     internal fun setCategoryEnabled(category: String, enabled: Boolean) {
-        if (WEBFONTS == category) {
-            blockWebfonts = enabled
-            return
-        }
-
         if (enabled) {
             if (enabledCategories.contains(category)) {
                 return
@@ -114,10 +108,6 @@ class UrlMatcher {
         val resourceHost = resourceURI.host
         val pageHost = pageURI.host
 
-        if (blockWebfonts && isWebFont(resourceURI)) {
-            return true
-        }
-
         if (previouslyUnmatched.contains(resourceURLString)) {
             return false
         }
@@ -151,13 +141,12 @@ class UrlMatcher {
         const val CONTENT = "Content"
         const val DISCONNECT = "Disconnect"
         const val SOCIAL = "Social"
-        const val WEBFONTS = "Webfonts"
         const val DEFAULT = "default"
 
         private val ignoredCategories = setOf("Legacy Disconnect", "Legacy Content")
         private val disconnectMoved = setOf("Facebook", "Twitter")
-        private val webfontExceptions = arrayOf(".woff2", ".woff", ".eot", ".ttf", ".otf")
-        private val supportedCategories = setOf(ADVERTISING, ANALYTICS, SOCIAL, CONTENT, WEBFONTS)
+        private val webfontExtensions = arrayOf(".woff2", ".woff", ".eot", ".ttf", ".otf")
+        private val supportedCategories = setOf(ADVERTISING, ANALYTICS, SOCIAL, CONTENT)
 
         /**
          * Creates a new matcher instance for the provided URL lists.
@@ -217,7 +206,7 @@ class UrlMatcher {
          */
         fun isWebFont(uri: Uri): Boolean {
             val path = uri.path ?: return false
-            return webfontExceptions.find { path.endsWith(it) } != null
+            return webfontExtensions.find { path.endsWith(it) } != null
         }
 
         private fun loadCategories(

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/UrlMatcherTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/UrlMatcherTest.kt
@@ -278,4 +278,15 @@ class UrlMatcherTest {
         verify(matcher).setCategoryEnabled("Analytics", true)
         verify(matcher).setCategoryEnabled("Content", true)
     }
+
+    @Test
+    fun webFontsNotBlockedByDefault() {
+        val matcher = UrlMatcher.createMatcher(
+                StringReader(BLOCK_LIST),
+                listOf(StringReader(OVERRIDES)),
+                StringReader(WHITE_LIST),
+                setOf(UrlMatcher.ADVERTISING, UrlMatcher.ANALYTICS, UrlMatcher.SOCIAL, UrlMatcher.CONTENT))
+
+        assertFalse(matcher.matches("http://mozilla.org/fonts/test.woff2", "http://mozilla.org"))
+    }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -68,7 +68,8 @@ abstract class EngineSession(
             const val ANALYTICS: Int = 1 shl 1
             const val SOCIAL: Int = 1 shl 2
             const val CONTENT: Int = 1 shl 3
-            const val WEBFONTS: Int = 1 shl 4
+            // This policy is just to align categories with GeckoView (which has CATEGORY_TEST = 1 << 4)
+            const val TEST: Int = 1 shl 4
             internal const val ALL: Int = (1 shl 5) - 1
 
             fun none(): TrackingProtectionPolicy = TrackingProtectionPolicy(NONE)

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -463,15 +463,15 @@ class EngineSessionTest {
                 TrackingProtectionPolicy.AD,
                 TrackingProtectionPolicy.ANALYTICS,
                 TrackingProtectionPolicy.CONTENT,
-                TrackingProtectionPolicy.SOCIAL,
-                TrackingProtectionPolicy.WEBFONTS).categories)
+                TrackingProtectionPolicy.TEST,
+                TrackingProtectionPolicy.SOCIAL).categories)
 
         val policy = TrackingProtectionPolicy.select(TrackingProtectionPolicy.AD, TrackingProtectionPolicy.ANALYTICS)
         assertTrue(policy.contains(TrackingProtectionPolicy.AD))
         assertTrue(policy.contains(TrackingProtectionPolicy.ANALYTICS))
-        assertFalse(policy.contains(TrackingProtectionPolicy.WEBFONTS))
         assertFalse(policy.contains(TrackingProtectionPolicy.SOCIAL))
         assertFalse(policy.contains(TrackingProtectionPolicy.CONTENT))
+        assertFalse(policy.contains(TrackingProtectionPolicy.TEST))
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,15 @@ permalink: /changelog/
 
   ```
 
+* **concept-engine**, **engine-system**:
+  * ⚠️ **This is a breaking change**
+  * Web font blocking is now controlled by an engine setting only. `TrackingProtectionPolicy.WEBFONTS` was removed:
+
+  ```Kotlin
+  // Disable web fonts by default
+  SystemEngine(runtime, DefaultSettings(webFontsEnabled = false))
+  ```
+
 # 0.30.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.29.0...v0.30.0),


### PR DESCRIPTION
Small change. We're basically removing the tracking protection policy, and making sure we're not blocking webfonts by default. The rest of the functionality can stay the same: If `engine.settings.webFontsEnabled = false`, we're blocking webfonts as we did before. This change only affects `SystemEngine`, which used both the policy and the setting. 