### PR TITLE
Closes #1491: Close underlying GeckoSession when GeckoEngineSession is getting closed.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -230,6 +230,15 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.close].
+     */
+    override fun close() {
+        super.close()
+
+        geckoSession.close()
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     @Suppress("ComplexMethod")

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1125,4 +1125,23 @@ class GeckoEngineSessionTest {
 
         assertEquals("1MB.zip", meaningFulFileName)
     }
+
+    @Test
+    fun `Closing engine session should close underlying gecko session`() {
+        val geckoSession = mockGeckoSession()
+
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        engineSession.geckoSession = geckoSession
+
+        engineSession.close()
+
+        verify(geckoSession).close()
+    }
+
+    private fun mockGeckoSession(): GeckoSession {
+        val session = mock(GeckoSession::class.java)
+        `when`(session.settings).thenReturn(
+            mock(GeckoSessionSettings::class.java))
+        return session
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -232,6 +232,15 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.close].
+     */
+    override fun close() {
+        super.close()
+
+        geckoSession.close()
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     @Suppress("ComplexMethod")

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1117,24 +1117,6 @@ class GeckoEngineSessionTest {
         verifyZeroInteractions(observer)
     }
 
-    private fun mockGeckoSession(): GeckoSession {
-        val session = mock(GeckoSession::class.java)
-        `when`(session.settings).thenReturn(
-                mock(GeckoSessionSettings::class.java))
-        return session
-    }
-
-    private fun mockLoadRequest(uri: String): GeckoSession.NavigationDelegate.LoadRequest {
-        val constructor = GeckoSession.NavigationDelegate.LoadRequest::class.java.getDeclaredConstructor(
-            String::class.java,
-            String::class.java,
-            Int::class.java,
-            Int::class.java)
-        constructor.isAccessible = true
-
-        return constructor.newInstance(uri, uri, 0, 0)
-    }
-
     @Test
     fun `after onCrash get called geckoSession must be reset`() {
         val runtime = mock(GeckoRuntime::class.java)
@@ -1178,5 +1160,34 @@ class GeckoEngineSessionTest {
         engineSession.geckoSession.contentDelegate.onExternalResponse(mock(), info)
 
         assertEquals("1MB.zip", meaningFulFileName)
+    }
+
+    @Test
+    fun `Closing engine session should close underlying gecko session`() {
+        val geckoSession = mockGeckoSession()
+
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java), geckoSessionProvider = { geckoSession })
+
+        engineSession.close()
+
+        verify(geckoSession).close()
+    }
+
+    private fun mockGeckoSession(): GeckoSession {
+        val session = mock(GeckoSession::class.java)
+        `when`(session.settings).thenReturn(
+            mock(GeckoSessionSettings::class.java))
+        return session
+    }
+
+    private fun mockLoadRequest(uri: String): GeckoSession.NavigationDelegate.LoadRequest {
+        val constructor = GeckoSession.NavigationDelegate.LoadRequest::class.java.getDeclaredConstructor(
+            String::class.java,
+            String::class.java,
+            Int::class.java,
+            Int::class.java)
+        constructor.isAccessible = true
+
+        return constructor.newInstance(uri, uri, 0, 0)
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -229,6 +229,15 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.close].
+     */
+    override fun close() {
+        super.close()
+
+        geckoSession.close()
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     @Suppress("ComplexMethod")

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1112,4 +1112,23 @@ class GeckoEngineSessionTest {
 
         assertEquals("1MB.zip", meaningFulFileName)
     }
+
+    @Test
+    fun `Closing engine session should close underlying gecko session`() {
+        val geckoSession = mockGeckoSession()
+
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        engineSession.geckoSession = geckoSession
+
+        engineSession.close()
+
+        verify(geckoSession).close()
+    }
+
+    private fun mockGeckoSession(): GeckoSession {
+        val session = mock(GeckoSession::class.java)
+        `when`(session.settings).thenReturn(
+            mock(GeckoSessionSettings::class.java))
+        return session
+    }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -210,5 +210,5 @@ abstract class EngineSession(
      * this session.
      */
     @CallSuper
-    fun close() = delegate.unregisterObservers()
+    open fun close() = delegate.unregisterObservers()
 }


### PR DESCRIPTION
It's surprising we never noticed this... :)