### PR TITLE
Closes #1420: Use `filesDir` as the parent folder for the places database file

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
@@ -8,6 +8,7 @@ import android.support.annotation.GuardedBy
 import org.mozilla.places.PlacesAPI
 import org.mozilla.places.PlacesConnection
 import java.io.Closeable
+import java.io.File
 
 const val DB_NAME = "places.sqlite"
 
@@ -18,9 +19,9 @@ internal object RustPlacesConnection : Connection {
     @GuardedBy("this")
     private var placesConnection: PlacesConnection? = null
 
-    fun init(dbPath: String, encryptionString: String?) = synchronized(this) {
+    fun init(parentDir: File, encryptionString: String?) = synchronized(this) {
         if (placesConnection == null) {
-            placesConnection = PlacesConnection(dbPath, encryptionString)
+            placesConnection = PlacesConnection(File(parentDir, DB_NAME).canonicalPath, encryptionString)
         }
     }
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -28,7 +28,7 @@ open class PlacesHistoryStorage(context: Context) : HistoryStorage {
 
     @VisibleForTesting
     internal open val places: Connection by lazy {
-        RustPlacesConnection.init(context.getDatabasePath(DB_NAME).canonicalPath, null)
+        RustPlacesConnection.init(context.filesDir, null)
         RustPlacesConnection
     }
 


### PR DESCRIPTION
Using getDatabasePath doesn't work without extra work on older API versions.
That location doesn't exist, and it seems like we'd need to add a bit of code
to check for its presence, create it, etc., before we can rely on that location.

All of our other code which stores files just uses `filesDir`, and I don't see
a reason not to put `places.sqlite` into that location as well. There isn't much
value in that file living in a "databases" folder.