### PR TITLE
Closes #1383: App crash caused by invalid URI in GeckoSession 

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -276,7 +276,7 @@ class GeckoEngineSession(
 
         override fun onLoadError(
             session: GeckoSession?,
-            uri: String,
+            uri: String?,
             category: Int,
             error: Int
         ): GeckoResult<String> {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -49,6 +49,7 @@ import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_IMAGE
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_NONE
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_VIDEO
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate.ERROR_CATEGORY_UNKNOWN
+import org.mozilla.geckoview.GeckoSession.NavigationDelegate.ERROR_MALFORMED_URI
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate.ERROR_UNKNOWN
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 import org.mozilla.geckoview.GeckoSession.ProgressDelegate.SecurityInformation
@@ -712,6 +713,21 @@ class GeckoEngineSessionTest {
             assertTrue(value!!.contains("data:text/html;base64,"))
             GeckoResult.fromValue(null)
         }
+    }
+
+    @Test
+    fun onLoadErrorCallsInterceptorWithInvalidUri() {
+        val requestInterceptor: RequestInterceptor = mock()
+        val defaultSettings = DefaultSettings(requestInterceptor = requestInterceptor)
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+
+        engineSession.geckoSession.navigationDelegate.onLoadError(
+            engineSession.geckoSession,
+            null,
+            ERROR_CATEGORY_UNKNOWN,
+            ERROR_MALFORMED_URI
+        )
+        verify(requestInterceptor).onErrorRequest(engineSession, ErrorType.ERROR_MALFORMED_URI, null)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -278,7 +278,7 @@ class GeckoEngineSession(
 
         override fun onLoadError(
             session: GeckoSession?,
-            uri: String,
+            uri: String?,
             error: WebRequestError
         ): GeckoResult<String> {
             settings.requestInterceptor?.onErrorRequest(

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -53,6 +53,7 @@ import org.mozilla.geckoview.GeckoSession.ProgressDelegate.SecurityInformation
 import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.SessionFinder
 import org.mozilla.geckoview.WebRequestError
+import org.mozilla.geckoview.WebRequestError.ERROR_MALFORMED_URI
 import org.mozilla.geckoview.createMockedWebResponseInfo
 import org.robolectric.RobolectricTestRunner
 
@@ -758,6 +759,20 @@ class GeckoEngineSessionTest {
             assertTrue(value!!.contains("data:text/html;base64,"))
             GeckoResult.fromValue(null)
         }
+    }
+
+    @Test
+    fun onLoadErrorCallsInterceptorWithInvalidUri() {
+        val requestInterceptor: RequestInterceptor = mock()
+        val defaultSettings = DefaultSettings(requestInterceptor = requestInterceptor)
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+
+        engineSession.geckoSession.navigationDelegate.onLoadError(
+            engineSession.geckoSession,
+            null,
+            WebRequestError(ERROR_MALFORMED_URI, ERROR_CATEGORY_UNKNOWN)
+        )
+        verify(requestInterceptor).onErrorRequest(engineSession, ErrorType.ERROR_MALFORMED_URI, null)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -49,6 +49,7 @@ import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_IMAGE
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_NONE
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ELEMENT_TYPE_VIDEO
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate.ERROR_CATEGORY_UNKNOWN
+import org.mozilla.geckoview.GeckoSession.NavigationDelegate.ERROR_MALFORMED_URI
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate.ERROR_UNKNOWN
 import org.mozilla.geckoview.GeckoSession.ProgressDelegate.SecurityInformation
 import org.mozilla.geckoview.GeckoSessionSettings
@@ -711,6 +712,21 @@ class GeckoEngineSessionTest {
             assertTrue(value!!.contains("data:text/html;base64,"))
             GeckoResult<String>(null)
         }
+    }
+
+    @Test
+    fun onLoadErrorCallsInterceptorWithInvalidUri() {
+        val requestInterceptor: RequestInterceptor = mock()
+        val defaultSettings = DefaultSettings(requestInterceptor = requestInterceptor)
+        val engineSession = GeckoEngineSession(mock(), defaultSettings = defaultSettings)
+
+        engineSession.geckoSession.navigationDelegate.onLoadError(
+                engineSession.geckoSession,
+                null,
+                ERROR_CATEGORY_UNKNOWN,
+                ERROR_MALFORMED_URI
+        )
+        verify(requestInterceptor).onErrorRequest(engineSession, ErrorType.ERROR_MALFORMED_URI, null)
     }
 
     @Test

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -55,7 +55,7 @@ class AwesomeBarFeature(
      */
     fun addSearchProvider(
         searchEngine: SearchEngine,
-        searchUseCase: SearchUseCases.DefaultSearchUrlUseCase
+        searchUseCase: SearchUseCases.DefaultSearchUseCase
     ): AwesomeBarFeature {
         awesomeBar.addProviders(SearchSuggestionProvider(searchEngine, searchUseCase))
         return this

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
@@ -19,7 +19,7 @@ import java.net.URL
  */
 class SearchSuggestionProvider(
     private val searchEngine: SearchEngine,
-    private val searchUseCase: SearchUseCases.DefaultSearchUrlUseCase
+    private val searchUseCase: SearchUseCases.DefaultSearchUseCase
 ) : AwesomeBar.SuggestionProvider {
     private val client = if (searchEngine.canProvideSearchSuggestions) {
         SearchSuggestionClient(searchEngine) {

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
@@ -53,7 +54,7 @@ class SearchSuggestionProviderTest {
                 searchEngineManager,
                 SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
             ).defaultSearch)
-            doNothing().`when`(useCase).invoke(any(), any())
+            doNothing().`when`(useCase).invoke(anyString(), any<Session>())
 
             val provider = SearchSuggestionProvider(searchEngine, useCase)
 
@@ -76,11 +77,11 @@ class SearchSuggestionProviderTest {
                 assertEquals("firefox nightly", suggestion.chips[9].title)
                 assertEquals("firefox clear cache", suggestion.chips[10].title)
 
-                verify(useCase, never()).invoke(any(), any())
+                verify(useCase, never()).invoke(anyString(), any<Session>())
 
                 suggestion.onChipClicked!!.invoke(suggestion.chips[6])
 
-                verify(useCase).invoke(eq("firefox focus"), any())
+                verify(useCase).invoke(eq("firefox focus"), any<Session>())
             } finally {
                 server.shutdown()
             }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -67,15 +67,16 @@ class IntentProcessor(
         when {
             TextUtils.isEmpty(extraText.trim()) -> false
 
-            extraText.isUrl() -> {
-                val session = createSession(extraText, source = Source.ACTION_SEND)
-                sessionUseCases.loadUrl.invoke(extraText, session)
-                true
-            }
             else -> {
-                val session = createSession(extraText, source = Source.ACTION_SEND)
-                searchUseCases.defaultSearch.invoke(extraText, session)
-                true
+                val url = extraText.split(" ").find { it.isUrl() }
+                if (url != null) {
+                    val session = createSession(url, source = Source.ACTION_SEND)
+                    sessionUseCases.loadUrl.invoke(url, session)
+                    true
+                } else {
+                    searchUseCases.defaultSearch.invoke(extraText, Source.ACTION_SEND, openNewTab)
+                    true
+                }
             }
         }
     }

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
 
+    testImplementation project(':support-test')
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
@@ -18,7 +18,7 @@ class SearchUseCases(
     private val sessionManager: SessionManager
 ) {
 
-    class DefaultSearchUrlUseCase(
+    class DefaultSearchUseCase(
         private val context: Context,
         private val searchEngineManager: SearchEngineManager,
         private val sessionManager: SessionManager
@@ -32,16 +32,38 @@ class SearchUseCases(
          * is provided.
          */
         fun invoke(searchTerms: String, session: Session = sessionManager.selectedSessionOrThrow) {
-            val searchEngine = searchEngineManager.getDefaultSearchEngine(context)
-            val searchUrl = searchEngine.buildSearchUrl(searchTerms)
+            val searchUrl = searchEngineManager.getDefaultSearchEngine(context).buildSearchUrl(searchTerms)
 
             session.searchTerms = searchTerms
 
             sessionManager.getOrCreateEngineSession(session).loadUrl(searchUrl)
         }
+
+        /**
+         * Triggers a search on a new session, using the default search engine for the provided search terms.
+         *
+         * @param searchTerms the search terms.
+         * @param selected whether or not the new session should be selected, defaults to true.
+         * @param private whether or not the new session should be private, defaults to false.
+         * @param source the source of the new session.
+         */
+        fun invoke(
+            searchTerms: String,
+            source: Session.Source,
+            selected: Boolean = true,
+            private: Boolean = false
+        ) {
+            val searchUrl = searchEngineManager.getDefaultSearchEngine(context).buildSearchUrl(searchTerms)
+
+            val session = Session(searchUrl, private, source)
+            session.searchTerms = searchTerms
+
+            sessionManager.add(session, selected)
+            sessionManager.getOrCreateEngineSession(session).loadUrl(searchUrl)
+        }
     }
 
-    val defaultSearch: DefaultSearchUrlUseCase by lazy {
-        DefaultSearchUrlUseCase(context, searchEngineManager, sessionManager)
+    val defaultSearch: DefaultSearchUseCase by lazy {
+        DefaultSearchUseCase(context, searchEngineManager, sessionManager)
     }
 }


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/1383#issuecomment-440468994 for all details.

The first commit makes sure we tolerate a MALFROMED_URI error from GeckoView. We do this because our ACTION_SEND handling problem might have caused malformed URIs to be persisted, and more importantly, to make sure we don't crash should a similar problem occur in the future. For engine-gecko release this already worked coincidentally.

The second commit fixes the cause of the malformed URL. When processing ACTION_SEND intents with EXTRA_TEXT that is not a URL, we no longer create a session with that text as URL. It also fixes the problem that the search wasn't properly triggered (using GeckoView) because of the two `loadUri` calls in quick succession. And while we're at it :), this also fixes the behaviour of how to decide whether to load the URL or search to align with Focus/Fennec.

 