### PR TITLE
[WIP] Update to Robolectric 4.0.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -7,8 +7,9 @@ private object Versions {
     const val kotlin = "1.3.10"
     const val coroutines = "1.0.1"
 
+    const val androidx_test = "1.0.0"
     const val junit = "4.12"
-    const val robolectric = "4.0-alpha-3"
+    const val robolectric = "4.0.2"//""4.0-alpha-3"
     const val mockito = "2.23.0"
 
     const val mockwebserver = "3.10.0"
@@ -41,6 +42,7 @@ object Dependencies {
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
 
+    const val testing_androidx = "androidx.test:core:${Versions.androidx_test}"
     const val testing_junit = "junit:junit:${Versions.junit}"
     const val testing_robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
     const val testing_mockito = "org.mockito:mockito-core:${Versions.mockito}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ private object Versions {
     const val support_libraries = "28.0.0"
     const val constraint_layout = "1.1.2"
     const val workmanager = "1.0.0-alpha09"
-    const val lifecycle = "1.1.1"
+    const val lifecycle = "2.0.0-rc01"//"1.1.1"
 
     const val dokka = "0.9.16"
     const val android_gradle_plugin = "3.1.4"
@@ -58,7 +58,7 @@ object Dependencies {
     const val support_constraintlayout = "com.android.support.constraint:constraint-layout:${Versions.constraint_layout}"
     const val support_compat = "com.android.support:support-compat:${Versions.support_libraries}"
 
-    const val arch_lifecycle = "android.arch.lifecycle:extensions:${Versions.lifecycle}"
+    const val arch_lifecycle = "androidx.lifecycle:lifecycle-extensions:${Versions.lifecycle}"
     const val arch_workmanager = "android.arch.work:work-runtime:${Versions.workmanager}"
 
     const val tools_dokka = "org.jetbrains.dokka:dokka-android-gradle-plugin:${Versions.dokka}"

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-base')
 
+    testImplementation Dependencies.testing_androidx
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean
 
+import android.os.SystemClock
 import mozilla.components.service.glean.storages.EventsStorageEngine
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -13,7 +14,6 @@ import org.junit.Test
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.shadows.ShadowSystemClock
 
 @RunWith(RobolectricTestRunner::class)
 class EventMetricTypeTest {
@@ -53,7 +53,7 @@ class EventMetricTypeTest {
         click.record("buttonA")
 
         val expectedTimeSinceStart: Long = 37
-        ShadowSystemClock.sleep(expectedTimeSinceStart)
+        SystemClock.sleep(expectedTimeSinceStart)
 
         click.record("buttonB")
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.glean
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -35,7 +37,7 @@ class GleanTest {
     @Before
     fun setup() {
         Glean.initialize(
-            applicationContext = RuntimeEnvironment.application
+            applicationContext = ApplicationProvider.getApplicationContext()
         )
     }
 
@@ -163,7 +165,10 @@ class GleanTest {
     @Test
     fun `initialize() must not crash the app if Glean's data dir is messed up`() {
         // Remove the Glean's data directory.
-        val gleanDir = File(RuntimeEnvironment.application.applicationInfo.dataDir, Glean.GLEAN_DATA_DIR)
+        val gleanDir = File(
+            ApplicationProvider.getApplicationContext<Context>().applicationInfo.dataDir,
+            Glean.GLEAN_DATA_DIR
+        )
         assertTrue(gleanDir.deleteRecursively())
 
         // Create a file in its place.
@@ -171,7 +176,7 @@ class GleanTest {
 
         // Try to init Glean: it should not crash.
         Glean.initialize(
-            applicationContext = RuntimeEnvironment.application
+            applicationContext = ApplicationProvider.getApplicationContext()
         )
 
         // Clean up after this, so that other tests don't fail.

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.glean
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -20,9 +21,9 @@ class StringMetricTypeTest {
 
     @Before
     fun setUp() {
-        StringsStorageEngine.applicationContext = RuntimeEnvironment.application
+        StringsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
-        RuntimeEnvironment.application
+        ApplicationProvider.getApplicationContext<Context>()
             .getSharedPreferences(StringsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
             .edit()
             .clear()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.glean
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import java.util.UUID
 
 import mozilla.components.service.glean.storages.UuidsStorageEngine
@@ -22,9 +23,9 @@ class UuidMetricTypeTest {
 
     @Before
     fun setUp() {
-        UuidsStorageEngine.applicationContext = RuntimeEnvironment.application
+        UuidsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
-        RuntimeEnvironment.application
+        ApplicationProvider.getApplicationContext<Context>()
             .getSharedPreferences(UuidsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
             .edit()
             .clear()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/firstrun/FileFirstRunDetectorTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/firstrun/FileFirstRunDetectorTest.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.glean.firstrun
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Test
 
 import org.junit.Assert.assertFalse
@@ -17,7 +19,8 @@ import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 class FileFirstRunDetectorTest {
-    private val dataDir: File = File(RuntimeEnvironment.application.applicationInfo.dataDir)
+    private val dataDir: File =
+        File(ApplicationProvider.getApplicationContext<Context>().applicationInfo.dataDir)
 
     @Before
     fun setUp() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -3,13 +3,13 @@
 
 package mozilla.components.service.glean.storages
 
+import android.os.SystemClock
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.shadows.ShadowSystemClock
 
 @RunWith(RobolectricTestRunner::class)
 class EventsStorageEngineTest {
@@ -76,7 +76,7 @@ class EventsStorageEngineTest {
         val expectedTimeSinceStart: Long = 37
 
         // Sleep a bit Record the event in the store.
-        ShadowSystemClock.sleep(expectedTimeSinceStart)
+        SystemClock.sleep(expectedTimeSinceStart)
         EventsStorageEngine.record(
                 stores = listOf("store1"),
                 category = "telemetry",

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericScalarStorageEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.CommonMetricData
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.support.base.log.logger.Logger
@@ -60,7 +61,7 @@ class GenericScalarStorageEngineTest {
         val dataPingLifetime = 3
 
         val storageEngine = MockScalarStorageEngine()
-        storageEngine.applicationContext = RuntimeEnvironment.application
+        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val metric1 = GenericMetricType(
             disabled = false,
@@ -108,7 +109,7 @@ class GenericScalarStorageEngineTest {
     @Test
     fun `metrics with empty 'category' must be properly recorded`() {
         val storageEngine = MockScalarStorageEngine()
-        storageEngine.applicationContext = RuntimeEnvironment.application
+        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val metric = GenericMetricType(
             disabled = false,
@@ -298,7 +299,7 @@ class GenericScalarStorageEngineTest {
     @Test
     fun `snapshotting must only clear 'ping' lifetime`() {
         val storageEngine = MockScalarStorageEngine()
-        storageEngine.applicationContext = RuntimeEnvironment.application
+        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val stores = listOf("store1", "store2")
 
@@ -369,7 +370,7 @@ class GenericScalarStorageEngineTest {
         // for the SharedPreferences.
         run {
             val storageEngine = MockScalarStorageEngine()
-            storageEngine.applicationContext = RuntimeEnvironment.application
+            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val metric1 = GenericMetricType(
                 disabled = false,
@@ -409,7 +410,7 @@ class GenericScalarStorageEngineTest {
         // Re-instantiate the engine: application lifetime probes should have been cleared.
         run {
             val storageEngine = MockScalarStorageEngine()
-            storageEngine.applicationContext = RuntimeEnvironment.application
+            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val snapshot = storageEngine.getSnapshot("store1", true)
             assertEquals(1, snapshot!!.size)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.storages
 
+import androidx.test.core.app.ApplicationProvider
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
@@ -18,7 +19,7 @@ import org.robolectric.RuntimeEnvironment
 class StorageEngineManagerTest {
     @Test
     fun `collect() must return an empty object for empty or unknown stores`() {
-        val manager = StorageEngineManager(applicationContext = RuntimeEnvironment.application)
+        val manager = StorageEngineManager(applicationContext = ApplicationProvider.getApplicationContext())
         val data = manager.collect("thisStoreNameDoesNotExist")
         assertNotNull(data)
         assertEquals("{}", data.toString())
@@ -29,7 +30,7 @@ class StorageEngineManagerTest {
         val manager = StorageEngineManager(storageEngines = mapOf(
             "engine1" to MockStorageEngine(JSONObject(mapOf("test" to "val"))),
             "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
-        ), applicationContext = RuntimeEnvironment.application)
+        ), applicationContext = ApplicationProvider.getApplicationContext())
 
         val data = manager.collect("test")
         assertEquals("{\"metrics\":{\"engine1\":{\"test\":\"val\"},\"engine2\":[\"a\",\"b\",\"c\"]}}",

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -5,6 +5,7 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.service.glean.StringMetricType
 import org.junit.Before
@@ -23,9 +24,9 @@ class StringsStorageEngineTest {
 
     @Before
     fun setUp() {
-        StringsStorageEngine.applicationContext = RuntimeEnvironment.application
+        StringsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
-        RuntimeEnvironment.application
+        ApplicationProvider.getApplicationContext<Context>()
             .getSharedPreferences(StringsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
             .edit()
             .clear()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -5,6 +5,7 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.service.glean.UuidMetricType
 import java.util.UUID
@@ -26,9 +27,9 @@ class UuidsStorageEngineTest {
 
     @Before
     fun setUp() {
-        UuidsStorageEngine.applicationContext = RuntimeEnvironment.application
+        UuidsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
-        RuntimeEnvironment.application
+        ApplicationProvider.getApplicationContext<Context>()
             .getSharedPreferences(UuidsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
             .edit()
             .clear()
@@ -162,7 +163,7 @@ class UuidsStorageEngineTest {
         val sampleUUID = "decaffde-caff-d3ca-ffd3-caffd3caffd3"
 
         val storageEngine = UuidsStorageEngineImplementation()
-        storageEngine.applicationContext = RuntimeEnvironment.application
+        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val metric = UuidMetricType(
             disabled = false,
@@ -178,7 +179,7 @@ class UuidsStorageEngineTest {
         )
 
         // Check that the persisted shared prefs contains the expected data.
-        val storedData = RuntimeEnvironment.application
+        val storedData = ApplicationProvider.getApplicationContext<Context>()
             .getSharedPreferences(storageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
             .all
 


### PR DESCRIPTION
This attempts to fix #1176 .

This is currently broken for two problems in glean which I'm not sure how to fix, so any input is more than welcome!

** Problem 1 **

>     [Robolectric] NOTICE: legacy resources mode is deprecated; see http://robolectric.org/migrating/#migrating-to-40

** Problem 2 **

>DefNotFound android/arch/lifecycle/ReportFragment$ActivityInitializationListener

I think this has probably something to do with the suggested migration to `androidx`, see [the migration docs](http://robolectric.org/migrating/#migrating-to-40).