### PR TITLE
[glean] 1510308: Move experiments inside of ping_info.

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'kotlin-android'
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "46cfccf"
+String GLEAN_PING_SCHEMA_GIT_HASH = "6041aa6"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/baseline/baseline.1.schema.json"
 
 android {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean.ping
 import android.support.annotation.VisibleForTesting
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.storages.StorageEngineManager
+import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.org.json.mergeWith
 import org.json.JSONException
@@ -43,6 +44,8 @@ internal class PingMaker(
         val pingInfo = JSONObject()
         pingInfo.put("ping_type", pingName)
         pingInfo.put("telemetry_sdk_build", BuildConfig.LIBRARY_VERSION)
+
+        pingInfo.put("experiments", ExperimentsStorageEngine.getSnapshotAsJSON("", false))
 
         // TODO this section is still missing real app_build, seq and experiments.
         // These fields will be added by bug 1497894 when 1499756 and 1501318 land.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -45,6 +45,7 @@ internal class PingMaker(
         pingInfo.put("ping_type", pingName)
         pingInfo.put("telemetry_sdk_build", BuildConfig.LIBRARY_VERSION)
 
+        // Experiments belong in ping_info, because they must appear in every ping
         pingInfo.put("experiments", ExperimentsStorageEngine.getSnapshotAsJSON("", false))
 
         // TODO this section is still missing real app_build, seq and experiments.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -15,7 +15,6 @@ import org.json.JSONObject
 internal class StorageEngineManager(
     private val storageEngines: Map<String, StorageEngine> = mapOf(
         "events" to EventsStorageEngine,
-        "experiments" to ExperimentsStorageEngine,
         "string" to StringsStorageEngine,
         "uuid" to UuidsStorageEngine
     ),

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -148,8 +148,8 @@ class GleanTest {
                     .getString("telemetry.string_metric")
             )
             assertNull(metricsJson.opt("events"))
-            assertNotNull(metricsJson.opt("experiments"))
             assertNotNull(metricsJson.opt("ping_info"))
+            assertNotNull(metricsJson.getJSONObject("ping_info").opt("experiments"))
             assert(
                 metricsPath.startsWith("/submit/glean/metrics/${Glean.SCHEMA_VERSION}/")
             )


### PR DESCRIPTION
This just moves the location of the `experiments` section of the ping inside of `ping_info`.

Schema side of the change is [here](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/222)