### PR TITLE
Delineates line in gradle output with module JSON

### DIFF
--- a/automation/taskcluster/lib/module_definitions.py
+++ b/automation/taskcluster/lib/module_definitions.py
@@ -15,7 +15,9 @@ def from_gradle():
     if exit_code is not 0:
         print("Gradle command returned error: {}".format(exit_code))
 
-    gradle_modules = json.loads(output)
+    modules_line = [line for line in output.splitlines() if line.startswith('modules: ')][0]
+    modules_json = modules_line.split(' ', 1)[1]
+    gradle_modules = json.loads(modules_json)
     return [{
         'name': module['name'][1:],  # Gradle prefixes all module names with ":", e.g.: ":browser-awesomebar"
         'artifact': "public/build/{}.maven.zip".format(module['name'][1:]),

--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ task printModules {
             buildPath: p.buildDir.toString(),
             shouldPublish: p.ext.shouldPublish
         ] }
-        println groovy.json.JsonOutput.toJson(modules)
+        println "modules: " + groovy.json.JsonOutput.toJson(modules)
     }
 }
 


### PR DESCRIPTION
In my original PR, I assumed that `--quiet` would keep Gradle entirely silent except for our special `println`, which turned out to be incorrect.
So, instead, I'm marking that line with our special output with "modules: ".
There's still a bit of a risk that some other output will start with "modules: ", but since `gradle` doesn't seem to have a ["non-porcelain mode"](https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain), `--quiet` with this might be the best solution (so far)