### PR TITLE
[glean] Add the missing required fields to the "baseline" ping

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -40,11 +40,14 @@ internal class PingMaker(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun getPingInfo(pingName: String): JSONObject {
-        // TODO this section is still missing app_build, client_id, seq and experiments.
-        // These fields will be added by bug 1497894 when 1499756 and 1501318 land.
         val pingInfo = JSONObject()
         pingInfo.put("ping_type", pingName)
         pingInfo.put("telemetry_sdk_build", BuildConfig.LIBRARY_VERSION)
+
+        // TODO this section is still missing real app_build, seq and experiments.
+        // These fields will be added by bug 1497894 when 1499756 and 1501318 land.
+        pingInfo.put("seq", 0)
+        pingInfo.put("app_build", "test-placeholder")
 
         pingInfo.mergeWith(getPingInfoMetrics())
 


### PR DESCRIPTION
These fields are needed so that the pipeline doesn't redirect the pings into the error stream. See the [ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/dev/schemas/glean/baseline/baseline.1.schema.json) for more details.