### PR TITLE
Closes #1067: Open / Close window support

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -243,6 +243,7 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
             override var userAgentString by WebSetting(s::getUserAgentString, s::setUserAgentString)
             override var displayZoomControls by WebSetting(s::getDisplayZoomControls, s::setDisplayZoomControls)
             override var loadWithOverviewMode by WebSetting(s::getLoadWithOverviewMode, s::setLoadWithOverviewMode)
+            override var supportMultipleWindows by WebSetting(s::supportMultipleWindows, s::setSupportMultipleWindows)
             override var allowFileAccessFromFileURLs by WebSetting(
                     s::getAllowFileAccessFromFileURLs, s::setAllowFileAccessFromFileURLs)
             override var allowUniversalAccessFromFileURLs by WebSetting(
@@ -292,6 +293,7 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
                 verticalScrollBarEnabled = it.verticalScrollBarEnabled
                 horizontalScrollBarEnabled = it.horizontalScrollBarEnabled
                 userAgentString = it.userAgentString
+                supportMultipleWindows = it.supportMultipleWindows
             }
         }
 

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -47,6 +47,10 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
     @Volatile internal var webFontsEnabled = true
     @Volatile internal var internalSettings: Settings? = null
 
+    // This is currently only used for window requests:
+    // TODO https://github.com/mozilla-mobile/android-components/issues/1195
+    @Volatile internal var webView: WebView? = null
+
     /**
      * See [EngineSession.loadUrl]
      */
@@ -184,7 +188,7 @@ class SystemEngineSession(private val defaultSettings: Settings? = null) : Engin
     }
 
     /**
-     * See [EngineSession.clearFindResults]
+     * See [EngineSession.clearFindMatches]
      */
     override fun clearFindMatches() {
         currentView()?.clearMatches()

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/window/SystemWindowRequest.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/window/SystemWindowRequest.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.system.window
+
+import android.os.Message
+import android.webkit.WebView
+import mozilla.components.browser.engine.system.SystemEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.window.WindowRequest
+
+/**
+ * WebView-based implementation of [WindowRequest].
+ *
+ * @property webView the WebView from which the request originated.
+ * @property newWebView the WebView to use for opening a new window, may be null for close requests.
+ * @property openAsDialog whether or not the window should be opened as a dialog, defaults to false.
+ * @property triggeredByUser whether or not the request was triggered by the user, defaults to false.
+ * @property resultMsg the message to send to the new WebView, may be null.
+ */
+class SystemWindowRequest(
+    private val webView: WebView,
+    private val newWebView: WebView? = null,
+    val openAsDialog: Boolean = false,
+    val triggeredByUser: Boolean = false,
+    private val resultMsg: Message? = null
+) : WindowRequest {
+
+    override val url: String = "about:blank"
+
+    override fun prepare(engineSession: EngineSession) {
+        (engineSession as SystemEngineSession).webView = newWebView
+    }
+
+    override fun start() {
+        val message = resultMsg
+        val transport = message?.obj as? WebView.WebViewTransport
+        transport?.let {
+            it.webView = newWebView
+            message.sendToTarget()
+        }
+    }
+}

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -261,6 +261,7 @@ class SystemEngineSessionTest {
         `when`(webViewSettings.allowContentAccess).thenReturn(true)
         `when`(webViewSettings.allowFileAccess).thenReturn(true)
         `when`(webViewSettings.mediaPlaybackRequiresUserGesture).thenReturn(true)
+        `when`(webViewSettings.supportMultipleWindows()).thenReturn(false)
 
         val webView = mock(WebView::class.java)
         `when`(webView.context).thenReturn(RuntimeEnvironment.application)
@@ -328,6 +329,10 @@ class SystemEngineSessionTest {
         engineSession.settings.horizontalScrollBarEnabled = false
         verify(webView).isHorizontalScrollBarEnabled = false
 
+        assertFalse(engineSession.settings.supportMultipleWindows)
+        engineSession.settings.supportMultipleWindows = true
+        verify(webViewSettings).setSupportMultipleWindows(true)
+
         assertTrue(engineSession.webFontsEnabled)
         assertTrue(engineSession.settings.webFontsEnabled)
         engineSession.settings.webFontsEnabled = false
@@ -360,7 +365,8 @@ class SystemEngineSessionTest {
                 mediaPlaybackRequiresUserGesture = false,
                 javaScriptCanOpenWindowsAutomatically = true,
                 displayZoomControls = false,
-                loadWithOverviewMode = true)
+                loadWithOverviewMode = true,
+                supportMultipleWindows = true)
         val engineSession = spy(SystemEngineSession(defaultSettings))
         val webView = mock(WebView::class.java)
         `when`(webView.context).thenReturn(RuntimeEnvironment.application)
@@ -377,6 +383,7 @@ class SystemEngineSessionTest {
         verify(webViewSettings).javaScriptCanOpenWindowsAutomatically = true
         verify(webViewSettings).displayZoomControls = false
         verify(webViewSettings).loadWithOverviewMode = true
+        verify(webViewSettings).setSupportMultipleWindows(true)
         verify(engineSession).enableTrackingProtection(EngineSession.TrackingProtectionPolicy.all())
         assertFalse(engineSession.webFontsEnabled)
     }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/window/SystemWindowRequestTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/window/SystemWindowRequestTest.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.system.window
+
+import android.os.Message
+import android.webkit.WebView
+import mozilla.components.browser.engine.system.SystemEngineSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class SystemWindowRequestTest {
+
+    @Test
+    fun `init request`() {
+        val curWebView = mock(WebView::class.java)
+        val newWebView = mock(WebView::class.java)
+        val request = SystemWindowRequest(curWebView, newWebView, true, true)
+
+        assertTrue(request.openAsDialog)
+        assertTrue(request.triggeredByUser)
+        assertEquals("about:blank", request.url)
+    }
+
+    @Test
+    fun `prepare sets webview on engine session`() {
+        val curWebView = mock(WebView::class.java)
+        val newWebView = mock(WebView::class.java)
+        val request = SystemWindowRequest(curWebView, newWebView)
+
+        val engineSession = SystemEngineSession()
+        request.prepare(engineSession)
+        assertSame(newWebView, engineSession.webView)
+    }
+
+    @Test
+    fun `start sends message to target`() {
+        val curWebView = mock(WebView::class.java)
+        val newWebView = mock(WebView::class.java)
+        val resultMsg = mock(Message::class.java)
+
+        SystemWindowRequest(curWebView, newWebView, false, false).start()
+        verify(resultMsg, never()).sendToTarget()
+
+        SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
+        verify(resultMsg, never()).sendToTarget()
+
+        resultMsg.obj = ""
+        SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
+        verify(resultMsg, never()).sendToTarget()
+
+        resultMsg.obj = mock(WebView.WebViewTransport::class.java)
+        SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
+        verify(resultMsg, times(1)).sendToTarget()
+    }
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -62,6 +63,8 @@ class Session(
         fun onContentPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onAppPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onPromptRequested(session: Session, promptRequest: PromptRequest): Boolean = false
+        fun onOpenWindowRequested(session: Session, windowRequest: WindowRequest): Boolean = false
+        fun onCloseWindowRequested(session: Session, windowRequest: WindowRequest): Boolean = false
     }
 
     /**
@@ -292,6 +295,24 @@ class Session(
     var promptRequest: Consumable<PromptRequest> by Delegates.vetoable(Consumable.empty()) {
             _, _, request ->
         val consumers = wrapConsumers<PromptRequest> { onPromptRequested(this@Session, it) }
+        !request.consumeBy(consumers)
+    }
+
+    /**
+     * [Consumable] request to open/create a window.
+     */
+    var openWindowRequest: Consumable<WindowRequest> by Delegates.vetoable(Consumable.empty()) {
+        _, _, request ->
+        val consumers = wrapConsumers<WindowRequest> { onOpenWindowRequested(this@Session, it) }
+        !request.consumeBy(consumers)
+    }
+
+    /**
+     * [Consumable] request to close a window.
+     */
+    var closeWindowRequest: Consumable<WindowRequest> by Delegates.vetoable(Consumable.empty()) {
+        _, _, request ->
+        val consumers = wrapConsumers<WindowRequest> { onCloseWindowRequested(this@Session, it) }
         !request.consumeBy(consumers)
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Consumable
 
 @Suppress("TooManyFunctions")
@@ -112,5 +113,13 @@ internal class EngineObserver(val session: Session) : EngineSession.Observer {
 
     override fun onPromptRequest(promptRequest: PromptRequest) {
         session.promptRequest = Consumable.from(promptRequest)
+    }
+
+    override fun onOpenWindowRequest(windowRequest: WindowRequest) {
+        session.openWindowRequest = Consumable.from(windowRequest)
+    }
+
+    override fun onCloseWindowRequest(windowRequest: WindowRequest) {
+        session.closeWindowRequest = Consumable.from(windowRequest)
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -9,7 +9,9 @@ import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.permission.PermissionRequest
+
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -543,6 +545,7 @@ class SessionTest {
         val contentPermissionRequest: PermissionRequest = mock()
         val appPermissionRequest: PermissionRequest = mock()
         val promptRequest: PromptRequest = mock()
+        val windowRequest: WindowRequest = mock()
 
         defaultObserver.onUrlChanged(session, "")
         defaultObserver.onTitleChanged(session, "")
@@ -563,6 +566,8 @@ class SessionTest {
         defaultObserver.onContentPermissionRequested(session, contentPermissionRequest)
         defaultObserver.onAppPermissionRequested(session, appPermissionRequest)
         defaultObserver.onPromptRequested(session, promptRequest)
+        defaultObserver.onOpenWindowRequested(session, windowRequest)
+        defaultObserver.onCloseWindowRequested(session, windowRequest)
     }
 
     @Test
@@ -654,5 +659,61 @@ class SessionTest {
 
         assertTrue(promptCallbackExecuted)
         assertTrue(session.contentPermissionRequest.isConsumed())
+    }
+
+    @Test
+    fun `window requests will be set on session if no observer consumes them`() {
+        val openWindowRequest: WindowRequest = mock()
+        val closeWindowRequest: WindowRequest = mock()
+
+        val session = Session("https://www.mozilla.org")
+        session.openWindowRequest = Consumable.from(openWindowRequest)
+        session.closeWindowRequest = Consumable.from(closeWindowRequest)
+        assertFalse(session.openWindowRequest.isConsumed())
+        assertFalse(session.closeWindowRequest.isConsumed())
+
+        var createWindowRequestIsSet = false
+        var closeWindowRequestIsSet = false
+        session.openWindowRequest.consume {
+            createWindowRequestIsSet = true
+            true
+        }
+        session.closeWindowRequest.consume {
+            closeWindowRequestIsSet = true
+            true
+        }
+        assertTrue(createWindowRequestIsSet)
+        assertTrue(closeWindowRequestIsSet)
+    }
+
+    @Test
+    fun `window requests will not be set on session if consumed by observer`() {
+        var openWindowRequestExecuted = false
+        var closeWindowRequestExecuted = false
+
+        val session = Session("https://www.mozilla.org")
+        session.register(object : Session.Observer {
+            override fun onOpenWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
+                openWindowRequestExecuted = true
+                return true
+            }
+
+            override fun onCloseWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
+                closeWindowRequestExecuted = true
+                return true
+            }
+        })
+
+        val createWindowRequest: WindowRequest = mock()
+        session.openWindowRequest = Consumable.from(createWindowRequest)
+
+        val closeWindowRequest: WindowRequest = mock()
+        session.closeWindowRequest = Consumable.from(closeWindowRequest)
+
+        assertTrue(openWindowRequestExecuted)
+        assertTrue(session.openWindowRequest.isConsumed())
+
+        assertTrue(closeWindowRequestExecuted)
+        assertTrue(session.closeWindowRequest.isConsumed())
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -10,7 +10,11 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.permission.PermissionRequest
+
 import mozilla.components.concept.engine.prompt.PromptRequest
+
+import mozilla.components.concept.engine.window.WindowRequest
+
 import mozilla.components.support.base.observer.Consumable
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -301,5 +305,20 @@ class EngineObserverTest {
         assertTrue(session.promptRequest.isConsumed())
         observer.onPromptRequest(promptRequest)
         assertFalse(session.promptRequest.isConsumed())
+    }
+
+    @Test
+    fun engineSessionObserverWithWindowRequests() {
+        val windowRequest = mock(WindowRequest::class.java)
+        val session = Session("")
+        val observer = EngineObserver(session)
+
+        assertTrue(session.openWindowRequest.isConsumed())
+        observer.onOpenWindowRequest(windowRequest)
+        assertFalse(session.openWindowRequest.isConsumed())
+
+        assertTrue(session.closeWindowRequest.isConsumed())
+        observer.onCloseWindowRequest(windowRequest)
+        assertFalse(session.closeWindowRequest.isConsumed())
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -7,7 +7,9 @@ package mozilla.components.concept.engine
 import android.graphics.Bitmap
 import android.support.annotation.CallSuper
 import mozilla.components.concept.engine.permission.PermissionRequest
+
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 
@@ -42,6 +44,8 @@ abstract class EngineSession(
         fun onContentPermissionRequest(permissionRequest: PermissionRequest) = permissionRequest.reject()
         fun onCancelContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
         fun onPromptRequest(promptRequest: PromptRequest) = Unit
+        fun onOpenWindowRequest(windowRequest: WindowRequest) = Unit
+        fun onCloseWindowRequest(windowRequest: WindowRequest) = Unit
 
         @Suppress("LongParameterList")
         fun onExternalResource(

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -108,6 +108,11 @@ abstract class Settings {
      * Setting to control whether or not remote debugging is enabled.
      */
     open var remoteDebuggingEnabled: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not multiple windows are supported.
+     */
+    open var supportMultipleWindows: Boolean by UnsupportedSetting()
 }
 
 /**
@@ -131,7 +136,8 @@ data class DefaultSettings(
     override var allowContentAccess: Boolean = true,
     override var verticalScrollBarEnabled: Boolean = true,
     override var horizontalScrollBarEnabled: Boolean = true,
-    override var remoteDebuggingEnabled: Boolean = false
+    override var remoteDebuggingEnabled: Boolean = false,
+    override var supportMultipleWindows: Boolean = false
 ) : Settings()
 
 class UnsupportedSetting<T> {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/window/WindowRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/window/WindowRequest.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.window
+
+import mozilla.components.concept.engine.EngineSession
+
+/**
+ * Represents a request to open or close a browser window.
+ */
+interface WindowRequest {
+
+    /**
+     * The URL which should be opened in a new window. May be
+     * empty if the request was created from JavaScript (using
+     * window.open()).
+     */
+    val url: String
+
+    /**
+     * Prepares the provided [EngineSession] for the window request. This
+     * is used to attach state (e.g. a native session) to the engine session.
+     *
+     * @param engineSession the engine session to prepare.
+     */
+    fun prepare(engineSession: EngineSession)
+
+    /**
+     * Starts the window request.
+     */
+    fun start()
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.concept.engine
 import android.graphics.Bitmap
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.permission.PermissionRequest
+import mozilla.components.concept.engine.window.WindowRequest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -29,6 +30,7 @@ class EngineSessionTest {
         val observer = mock(EngineSession.Observer::class.java)
         val emptyBitmap = spy(Bitmap::class.java)
         val permissionRequest = mock(PermissionRequest::class.java)
+        val windowRequest = mock(WindowRequest::class.java)
         session.register(observer)
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
@@ -48,6 +50,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
@@ -66,6 +70,8 @@ class EngineSessionTest {
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
+        verify(observer).onOpenWindowRequest(windowRequest)
+        verify(observer).onCloseWindowRequest(windowRequest)
         verifyNoMoreInteractions(observer)
     }
 
@@ -76,6 +82,8 @@ class EngineSessionTest {
         val otherHitResult = HitResult.UNKNOWN("file://foobaz")
         val permissionRequest = mock(PermissionRequest::class.java)
         val otherPermissionRequest = mock(PermissionRequest::class.java)
+        val windowRequest = mock(WindowRequest::class.java)
+        val otherWindowRequest = mock(WindowRequest::class.java)
         val emptyBitmap = spy(Bitmap::class.java)
         session.register(observer)
 
@@ -94,6 +102,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
         session.unregister(observer)
 
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
@@ -111,6 +121,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(otherWindowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(otherWindowRequest) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -127,6 +139,8 @@ class EngineSessionTest {
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
+        verify(observer).onOpenWindowRequest(windowRequest)
+        verify(observer).onCloseWindowRequest(windowRequest)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -142,6 +156,8 @@ class EngineSessionTest {
         verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
+        verify(observer, never()).onOpenWindowRequest(otherWindowRequest)
+        verify(observer, never()).onCloseWindowRequest(otherWindowRequest)
         verifyNoMoreInteractions(observer)
     }
 
@@ -152,6 +168,8 @@ class EngineSessionTest {
         val otherObserver = mock(EngineSession.Observer::class.java)
         val permissionRequest = mock(PermissionRequest::class.java)
         val otherPermissionRequest = mock(PermissionRequest::class.java)
+        val windowRequest = mock(WindowRequest::class.java)
+        val otherWindowRequest = mock(WindowRequest::class.java)
         val otherHitResult = HitResult.UNKNOWN("file://foobaz")
         val emptyBitmap = spy(Bitmap::class.java)
         session.register(observer)
@@ -172,6 +190,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
 
         session.unregisterObservers()
 
@@ -190,6 +210,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(otherWindowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(otherWindowRequest) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -206,6 +228,8 @@ class EngineSessionTest {
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
+        verify(observer).onOpenWindowRequest(windowRequest)
+        verify(observer).onCloseWindowRequest(windowRequest)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -221,6 +245,8 @@ class EngineSessionTest {
         verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
+        verify(observer, never()).onOpenWindowRequest(otherWindowRequest)
+        verify(observer, never()).onCloseWindowRequest(otherWindowRequest)
         verify(otherObserver, never()).onLocationChange("https://www.firefox.com")
         verify(otherObserver, never()).onProgress(100)
         verify(otherObserver, never()).onLoadingStateChange(false)
@@ -233,9 +259,11 @@ class EngineSessionTest {
         verify(otherObserver, never()).onFindResult(0, 1, false)
         verify(otherObserver, never()).onFullScreenChange(false)
         verify(otherObserver, never()).onThumbnailChange(null)
-        verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
-        verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
-        verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
+        verify(otherObserver, never()).onAppPermissionRequest(otherPermissionRequest)
+        verify(otherObserver, never()).onContentPermissionRequest(otherPermissionRequest)
+        verify(otherObserver, never()).onCancelContentPermissionRequest(otherPermissionRequest)
+        verify(otherObserver, never()).onOpenWindowRequest(otherWindowRequest)
+        verify(otherObserver, never()).onCloseWindowRequest(otherWindowRequest)
     }
 
     @Test
@@ -245,6 +273,8 @@ class EngineSessionTest {
         val otherHitResult = HitResult.UNKNOWN("file://foobaz")
         val permissionRequest = mock(PermissionRequest::class.java)
         val otherPermissionRequest = mock(PermissionRequest::class.java)
+        val windowRequest = mock(WindowRequest::class.java)
+        val otherWindowRequest = mock(WindowRequest::class.java)
         val emptyBitmap = spy(Bitmap::class.java)
         session.register(observer)
 
@@ -263,6 +293,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
 
         session.close()
 
@@ -281,6 +313,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(otherWindowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(otherWindowRequest) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -297,6 +331,8 @@ class EngineSessionTest {
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
+        verify(observer).onOpenWindowRequest(windowRequest)
+        verify(observer).onCloseWindowRequest(windowRequest)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -312,6 +348,8 @@ class EngineSessionTest {
         verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
+        verify(observer, never()).onOpenWindowRequest(otherWindowRequest)
+        verify(observer, never()).onCloseWindowRequest(otherWindowRequest)
         verifyNoMoreInteractions(observer)
     }
 
@@ -320,6 +358,7 @@ class EngineSessionTest {
         val session = spy(DummyEngineSession())
         val otherSession = spy(DummyEngineSession())
         val permissionRequest = mock(PermissionRequest::class.java)
+        val windowRequest = mock(WindowRequest::class.java)
         val emptyBitmap = spy(Bitmap::class.java)
         val observer = mock(EngineSession.Observer::class.java)
         session.register(observer)
@@ -340,6 +379,8 @@ class EngineSessionTest {
         otherSession.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         otherSession.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         otherSession.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
+        otherSession.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
+        otherSession.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
         verify(observer, never()).onLocationChange("https://www.mozilla.org")
         verify(observer, never()).onProgress(25)
         verify(observer, never()).onLoadingStateChange(true)
@@ -355,6 +396,8 @@ class EngineSessionTest {
         verify(observer, never()).onAppPermissionRequest(permissionRequest)
         verify(observer, never()).onContentPermissionRequest(permissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(permissionRequest)
+        verify(observer, never()).onOpenWindowRequest(windowRequest)
+        verify(observer, never()).onCloseWindowRequest(windowRequest)
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
@@ -371,6 +414,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
+        session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
         verify(observer, times(1)).onLocationChange("https://www.mozilla.org")
         verify(observer, times(1)).onProgress(25)
         verify(observer, times(1)).onLoadingStateChange(true)
@@ -386,6 +431,8 @@ class EngineSessionTest {
         verify(observer, times(1)).onAppPermissionRequest(permissionRequest)
         verify(observer, times(1)).onContentPermissionRequest(permissionRequest)
         verify(observer, times(1)).onCancelContentPermissionRequest(permissionRequest)
+        verify(observer, times(1)).onOpenWindowRequest(windowRequest)
+        verify(observer, times(1)).onCloseWindowRequest(windowRequest)
         verifyNoMoreInteractions(observer)
     }
 
@@ -497,6 +544,8 @@ class EngineSessionTest {
         defaultObserver.onAppPermissionRequest(mock(PermissionRequest::class.java))
         defaultObserver.onContentPermissionRequest(mock(PermissionRequest::class.java))
         defaultObserver.onCancelContentPermissionRequest(mock(PermissionRequest::class.java))
+        defaultObserver.onOpenWindowRequest(mock(WindowRequest::class.java))
+        defaultObserver.onCloseWindowRequest(mock(WindowRequest::class.java))
     }
 
     @Test

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -57,7 +57,9 @@ class SettingsTest {
             { settings.horizontalScrollBarEnabled },
             { settings.horizontalScrollBarEnabled = false },
             { settings.remoteDebuggingEnabled },
-            { settings.remoteDebuggingEnabled = false }
+            { settings.remoteDebuggingEnabled = false },
+            { settings.supportMultipleWindows },
+            { settings.supportMultipleWindows = false }
         )
     }
 
@@ -87,6 +89,7 @@ class SettingsTest {
         assertTrue(settings.verticalScrollBarEnabled)
         assertTrue(settings.horizontalScrollBarEnabled)
         assertFalse(settings.remoteDebuggingEnabled)
+        assertFalse(settings.supportMultipleWindows)
 
         val interceptor: RequestInterceptor = mock()
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
@@ -109,7 +112,8 @@ class SettingsTest {
             allowUniversalAccessFromFileURLs = true,
             verticalScrollBarEnabled = false,
             horizontalScrollBarEnabled = false,
-            remoteDebuggingEnabled = true)
+            remoteDebuggingEnabled = true,
+            supportMultipleWindows = true)
 
         assertFalse(defaultSettings.domStorageEnabled)
         assertFalse(defaultSettings.javascriptEnabled)
@@ -129,5 +133,6 @@ class SettingsTest {
         assertFalse(defaultSettings.verticalScrollBarEnabled)
         assertFalse(defaultSettings.horizontalScrollBarEnabled)
         assertTrue(defaultSettings.remoteDebuggingEnabled)
+        assertTrue(defaultSettings.supportMultipleWindows)
     }
 }

--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.support_design
 
+    testImplementation project(':support-test')
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/WindowFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/WindowFeature.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import mozilla.components.browser.session.SelectionAwareSessionObserver
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.window.WindowRequest
+
+/**
+ * Feature implementation for handling window requests.
+ */
+class WindowFeature(private val engine: Engine, private val sessionManager: SessionManager) {
+
+    internal val windowObserver = object : SelectionAwareSessionObserver(sessionManager) {
+        override fun onOpenWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
+            val newSession = Session(windowRequest.url, session.private)
+            val newEngineSession = engine.createSession(session.private)
+            windowRequest.prepare(newEngineSession)
+
+            sessionManager.add(newSession, true, newEngineSession, parent = session)
+            windowRequest.start()
+            return true
+        }
+
+        override fun onCloseWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
+            sessionManager.remove(session)
+            return true
+        }
+    }
+
+    /**
+     * Starts the feature and a observer to listen for window requests.
+     */
+    fun start() {
+        windowObserver.observeSelected()
+    }
+
+    /**
+     * Stops the feature and the window request observer.
+     */
+    fun stop() {
+        windowObserver.stop()
+    }
+}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/WindowFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/WindowFeatureTest.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.window.WindowRequest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import mozilla.components.support.test.any
+
+class WindowFeatureTest {
+
+    private lateinit var engine: Engine
+    private lateinit var sessionManager: SessionManager
+
+    @Before
+    fun setup() {
+        engine = mock(Engine::class.java)
+        sessionManager = mock(SessionManager::class.java)
+    }
+
+    @Test
+    fun `start registers window observer`() {
+        val feature = WindowFeature(engine, sessionManager)
+        feature.start()
+        verify(sessionManager).register(feature.windowObserver)
+    }
+
+    @Test
+    fun `observer handles open window request`() {
+        val session = Session("https://www.mozilla.org")
+        val request = mock(WindowRequest::class.java)
+        `when`(request.url).thenReturn("about:blank")
+
+        val feature = WindowFeature(engine, sessionManager)
+        feature.windowObserver.onOpenWindowRequested(session, request)
+
+        verify(request).prepare(any())
+        verify(sessionManager).add(any(), eq(true), any(), eq(session))
+        verify(request).start()
+    }
+
+    @Test
+    fun `session is removed when window should be closed`() {
+        val session = Session("https://www.mozilla.org")
+
+        val feature = WindowFeature(engine, sessionManager)
+        feature.windowObserver.onCloseWindowRequested(session, mock(WindowRequest::class.java))
+        verify(sessionManager).remove(session)
+    }
+
+    @Test
+    fun `stop unregisters window observer`() {
+        val feature = WindowFeature(engine, sessionManager)
+        feature.stop()
+        verify(sessionManager).unregister(feature.windowObserver)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,32 @@ permalink: /changelog/
   promptFeature.stop()
   ```
 
+* **feature-session**, **browser-session**, **concept-engine**, **browser-engine-system**:  
+  * Added functionality to observe window requests from the browser engine. These requests can be observed on the session directly using `onOpenWindowRequest` and `onCloseWindowRequest`, but we also provide a feature class, which will automatically open and close the corresponding window:
+
+  ```Kotlin
+  windowFeature = WindowFeature(engine, sessionManager)
+
+  override fun onStart() {    
+    windowFeature.start()
+  }
+
+  override fun onStop() {
+    windowFeature.stop()
+  }
+
+  ```
+
+  In addition, to observe window requests the new engine setting `supportMultipleWindows` has to be set to true:
+
+  ```Kotlin
+  val engine = SystemEngine(context, 
+    DefaultSettings(
+      supportMultipleWindows = true
+    )
+  )
+  ```
+
 # 0.33.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.32.0...v0.33.0),

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.session.CoordinateScrollingFeature
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.SessionFeature
+import mozilla.components.feature.session.WindowFeature
 import mozilla.components.feature.storage.HistoryTrackingFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
@@ -35,6 +36,7 @@ class BrowserFragment : Fragment(), BackHandler {
     private lateinit var scrollFeature: CoordinateScrollingFeature
     private lateinit var contextMenuFeature: ContextMenuFeature
     private lateinit var promptFeature: PromptFeature
+    private lateinit var windowFeature: WindowFeature
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_browser, container, false)
@@ -93,6 +95,8 @@ class BrowserFragment : Fragment(), BackHandler {
                 view))
 
         promptFeature = PromptFeature(components.sessionManager, requireFragmentManager())
+
+        windowFeature = WindowFeature(components.engine, components.sessionManager)
     }
 
     private fun showTabs() {
@@ -108,6 +112,7 @@ class BrowserFragment : Fragment(), BackHandler {
         super.onStart()
 
         sessionFeature.start()
+        windowFeature.start()
         toolbarFeature.start()
         downloadsFeature.start()
         scrollFeature.start()
@@ -119,6 +124,7 @@ class BrowserFragment : Fragment(), BackHandler {
         super.onStop()
 
         sessionFeature.stop()
+        windowFeature.stop()
         toolbarFeature.stop()
         downloadsFeature.stop()
         scrollFeature.stop()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -34,7 +34,8 @@ open class DefaultComponents(private val applicationContext: Context) {
     // Engine
     open val engine: Engine by lazy {
         val settings = DefaultSettings(
-            requestInterceptor = SampleRequestInterceptor(applicationContext)
+            requestInterceptor = SampleRequestInterceptor(applicationContext),
+            supportMultipleWindows = true
         )
         SystemEngine(applicationContext, settings)
     }


### PR DESCRIPTION
This brings in new engine API to support opening and closing windows, as well as a feature that uses it.

This works for both `window.open` and `target="_blank"` (and closing windows), but only using engine-system. For Gecko, we're waiting for: https://bugzilla.mozilla.org/show_bug.cgi?id=1510314

This can be further cleaned up once #1195 lands, which is similar to what's being done here for window requests. `WindowRequest` has a prepare method which allows attaching state to an engine session. This will either be the new native `GeckoSession` or the newly created `WebView`.

The second commit exposes a new setting `supportMultipleWindows`, which I kept `false` by default for now, until we can implement the Gecko side of things. This way we don't need to update existing clients.

