### PR TITLE
[glean] Enable sending the "baseline" ping from the sample app

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/GleanInternalMetrics.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/GleanInternalMetrics.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.metrics
+
+import mozilla.components.service.glean.Lifetime
+import mozilla.components.service.glean.UuidMetricType
+
+/**
+ * This class holds the set of core metrics handled by the Glean library.
+ * This metrics are not meant to be exposed to the outside: their values
+ * are only relevant to Glean, updated and fetched when needed.
+ *
+ * Ideally, this should be generated from an internal metrics.yaml file.
+ * Bug 1507743 is for dealing with that.
+ */
+class GleanInternalMetrics {
+    val clientId: UuidMetricType by lazy {
+        UuidMetricType(
+            name = "client_id",
+            category = "",
+            sendInPings = listOf("glean_ping_info"),
+            lifetime = Lifetime.User,
+            disabled = false
+        )
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -7,6 +7,9 @@ package mozilla.components.service.glean.ping
 import android.support.annotation.VisibleForTesting
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.storages.StorageEngineManager
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.org.json.mergeWith
+import org.json.JSONException
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -15,6 +18,7 @@ import java.util.Locale
 internal class PingMaker(
     private val storageManager: StorageEngineManager
 ) {
+    private val logger = Logger("glean/PingMaker")
     private val pingStartTimes: MutableMap<String, String> = mutableMapOf()
     private val objectStartTime = getISOTimeString()
 
@@ -42,6 +46,8 @@ internal class PingMaker(
         pingInfo.put("ping_type", pingName)
         pingInfo.put("telemetry_sdk_build", BuildConfig.LIBRARY_VERSION)
 
+        pingInfo.mergeWith(getPingInfoMetrics())
+
         // This needs to be a bit more involved for start-end times. "start_time" is
         // the time the ping was generated the last time. If not available, we use the
         // date the object was initialized.
@@ -52,6 +58,32 @@ internal class PingMaker(
         // Update the start time with the current time.
         pingStartTimes[pingName] = endTime
         return pingInfo
+    }
+
+    /**
+     * Collect the metrics stored in the "glean_ping_info" bucket.
+     *
+     * @return a [JSONObject] containing the metrics belonging to the "ping_info"
+     *         section of the ping.
+     */
+    private fun getPingInfoMetrics(): JSONObject {
+        val pingInfoData = storageManager.collect("glean_ping_info")
+
+        // The data returned by the manager is keyed by the storage engine name.
+        // For example, the client id will live in the "uuid" object, within
+        // `pingInfoData`. Remove the first level of indirection and return
+        // the flattened data to the caller.
+        val flattenedData = JSONObject()
+        try {
+            val metricsData = pingInfoData.getJSONObject("metrics")
+            for (key in metricsData.keys()) {
+                flattenedData.mergeWith(metricsData.getJSONObject(key))
+            }
+        } catch (e: JSONException) {
+            logger.warn("Empty ping info data.")
+        }
+
+        return flattenedData
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -183,7 +183,9 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
             if (lifetime == Lifetime.User) userLifetimeStorage.edit() else null
         stores.forEach {
             val storeData = dataStores[lifetime.ordinal].getOrPut(it) { mutableMapOf() }
-            val entryName = "$category.$name"
+            // We support empty categories for enabling the internal use of metrics
+            // when assembling pings in [PingMaker].
+            val entryName = if (category.isEmpty()) name else "$category.$name"
             storeData[entryName] = value
             // Persist data with "user" lifetime
             if (lifetime == Lifetime.User) {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
@@ -88,6 +88,27 @@ class GenericScalarStorageEngineTest {
     }
 
     @Test
+    fun `metrics with empty 'category' must be properly recorded`() {
+        val storageEngine = MockScalarStorageEngine()
+        storageEngine.applicationContext = RuntimeEnvironment.application
+
+        // Record a value with User lifetime
+        storageEngine.record(
+            stores = listOf("store1"),
+            category = "",
+            name = "noCategoryName",
+            lifetime = Lifetime.Ping,
+            value = 37
+        )
+
+        // Take a snapshot and clear the store: this snapshot must contain the data for
+        // both metrics.
+        val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
+        assertEquals(1, snapshot!!.size)
+        assertEquals(37, snapshot["noCategoryName"])
+    }
+
+    @Test
     fun `metric with 'user' lifetime must be correctly unpersisted when recording 'user' values`() {
         // Make up the test data that we pretend to be unserialized.
         val persistedSample = mapOf(

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/org/json/JSONObject.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/org/json/JSONObject.kt
@@ -73,3 +73,16 @@ fun JSONObject.sortKeys(): JSONObject {
 fun Map<String, String>.toJSON() = JSONObject().apply {
     forEach { (key, value) -> put(key, value) }
 }
+
+/**
+ * Merge the contents of another [JSONObject] with this object,
+ * overwriting the colliding keys.
+ *
+ * @param other the [JSONObject] providing the data to be
+ *        merged with this one.
+ */
+fun JSONObject.mergeWith(other: JSONObject) {
+    for (key in other.keys()) {
+        put(key, other[key])
+    }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/org/json/JSONObjectTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/org/json/JSONObjectTest.kt
@@ -76,4 +76,24 @@ class JSONObjectTest {
         val jsonObject = JSONObject("""{"key":3}""")
         assertEquals(3, jsonObject.tryGetInt("key"))
     }
+
+    @Test
+    fun mergeWith() {
+        val merged = JSONObject(mapOf(
+            "toKeep" to 3,
+            "toOverride" to "OHNOZ"
+        ))
+
+        merged.mergeWith(JSONObject(mapOf(
+            "newKey" to 5,
+            "toOverride" to "YAY"
+        )))
+
+        val expectedObject = JSONObject(mapOf(
+            "toKeep" to 3,
+            "toOverride" to "YAY",
+            "newKey" to 5
+        ))
+        assertEquals(expectedObject.toString(), merged.toString())
+    }
 }

--- a/samples/glean/metrics.yaml
+++ b/samples/glean/metrics.yaml
@@ -29,14 +29,3 @@ basic:
       - 123456789
     notification_emails:
       - telemetry-client-dev@mozilla.com
-
-  client_id:
-    type: uuid
-    lifetime: user
-    description: >
-      A UUID identifying a profile and allowing user-oriented correlation of
-      data.
-    bugs:
-      - 123456789
-    notification_emails:
-      - telemetry-client-dev@mozilla.com

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -6,7 +6,10 @@ package org.mozilla.samples.glean
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.view.View
+import kotlinx.android.synthetic.main.activity_main.buttonGenerateData
+import kotlinx.android.synthetic.main.activity_main.buttonSendPing
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
 
@@ -18,11 +21,15 @@ open class MainActivity : AppCompatActivity() {
 
         Log.addSink(AndroidLogSink())
 
+        // Initialize the Glean library. Ideally, this is the first thing that
+        // must be done right after enabling logging.
+        Glean.initialize(applicationContext, Configuration())
+
+        // Set a sample value for a metric.
         GleanMetrics.Basic.os.set("Android")
-        GleanMetrics.Basic.clientId.generateAndSet()
 
         // Generate an event when user clicks on the button.
-        findViewById<View>(R.id.buttonWebView).setOnClickListener {
+        buttonGenerateData.setOnClickListener {
             GleanMetrics.BrowserEngagement.click.record(
                     "object1",
                     "data",
@@ -31,6 +38,11 @@ open class MainActivity : AppCompatActivity() {
                             "key2" to "extra_value_2"
                     )
             )
+        }
+
+        // Generate a "baseline" ping on click.
+        buttonSendPing.setOnClickListener {
+            Glean.handleEvent(Glean.PingEvent.Background)
         }
     }
 }

--- a/samples/glean/src/main/res/layout/activity_main.xml
+++ b/samples/glean/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:id="@+id/container"
-    tools:context="org.mozilla.samples.sync.logins.MainActivity">
+    tools:context="org.mozilla.samples.glean.MainActivity">
 
 
     <LinearLayout
@@ -19,7 +19,7 @@
         android:layout_alignParentTop="true"
         android:orientation="vertical"
         android:id="@+id/buttonList"
-        tools:context="org.mozilla.samples.sync.logins.MainActivity"
+        tools:context="org.mozilla.samples.glean.MainActivity"
         tools:ignore="UselessParent">
 
         <Button

--- a/samples/glean/src/main/res/layout/activity_main.xml
+++ b/samples/glean/src/main/res/layout/activity_main.xml
@@ -23,10 +23,17 @@
         tools:ignore="UselessParent">
 
         <Button
-            android:id="@+id/buttonWebView"
+            android:id="@+id/buttonGenerateData"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/sign_in_webview" />
+            android:text="@string/generate_data" />
+
+        <Button
+            android:id="@+id/buttonSendPing"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/send_baseline_ping" />
 
     </LinearLayout>
+
 </RelativeLayout>

--- a/samples/glean/src/main/res/values/strings.xml
+++ b/samples/glean/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <string name="app_name">Glean - Metrics Demo</string>
-    <string name="sign_in_webview">Generate data</string>
+    <string name="send_baseline_ping">Send "baseline" ping</string>
+    <string name="generate_data">Generate data</string>
 </resources>


### PR DESCRIPTION
This PR additionally fixes a few bugs in the ping submission code:
- HTTP I/O needs to happen off the main thread otherwise we crash;
- `path` and `payload` arguments where swapped in `upload()`

Moreover, this PR also introduces:

- the internal object that manages the set of core metrics used by
Glean. This file will be removed and automatically generated on build
in future PRs;
- the (internal) ability to have metrics without a category name, for
using built-in metrics when assembling the "ping_info" section of the ping;
- the "mergeWith" `JSONObject` extension function, to merge two `JSONObject`
instances.