### PR TITLE
1506061: [glean] Refactor to pass whole CommonMetricType rather than fields

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -56,10 +56,7 @@ data class StringMetricType(
 
         // Delegate storing the string to the storage engine.
         StringsStorageEngine.record(
-            stores = getStorageNames(),
-            category = category,
-            name = name,
-            lifetime = lifetime,
+            this,
             value = truncatedValue
         )
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
@@ -50,10 +50,7 @@ data class UuidMetricType(
 
         // Delegate storing the event to the storage engine.
         UuidsStorageEngine.record(
-                stores = sendInPings,
-                category = category,
-                name = name,
-                lifetime = lifetime,
+                this,
                 value = value
         )
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -170,7 +170,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
      * simple scalars to the internal storage.
      */
     protected fun recordScalar(
-        metric: CommonMetricData,
+        metricData: CommonMetricData,
         value: ScalarType
     ) {
         checkNotNull(applicationContext) { "No recording can take place without an application context" }
@@ -178,19 +178,19 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
         // Record a copy of the metric in all the needed stores.
         @SuppressLint("CommitPrefEdits")
         val userPrefs: SharedPreferences.Editor? =
-            if (metric.lifetime == Lifetime.User) userLifetimeStorage.edit() else null
-        metric.getStorageNames().forEach {
-            val storeData = dataStores[metric.lifetime.ordinal].getOrPut(it) { mutableMapOf() }
+            if (metricData.lifetime == Lifetime.User) userLifetimeStorage.edit() else null
+        metricData.getStorageNames().forEach {
+            val storeData = dataStores[metricData.lifetime.ordinal].getOrPut(it) { mutableMapOf() }
             // We support empty categories for enabling the internal use of metrics
             // when assembling pings in [PingMaker].
-            val entryName = if (metric.category.isEmpty()) {
-                metric.name
+            val entryName = if (metricData.category.isEmpty()) {
+                metricData.name
             } else {
-                "${metric.category}.${metric.name}"
+                "${metricData.category}.${metricData.name}"
             }
             storeData[entryName] = value
             // Persist data with "user" lifetime
-            if (metric.lifetime == Lifetime.User) {
+            if (metricData.lifetime == Lifetime.User) {
                 userPrefs?.putString("$it#$entryName", serializeSingleMetric(value))
             }
         }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -5,7 +5,7 @@
 package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
-import mozilla.components.service.glean.Lifetime
+import mozilla.components.service.glean.CommonMetricData
 import mozilla.components.support.base.log.logger.Logger
 
 /**
@@ -39,12 +39,9 @@ open class StringsStorageEngineImplementation(
      */
     @Synchronized
     fun record(
-        stores: List<String>,
-        category: String,
-        name: String,
-        lifetime: Lifetime,
+        metric: CommonMetricData,
         value: String
     ) {
-        super.recordScalar(stores, category, name, lifetime, value)
+        super.recordScalar(metric, value)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -31,17 +31,14 @@ open class StringsStorageEngineImplementation(
     /**
      * Record a string in the desired stores.
      *
-     * @param stores the list of stores to record the string into
-     * @param category the category of the string
-     * @param name the name of the string
-     * @param lifetime the lifetime of the stored metric data
+     * @param metricData object with metric settings
      * @param value the string value to record
      */
     @Synchronized
     fun record(
-        metric: CommonMetricData,
+        metricData: CommonMetricData,
         value: String
     ) {
-        super.recordScalar(metric, value)
+        super.recordScalar(metricData, value)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -5,9 +5,9 @@
 package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
+import mozilla.components.service.glean.CommonMetricData
 import java.util.UUID
 
-import mozilla.components.service.glean.Lifetime
 import mozilla.components.support.base.log.logger.Logger
 
 /**
@@ -45,12 +45,9 @@ open class UuidsStorageEngineImplementation(
      */
     @Synchronized
     fun record(
-        stores: List<String>,
-        category: String,
-        name: String,
-        lifetime: Lifetime,
+        metric: CommonMetricData,
         value: UUID
     ) {
-        super.recordScalar(stores, category, name, lifetime, value)
+        super.recordScalar(metric, value)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -37,17 +37,14 @@ open class UuidsStorageEngineImplementation(
     /**
      * Record a uuid in the desired stores.
      *
-     * @param stores the list of stores to record the uuid into
-     * @param category the category of the uuid
-     * @param name the name of the uuid
-     * @param lifetime the lifetime of the stored metric data
+     * @param metricData object with metric settings
      * @param value the uuid value to record
      */
     @Synchronized
     fun record(
-        metric: CommonMetricData,
+        metricData: CommonMetricData,
         value: UUID
     ) {
-        super.recordScalar(metric, value)
+        super.recordScalar(metricData, value)
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
@@ -37,10 +37,10 @@ class GenericScalarStorageEngineTest {
         }
 
         fun record(
-            metric: CommonMetricData,
+            metricData: CommonMetricData,
             value: Int
         ) {
-            super.recordScalar(metric, value)
+            super.recordScalar(metricData, value)
         }
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
+import mozilla.components.service.glean.CommonMetricData
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.support.base.log.logger.Logger
 import org.junit.Assert.assertEquals
@@ -36,14 +37,21 @@ class GenericScalarStorageEngineTest {
         }
 
         fun record(
-            stores: List<String>,
-            category: String,
-            name: String,
-            lifetime: Lifetime,
+            metric: CommonMetricData,
             value: Int
         ) {
-            super.recordScalar(stores, category, name, lifetime, value)
+            super.recordScalar(metric, value)
         }
+    }
+
+    private data class GenericMetricType(
+        override val disabled: Boolean,
+        override val category: String,
+        override val lifetime: Lifetime,
+        override val name: String,
+        override val sendInPings: List<String>
+    ) : CommonMetricData {
+        override val defaultStorageDestinations: List<String> = listOf("metrics")
     }
 
     @Test
@@ -54,21 +62,31 @@ class GenericScalarStorageEngineTest {
         val storageEngine = MockScalarStorageEngine()
         storageEngine.applicationContext = RuntimeEnvironment.application
 
+        val metric1 = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.User,
+            name = "userLifetimeData",
+            sendInPings = listOf("store1")
+        )
+
         // Record a value with User lifetime
         storageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "userLifetimeData",
-            lifetime = Lifetime.User,
+            metric1,
             value = dataUserLifetime
+        )
+
+        val metric2 = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "pingLifetimeData",
+            sendInPings = listOf("store1")
         )
 
         // Record a value with Ping lifetime
         storageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "pingLifetimeData",
-            lifetime = Lifetime.Ping,
+            metric2,
             value = dataPingLifetime
         )
 
@@ -92,12 +110,17 @@ class GenericScalarStorageEngineTest {
         val storageEngine = MockScalarStorageEngine()
         storageEngine.applicationContext = RuntimeEnvironment.application
 
+        val metric = GenericMetricType(
+            disabled = false,
+            category = "",
+            lifetime = Lifetime.Ping,
+            name = "noCategoryName",
+            sendInPings = listOf("store1")
+        )
+
         // Record a value with User lifetime
         storageEngine.record(
-            stores = listOf("store1"),
-            category = "",
-            name = "noCategoryName",
-            lifetime = Lifetime.Ping,
+            metric,
             value = 37
         )
 
@@ -131,12 +154,17 @@ class GenericScalarStorageEngineTest {
         val storageEngine = MockScalarStorageEngine()
         storageEngine.applicationContext = context
 
+        val metric = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.User,
+            name = "pingLifetimeData",
+            sendInPings = listOf("store1")
+        )
+
         // Record a value with Ping lifetime
         storageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "pingLifetimeData",
-            lifetime = Lifetime.User,
+            metric,
             value = 37
         )
 
@@ -165,12 +193,17 @@ class GenericScalarStorageEngineTest {
         val storageEngine = MockScalarStorageEngine()
         storageEngine.applicationContext = context
 
+        val metric = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "pingLifetimeData",
+            sendInPings = listOf("store1")
+        )
+
         // Record a value with Ping lifetime
         storageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "pingLifetimeData",
-            lifetime = Lifetime.Ping,
+            metric,
             value = 37
         )
 
@@ -269,30 +302,45 @@ class GenericScalarStorageEngineTest {
 
         val stores = listOf("store1", "store2")
 
+        val metric1 = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.User,
+            name = "userLifetimeData",
+            sendInPings = stores
+        )
+
         // Record a value with User lifetime
         storageEngine.record(
-            stores = stores,
-            category = "telemetry",
-            name = "userLifetimeData",
-            lifetime = Lifetime.User,
+            metric1,
             value = 11
+        )
+
+        val metric2 = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "applicationLifetimeData",
+            sendInPings = stores
         )
 
         // Record a value with Application lifetime
         storageEngine.record(
-            stores = stores,
-            category = "telemetry",
-            name = "applicationLifetimeData",
-            lifetime = Lifetime.Application,
+            metric2,
             value = 7
+        )
+
+        val metric3 = GenericMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "pingLifetimeData",
+            sendInPings = stores
         )
 
         // Record a value with Ping lifetime
         storageEngine.record(
-            stores = stores,
-            category = "telemetry",
-            name = "pingLifetimeData",
-            lifetime = Lifetime.Ping,
+            metric3,
             value = 2015
         )
 
@@ -323,21 +371,31 @@ class GenericScalarStorageEngineTest {
             val storageEngine = MockScalarStorageEngine()
             storageEngine.applicationContext = RuntimeEnvironment.application
 
+            val metric1 = GenericMetricType(
+                disabled = false,
+                category = "telemetry",
+                lifetime = Lifetime.User,
+                name = "userLifetimeData",
+                sendInPings = listOf("store1")
+            )
+
             // Record a value with User lifetime
             storageEngine.record(
-                stores = listOf("store1"),
-                category = "telemetry",
-                name = "userLifetimeData",
-                lifetime = Lifetime.User,
+                metric1,
                 value = 37
+            )
+
+            val metric2 = GenericMetricType(
+                disabled = false,
+                category = "telemetry",
+                lifetime = Lifetime.Application,
+                name = "applicationLifetimeData",
+                sendInPings = listOf("store1")
             )
 
             // Record a value with Application lifetime
             storageEngine.record(
-                stores = listOf("store1"),
-                category = "telemetry",
-                name = "applicationLifetimeData",
-                lifetime = Lifetime.Application,
+                metric2,
                 value = 85
             )
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import mozilla.components.service.glean.Lifetime
+import mozilla.components.service.glean.StringMetricType
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
@@ -62,13 +63,18 @@ class StringsStorageEngineTest {
     fun `setValue() properly sets the value in all stores`() {
         val storeNames = listOf("store1", "store2")
 
+        val metric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "string_metric",
+            sendInPings = storeNames
+        )
+
         // Record the string in the stores, without providing optional arguments.
         StringsStorageEngine.record(
-                stores = storeNames,
-                category = "telemetry",
-                name = "string_metric",
-                lifetime = Lifetime.Ping,
-                value = "test_string_object"
+            metric,
+            value = "test_string_object"
         )
 
         // Check that the data was correctly set in each store.
@@ -89,12 +95,17 @@ class StringsStorageEngineTest {
     fun `getSnapshot() correctly clears the stores`() {
         val storeNames = listOf("store1", "store2")
 
+        val metric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "string_metric",
+            sendInPings = storeNames
+        )
+
         // Record the string in the stores, without providing optional arguments.
         StringsStorageEngine.record(
-            stores = storeNames,
-            category = "telemetry",
-            name = "string_metric",
-            lifetime = Lifetime.Ping,
+            metric,
             value = "test_string_value"
         )
 
@@ -114,12 +125,17 @@ class StringsStorageEngineTest {
 
     @Test
     fun `Strings are serialized in the correct JSON format`() {
+        val metric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "string_metric",
+            sendInPings = listOf("store1")
+        )
+
         // Record the string in the store, without providing optional arguments.
         StringsStorageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "string_metric",
-            lifetime = Lifetime.Ping,
+            metric,
             value = "test_string_value"
         )
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import mozilla.components.service.glean.Lifetime
+import mozilla.components.service.glean.UuidMetricType
 import java.util.UUID
 
 import org.junit.Before
@@ -66,13 +67,18 @@ class UuidsStorageEngineTest {
         val storeNames = listOf("store1", "store2")
         val uuid = UUID.fromString("ce2adeb8-843a-4232-87a5-a099ed1e7bb3")
 
+        val metric = UuidMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "uuid_metric",
+            sendInPings = storeNames
+        )
+
         // Record the uuid in the stores, without providing optional arguments.
         UuidsStorageEngine.record(
-                stores = storeNames,
-                category = "telemetry",
-                name = "uuid_metric",
-                lifetime = Lifetime.Ping,
-                value = uuid
+            metric,
+            value = uuid
         )
 
         // Check that the data was correctly set in each store.
@@ -95,13 +101,18 @@ class UuidsStorageEngineTest {
 
         val uuid = UUID.fromString("ce2adeb8-843a-4232-87a5-a099ed1e7bb3")
 
+        val metric = UuidMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "uuid_metric",
+            sendInPings = storeNames
+        )
+
         // Record the uuid in the stores, without providing optional arguments.
         UuidsStorageEngine.record(
-                stores = storeNames,
-                category = "telemetry",
-                name = "uuid_metric",
-                lifetime = Lifetime.Ping,
-                value = uuid
+            metric,
+            value = uuid
         )
 
         // Get the snapshot from "store1" and clear it.
@@ -122,12 +133,17 @@ class UuidsStorageEngineTest {
     fun `Uuids are serialized in the correct JSON format`() {
         val testUUID = "ce2adeb8-843a-4232-87a5-a099ed1e7bb3"
 
+        val metric = UuidMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "uuid_metric",
+            sendInPings = listOf("store1")
+        )
+
         // Record the string in the store, without providing optional arguments.
         UuidsStorageEngine.record(
-            stores = listOf("store1"),
-            category = "telemetry",
-            name = "uuid_metric",
-            lifetime = Lifetime.Ping,
+            metric,
             value = UUID.fromString(testUUID)
         )
 
@@ -148,11 +164,16 @@ class UuidsStorageEngineTest {
         val storageEngine = UuidsStorageEngineImplementation()
         storageEngine.applicationContext = RuntimeEnvironment.application
 
-        storageEngine.record(
-            stores = listOf("some_store", "other_store"),
+        val metric = UuidMetricType(
+            disabled = false,
             category = "telemetry",
-            name = "uuidMetric",
             lifetime = Lifetime.User,
+            name = "uuidMetric",
+            sendInPings = listOf("some_store", "other_store")
+        )
+
+        storageEngine.record(
+            metric,
             value = UUID.fromString(sampleUUID)
         )
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1506061

This is just a refactor.  Rather than passing individual fields of the CommonMetricType from the MetricType down into the storage engines, we just pass the CommonMetricType.  Since we expect the number of fields and metric types to grow, this should make it easier to do that for multiple metric types in the future.