### PR TITLE
[WIP] Use new combined fxa config

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -23,10 +23,13 @@ class Config internal constructor(internal val inner: InternalConfig) : AutoClos
     companion object {
         /**
          * Set up endpoints used in the production Firefox Accounts instance.
+         *
+         * @param client_id Client Id of the FxA relier
+         * @param redirect_uri Redirect Uri of the FxA relier
          */
-        fun release(): Deferred<Config> {
+        fun release(client_id: String, redirect_uri: String): Deferred<Config> {
             return GlobalScope.async(Dispatchers.IO) {
-                Config(InternalConfig.release())
+                Config(InternalConfig.release(client_id, redirect_uri))
             }
         }
 
@@ -34,10 +37,12 @@ class Config internal constructor(internal val inner: InternalConfig) : AutoClos
          * Set up endpoints used by a custom host for authentication
          *
          * @param content_base Hostname of the FxA auth service provider
+         * @param client_id Client Id of the FxA relier
+         * @param redirect_uri Redirect Uri of the FxA relier
          */
-        fun custom(content_base: String): Deferred<Config> {
+        fun custom(content_base: String, client_id: String, redirect_uri: String): Deferred<Config> {
             return GlobalScope.async(Dispatchers.IO) {
-                Config(InternalConfig.custom(content_base))
+                Config(InternalConfig.custom(content_base, client_id, redirect_uri))
             }
         }
     }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -26,8 +26,8 @@ class FirefoxAccount internal constructor(private val inner: InternalFxAcct) : A
      * Note that it is not necessary to `close` the Config if this constructor is used (however
      * doing so will not cause an error).
      */
-    constructor(config: Config, clientId: String, redirectUri: String)
-            : this(InternalFxAcct(config.inner, clientId, redirectUri))
+    constructor(config: Config)
+            : this(InternalFxAcct(config.inner))
 
     override fun close() {
         job.cancel()

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -59,15 +59,15 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
                 return@async it
             }
             intent.extras?.getString("pairingUrl")?.let { pairingUrl ->
-                Config.custom(CONFIG_URL_PAIRING).await().use { config ->
-                    val acct = FirefoxAccount(config, CLIENT_ID, REDIRECT_URL)
+                Config.custom(CONFIG_URL_PAIRING, CLIENT_ID, REDIRECT_URL).await().use { config ->
+                    val acct = FirefoxAccount(config)
                     val url = acct.beginPairingFlow(pairingUrl, scopes).await()
                     openWebView(url)
                     return@async acct
                 }
             }
-            return@async Config.custom(CONFIG_URL).await().use { config ->
-                FirefoxAccount(config, CLIENT_ID, REDIRECT_URL)
+            return@async Config.custom(CONFIG_URL, CLIENT_ID, REDIRECT_URL).await().use { config ->
+                FirefoxAccount(config)
             }
         }
 


### PR DESCRIPTION
This PR connects with https://github.com/mozilla/application-services/pull/403 and updates the sample FxA application to use the new config. 

A new config objected is created with 
```
Config.custom(CONFIG_URL, CLIENT_ID, REDIRECT_URL).await()...

val acct = FirefoxAccount(config)...
```

With the introduction of https://github.com/mozilla/application-services/pull/388, the project wouldn't compile. I briefly looked at fixing the issues but wasn't able to get it properly updated so I just commented out the code that broke.

Depends on https://github.com/mozilla-mobile/android-components/pull/1354

cc @eoger 