### PR TITLE
SessionState refactoring

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -9,9 +9,11 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import org.json.JSONObject
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -35,6 +37,13 @@ class GeckoEngine(
      */
     override fun createSession(private: Boolean): EngineSession {
         return GeckoEngineSession(runtime, private, defaultSettings)
+    }
+
+    /**
+     * See [Engine.createSessionState].
+     */
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        return GeckoEngineSessionState.fromJSON(json)
     }
 
     override fun name(): String = "Gecko"

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import mozilla.components.concept.engine.EngineSessionState
+import org.json.JSONException
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoSession
+
+private const val GECKO_STATE_KEY = "GECKO_STATE"
+
+class GeckoEngineSessionState internal constructor(
+    internal val actualState: GeckoSession.SessionState?
+) : EngineSessionState {
+    override fun toJSON() = JSONObject().apply {
+        if (actualState != null) {
+            put(GECKO_STATE_KEY, actualState.toString())
+        }
+    }
+
+    companion object {
+        fun fromJSON(json: JSONObject): GeckoEngineSessionState = try {
+            val state = json.getString(GECKO_STATE_KEY)
+            GeckoEngineSessionState(GeckoSession.SessionState(state))
+        } catch (e: JSONException) {
+            GeckoEngineSessionState(null)
+        }
+    }
+}

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoSession
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineSessionStateTest {
+    @Test
+    fun toJSON() {
+        val state = GeckoEngineSessionState(GeckoSession.SessionState("<state>"))
+
+        val json = state.toJSON()
+
+        assertEquals(1, json.length())
+        assertTrue(json.has("GECKO_STATE"))
+        assertEquals("<state>", json.getString("GECKO_STATE"))
+    }
+
+    @Test
+    fun fromJSON() {
+        val json = JSONObject().apply {
+            put("GECKO_STATE", "<state>")
+        }
+
+        val state = GeckoEngineSessionState.fromJSON(json)
+
+        assertEquals("<state>", state.actualState.toString())
+    }
+
+    @Test
+    fun `fromJSON with invalid JSON returns empty State`() {
+        val json = JSONObject().apply {
+            put("nothing", "helpful")
+        }
+
+        val state = GeckoEngineSessionState.fromJSON(json)
+
+        assertNull(state.actualState)
+    }
+}

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -374,21 +374,38 @@ class GeckoEngineSessionTest {
     @Test
     fun saveState() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
-                geckoSessionProvider = geckoSessionProvider)
-        val currentState = GeckoSession.SessionState("")
-        val stateMap = mapOf(GeckoEngineSession.GECKO_STATE_KEY to currentState.toString())
+            geckoSessionProvider = geckoSessionProvider)
+        val currentState = GeckoSession.SessionState("<state>")
 
         `when`(geckoSession.saveState()).thenReturn(GeckoResult.fromValue(currentState))
-        assertEquals(stateMap, engineSession.saveState())
+
+        val savedState = engineSession.saveState() as GeckoEngineSessionState
+
+        assertEquals(currentState, savedState.actualState)
+        assertEquals("{\"GECKO_STATE\":\"<state>\"}", savedState.toJSON().toString())
     }
 
     @Test
     fun restoreState() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
-                geckoSessionProvider = geckoSessionProvider)
+            geckoSessionProvider = geckoSessionProvider)
 
-        engineSession.restoreState(mapOf(GeckoEngineSession.GECKO_STATE_KEY to ""))
+        val actualState: GeckoSession.SessionState = mock()
+        val state = GeckoEngineSessionState(actualState)
+
+        engineSession.restoreState(state)
         verify(geckoSession).restoreState(any())
+    }
+
+    @Test
+    fun `restoreState does nothing for null state`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+            geckoSessionProvider = geckoSessionProvider)
+
+        val state = GeckoEngineSessionState(null)
+
+        engineSession.restoreState(state)
+        verify(geckoSession, never()).restoreState(any())
     }
 
     class MockSecurityInformation(origin: String) : SecurityInformation() {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -9,9 +9,11 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import org.json.JSONObject
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -22,7 +24,6 @@ class GeckoEngine(
     private val defaultSettings: Settings? = null,
     private val runtime: GeckoRuntime = GeckoRuntime.getDefault(context)
 ) : Engine {
-
     /**
      * Creates a new Gecko-based EngineView.
      */
@@ -35,6 +36,13 @@ class GeckoEngine(
      */
     override fun createSession(private: Boolean): EngineSession {
         return GeckoEngineSession(runtime, private, defaultSettings)
+    }
+
+    /**
+     * See [Engine.createSessionState].
+     */
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        return GeckoEngineSessionState.fromJSON(json)
     }
 
     override fun name(): String = "Gecko"

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -17,6 +17,7 @@ import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
@@ -35,6 +36,7 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate
 import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.WebRequestError
+import java.lang.IllegalStateException
 
 /**
  * Gecko-based EngineSession implementation.
@@ -120,9 +122,6 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.saveState]
      *
-     * GeckoView provides a String representing the entire session state. We
-     * store this String using a single Map entry with key GECKO_STATE_KEY.
-
      * See https://bugzilla.mozilla.org/show_bug.cgi?id=1441810 for
      * discussion on sync vs. async, where a decision was made that
      * callers should provide synchronous wrappers, if needed. In case we're
@@ -130,30 +129,35 @@ class GeckoEngineSession(
      * is used so we're not blocking anything else. In case of calling this
      * method from onPause or similar, we also want a synchronous response.
      */
-    override fun saveState(): Map<String, Any> = runBlocking {
-        val stateMap = CompletableDeferred<Map<String, Any>>()
+    override fun saveState(): EngineSessionState = runBlocking {
+        val state = CompletableDeferred<GeckoEngineSessionState>()
 
         ThreadUtils.postToBackgroundThread {
-            geckoSession.saveState().then({ state ->
-                stateMap.complete(mapOf(GECKO_STATE_KEY to state.toString()))
+            geckoSession.saveState().then({ sessionState ->
+                state.complete(GeckoEngineSessionState(sessionState))
                 GeckoResult<Void>()
             }, { throwable ->
-                stateMap.cancel(throwable)
+                state.completeExceptionally(throwable)
                 GeckoResult<Void>()
             })
         }
 
-        stateMap.await()
+        state.await()
     }
 
     /**
      * See [EngineSession.restoreState]
      */
-    override fun restoreState(state: Map<String, Any>) {
-        if (state.containsKey(GECKO_STATE_KEY)) {
-            val sessionState = GeckoSession.SessionState(state[GECKO_STATE_KEY] as String)
-            geckoSession.restoreState(sessionState)
+    override fun restoreState(state: EngineSessionState) {
+        if (state !is GeckoEngineSessionState) {
+            throw IllegalStateException("Can only restore from GeckoEngineSessionState")
         }
+
+        if (state.actualState == null) {
+            return
+        }
+
+        geckoSession.restoreState(state.actualState)
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import mozilla.components.concept.engine.EngineSessionState
+import org.json.JSONException
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoSession
+
+private const val GECKO_STATE_KEY = "GECKO_STATE"
+
+class GeckoEngineSessionState internal constructor(
+    internal val actualState: GeckoSession.SessionState?
+) : EngineSessionState {
+    override fun toJSON() = JSONObject().apply {
+        if (actualState != null) {
+            // GeckoView provides a String representing the entire session state. We
+            // store this String using a single Map entry with key GECKO_STATE_KEY.
+
+            put(GECKO_STATE_KEY, actualState.toString())
+        }
+    }
+
+    companion object {
+        fun fromJSON(json: JSONObject): GeckoEngineSessionState = try {
+            val state = json.getString(GECKO_STATE_KEY)
+            GeckoEngineSessionState(GeckoSession.SessionState(state))
+        } catch (e: JSONException) {
+            GeckoEngineSessionState(null)
+        }
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoSession
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineSessionStateTest {
+    @Test
+    fun toJSON() {
+        val state = GeckoEngineSessionState(GeckoSession.SessionState("<state>"))
+
+        val json = state.toJSON()
+
+        assertEquals(1, json.length())
+        assertTrue(json.has("GECKO_STATE"))
+        assertEquals("<state>", json.getString("GECKO_STATE"))
+    }
+
+    @Test
+    fun fromJSON() {
+        val json = JSONObject().apply {
+            put("GECKO_STATE", "<state>")
+        }
+
+        val state = GeckoEngineSessionState.fromJSON(json)
+
+        assertEquals("<state>", state.actualState.toString())
+    }
+
+    @Test
+    fun `fromJSON with invalid JSON returns empty State`() {
+        val json = JSONObject().apply {
+            put("nothing", "helpful")
+        }
+
+        val state = GeckoEngineSessionState.fromJSON(json)
+
+        assertNull(state.actualState)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -375,11 +375,14 @@ class GeckoEngineSessionTest {
     fun saveState() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider)
-        val currentState = GeckoSession.SessionState("")
-        val stateMap = mapOf(GeckoEngineSession.GECKO_STATE_KEY to currentState.toString())
+        val currentState = GeckoSession.SessionState("<state>")
 
         `when`(geckoSession.saveState()).thenReturn(GeckoResult.fromValue(currentState))
-        assertEquals(stateMap, engineSession.saveState())
+
+        val savedState = engineSession.saveState() as GeckoEngineSessionState
+
+        assertEquals(currentState, savedState.actualState)
+        assertEquals("{\"GECKO_STATE\":\"<state>\"}", savedState.toJSON().toString())
     }
 
     @Test
@@ -387,8 +390,22 @@ class GeckoEngineSessionTest {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider)
 
-        engineSession.restoreState(mapOf(GeckoEngineSession.GECKO_STATE_KEY to ""))
+        val actualState: GeckoSession.SessionState = mock()
+        val state = GeckoEngineSessionState(actualState)
+
+        engineSession.restoreState(state)
         verify(geckoSession).restoreState(any())
+    }
+
+    @Test
+    fun `restoreState does nothing for null state`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+            geckoSessionProvider = geckoSessionProvider)
+
+        val state = GeckoEngineSessionState(null)
+
+        engineSession.restoreState(state)
+        verify(geckoSession, never()).restoreState(any())
     }
 
     class MockSecurityInformation(origin: String) : SecurityInformation() {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -9,9 +9,11 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import org.json.JSONObject
 import org.mozilla.geckoview.GeckoRuntime
 
 /**
@@ -34,6 +36,13 @@ class GeckoEngine(
      */
     override fun createSession(private: Boolean): EngineSession {
         return GeckoEngineSession(runtime, private, defaultSettings)
+    }
+
+    /**
+     * See [Engine.createSessionState].
+     */
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        return GeckoEngineSessionState.fromJSON(json)
     }
 
     override fun name(): String = "Gecko"

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
@@ -109,9 +110,6 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.saveState]
      *
-     * GeckoView provides a String representing the entire session state. We
-     * store this String using a single Map entry with key GECKO_STATE_KEY.
-
      * See https://bugzilla.mozilla.org/show_bug.cgi?id=1441810 for
      * discussion on sync vs. async, where a decision was made that
      * callers should provide synchronous wrappers, if needed. In case we're
@@ -119,30 +117,35 @@ class GeckoEngineSession(
      * is used so we're not blocking anything else. In case of calling this
      * method from onPause or similar, we also want a synchronous response.
      */
-    override fun saveState(): Map<String, Any> = runBlocking {
-        val stateMap = CompletableDeferred<Map<String, Any>>()
+    override fun saveState(): EngineSessionState = runBlocking {
+        val state = CompletableDeferred<GeckoEngineSessionState>()
 
         ThreadUtils.sGeckoHandler.post {
-            geckoSession.saveState().then({ state ->
-                stateMap.complete(mapOf(GECKO_STATE_KEY to state.toString()))
+            geckoSession.saveState().then({ sessionState ->
+                state.complete(GeckoEngineSessionState(sessionState))
                 GeckoResult<Void>()
             }, { throwable ->
-                stateMap.cancel(throwable)
+                state.completeExceptionally(throwable)
                 GeckoResult<Void>()
             })
         }
 
-        stateMap.await()
+        state.await()
     }
 
     /**
      * See [EngineSession.restoreState]
      */
-    override fun restoreState(state: Map<String, Any>) {
-        if (state.containsKey(GECKO_STATE_KEY)) {
-            val sessionState = GeckoSession.SessionState(state[GECKO_STATE_KEY] as String)
-            geckoSession.restoreState(sessionState)
+    override fun restoreState(state: EngineSessionState) {
+        if (state !is GeckoEngineSessionState) {
+            throw IllegalStateException("Can only restore from GeckoEngineSessionState")
         }
+
+        if (state.actualState == null) {
+            return
+        }
+
+        geckoSession.restoreState(state.actualState)
     }
 
     /**

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import mozilla.components.concept.engine.EngineSessionState
+import org.json.JSONException
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoSession
+
+private const val GECKO_STATE_KEY = "GECKO_STATE"
+
+class GeckoEngineSessionState internal constructor(
+    internal val actualState: GeckoSession.SessionState?
+) : EngineSessionState {
+    override fun toJSON() = JSONObject().apply {
+        if (actualState != null) {
+            put(GECKO_STATE_KEY, actualState.toString())
+        }
+    }
+
+    companion object {
+        fun fromJSON(json: JSONObject): GeckoEngineSessionState = try {
+            val state = json.getString(GECKO_STATE_KEY)
+            GeckoEngineSessionState(GeckoSession.SessionState(state))
+        } catch (e: JSONException) {
+            GeckoEngineSessionState(null)
+        }
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoSession
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoEngineSessionStateTest {
+    @Test
+    fun toJSON() {
+        val state = GeckoEngineSessionState(GeckoSession.SessionState("<state>"))
+
+        val json = state.toJSON()
+
+        assertEquals(1, json.length())
+        assertTrue(json.has("GECKO_STATE"))
+        assertEquals("<state>", json.getString("GECKO_STATE"))
+    }
+
+    @Test
+    fun fromJSON() {
+        val json = JSONObject().apply {
+            put("GECKO_STATE", "<state>")
+        }
+
+        val state = GeckoEngineSessionState.fromJSON(json)
+
+        assertEquals("<state>", state.actualState.toString())
+    }
+
+    @Test
+    fun `fromJSON with invalid JSON returns empty State`() {
+        val json = JSONObject().apply {
+            put("nothing", "helpful")
+        }
+
+        val state = GeckoEngineSessionState.fromJSON(json)
+
+        assertNull(state.actualState)
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -343,7 +343,7 @@ class GeckoEngineSessionTest {
     fun saveState() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
         engineSession.geckoSession = mock(GeckoSession::class.java)
-        val currentState = GeckoSession.SessionState("")
+        val currentState = GeckoSession.SessionState("<state>")
         val stateMap = mapOf(GeckoEngineSession.GECKO_STATE_KEY to currentState.toString())
 
         ThreadUtils.sGeckoHandler = object : Handler() {
@@ -360,7 +360,11 @@ class GeckoEngineSessionTest {
             }
         }
         `when`(engineSession.geckoSession.saveState()).thenReturn(GeckoResult.fromValue(currentState))
-        assertEquals(stateMap, engineSession.saveState())
+
+        val savedState = engineSession.saveState() as GeckoEngineSessionState
+
+        assertEquals(currentState, savedState.actualState)
+        assertEquals("{\"GECKO_STATE\":\"<state>\"}", savedState.toJSON().toString())
     }
 
     @Test
@@ -372,7 +376,7 @@ class GeckoEngineSessionTest {
                 "GeckoView:RestoreState"
         )
 
-        engineSession.restoreState(mapOf(GeckoEngineSession.GECKO_STATE_KEY to ""))
+        engineSession.restoreState(GeckoEngineSessionState(GeckoSession.SessionState("<state>")))
         assertTrue(eventReceived)
     }
 

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngine.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngine.kt
@@ -9,9 +9,11 @@ import android.util.AttributeSet
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import org.json.JSONObject
 
 /**
  * Servo-based implementation of the Engine interface.
@@ -25,6 +27,10 @@ class ServoEngine(
 
     override fun createSession(private: Boolean): EngineSession {
         return ServoEngineSession(defaultSettings)
+    }
+
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        return ServoEngineSessionState.fromJSON(json)
     }
 
     override fun name(): String = "Servo"

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSession.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSession.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.Settings
 import org.mozilla.servoview.Servo
 import org.mozilla.servoview.ServoView
@@ -103,11 +104,11 @@ class ServoEngineSession(
         view?.goForward()
     }
 
-    override fun saveState(): Map<String, Any> {
-        return mapOf() // not implemented yet
+    override fun saveState(): EngineSessionState {
+        return ServoEngineSessionState()
     }
 
-    override fun restoreState(state: Map<String, Any>) {
+    override fun restoreState(state: EngineSessionState) {
         // not implemented yet
     }
 

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSessionState.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSessionState.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.servo
+
+import mozilla.components.concept.engine.EngineSessionState
+import org.json.JSONObject
+
+/**
+ * No-op implementation of [EngineSessionState].
+ */
+class ServoEngineSessionState : EngineSessionState {
+    override fun toJSON() = JSONObject()
+
+    companion object {
+        fun fromJSON(json: JSONObject) = ServoEngineSessionState()
+    }
+}

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -13,9 +13,11 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import org.json.JSONObject
 
 /**
  * WebView-based implementation of the Engine interface.
@@ -24,7 +26,6 @@ class SystemEngine(
     context: Context,
     private val defaultSettings: Settings = DefaultSettings()
 ) : Engine {
-
     init {
         initDefaultUserAgent(context)
     }
@@ -50,6 +51,10 @@ class SystemEngine(
      * See [Engine.name]
      */
     override fun name(): String = "System"
+
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        return SystemEngineSessionState.fromJSON(json)
+    }
 
     /**
      * See [Engine.settings]

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSessionState.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSessionState.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.system
+
+import android.os.Bundle
+import mozilla.components.concept.engine.EngineSessionState
+import org.json.JSONObject
+
+class SystemEngineSessionState(
+    internal val bundle: Bundle?
+) : EngineSessionState {
+    override fun toJSON(): JSONObject {
+        if (bundle == null) {
+            return JSONObject()
+        }
+
+        return JSONObject().apply {
+            bundle.keySet().forEach { key ->
+                val value = bundle[key]
+
+                if (shouldSerialize(value)) {
+                    put(key, value)
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun fromJSON(json: JSONObject): SystemEngineSessionState {
+            return SystemEngineSessionState(json.toBundle())
+        }
+    }
+}
+
+private fun shouldSerialize(value: Any?): Boolean {
+    // For now we only persist primitive types
+    // https://github.com/mozilla-mobile/android-components/issues/279
+    return when (value) {
+        is Number -> true
+        is Boolean -> true
+        is String -> true
+        else -> false
+    }
+}
+
+@Suppress("ComplexMethod")
+private fun JSONObject.toBundle(): Bundle {
+    val bundle = Bundle()
+
+    keys().forEach { key ->
+        val value = get(key)
+        when (value) {
+            is Int -> bundle.putInt(key, value)
+            is Double -> bundle.putDouble(key, value)
+            is Long -> bundle.putLong(key, value)
+            is Float -> bundle.putFloat(key, value)
+            is Char -> bundle.putChar(key, value)
+            is Short -> bundle.putShort(key, value)
+            is Byte -> bundle.putByte(key, value)
+            is String -> bundle.putString(key, value)
+            is Boolean -> bundle.putBoolean(key, value)
+        }
+    }
+
+    return bundle
+}

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.system
+
+import android.os.Bundle
+import junit.framework.Assert.assertTrue
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SystemEngineSessionStateTest {
+    @Test
+    fun toJSON() {
+        val state = SystemEngineSessionState(Bundle().apply {
+            putString("k0", "v0")
+            putInt("k1", 1)
+            putBoolean("k2", true)
+            putStringArrayList("k3", ArrayList<String>(listOf("Hello", "World")))
+            putDouble("k4", 5.0)
+            putFloat("k5", 1.0f)
+        })
+
+        val json = state.toJSON()
+
+        assertEquals(5, json.length())
+
+        assertTrue(json.has("k0"))
+        assertTrue(json.has("k1"))
+        assertTrue(json.has("k2"))
+        assertTrue(json.has("k4"))
+        assertTrue(json.has("k5"))
+
+        assertEquals("v0", json.get("k0"))
+        assertEquals(1, json.get("k1"))
+        assertEquals(true, json.get("k2"))
+        assertEquals(5.0, json.get("k4"))
+        assertEquals(1.0f, json.get("k5"))
+    }
+
+    @Test
+    fun fromJSON() {
+        val json = JSONObject().apply {
+            put("k0", "v0")
+            put("k1", 1)
+            put("k2", true)
+            put("k3", 5.0)
+            put("k4", 1.0f)
+            put("k5", JSONArray(listOf(1, 2, 3)))
+        }
+
+        val state = SystemEngineSessionState.fromJSON(json)
+        val bundle = state.bundle!!
+
+        assertEquals(5, bundle.size())
+
+        assertTrue(bundle.containsKey("k0"))
+        assertTrue(bundle.containsKey("k1"))
+        assertTrue(bundle.containsKey("k2"))
+        assertTrue(bundle.containsKey("k3"))
+        assertTrue(bundle.containsKey("k4"))
+
+        assertEquals("v0", bundle.get("k0"))
+        assertEquals(1, bundle.get("k1"))
+        assertEquals(true, bundle.get("k2"))
+        assertEquals(5.0, bundle.get("k3"))
+        assertEquals(1.0f, bundle.get("k4"))
+    }
+}

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -206,12 +206,12 @@ class SystemEngineSessionTest {
         val engineSession = spy(SystemEngineSession())
         val webView = mock(WebView::class.java)
 
-        engineSession.restoreState(emptyMap())
+        engineSession.restoreState(SystemEngineSessionState(Bundle()))
         verify(webView, never()).restoreState(any(Bundle::class.java))
 
         `when`(engineSession.currentView()).thenReturn(webView)
 
-        engineSession.restoreState(emptyMap())
+        engineSession.restoreState(SystemEngineSessionState(Bundle()))
         verify(webView).restoreState(any(Bundle::class.java))
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineSessionHolder.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineSessionHolder.kt
@@ -4,9 +4,16 @@
 
 package mozilla.components.browser.session.engine
 
+import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 
+/**
+ * Used for linking a [Session] to an [EngineSession] or the [EngineSessionState] to create an [EngineSession] from it.
+ * The attached [EngineObserver] is used to update the [Session] whenever the [EngineSession] emits events.
+ */
 internal class EngineSessionHolder {
     @Volatile var engineSession: EngineSession? = null
     @Volatile var engineObserver: EngineObserver? = null
+    @Volatile var engineSessionState: EngineSessionState? = null
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -351,7 +352,7 @@ class SessionManagerTest {
 
         // Multiple sessions in the snapshot.
         val regularSession = Session("http://www.firefox.com")
-        val engineSessionState = mutableMapOf("k0" to "v0", "k1" to 1, "k2" to true, "k3" to emptyList<Any>())
+        val engineSessionState: EngineSessionState = mock()
         val engineSession = mock(EngineSession::class.java)
         `when`(engineSession.saveState()).thenReturn(engineSessionState)
 
@@ -368,12 +369,8 @@ class SessionManagerTest {
         manager.restore(snapshot)
         assertEquals(3, manager.size)
         assertEquals("http://www.firefox.com", manager.selectedSessionOrThrow.url)
-        val snapshotState = manager.selectedSessionOrThrow.engineSessionHolder.engineSession!!.saveState()
-        assertEquals(4, snapshotState.size)
-        assertEquals("v0", snapshotState["k0"])
-        assertEquals(1, snapshotState["k1"])
-        assertEquals(true, snapshotState["k2"])
-        assertEquals(emptyList<Any>(), snapshotState["k3"])
+        assertEquals(engineSession, manager.selectedSessionOrThrow.engineSessionHolder.engineSession)
+        assertNull(manager.selectedSessionOrThrow.engineSessionHolder.engineSessionState)
     }
 
     @Test
@@ -430,7 +427,7 @@ class SessionManagerTest {
         privateCustomTabSession.customTabConfig = Mockito.mock(CustomTabConfig::class.java)
 
         val regularSession = Session("http://www.firefox.com")
-        val engineSessionState = mutableMapOf("k0" to "v0", "k1" to 1, "k2" to true, "k3" to emptyList<Any>())
+        val engineSessionState: EngineSessionState = mock()
         val engineSession = mock(EngineSession::class.java)
         `when`(engineSession.saveState()).thenReturn(engineSessionState)
 
@@ -453,11 +450,7 @@ class SessionManagerTest {
         assertEquals("http://www.firefox.com", snapshotSession.session.url)
 
         val snapshotState = snapshotSession.engineSession!!.saveState()
-        assertEquals(4, snapshotState.size)
-        assertEquals("v0", snapshotState["k0"])
-        assertEquals(1, snapshotState["k1"])
-        assertEquals(true, snapshotState["k2"])
-        assertEquals(emptyList<Any>(), snapshotState["k3"])
+        assertEquals(engineSessionState, snapshotState)
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.session.engine
 import android.graphics.Bitmap
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.permission.PermissionRequest
@@ -16,6 +17,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
 
 import mozilla.components.support.base.observer.Consumable
+import mozilla.components.support.test.mock
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,7 +40,7 @@ class EngineObserverTest {
             override fun goForward() {}
             override fun reload() {}
             override fun stopLoading() {}
-            override fun restoreState(state: Map<String, Any>) {}
+            override fun restoreState(state: EngineSessionState) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
@@ -50,7 +52,7 @@ class EngineObserverTest {
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
             override fun captureThumbnail(): Bitmap? = null
-            override fun saveState(): Map<String, Any> = emptyMap()
+            override fun saveState(): EngineSessionState = mock()
 
             override fun loadData(data: String, mimeType: String, encoding: String) {
                 notifyObservers { onLocationChange(data) }
@@ -89,7 +91,7 @@ class EngineObserverTest {
             override fun goForward() {}
             override fun stopLoading() {}
             override fun reload() {}
-            override fun restoreState(state: Map<String, Any>) {}
+            override fun restoreState(state: EngineSessionState) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
@@ -99,7 +101,7 @@ class EngineObserverTest {
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
             override fun captureThumbnail(): Bitmap? = null
-            override fun saveState(): Map<String, Any> = emptyMap()
+            override fun saveState(): EngineSessionState = mock()
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun loadUrl(url: String) {
                 if (url.startsWith("https://")) {
@@ -129,7 +131,7 @@ class EngineObserverTest {
             override fun goForward() {}
             override fun stopLoading() {}
             override fun reload() {}
-            override fun restoreState(state: Map<String, Any>) {}
+            override fun restoreState(state: EngineSessionState) {}
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {
                 notifyObservers { onTrackerBlockingEnabledChange(true) }
             }
@@ -139,7 +141,7 @@ class EngineObserverTest {
 
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
             override fun captureThumbnail(): Bitmap? = null
-            override fun saveState(): Map<String, Any> = emptyMap()
+            override fun saveState(): EngineSessionState = mock()
             override fun loadUrl(url: String) {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun clearData() {}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import android.content.Context
 import android.util.AttributeSet
+import org.json.JSONObject
 
 /**
  * Entry point for interacting with the engine implementation.
@@ -30,6 +31,11 @@ interface Engine {
      * @return the newly created [EngineSession].
      */
     fun createSession(private: Boolean = false): EngineSession
+
+    /**
+     * Create a new [EngineSessionState] instance from the serialized JSON representation.
+     */
+    fun createSessionState(json: JSONObject): EngineSessionState
 
     /**
      * Returns the name of this engine. The returned string might be used

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -150,14 +150,14 @@ abstract class EngineSession(
      * to restore the original state. See [restoreState] and the specific
      * engine implementation for details.
      */
-    abstract fun saveState(): Map<String, Any>
+    abstract fun saveState(): EngineSessionState
 
     /**
      * Restores the engine state as provided by [saveState].
      *
      * @param state state retrieved from [saveState]
      */
-    abstract fun restoreState(state: Map<String, Any>)
+    abstract fun restoreState(state: EngineSessionState)
 
     /**
      * Enables tracking protection for this engine session.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSessionState.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSessionState.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine
+
+import org.json.JSONObject
+
+/**
+ * The state of an [EngineSession]. An instance can be obtained from [EngineSession.saveState]. Creating a new
+ * [EngineSession] and calling [EngineSession.restoreState] with the same state instance should restore the previous
+ * session.
+ */
+interface EngineSessionState {
+    /**
+     * Create a JSON representation of this state that can be saved to disk.
+     *
+     * When reading JSON from disk [Engine.createSessionState] can be used to turn it back into an [EngineSessionState]
+     * instance.
+     */
+    fun toJSON(): JSONObject
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -564,9 +565,9 @@ open class DummyEngineSession : EngineSession() {
     override val settings: Settings
         get() = mock(Settings::class.java)
 
-    override fun restoreState(state: Map<String, Any>) {}
+    override fun restoreState(state: EngineSessionState) {}
 
-    override fun saveState(): Map<String, Any> { return emptyMap() }
+    override fun saveState(): EngineSessionState { return mock() }
 
     override fun loadUrl(url: String) {}
 


### PR DESCRIPTION
@csadilek This is incomplete. I want to share this approach for discussion before continuing on the PR. Note that this PR only has an implementation for `browser-engine-gecko-nightly` at this point. Ignore changes in the other components.

The main change here is that `EngineSessionHolder` can now hold an `EngineState` and this state is used when we need to create an `EngineSession` (which will clear the state). This has the following advantages:

* When restoring we can just attach the `EngineState` and do not need to create the `EngineSession` immediately. With that we do not load all the `EngineSessions` and everything at once. Initially only the selected `EngineSession` will be created and loaded. That will make the restore faster and use less resources when restoring a lot of sessions.

* (Not in this PR, for a follow-up) It allows us to close `EngineSession` instances and just keep the `EngineState` around until we need the `EngineSession` again. That's something we could do in low memory situations or when there are just too many sessions/tabs open to be performant (e.g. only keep the last recently used `EngineSession` instances around).

This refactoring caused two other changes:

* The `EngineState` is now responsible for knowing how to serialize/deserialize itself. I think that's fine but unfortunately that leaks the serialization format via the toJSON() / fromJSON() methods.

* For the `SessionStorage` to be able to re-create the `EngineState` objects after reading from disk it needs to go through `Engine` because otherwise it doesn't know what kind of class to use. That again leaks the JSON format.

So what I do not like about the current state is that we now have those JSON methods and whenever we would want to have a different format (which will not be easy to change once shipped anyways..) we would have to add additional methods everywhere.

What do you think?
 