### PR TITLE
Issue #1348: (tooling-fetch-tests) Ignore external jars when running lint.

### DIFF
--- a/components/tooling/fetch-tests/build.gradle
+++ b/components/tooling/fetch-tests/build.gradle
@@ -21,6 +21,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+
+    lintOptions {
+        lintConfig file("lint.xml")
+    }
 }
 
 dependencies {

--- a/components/tooling/fetch-tests/lint.xml
+++ b/components/tooling/fetch-tests/lint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="**/bcprov-*on-*.jar"/>
+        <ignore path="**/junit-*.jar"/>
+    </issue>
+</lint>


### PR DESCRIPTION
Fixes the issues we saw in PR #1350.