### PR TITLE
[glean] Check generated ping content against their json schema

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -2,8 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+plugins {
+    id "com.jetbrains.python.envs" version "0.0.25"
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+
+/*
+ * This defines the location of the JSON schema used to validate the pings
+ * created during unit testing.
+ * This uses a specific version of the schema identified by a git commit hash.
+ */
+String GLEAN_PING_SCHEMA_GIT_HASH = "3a15121c"
+String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/baseline/baseline.1.schema.json"
 
 android {
     compileSdkVersion Config.compileSdkVersion
@@ -13,6 +25,7 @@ android {
         targetSdkVersion Config.targetSdkVersion
 
         buildConfigField("String", "LIBRARY_VERSION", "\"" + Config.componentsVersion + "\"")
+        buildConfigField("String", "GLEAN_PING_SCHEMA_URL", "\"" + GLEAN_PING_SCHEMA_URL + "\"")
     }
 
     buildTypes {
@@ -39,3 +52,5 @@ dependencies {
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(Config.componentsGroupId, archivesBaseName, gradle.componentDescriptions[archivesBaseName])
+
+apply from: './scripts/sdk_generator.gradle'

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -4,8 +4,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-String GLEAN_PARSER_VERSION
-GLEAN_PARSER_VERSION = "0.6.0"
+String GLEAN_PARSER_VERSION = "0.7.0"
 
 /* This script runs a given Python module as a "main" module, like
  * `python -m module`. However, it first checks that the installed
@@ -49,7 +48,8 @@ envs {
     envsDirectory = new File(buildDir, 'envs')
     pipInstallOptions = "--trusted-host pypi.python.org --no-cache-dir"
 
-    // Setup a miniconda environment.
+    // Setup a miniconda environment. conda is used because it works
+    // non-interactively on Windows, unlike the other options
     conda "Miniconda3", "Miniconda3-latest", "64", ["glean_parser==${GLEAN_PARSER_VERSION}"]
 }
 
@@ -74,7 +74,7 @@ preBuild.dependsOn(createBuildDir)
 preBuild.finalizedBy("build_envs")
 
 // Generate the Metrics API
-android.applicationVariants.all { variant ->
+ext.gleanGenerateMetricsAPI = { variant ->
     def sourceOutputDir =  "$buildDir/telemetry/src/${variant.name}/kotlin"
     def generateKotlinAPI = task("generateMetricsSourceFor${variant.name.capitalize()}", type: Exec) {
         description = "Generate the Kotlin code for the Metrics API"
@@ -115,4 +115,8 @@ android.applicationVariants.all { variant ->
     // The added directory doesn't appear in the paths listed by the
     // `sourceSets` task, for reasons unknown.
     variant.registerJavaGeneratingTask(generateKotlinAPI, new File(sourceOutputDir))
+}
+
+if (android.hasProperty('applicationVariants')) {
+    android.applicationVariants.all(ext.gleanGenerateMetricsAPI)
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -143,6 +143,7 @@ class GleanTest {
 
             val (metricsJsonData, metricsPath) = payloads.get("metrics")!!
             val metricsJson = JSONObject(metricsJsonData)
+            checkPingSchema(metricsJson)
             assertEquals(
                 "foo",
                 metricsJson.getJSONObject("metrics")

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+import org.json.JSONObject
+
+fun checkPingSchema(content: JSONObject) {
+    val os = System.getProperty("os.name")?.toLowerCase()
+    val pythonExecutable =
+        if (os?.indexOf("win")?.compareTo(0) == 0)
+            "./build/bootstrap/Miniconda3/python"
+        else
+            "./build/bootstrap/Miniconda3/bin/python"
+
+    val proc = ProcessBuilder(
+        listOf(
+            pythonExecutable,
+            "-m",
+            "glean_parser",
+            "check",
+            "-s",
+            "${BuildConfig.GLEAN_PING_SCHEMA_URL}"
+        )
+    ).redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+    val process = proc.start()
+
+    val jsonString = content.toString()
+    with(process.outputStream.bufferedWriter()) {
+        write(jsonString)
+        newLine()
+        flush()
+        close()
+    }
+
+    val exitCode = process.waitFor()
+    assert(exitCode == 0)
+}


### PR DESCRIPTION
The purpose of this change is to be able to write unit tests that validate the generated pings (in JSON) against the JSON schema that will be validating the pings on the backend in production (and thus catch any schema violations early, prior to merging).

@Dexterp37 did some [initial investigation](https://bugzilla.mozilla.org/show_bug.cgi?id=1504200) doing this with Java/Kotlin. tl;dr: there are two candidate libraries for JSON schema available, one doesn't work with Android due to differences in the `org.json` API, and one is basically a dormant project that doesn't support recent versions of JSON schema.

The approach here is to use Python (which we are already using for code generation at build time) to do the schema validation. This has the added benefit that we can use exactly the same [schema validation library](https://github.com/Julian/jsonschema) that we use in production, so we don't have to "hope" that it has the same corner case bugs as some other JSON schema validation library.

Prior to this change, the Python environment was installed to the application build directory (`samples/glean/build`).  In order to use it for unit testing, we need to be able to use it in the from the library, so it now installs the Python environment to the library's build directory (`components/services/glean/build`).  The same Python environment is thus used for both purposes: doing JSON schema validation as part of the library's unit tests and build-time code generation for the application.  Additionally, the same Python library/script (`glean_parser`) is used for both purposes.

One wrinkle is that the library needs to know how to find the Python executable within the library build directory, even when run as part of the application's build process.  There doesn't seem to be a way to write a Gradle plugin that looks for things relative to the plugin's location, only to the build or project root.  Therefore, using Glean's custom gradle plugin is a two step process: import the plugin using `apply from:` and then calling a function `setupGlean` and passing in the path to the library relative to the project root.  That definitely should be documented, but I thought I would solicit feedback on the approach first.

Requires: 
- [x] https://github.com/mozilla/glean_parser/pull/15 to be merged first