### PR TITLE
Closes #1356: Introduce consumable stream for session fields

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Consumable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Consumable.kt
@@ -4,18 +4,12 @@
 
 package mozilla.components.support.base.observer
 
-import android.support.annotation.VisibleForTesting
-
 /**
  * A generic wrapper for values that can get consumed.
  */
 class Consumable<T> private constructor(
-    private var value: T?
+    internal var value: T?
 ) {
-    // Internal getter for testing only.
-    @VisibleForTesting internal val internalValue: T?
-        get() = value
-
     /**
      * Invokes the given lambda and marks the value as consumed if the lambda returns true.
      */
@@ -31,7 +25,7 @@ class Consumable<T> private constructor(
 
     /**
      * Invokes the given list of lambdas and marks the value as consumed if at least one lambda
-     * returned true.
+     * returns true.
      */
     @Synchronized
     fun consumeBy(consumers: List<(T) -> Boolean>): Boolean {
@@ -54,13 +48,120 @@ class Consumable<T> private constructor(
 
     companion object {
         /**
-         * Create a new Consumable wrapping the given value.
+         * Creates a new Consumable wrapping the given value.
          */
         fun <T> from(value: T): Consumable<T> = Consumable(value)
+
+        /**
+         * Creates a new Consumable stream for the provided values.
+         */
+        fun <T> stream(vararg values: T): ConsumableStream<T> = ConsumableStream(
+            values.map { Consumable(it) }
+        )
 
         /**
          * Returns an empty Consumable with not value as if it was consumed already.
          */
         fun <T> empty(): Consumable<T> = Consumable(null)
     }
+}
+
+/**
+ * A generic wrapper for a stream of values that can be consumed. Values will
+ * be consumed first in, first out.
+ */
+class ConsumableStream<T> internal constructor(private val consumables: List<Consumable<T>>) {
+
+    /**
+     * Invokes the given lambda with the next consumable value and marks the value
+     * as consumed if the lambda returns true.
+     *
+     * @param consumer a lambda accepting a consumable value.
+     * @return true if the consumable was consumed, otherwise false.
+     */
+    @Synchronized
+    fun consumeNext(consumer: (value: T) -> Boolean): Boolean {
+        val consumable = consumables.find { !it.isConsumed() }
+        return consumable?.consume(consumer) ?: false
+    }
+
+    /**
+     * Invokes the given lambda for each consumable value and marks the values
+     * as consumed if the lambda returns true.
+     *
+     * @param consumer a lambda accepting a consumable value.
+     * @return true if all consumables were consumed, otherwise false.
+     */
+    @Synchronized
+    fun consumeAll(consumer: (value: T) -> Boolean): Boolean {
+        val results = consumables.map { if (!it.isConsumed()) it.consume(consumer) else true }
+        return !results.contains(false)
+    }
+
+    /**
+     * Invokes the given list of lambdas with the next consumable value and marks the
+     * value as consumed if at least one lambda returns true.
+     *
+     * @param consumers the lambdas accepting the next consumable value.
+     * @return true if the consumable was consumed, otherwise false.
+     */
+    @Synchronized
+    fun consumeNextBy(consumers: List<(T) -> Boolean>): Boolean {
+        val consumable = consumables.find { !it.isConsumed() }
+        return consumable?.consumeBy(consumers) ?: false
+    }
+
+    /**
+     * Invokes the given list of lambdas for each consumable value and marks the
+     * values as consumed if at least one lambda returns true.
+     *
+     * @param consumers the lambdas accepting a consumable value.
+     * @return true if all consumables were consumed, otherwise false.
+     */
+    @Synchronized
+    fun consumeAllBy(consumers: List<(T) -> Boolean>): Boolean {
+        val results = consumables.map { if (!it.isConsumed()) it.consumeBy(consumers) else true }
+        return !results.contains(false)
+    }
+
+    /**
+     * Copies the stream and appends the provided values.
+     *
+     * @param values the values to append.
+     * @return a new consumable stream with the values appended.
+     */
+    @Synchronized
+    fun append(vararg values: T): ConsumableStream<T> =
+        ConsumableStream(consumables + values.map { Consumable.from(it) })
+
+    /**
+     * Copies the stream but removes all consumables equal to the provided value.
+     *
+     * @param value the value to remove.
+     * @return a new consumable stream with the matching values removed.
+     */
+    @Synchronized
+    fun remove(value: T): ConsumableStream<T> =
+        ConsumableStream(consumables.filterNot { it.value == value })
+
+    /**
+     * Copies the stream but removes all consumed values.
+     *
+     * @return a new consumable stream with the consumed values removed.
+     */
+    @Synchronized
+    fun removeConsumed(): ConsumableStream<T> =
+        ConsumableStream(consumables.filterNot { it.isConsumed() })
+
+    /**
+     * Returns true if all values in this stream were consumed, otherwise false.
+     */
+    @Synchronized
+    fun isConsumed() = consumables.filterNot { it.isConsumed() }.isEmpty()
+
+    /**
+     * Returns true if the stream is empty, otherwise false.
+     */
+    @Synchronized
+    fun isEmpty() = consumables.isEmpty()
 }


### PR DESCRIPTION
This builds on our existing `Consumable` concept and enhances it to support streams of consumable values.

Say we wanted to have multiple concurrent downloads in a session, our `EngineObserver` would set the field as:

```Kotlin
session.downloads = Consumable.stream(download1)
```
and if it later observes more engine download events, it can keep appending or cancelling:
```Kotlin
session.downloads = session.downloads.append(download2)
session.downloads = session.downloads.remove(download2)
```

Within our browser session, we can use `Delegates.vetoable` just as we do now where we veto the new values if that are all consumed, and otherwise keep them to be consumed later:

```Kotlin
 var downloads: ConsumableStream<Download> by Delegates.vetoable(Consumable.stream()) {
    _, _, consumables ->
      val consumers = wrapConsumers<Download> { onDownload(this@Session, it) }
      !consumables.consumeAllBy(consumers)
 }
``` 

The implemenation was pretty simple with our existing `Consumable`. I've added a few more methods that allow us to consume individual values as well as all at once.