### PR TITLE
 Closes #1534: Add setting to enable testing mode 

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -426,7 +426,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `GeckoEngineSession keeps track of current url via onPageStart events`() {
+    fun `keeps track of current url via onPageStart events`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
 
         assertNull(engineSession.currentUrl)
@@ -438,7 +438,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of title changes`() = runBlocking {
+    fun `notifies configured history delegate of title changes`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
@@ -458,7 +458,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of title changes for private sessions`() = runBlocking {
+    fun `notifies configured history delegate of title changes for private sessions`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java), privateMode = true)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -66,12 +66,17 @@ class GeckoEngine(
         override var historyTrackingDelegate: HistoryTrackingDelegate?
             get() = defaultSettings?.historyTrackingDelegate
             set(value) { defaultSettings?.historyTrackingDelegate = value }
+
+        override var testingModeEnabled: Boolean
+            get() = defaultSettings?.testingModeEnabled ?: false
+            set(value) { defaultSettings?.testingModeEnabled = value }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled
             this.webFontsEnabled = it.webFontsEnabled
             this.trackingProtectionPolicy = it.trackingProtectionPolicy
             this.remoteDebuggingEnabled = it.remoteDebuggingEnabled
+            this.testingModeEnabled = it.testingModeEnabled
         }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -545,6 +545,9 @@ class GeckoEngineSession(
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
         defaultSettings?.historyTrackingDelegate?.let { settings.historyTrackingDelegate = it }
+        defaultSettings?.testingModeEnabled?.let {
+            geckoSession.settings.setBoolean(GeckoSessionSettings.FULL_ACCESSIBILITY_TREE, it)
+        }
 
         geckoSession.settings.setBoolean(GeckoSessionSettings.USE_PRIVATE_MODE, privateMode)
         geckoSession.open(runtime)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -446,7 +446,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `GeckoEngineSession keeps track of current url via onPageStart events`() {
+    fun `keeps track of current url via onPageStart events`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider)
 
@@ -461,7 +461,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of title changes`() = runBlocking {
+    fun `notifies configured history delegate of title changes`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -485,7 +485,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client does not notify configured history delegate of title changes for private sessions`() = runBlocking {
+    fun `does not notify configured history delegate of title changes for private sessions`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext,
@@ -515,7 +515,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client does not notify configured history delegate for redirects`() {
+    fun `does not notify configured history delegate for redirects`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -539,7 +539,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client does not notify configured history delegate for top-level visits to error pages`() {
+    fun `does not notify configured history delegate for top-level visits to error pages`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -557,7 +557,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of visits`() {
+    fun `notifies configured history delegate of visits`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -575,7 +575,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of reloads`() = runBlocking {
+    fun `notifies configured history delegate of reloads`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -593,7 +593,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client does not notify configured history delegate of visits for private sessions`() {
+    fun `does not notify configured history delegate of visits for private sessions`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext,
@@ -612,7 +612,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client requests visited URLs from configured history delegate`() {
+    fun `requests visited URLs from configured history delegate`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -636,7 +636,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client does not request visited URLs from configured history delegate in private sessions`() {
+    fun `does not request visited URLs from configured history delegate in private sessions`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext,

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -735,6 +735,22 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun settingTestingMode() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        GeckoEngineSession(runtime,
+                geckoSessionProvider = geckoSessionProvider,
+                defaultSettings = DefaultSettings())
+        verify(geckoSession.settings).setBoolean(GeckoSessionSettings.FULL_ACCESSIBILITY_TREE, false)
+
+        GeckoEngineSession(runtime,
+            geckoSessionProvider = geckoSessionProvider,
+            defaultSettings = DefaultSettings(testingModeEnabled = true))
+        verify(geckoSession.settings).setBoolean(GeckoSessionSettings.FULL_ACCESSIBILITY_TREE, true)
+    }
+
+    @Test
     fun unsupportedSettings() {
         val settings = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider).settings

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -51,7 +51,7 @@ class GeckoEngineTest {
         `when`(runtimeSettings.webFontsEnabled).thenReturn(true)
         `when`(runtimeSettings.trackingProtectionCategories).thenReturn(TrackingProtectionPolicy.none().categories)
         `when`(runtime.settings).thenReturn(runtimeSettings)
-        val engine = GeckoEngine(context, runtime = runtime)
+        val engine = GeckoEngine(context, runtime = runtime, defaultSettings = DefaultSettings())
 
         assertTrue(engine.settings.javascriptEnabled)
         engine.settings.javascriptEnabled = false
@@ -64,6 +64,10 @@ class GeckoEngineTest {
         assertFalse(engine.settings.remoteDebuggingEnabled)
         engine.settings.remoteDebuggingEnabled = true
         verify(runtimeSettings).remoteDebuggingEnabled = true
+
+        assertFalse(engine.settings.testingModeEnabled)
+        engine.settings.testingModeEnabled = true
+        assertTrue(engine.settings.testingModeEnabled)
 
         assertEquals(TrackingProtectionPolicy.none(), engine.settings.trackingProtectionPolicy)
         engine.settings.trackingProtectionPolicy = TrackingProtectionPolicy.all()
@@ -87,15 +91,17 @@ class GeckoEngineTest {
         `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
         `when`(runtime.settings).thenReturn(runtimeSettings)
 
-        GeckoEngine(context, DefaultSettings(
+        val engine = GeckoEngine(context, DefaultSettings(
                 trackingProtectionPolicy = TrackingProtectionPolicy.all(),
                 javascriptEnabled = false,
                 webFontsEnabled = false,
-                remoteDebuggingEnabled = true), runtime)
+                remoteDebuggingEnabled = true,
+                testingModeEnabled = true), runtime)
 
         verify(runtimeSettings).javaScriptEnabled = false
         verify(runtimeSettings).webFontsEnabled = false
         verify(runtimeSettings).remoteDebuggingEnabled = true
         verify(runtimeSettings).trackingProtectionCategories = TrackingProtectionPolicy.all().categories
+        assertTrue(engine.settings.testingModeEnabled)
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -449,7 +449,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of title changes`() = runBlocking {
+    fun `notifies configured history delegate of title changes`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
@@ -469,7 +469,7 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `WebView client notifies configured history delegate of title changes for private sessions`() = runBlocking {
+    fun `notifies configured history delegate of title changes for private sessions`() = runBlocking {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java), privateMode = true)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -113,6 +113,11 @@ abstract class Settings {
      * Setting to control whether or not multiple windows are supported.
      */
     open var supportMultipleWindows: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether or not testing mode is enabled.
+     */
+    open var testingModeEnabled: Boolean by UnsupportedSetting()
 }
 
 /**
@@ -137,7 +142,8 @@ data class DefaultSettings(
     override var verticalScrollBarEnabled: Boolean = true,
     override var horizontalScrollBarEnabled: Boolean = true,
     override var remoteDebuggingEnabled: Boolean = false,
-    override var supportMultipleWindows: Boolean = false
+    override var supportMultipleWindows: Boolean = false,
+    override var testingModeEnabled: Boolean = false
 ) : Settings()
 
 class UnsupportedSetting<T> {

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -59,7 +59,9 @@ class SettingsTest {
             { settings.remoteDebuggingEnabled },
             { settings.remoteDebuggingEnabled = false },
             { settings.supportMultipleWindows },
-            { settings.supportMultipleWindows = false }
+            { settings.supportMultipleWindows = false },
+            { settings.testingModeEnabled },
+            { settings.testingModeEnabled = false }
         )
     }
 
@@ -90,6 +92,7 @@ class SettingsTest {
         assertTrue(settings.horizontalScrollBarEnabled)
         assertFalse(settings.remoteDebuggingEnabled)
         assertFalse(settings.supportMultipleWindows)
+        assertFalse(settings.testingModeEnabled)
 
         val interceptor: RequestInterceptor = mock()
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
@@ -113,7 +116,8 @@ class SettingsTest {
             verticalScrollBarEnabled = false,
             horizontalScrollBarEnabled = false,
             remoteDebuggingEnabled = true,
-            supportMultipleWindows = true)
+            supportMultipleWindows = true,
+            testingModeEnabled = true)
 
         assertFalse(defaultSettings.domStorageEnabled)
         assertFalse(defaultSettings.javascriptEnabled)
@@ -134,5 +138,6 @@ class SettingsTest {
         assertFalse(defaultSettings.horizontalScrollBarEnabled)
         assertTrue(defaultSettings.remoteDebuggingEnabled)
         assertTrue(defaultSettings.supportMultipleWindows)
+        assertTrue(defaultSettings.testingModeEnabled)
     }
 }


### PR DESCRIPTION
The root setting we want here is on the Gecko session, but it makes most sense to have `testingModeEnabled` on the engine, and as a default. It will be applied to all sessions.

So, to use this:

```Kotlin
val engine = GeckoEngine(runtime, DefaultSettings(testingModeEnabled=true))
```

or to change later:

```Kotlin
engine.settings.testingModeEnabled = false
```

I've found a bunch of `GeckoEngine` tests that referred to WebView which I fixed in a separate commit.