### PR TITLE
Closes #1436: Add support for html input type date for GeckoEngine

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko.prompt
 import android.support.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.prompt.Choice
+import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
@@ -24,6 +25,15 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SING
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.ChoiceCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FileCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import mozilla.components.support.ktx.kotlin.toDate
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
 
 typealias GeckoChoice = GeckoSession.PromptDelegate.Choice
 
@@ -100,6 +110,60 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onDateTimePrompt(
+        session: GeckoSession?,
+        title: String?,
+        type: Int,
+        value: String?,
+        minDate: String?,
+        maxDate: String?,
+        geckoCallback: TextCallback
+    ) {
+        val initialDateString = value ?: ""
+        val onClear: () -> Unit = {
+            geckoCallback.confirm("")
+        }
+        when (type) {
+            DATETIME_TYPE_DATE -> {
+                notifyDatePromptRequest(
+                    title ?: "",
+                    initialDateString,
+                    minDate,
+                    maxDate,
+                    onClear,
+                    "yyyy-MM-dd",
+                    geckoCallback
+                )
+            }
+            DATETIME_TYPE_MONTH -> {
+                notifyDatePromptRequest(
+                    title ?: "",
+                    initialDateString,
+                    minDate,
+                    maxDate,
+                    onClear,
+                    "yyyy-MM",
+                    geckoCallback
+                )
+            }
+            DATETIME_TYPE_WEEK -> {
+                notifyDatePromptRequest(
+                    title ?: "",
+                    initialDateString,
+                    minDate,
+                    maxDate,
+                    onClear,
+                    "yyyy-'W'ww",
+                    geckoCallback
+                )
+            }
+            DATETIME_TYPE_TIME -> {
+            }
+            DATETIME_TYPE_DATETIME_LOCAL -> {
+            }
+        }
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession?,
         title: String?,
@@ -107,16 +171,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback?
     ) = Unit
-
-    override fun onDateTimePrompt(
-        session: GeckoSession?,
-        title: String?,
-        type: Int,
-        value: String?,
-        min: String?,
-        max: String?,
-        callback: TextCallback?
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1436
 
     override fun onFilePrompt(
         session: GeckoSession?,
@@ -179,9 +233,39 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
 
         return Pair(arrayOfChoices, mapChoicesToGeckoChoices)
     }
+
+    @Suppress("LongParameterList")
+    private fun notifyDatePromptRequest(
+        title: String,
+        initialDateString: String,
+        minDateString: String?,
+        maxDateString: String?,
+        onClear: () -> Unit,
+        format: String,
+        geckoCallback: TextCallback
+    ) {
+        val initialDate = initialDateString.toDate(format)
+        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate(format)
+        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate(format)
+        val onSelect: (Date) -> Unit = {
+            val stringDate = it.toString(format)
+            geckoCallback.confirm(stringDate)
+        }
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Date(title, initialDate, minDate, maxDate, onSelect, onClear)
+            )
+        }
+    }
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal fun Array<Choice>.toIdsArray(): Array<String> {
     return this.map { it.id }.toTypedArray()
+}
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal fun Date.toString(format: String): String {
+    val formatter = SimpleDateFormat(format, Locale.ROOT)
+    return formatter.format(this) ?: ""
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -21,6 +21,17 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULTIPLE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
 import org.robolectric.RobolectricTestRunner
+import mozilla.components.support.ktx.kotlin.toDate
+import org.junit.Assert.assertNotNull
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
+import java.util.Date
+import java.util.Calendar
+import java.util.Calendar.YEAR
 
 typealias GeckoChoice = GeckoSession.PromptDelegate.Choice
 
@@ -206,12 +217,25 @@ class GeckoPromptDelegateTest {
         val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
-        gecko.onDateTimePrompt(null, "", 0, null, null, null, null)
+        gecko.onDateTimePrompt(null, "", 0, null, null, null, mock())
         gecko.onFilePrompt(null, "", 0, null, null)
         gecko.onColorPrompt(null, "", "", null)
         gecko.onAuthPrompt(null, "", "", null, null)
         gecko.onTextPrompt(null, "", "", null, null)
         gecko.onPopupRequest(null, "")
+        gecko.onDateTimePrompt(null, "", DATETIME_TYPE_TIME, null, "", "", mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_DATETIME_LOCAL, "", "", "", mock())
+        gecko.onDateTimePrompt(null, "", DATETIME_TYPE_DATETIME_LOCAL, "", "", "", mock())
+    }
+
+    @Test
+    fun `hitting default values`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val gecko = GeckoPromptDelegate(mockSession)
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_DATE, null, null, null, mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_WEEK, null, null, null, mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_MONTH, null, null, null, mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_TIME, null, "", "", mock())
     }
 
     @Test
@@ -221,5 +245,237 @@ class GeckoPromptDelegateTest {
         ids.forEachIndexed { index, item ->
             assertEquals("$index", item)
         }
+    }
+
+    @Test
+    fun `onDateTimePrompt called with DATETIME_TYPE_DATE must provide a date PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest? = null
+        var confirmCalled = false
+        var onClearPicker = false
+
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                confirmCalled = true
+                if (text!!.isEmpty()) {
+                    onClearPicker = true
+                }
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest
+            }
+        })
+        promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_DATE, "", "", "", callback)
+        assertTrue(dateRequest is PromptRequest.Date)
+        (dateRequest as PromptRequest.Date).onSelect(Date())
+        assertTrue(confirmCalled)
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+
+        (dateRequest as PromptRequest.Date).onClear()
+        assertTrue(onClearPicker)
+    }
+
+    @Test
+    fun `onDateTimePrompt DATETIME_TYPE_DATE with date parameters must format dates correctly`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest.Date? = null
+        var geckoDate: String? = null
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                geckoDate = text
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest as PromptRequest.Date
+            }
+        })
+        promptDelegate.onDateTimePrompt(
+                null,
+                "title",
+                DATETIME_TYPE_DATE,
+                "2019-11-29",
+                "2019-11-28",
+                "2019-11-30",
+                callback
+        )
+        assertNotNull(dateRequest)
+        with(dateRequest!!) {
+            assertEquals(initialDate, "2019-11-29".toDate("yyyy-MM-dd"))
+            assertEquals(minimumDate, "2019-11-28".toDate("yyyy-MM-dd"))
+            assertEquals(maximumDate, "2019-11-30".toDate("yyyy-MM-dd"))
+        }
+        val selectedDate = "2019-11-28".toDate("yyyy-MM-dd")
+        (dateRequest as PromptRequest.Date).onSelect(selectedDate)
+        assertNotNull(geckoDate?.toDate("yyyy-MM-dd")?.equals(selectedDate))
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt called with DATETIME_TYPE_MONTH must provide a date PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest? = null
+        var confirmCalled = false
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                confirmCalled = true
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest
+            }
+        })
+        promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_MONTH, "", "", "", callback)
+        assertTrue(dateRequest is PromptRequest.Date)
+        (dateRequest as PromptRequest.Date).onSelect(Date())
+        assertTrue(confirmCalled)
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt DATETIME_TYPE_MONTH with date parameters must format dates correctly`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest.Date? = null
+        var geckoDate: String? = null
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                geckoDate = text
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest as PromptRequest.Date
+            }
+        })
+        promptDelegate.onDateTimePrompt(
+                null,
+                "title",
+                DATETIME_TYPE_MONTH,
+                "2019-11",
+                "2019-11",
+                "2019-11",
+                callback
+        )
+        assertNotNull(dateRequest)
+        with(dateRequest!!) {
+            assertEquals(initialDate, "2019-11".toDate("yyyy-MM"))
+            assertEquals(minimumDate, "2019-11".toDate("yyyy-MM"))
+            assertEquals(maximumDate, "2019-11".toDate("yyyy-MM"))
+        }
+        val selectedDate = "2019-11".toDate("yyyy-MM")
+        (dateRequest as PromptRequest.Date).onSelect(selectedDate)
+        assertNotNull(geckoDate?.toDate("yyyy-MM")?.equals(selectedDate))
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt called with DATETIME_TYPE_WEEK must provide a date PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest? = null
+        var confirmCalled = false
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                confirmCalled = true
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest
+            }
+        })
+        promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_WEEK, "", "", "", callback)
+        assertTrue(dateRequest is PromptRequest.Date)
+        (dateRequest as PromptRequest.Date).onSelect(Date())
+        assertTrue(confirmCalled)
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt DATETIME_TYPE_WEEK with date parameters must format dates correctly`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest.Date? = null
+        var geckoDate: String? = null
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                geckoDate = text
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest as PromptRequest.Date
+            }
+        })
+        promptDelegate.onDateTimePrompt(
+                null,
+                "title",
+                DATETIME_TYPE_WEEK,
+                "2018-W18",
+                "2018-W18",
+                "2018-W26",
+                callback
+        )
+        assertNotNull(dateRequest)
+        with(dateRequest!!) {
+            assertEquals(initialDate, "2018-W18".toDate("yyyy-'W'ww"))
+            assertEquals(minimumDate, "2018-W18".toDate("yyyy-'W'ww"))
+            assertEquals(maximumDate, "2018-W26".toDate("yyyy-'W'ww"))
+        }
+        val selectedDate = "2018-W26".toDate("yyyy-'W'ww")
+        (dateRequest as PromptRequest.Date).onSelect(selectedDate)
+        assertNotNull(geckoDate?.toDate("yyyy-'W'ww")?.equals(selectedDate))
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `date to string`() {
+        val date = Date()
+
+        var dateString = date.toString()
+        assertNotNull(dateString.isEmpty())
+
+        dateString = date.toString("yyyy")
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        val year = calendar[YEAR].toString()
+        assertEquals(dateString, year)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -21,6 +21,17 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULTIPLE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
 import org.robolectric.RobolectricTestRunner
+import mozilla.components.support.ktx.kotlin.toDate
+import org.junit.Assert.assertNotNull
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
+import java.util.Date
+import java.util.Calendar
+import java.util.Calendar.YEAR
 
 typealias GeckoChoice = GeckoSession.PromptDelegate.Choice
 
@@ -142,15 +153,15 @@ class GeckoPromptDelegateTest {
         val geckoChoices = arrayOf<GeckoChoice>()
 
         mockSession.register(
-            object : EngineSession.Observer {
-                override fun onPromptRequest(promptRequest: PromptRequest) {
-                    promptRequestSingleChoice = promptRequest
-                }
-            })
+                object : EngineSession.Observer {
+                    override fun onPromptRequest(promptRequest: PromptRequest) {
+                        promptRequestSingleChoice = promptRequest
+                    }
+                })
 
         gecko.onChoicePrompt(
-            null, null, null,
-            GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MENU, geckoChoices, callback
+                null, null, null,
+                GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MENU, geckoChoices, callback
         )
 
         assertTrue(promptRequestSingleChoice is PromptRequest.MenuChoice)
@@ -208,12 +219,25 @@ class GeckoPromptDelegateTest {
         val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
-        gecko.onDateTimePrompt(null, "", 0, null, null, null, null)
+        gecko.onDateTimePrompt(null, "", 0, null, null, null, mock())
         gecko.onFilePrompt(null, "", 0, null, null)
         gecko.onColorPrompt(null, "", "", null)
         gecko.onAuthPrompt(null, "", "", null, null)
         gecko.onTextPrompt(null, "", "", null, null)
         gecko.onPopupRequest(null, "")
+        gecko.onDateTimePrompt(null, "", DATETIME_TYPE_TIME, null, "", "", mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_DATETIME_LOCAL, "", "", "", mock())
+        gecko.onDateTimePrompt(null, "", DATETIME_TYPE_DATETIME_LOCAL, "", "", "", mock())
+    }
+
+    @Test
+    fun `hitting default values`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val gecko = GeckoPromptDelegate(mockSession)
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_DATE, null, null, null, mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_WEEK, null, null, null, mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_MONTH, null, null, null, mock())
+        gecko.onDateTimePrompt(null, null, DATETIME_TYPE_TIME, null, "", "", mock())
     }
 
     @Test
@@ -223,5 +247,237 @@ class GeckoPromptDelegateTest {
         ids.forEachIndexed { index, item ->
             assertEquals("$index", item)
         }
+    }
+
+    @Test
+    fun `onDateTimePrompt called with DATETIME_TYPE_DATE must provide a date PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest? = null
+        var confirmCalled = false
+        var onClearPicker = false
+
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                confirmCalled = true
+                if (text!!.isEmpty()) {
+                    onClearPicker = true
+                }
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest
+            }
+        })
+        promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_DATE, "", "", "", callback)
+        assertTrue(dateRequest is PromptRequest.Date)
+        (dateRequest as PromptRequest.Date).onSelect(Date())
+        assertTrue(confirmCalled)
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+
+        (dateRequest as PromptRequest.Date).onClear()
+        assertTrue(onClearPicker)
+    }
+
+    @Test
+    fun `onDateTimePrompt DATETIME_TYPE_DATE with date parameters must format dates correctly`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest.Date? = null
+        var geckoDate: String? = null
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                geckoDate = text
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest as PromptRequest.Date
+            }
+        })
+        promptDelegate.onDateTimePrompt(
+                null,
+                "title",
+                DATETIME_TYPE_DATE,
+                "2019-11-29",
+                "2019-11-28",
+                "2019-11-30",
+                callback
+        )
+        assertNotNull(dateRequest)
+        with(dateRequest!!) {
+            assertEquals(initialDate, "2019-11-29".toDate("yyyy-MM-dd"))
+            assertEquals(minimumDate, "2019-11-28".toDate("yyyy-MM-dd"))
+            assertEquals(maximumDate, "2019-11-30".toDate("yyyy-MM-dd"))
+        }
+        val selectedDate = "2019-11-28".toDate("yyyy-MM-dd")
+        (dateRequest as PromptRequest.Date).onSelect(selectedDate)
+        assertNotNull(geckoDate?.toDate("yyyy-MM-dd")?.equals(selectedDate))
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt called with DATETIME_TYPE_MONTH must provide a date PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest? = null
+        var confirmCalled = false
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                confirmCalled = true
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest
+            }
+        })
+        promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_MONTH, "", "", "", callback)
+        assertTrue(dateRequest is PromptRequest.Date)
+        (dateRequest as PromptRequest.Date).onSelect(Date())
+        assertTrue(confirmCalled)
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt DATETIME_TYPE_MONTH with date parameters must format dates correctly`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest.Date? = null
+        var geckoDate: String? = null
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                geckoDate = text
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest as PromptRequest.Date
+            }
+        })
+        promptDelegate.onDateTimePrompt(
+                null,
+                "title",
+                DATETIME_TYPE_MONTH,
+                "2019-11",
+                "2019-11",
+                "2019-11",
+                callback
+        )
+        assertNotNull(dateRequest)
+        with(dateRequest!!) {
+            assertEquals(initialDate, "2019-11".toDate("yyyy-MM"))
+            assertEquals(minimumDate, "2019-11".toDate("yyyy-MM"))
+            assertEquals(maximumDate, "2019-11".toDate("yyyy-MM"))
+        }
+        val selectedDate = "2019-11".toDate("yyyy-MM")
+        (dateRequest as PromptRequest.Date).onSelect(selectedDate)
+        assertNotNull(geckoDate?.toDate("yyyy-MM")?.equals(selectedDate))
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt called with DATETIME_TYPE_WEEK must provide a date PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest? = null
+        var confirmCalled = false
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                confirmCalled = true
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest
+            }
+        })
+        promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_WEEK, "", "", "", callback)
+        assertTrue(dateRequest is PromptRequest.Date)
+        (dateRequest as PromptRequest.Date).onSelect(Date())
+        assertTrue(confirmCalled)
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `onDateTimePrompt DATETIME_TYPE_WEEK with date parameters must format dates correctly`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var dateRequest: PromptRequest.Date? = null
+        var geckoDate: String? = null
+        val callback = object : TextCallback {
+            override fun dismiss() = Unit
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+            override fun confirm(text: String?) {
+                geckoDate = text
+            }
+        }
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                dateRequest = promptRequest as PromptRequest.Date
+            }
+        })
+        promptDelegate.onDateTimePrompt(
+                null,
+                "title",
+                DATETIME_TYPE_WEEK,
+                "2018-W18",
+                "2018-W18",
+                "2018-W26",
+                callback
+        )
+        assertNotNull(dateRequest)
+        with(dateRequest!!) {
+            assertEquals(initialDate, "2018-W18".toDate("yyyy-'W'ww"))
+            assertEquals(minimumDate, "2018-W18".toDate("yyyy-'W'ww"))
+            assertEquals(maximumDate, "2018-W26".toDate("yyyy-'W'ww"))
+        }
+        val selectedDate = "2018-W26".toDate("yyyy-'W'ww")
+        (dateRequest as PromptRequest.Date).onSelect(selectedDate)
+        assertNotNull(geckoDate?.toDate("yyyy-'W'ww")?.equals(selectedDate))
+        assertEquals((dateRequest as PromptRequest.Date).title, "title")
+    }
+
+    @Test
+    fun `date to string`() {
+        val date = Date()
+
+        var dateString = date.toString()
+        assertNotNull(dateString.isEmpty())
+
+        dateString = date.toString("yyyy")
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        val year = calendar[YEAR].toString()
+        assertEquals(dateString, year)
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -5,9 +5,9 @@
 package mozilla.components.browser.engine.gecko.prompt
 
 import android.support.annotation.VisibleForTesting
-import android.support.annotation.VisibleForTesting.PRIVATE
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.prompt.Choice
+import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
@@ -24,6 +24,15 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SING
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.ChoiceCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FileCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import mozilla.components.support.ktx.kotlin.toDate
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
 
 typealias GeckoChoice = GeckoSession.PromptDelegate.Choice
 
@@ -100,6 +109,61 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onDateTimePrompt(
+        session: GeckoSession?,
+        title: String?,
+        type: Int,
+        value: String?,
+        minDate: String?,
+        maxDate: String?,
+        geckoCallback: TextCallback
+    ) {
+        val initialDateString = value ?: ""
+        val onClear: () -> Unit = {
+            geckoCallback.confirm("")
+        }
+
+        when (type) {
+            DATETIME_TYPE_DATE -> {
+                notifyDatePromptRequest(
+                    title ?: "",
+                    initialDateString,
+                    minDate,
+                    maxDate,
+                    onClear,
+                    "yyyy-MM-dd",
+                    geckoCallback
+                )
+            }
+            DATETIME_TYPE_MONTH -> {
+                notifyDatePromptRequest(
+                    title ?: "",
+                    initialDateString,
+                    minDate,
+                    maxDate,
+                    onClear,
+                    "yyyy-MM",
+                    geckoCallback
+                )
+            }
+            DATETIME_TYPE_WEEK -> {
+                notifyDatePromptRequest(
+                    title ?: "",
+                    initialDateString,
+                    minDate,
+                    maxDate,
+                    onClear,
+                    "yyyy-'W'ww",
+                    geckoCallback
+                )
+            }
+            DATETIME_TYPE_TIME -> {
+            } // Related issue: https://github.com/mozilla-mobile/android-components/issues/1530
+            DATETIME_TYPE_DATETIME_LOCAL -> {
+            } // Related issue: https://github.com/mozilla-mobile/android-components/issues/1530
+        }
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession?,
         title: String?,
@@ -107,16 +171,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback?
     ) = Unit
-
-    override fun onDateTimePrompt(
-        session: GeckoSession?,
-        title: String?,
-        type: Int,
-        value: String?,
-        min: String?,
-        max: String?,
-        callback: TextCallback?
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1436
 
     override fun onFilePrompt(
         session: GeckoSession?,
@@ -179,9 +233,39 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
 
         return Pair(arrayOfChoices, mapChoicesToGeckoChoices)
     }
+
+    @Suppress("LongParameterList")
+    private fun notifyDatePromptRequest(
+        title: String,
+        initialDateString: String,
+        minDateString: String?,
+        maxDateString: String?,
+        onClear: () -> Unit,
+        format: String,
+        geckoCallback: TextCallback
+    ) {
+        val initialDate = initialDateString.toDate(format)
+        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate(format)
+        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate(format)
+        val onSelect: (Date) -> Unit = {
+            val stringDate = it.toString(format)
+            geckoCallback.confirm(stringDate)
+        }
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Date(title, initialDate, minDate, maxDate, onSelect, onClear)
+            )
+        }
+    }
 }
 
-@VisibleForTesting(otherwise = PRIVATE)
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal fun Array<Choice>.toIdsArray(): Array<String> {
     return this.map { it.id }.toTypedArray()
+}
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal fun Date.toString(format: String): String {
+    val formatter = SimpleDateFormat(format, Locale.ROOT)
+    return formatter.format(this) ?: ""
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -45,4 +45,22 @@ sealed class PromptRequest {
         val onDismiss: () -> Unit,
         val onShouldShowNoMoreDialogs: (Boolean) -> Unit
     ) : PromptRequest()
+
+    /**
+     * Value type that represents a request for a date prompt for picking a year, month, and day.
+     * @property title of the dialog.
+     * @property initialDate date that dialog should be set by default.
+     * @property minimumDate date allow to be selected.
+     * @property maximumDate date allow to be selected.
+     * @property onSelect callback that is called when the date is selected.
+     * @property onClear callback that is called when the user requests the picker to be clear up.
+     */
+    data class Date(
+        val title: String,
+        val initialDate: java.util.Date,
+        val minimumDate: java.util.Date?,
+        val maximumDate: java.util.Date?,
+        val onSelect: (java.util.Date) -> Unit,
+        val onClear: () -> Unit
+    ) : PromptRequest()
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.Date
 
 class PromptRequestTest {
 
@@ -35,5 +36,13 @@ class PromptRequestTest {
         assertEquals(alert.hasShownManyDialogs, true)
         alert.onDismiss()
         alert.onShouldShowNoMoreDialogs(true)
+
+        val dateRequest = PromptRequest.Date("title", Date(), Date(), Date(), {}) {}
+        assertEquals(dateRequest.title, "title")
+        assertNotNull(dateRequest.initialDate)
+        assertNotNull(dateRequest.minimumDate)
+        assertNotNull(dateRequest.maximumDate)
+        dateRequest.onSelect(Date())
+        dateRequest.onClear()
     }
 }

--- a/components/feature/prompts/build.gradle
+++ b/components/feature/prompts/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_androidx
     testImplementation project(':support-test')
+    testImplementation project(':support-ktx')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/DatePickerDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/DatePickerDialogFragment.kt
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.feature.prompts
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.support.annotation.VisibleForTesting
+import android.support.annotation.VisibleForTesting.PRIVATE
+import android.support.v7.app.AlertDialog
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.DatePicker
+import java.util.Calendar
+import java.util.Date
+
+private const val KEY_INITIAL_DATE = "KEY_INITIAL_DATE"
+private const val KEY_MIN_DATE = "KEY_MIN_DATE"
+private const val KEY_MAX_DATE = "KEY_MAX_DATE"
+private const val KEY_SELECTED_DATE = "KEY_SELECTED_DATE"
+
+/**
+ * [android.support.v4.app.DialogFragment] implementation to display date picker with a native dialog.
+ */
+internal class DatePickerDialogFragment : PromptDialogFragment(), DatePicker.OnDateChangedListener {
+    private val initialDate: Date by lazy { safeArguments.getSerializable(KEY_INITIAL_DATE) as Date }
+    private val minimumDate: Date? by lazy { safeArguments.getSerializable((KEY_MIN_DATE)) as? Date }
+    private val maximumDate: Date? by lazy { safeArguments.getSerializable(KEY_MAX_DATE) as? Date }
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal var selectedDate: Date
+        get() = safeArguments.getSerializable(KEY_SELECTED_DATE) as Date
+        set(value) {
+            safeArguments.putSerializable(KEY_SELECTED_DATE, value)
+        }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val inflater = LayoutInflater.from(requireContext())
+        return AlertDialog.Builder(requireContext())
+                .setCancelable(true)
+                .setPositiveButton(R.string.mozac_feature_prompts_set_date) { _, _ -> onPositiveClickAction() }
+                .setView(createDialogContentView(inflater))
+                .setNegativeButton(R.string.mozac_feature_prompts_cancel) { _, _ -> feature?.onCancel(sessionId) }
+                .setNeutralButton(R.string.mozac_feature_prompts_clear) { _, _ -> onClearClickAction() }
+                .setupTitle()
+                .create()
+    }
+
+    /**
+     * Called when the user touches outside of the dialog.
+     */
+    override fun onCancel(dialog: DialogInterface?) {
+        super.onCancel(dialog)
+        feature?.onCancel(sessionId)
+    }
+
+    @SuppressLint("InflateParams")
+    internal fun createDialogContentView(inflater: LayoutInflater): View {
+        val view = inflater.inflate(R.layout.mozac_feature_prompts_date_picker, null)
+        val datePicker = view.findViewById<DatePicker>(R.id.date_picker)
+        val calendar = Calendar.getInstance()
+        calendar.time = initialDate
+        minimumDate?.let {
+            datePicker.minDate = it.time
+        }
+        maximumDate?.let {
+            datePicker.maxDate = it.time
+        }
+        with(calendar) {
+            datePicker.init(year, month, day, this@DatePickerDialogFragment)
+        }
+        return view
+    }
+
+    override fun onDateChanged(view: DatePicker?, year: Int, monthOfYear: Int, dayOfMonth: Int) {
+        val calendar = Calendar.getInstance()
+        calendar.set(year, monthOfYear, dayOfMonth)
+        selectedDate = calendar.time
+    }
+
+    private fun onClearClickAction() {
+        feature?.onClear(sessionId)
+    }
+
+    private fun onPositiveClickAction() {
+        feature?.onSelect(sessionId, selectedDate)
+    }
+
+    companion object {
+        /**
+         * A builder method for creating a [DatePickerDialogFragment]
+         * @param sessionId to create the dialog.
+         * @param title of the dialog.
+         * @param initialDate date that will be selected by default.
+         * @param minDate the minimumDate date that will be allowed to be selected.
+         * @param maxDate the maximumDate date that will be allowed to be selected.
+         * @return a new instance of [DatePickerDialogFragment]
+         */
+        fun newInstance(
+            sessionId: String,
+            title: String,
+            initialDate: Date,
+            minDate: Date?,
+            maxDate: Date?
+        ): DatePickerDialogFragment {
+            val fragment = DatePickerDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+            fragment.arguments = arguments
+            with(arguments) {
+                putString(KEY_SESSION_ID, sessionId)
+                putString(KEY_TITLE, title)
+                putSerializable(KEY_INITIAL_DATE, initialDate)
+                putSerializable(KEY_MIN_DATE, minDate)
+                putSerializable(KEY_MAX_DATE, maxDate)
+            }
+            fragment.selectedDate = initialDate
+            return fragment
+        }
+    }
+
+    private fun AlertDialog.Builder.setupTitle(): AlertDialog.Builder {
+        return if (title.isEmpty()) {
+            setTitle(R.string.mozac_feature_prompts_pick_a_date)
+        } else {
+            setTitle(title)
+        }
+    }
+}
+
+internal val Calendar.day: Int
+    get() = get(Calendar.DAY_OF_MONTH)
+internal val Calendar.year: Int
+    get() = get(Calendar.YEAR)
+internal val Calendar.month: Int
+    get() = get(Calendar.MONTH)

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.MULTIPLE_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.MENU_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.SINGLE_CHOICE_DIALOG_TYPE
+import java.util.Date
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal const val FRAGMENT_TAG = "mozac_feature_prompt_dialog"
@@ -93,6 +94,12 @@ class PromptFeature(
                     AlertDialogFragment.newInstance(session.id, title, message, hasShownManyDialogs)
                 }
             }
+
+            is PromptRequest.Date -> {
+                with(promptRequest) {
+                    DatePickerDialogFragment.newInstance(session.id, title, initialDate, minimumDate, maximumDate)
+                }
+            }
         }
 
         dialog.feature = this
@@ -156,6 +163,37 @@ class PromptFeature(
         session.promptRequest.consume {
             when (it) {
                 is Alert -> it.onShouldShowNoMoreDialogs(isChecked)
+            }
+            true
+        }
+    }
+
+    /**
+     * Event that is called when the user is requesting to select a date from the date picker dialog.
+     * This consumes the [PromptFeature] value from the [Session] indicated by [sessionId].
+     * @param sessionId that requested to show the dialog.
+     * @param selectedDate the selected date from the dialog.
+     */
+    internal fun onSelect(sessionId: String, selectedDate: Date) {
+        val session = sessionManager.findSessionById(sessionId) ?: return
+        session.promptRequest.consume {
+            when (it) {
+                is PromptRequest.Date -> it.onSelect(selectedDate)
+            }
+            true
+        }
+    }
+
+    /**
+     * Event that is called when the user is requesting to clear the selected value from the dialog.
+     * This consumes the [PromptFeature] value from the [Session] indicated by [sessionId].
+     * @param sessionId that requested to show the dialog.
+     */
+    internal fun onClear(sessionId: String) {
+        val session = sessionManager.findSessionById(sessionId) ?: return
+        session.promptRequest.consume {
+            when (it) {
+                is PromptRequest.Date -> it.onClear()
             }
             true
         }

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_date_picker.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_date_picker.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<DatePicker
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/date_picker"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"/>

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -11,4 +11,13 @@
 
     <!-- When a page shows many dialogs, this checkbox will appear for letting the user choose to prevent showing more dialogs. -->
     <string name="mozac_feature_prompts_no_more_dialogs">Prevent this page from creating additional dialogs</string>
+
+    <!-- Title of a date picker dialog, this text is shown above a date picker. -->
+    <string name="mozac_feature_prompts_pick_a_date">Pick a date</string>
+
+    <!-- Text for a positive button, when an user selects a date in date/time picker. -->
+    <string name="mozac_feature_prompts_set_date">Set</string>
+
+    <!-- Text for a button that clears the selected input in the date/time picker. -->
+    <string name="mozac_feature_prompts_clear">Clear</string>
 </resources>

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/DatePickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/DatePickerDialogFragmentTest.kt
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.content.Context
+import android.content.DialogInterface.BUTTON_NEGATIVE
+import android.content.DialogInterface.BUTTON_POSITIVE
+import android.content.DialogInterface.BUTTON_NEUTRAL
+import android.support.v7.app.AlertDialog
+import android.support.v7.appcompat.R
+import android.view.ContextThemeWrapper
+import android.widget.DatePicker
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.support.ktx.kotlin.toDate
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+import java.util.Date
+
+@RunWith(RobolectricTestRunner::class)
+class DatePickerDialogFragmentTest {
+    private val context: Context
+        get() = ContextThemeWrapper(
+                ApplicationProvider.getApplicationContext(),
+                R.style.Theme_AppCompat
+        )
+
+    @Test
+    fun `build dialog`() {
+        val initialDate = "2019-11-29".toDate("yyyy-MM-dd")
+        val minDate = "2019-11-28".toDate("yyyy-MM-dd")
+        val maxDate = "2019-11-30".toDate("yyyy-MM-dd")
+        val fragment = spy(
+                DatePickerDialogFragment.newInstance("sessionId", "title", initialDate, minDate, maxDate)
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val titleTextView = dialog.findViewById<TextView>(android.support.v7.appcompat.R.id.alertTitle)
+        val datePicker = dialog.findViewById<DatePicker>(mozilla.components.feature.prompts.R.id.date_picker)
+
+        assertEquals(titleTextView.text, "title")
+        assertEquals(2019, datePicker.year)
+        assertEquals(11, datePicker.month + 1)
+        assertEquals(29, datePicker.dayOfMonth)
+        assertEquals(minDate, Date(datePicker.minDate))
+        assertEquals(maxDate, Date(datePicker.maxDate))
+
+        datePicker.updateDate(2101, 10, 28)
+
+        val selectedDate = fragment.selectedDate
+        val calendar = Calendar.getInstance()
+        calendar.time = selectedDate
+
+        assertEquals(2101, calendar.year)
+        assertEquals(10, calendar.month)
+        assertEquals(28, calendar.day)
+    }
+
+    @Test
+    fun `Clicking on positive, neutral and negative button notifies the feature`() {
+        val mockFeature: PromptFeature = mock()
+        val initialDate = "2019-11-29".toDate("yyyy-MM-dd")
+        val fragment = spy(
+                DatePickerDialogFragment.newInstance("sessionId", "", initialDate, null, null)
+        )
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
+        positiveButton.performClick()
+        verify(mockFeature).onSelect("sessionId", initialDate)
+
+        val neutralButton = dialog.getButton(BUTTON_NEUTRAL)
+        neutralButton.performClick()
+        verify(mockFeature).onClear("sessionId")
+
+        val negativeButton = dialog.getButton(BUTTON_NEGATIVE)
+        negativeButton.performClick()
+        verify(mockFeature).onCancel("sessionId")
+    }
+
+    @Test
+    fun `touching outside of the dialog must notify the feature onCancel`() {
+        val mockFeature: PromptFeature = mock()
+        val fragment = spy(
+                DatePickerDialogFragment.newInstance("sessionId", "", Date(), null, null)
+        )
+        fragment.feature = mockFeature
+        doReturn(context).`when`(fragment).requireContext()
+        fragment.onCancel(null)
+        verify(mockFeature).onCancel("sessionId")
+    }
+}

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -6,6 +6,9 @@ package mozilla.components.support.ktx.kotlin
 
 import android.net.Uri
 import android.text.TextUtils
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * Normalizes a URL String.
@@ -36,3 +39,19 @@ fun String.isPhone(): Boolean = contains("tel:", true)
 fun String.isEmail(): Boolean = contains("mailto:", true)
 
 fun String.isGeoLocation(): Boolean = contains("geo:", true)
+
+/**
+ * Converts a [String] to a [Date] object.
+ * @param format date format used for formatting the this given [String] object.
+ * @param locale the locale to use when converting the String, defaults to [Locale.ROOT].
+ * @return a [Date] object with the values in the provided in this string, if empty string was provided, a current date
+ * will be returned.
+ */
+fun String.toDate(format: String, locale: Locale = Locale.ROOT): Date {
+    val formatter = SimpleDateFormat(format, locale)
+    return if (!this.isEmpty()) {
+        formatter.parse(this)
+    } else {
+        Date()
+    }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -5,11 +5,14 @@
 package mozilla.components.support.ktx.kotlin
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+import java.util.Calendar.MILLISECOND
 
 @RunWith(RobolectricTestRunner::class)
 class StringTest {
@@ -64,5 +67,16 @@ class StringTest {
         assertTrue("geo:1,-1 ".isGeoLocation())
         assertTrue("GEO:1,-1".isGeoLocation())
         assertTrue("Geo:1,-1".isGeoLocation())
+    }
+
+    @Test
+    fun toDate() {
+        val calendar = Calendar.getInstance()
+        calendar.set(2019, 10, 29, 0, 0, 0)
+        calendar[MILLISECOND] = 0
+        assertEquals(calendar.time, "2019-11-29".toDate("yyyy-MM-dd"))
+        calendar.set(2019, 10, 28, 0, 0, 0)
+        assertEquals(calendar.time, "2019-11-28".toDate("yyyy-MM-dd"))
+        assertNotNull("".toDate("yyyy-MM-dd"))
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,7 +30,14 @@ permalink: /changelog/
   }
   ```
 * **feature-prompts**
-  * Added support alerts dialogs.
+  * Added support for alerts dialogs.
+  * Added support for date picker dialogs.
+
+* **support-ktx**
+  New extension function `toDate` that converts a string to a Date object from a formatter input.
+  ```Kotlin
+       val date = "2019-11-28".toDate("yyyy-MM-dd")
+  ```
 
 * **concept-engine**, **engine-gecko-nightly**:
   * Add setting to enable testing mode which is used in engine-gecko to set `FULL_ACCESSIBILITY_TREE` to `true`. This allows access to the full DOM tree for testing purposes.


### PR DESCRIPTION
Depends on: https://github.com/mozilla-mobile/android-components/pull/1501