### PR TITLE
Closes #1523: Remove references to org.mozilla.gecko.

### DIFF
--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -8,15 +8,16 @@ import android.Manifest
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.concept.engine.permission.Permission.ContentAutoplayMedia
 import mozilla.components.support.test.mock
+import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
-import org.mozilla.gecko.util.GeckoBundle
 import org.mozilla.geckoview.GeckoSession
 import org.robolectric.RobolectricTestRunner
 
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_MEDIA
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
@@ -113,16 +114,25 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.MediaCallback = mock()
         val uri = "https://mozilla.org"
 
-        val audioMicrophone = getMediaSource("audioMicrophone", "audioMicrophone", "microphone", "audioinput")
-        val audioCapture = getMediaSource("audioCapture", "audioCapture", "audioCapture", "audioinput")
-        val audioOther = getMediaSource("audioOther", "audioOther", "other", "audioinput")
+        val audioMicrophone = MockMediaSource("audioMicrophone", "audioMicrophone",
+                MediaSource.SOURCE_MICROPHONE, MediaSource.TYPE_AUDIO)
+        val audioCapture = MockMediaSource("audioCapture", "audioCapture",
+                MediaSource.SOURCE_AUDIOCAPTURE, MediaSource.TYPE_AUDIO)
+        val audioOther = MockMediaSource("audioOther", "audioOther",
+                MediaSource.SOURCE_OTHER, MediaSource.TYPE_AUDIO)
 
-        val videoCamera = getMediaSource("videoCamera", "videoCamera", "camera", "videoinput")
-        val videoBrowser = getMediaSource("videoBrowser", "videoBrowser", "browser", "videoinput")
-        val videoApplication = getMediaSource("videoApplication", "videoApplication", "application", "videoinput")
-        val videoScreen = getMediaSource("videoScreen", "videoScreen", "screen", "videoinput")
-        val videoWindow = getMediaSource("videoWindow", "videoWindow", "window", "videoinput")
-        val videoOther = getMediaSource("videoOther", "videoOther", "other", "videoinput")
+        val videoCamera = MockMediaSource("videoCamera", "videoCamera",
+                MediaSource.SOURCE_CAMERA, MediaSource.TYPE_VIDEO)
+        val videoBrowser = MockMediaSource("videoBrowser", "videoBrowser",
+                MediaSource.SOURCE_BROWSER, MediaSource.TYPE_VIDEO)
+        val videoApplication = MockMediaSource("videoApplication", "videoApplication",
+                MediaSource.SOURCE_APPLICATION, MediaSource.TYPE_VIDEO)
+        val videoScreen = MockMediaSource("videoScreen", "videoScreen",
+                MediaSource.SOURCE_SCREEN, MediaSource.TYPE_VIDEO)
+        val videoWindow = MockMediaSource("videoWindow", "videoWindow",
+                MediaSource.SOURCE_WINDOW, MediaSource.TYPE_VIDEO)
+        val videoOther = MockMediaSource("videoOther", "videoOther",
+                MediaSource.SOURCE_OTHER, MediaSource.TYPE_VIDEO)
 
         val audioSources = listOf(audioCapture, audioMicrophone, audioOther)
         val videoSources = listOf(videoApplication, videoBrowser, videoCamera, videoOther, videoScreen, videoWindow)
@@ -150,8 +160,10 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.MediaCallback = mock()
         val uri = "https://mozilla.org"
 
-        val audioMicrophone = getMediaSource("audioMicrophone", "audioMicrophone", "microphone", "audioinput")
-        val videoCamera = getMediaSource("videoCamera", "videoCamera", "camera", "videoinput")
+        val audioMicrophone = MockMediaSource("audioMicrophone", "audioMicrophone",
+                MediaSource.SOURCE_MICROPHONE, MediaSource.TYPE_AUDIO)
+        val videoCamera = MockMediaSource("videoCamera", "videoCamera",
+                MediaSource.SOURCE_CAMERA, MediaSource.TYPE_VIDEO)
 
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
@@ -166,8 +178,10 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.MediaCallback = mock()
         val uri = "https://mozilla.org"
 
-        val audioMicrophone = getMediaSource("audioMicrophone", "audioMicrophone", "microphone", "audioinput")
-        val videoCamera = getMediaSource("videoCamera", "videoCamera", "camera", "videoinput")
+        val audioMicrophone = MockMediaSource("audioMicrophone", "audioMicrophone",
+                MediaSource.SOURCE_MICROPHONE, MediaSource.TYPE_AUDIO)
+        val videoCamera = MockMediaSource("videoCamera", "videoCamera",
+                MediaSource.SOURCE_CAMERA, MediaSource.TYPE_VIDEO)
 
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
@@ -177,15 +191,12 @@ class GeckoPermissionRequestTest {
         verify(callback).reject()
     }
 
-    private fun getMediaSource(id: String, name: String, source: String, type: String): GeckoSession.PermissionDelegate.MediaSource {
-        val bundle = GeckoBundle()
-        bundle.putString("id", id)
-        bundle.putString("name", name)
-        bundle.putString("mediaSource", source)
-        bundle.putString("type", type)
-
-        val constructor = GeckoSession.PermissionDelegate.MediaSource::class.java.getDeclaredConstructor(GeckoBundle::class.java)
-        constructor.isAccessible = true
-        return constructor.newInstance(bundle)
+    class MockMediaSource(id: String, name: String, source: Int, type: Int) : MediaSource() {
+        init {
+            ReflectionUtils.setField(this, "id", id)
+            ReflectionUtils.setField(this, "name", name)
+            ReflectionUtils.setField(this, "source", source)
+            ReflectionUtils.setField(this, "type", type)
+        }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/test/ReflectionUtils.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/test/ReflectionUtils.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.test
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+
+object ReflectionUtils {
+    fun <T : Any> setField(instance: T, fieldName: String, value: Any?) {
+        val originField = instance.javaClass.getField(fieldName)
+
+        val modifiersField = Field::class.java.getDeclaredField("modifiers")
+        modifiersField.isAccessible = true
+        modifiersField.setInt(originField, originField.modifiers and Modifier.FINAL.inv())
+
+        originField.set(instance, value)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/org/mozilla/geckoview/MockWebResponseInfo.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/org/mozilla/geckoview/MockWebResponseInfo.kt
@@ -4,36 +4,18 @@
 
 package org.mozilla.geckoview
 
-import org.mozilla.gecko.util.GeckoBundle
+import mozilla.components.test.ReflectionUtils
 
-/**
- * Creates a mocked WebResponseInfo object.
- *
- * We need to jump through several hoops here:
- *  1) We can't mock WebResponseInfo because values are accessed via properties and not methods.
- *  2) The constructor of WebResponseInfo has 'package' visibility so we need to create it from
- *     inside the org.mozilla.geckoview package.
- *  3) WebResponseInfo is not static, so it needs to be created from inside a GeckoSession.
- *
- *  https://bugzilla.mozilla.org/show_bug.cgi?id=1476552
- */
-fun createMockedWebResponseInfo(
+class MockWebResponseInfo(
     uri: String,
     contentType: String,
     contentLength: Long,
     filename: String?
-): GeckoSession.WebResponseInfo {
-    val session = object : GeckoSession(null) {
-        fun createMockedWebResponseInfo(): WebResponseInfo {
-            val bundle = GeckoBundle()
-            bundle.putString("uri", uri)
-            bundle.putString("contentType", contentType)
-            bundle.putLong("contentLength", contentLength)
-            bundle.putString("filename", filename)
-
-            return WebResponseInfo(bundle)
-        }
+) : GeckoSession.WebResponseInfo() {
+    init {
+        ReflectionUtils.setField(this, "uri", uri)
+        ReflectionUtils.setField(this, "contentType", contentType)
+        ReflectionUtils.setField(this, "filename", filename)
+        ReflectionUtils.setField(this, "contentLength", contentLength)
     }
-
-    return session.createMockedWebResponseInfo()
 }


### PR DESCRIPTION
This removes all remaining references to `org.mozilla.gecko` in
`engine-gecko-nightly`. It also adds a `ReflectionUtils#setField`
method to set final fields in tests.