### PR TITLE
Closes #1451: Provide tab filter to TabsFeature.

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.feature.tabs.tabstray
 
+import android.support.annotation.VisibleForTesting
+import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.TabsUseCases
@@ -17,12 +19,15 @@ class TabsFeature(
     tabsUseCases: TabsUseCases,
     closeTabsTray: () -> Unit
 ) {
-    private val presenter = TabsTrayPresenter(
+    @VisibleForTesting
+    internal var presenter = TabsTrayPresenter(
         tabsTray,
         sessionManager,
-        closeTabsTray)
+        closeTabsTray
+    )
 
-    private val interactor = TabsTrayInteractor(
+    @VisibleForTesting
+    internal var interactor = TabsTrayInteractor(
         tabsTray,
         tabsUseCases.selectSession,
         tabsUseCases.removeSession,
@@ -36,5 +41,10 @@ class TabsFeature(
     fun stop() {
         presenter.stop()
         interactor.stop()
+    }
+
+    fun filterTabs(tabsFilter: (Session) -> Boolean) {
+        presenter.sessionsFilter = tabsFilter
+        presenter.calculateDiffAndUpdateTabsTray()
     }
 }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
@@ -17,9 +17,10 @@ import mozilla.components.concept.tabstray.TabsTray
 class TabsTrayPresenter(
     private val tabsTray: TabsTray,
     private val sessionManager: SessionManager,
-    private val closeTabsTray: () -> Unit
+    private val closeTabsTray: () -> Unit,
+    internal var sessionsFilter: (Session) -> Boolean = { true }
 ) : SessionManager.Observer {
-    private var sessions = sessionManager.sessions
+    private var sessions = sessionManager.sessions.filter { sessionsFilter(it) }
     private var selectedIndex = sessions.indexOf(sessionManager.selectedSession)
 
     fun start() {
@@ -59,8 +60,8 @@ class TabsTrayPresenter(
      * tab tray with the new data and notifies it about what changes happened so that it can animate
      * those changes.
      */
-    private fun calculateDiffAndUpdateTabsTray() {
-        val updatedSessions = sessionManager.sessions
+    internal fun calculateDiffAndUpdateTabsTray() {
+        val updatedSessions = sessionManager.sessions.filter { sessionsFilter(it) }
         val updatedIndex = if (updatedSessions.isNotEmpty()) {
             updatedSessions.indexOf(sessionManager.selectedSession)
         } else {
@@ -74,7 +75,10 @@ class TabsTrayPresenter(
         sessions = updatedSessions
         selectedIndex = updatedIndex
 
-        tabsTray.updateSessions(updatedSessions, updatedIndex)
+        tabsTray.apply {
+            displaySessions(updatedSessions, updatedIndex)
+            updateSessions(updatedSessions, updatedIndex)
+        }
 
         result.dispatchUpdatesTo(object : ListUpdateCallback {
             override fun onChanged(position: Int, count: Int, payload: Any?) {

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
@@ -1,0 +1,92 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.tabs.tabstray
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+class TabsFeatureTest {
+
+    @Test
+    fun `asserting getters`() {
+        val sessionManager = SessionManager(engine = mock())
+        val presenter: TabsTrayPresenter = mock()
+        val interactor: TabsTrayInteractor = mock()
+        val useCases = TabsUseCases(sessionManager)
+        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+
+        assertNotEquals(tabsFeature.interactor, interactor)
+        assertNotEquals(tabsFeature.presenter, presenter)
+
+        tabsFeature.interactor = interactor
+        tabsFeature.presenter = presenter
+
+        assertEquals(tabsFeature.interactor, interactor)
+        assertEquals(tabsFeature.presenter, presenter)
+    }
+
+    @Test
+    fun start() {
+        val sessionManager = SessionManager(engine = mock())
+        val presenter: TabsTrayPresenter = mock()
+        val interactor: TabsTrayInteractor = mock()
+        val useCases = TabsUseCases(sessionManager)
+        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+
+        tabsFeature.presenter = presenter
+        tabsFeature.interactor = interactor
+
+        tabsFeature.start()
+
+        verify(presenter).start()
+        verify(interactor).start()
+    }
+
+    @Test
+    fun stop() {
+        val sessionManager = SessionManager(engine = mock())
+        val presenter: TabsTrayPresenter = mock()
+        val interactor: TabsTrayInteractor = mock()
+        val useCases = TabsUseCases(sessionManager)
+        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+
+        tabsFeature.presenter = presenter
+        tabsFeature.interactor = interactor
+
+        tabsFeature.stop()
+
+        verify(presenter).stop()
+        verify(interactor).stop()
+    }
+
+    @Test
+    fun filterTabs() {
+        val sessionManager = SessionManager(engine = mock())
+        val presenter: TabsTrayPresenter = mock()
+        val interactor: TabsTrayInteractor = mock()
+        val useCases = TabsUseCases(sessionManager)
+        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+
+        tabsFeature.presenter = presenter
+        tabsFeature.interactor = interactor
+
+        val filter: (Session) -> Boolean = { true }
+
+        tabsFeature.filterTabs(filter)
+
+        verify(presenter).sessionsFilter = filter
+        verify(presenter).calculateDiffAndUpdateTabsTray()
+    }
+}

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -16,6 +16,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.anyList
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
@@ -218,6 +220,37 @@ class TabsTrayPresenterTest {
         assertTrue(closed)
 
         presenter.stop()
+    }
+
+    @Test
+    fun `presenter calls update and display sessions when calculating diff`() {
+        val sessionManager = SessionManager(engine = mock())
+
+        sessionManager.add(Session("https://www.mozilla.org"))
+        sessionManager.add(Session("https://getpocket.com"))
+
+        val tabsTray: MockedTabsTray = spy(MockedTabsTray())
+        val presenter = TabsTrayPresenter(tabsTray, sessionManager, mock())
+
+        presenter.calculateDiffAndUpdateTabsTray()
+
+        verify(tabsTray).displaySessions(anyList(), anyInt())
+        verify(tabsTray).updateSessions(anyList(), anyInt())
+    }
+
+    @Test
+    fun `presenter invokes session filtering`() {
+        val sessionManager = SessionManager(engine = mock())
+
+        sessionManager.add(Session("https://www.mozilla.org"))
+        sessionManager.add(Session("https://getpocket.com", private = true))
+
+        val tabsTray: MockedTabsTray = spy(MockedTabsTray())
+        val presenter = TabsTrayPresenter(tabsTray, sessionManager, mock(), { it.private })
+
+        presenter.calculateDiffAndUpdateTabsTray()
+
+        assertTrue(tabsTray.displaySessionsList?.size == 1)
     }
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,20 @@ permalink: /changelog/
 * **feature-session**
   * Introducing `CoordinateScrollingFeature` a new feature to coordinate scrolling behavior between an `EngineView` and the view that you specify. For a full example take a look at its usages in [Sample Browser](https://github.com/mozilla-mobile/android-components/tree/master/samples/browser).
 
+* **feature-tabs**
+  * Added a filter to `TabsFeature` to allow you to choose which sessions to show in the TabsTray. This is particularly useful if you want to filter out private tabs based on some UI interaction:
+
+  ```kotlin
+  val tabsFeature = TabsFeature(
+    tabsTray,
+    sessionManager,
+    closeTabsTray = closeTabs()
+  )
+  tabsFeature.filterTabs {
+    it.private
+  }
+  ```
+
 * **engine-gecko,engine-gecko-beta and engine-gecko-nightly**
   * Fixing bug #1333. This issue didn't allow to use a `GeckoEngineSession` after sending a crash report.
 
@@ -50,7 +64,7 @@ permalink: /changelog/
 * **browser-session**:
   * Replace `DefaultSessionStorage` with a new configurable implementation called `SessionStorage`:
 
-  ```Kotlin
+  ```kotlin
   SessionStorage().autoSave(sessionManager)
     .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
     .whenGoingToBackground()


### PR DESCRIPTION
~~Also exposes an invalidate so that clients can call it when they expect
to see changes.~~

We have a filter method on `TabsFeature` that allows us to filter the sessions and update the TabsTray accordingly.

**Q. Why do this instead of just adding a 'private' flag?**
**A:** It's more versatile to pass in a filter. Currently we may have three possible options: all, regular, private. With this alone a boolean doesn't work.
In the future, this allows new features for tab grouping to be done by the application by their own definition.