### PR TITLE
Update compare-locales to recent major version, stop using l10n_base in config

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -105,7 +105,7 @@ def create_compare_locales_task():
     return create_raw_task(
         name='Android Components - compare-locales',
         description='Validate strings.xml with compare-locales',
-        full_command='pip install "compare-locales>=4.0.1,<5.0" && compare-locales --validate l10n.toml .')
+        full_command='pip install "compare-locales>=5.0.2,<6.0" && compare-locales --validate l10n.toml .')
 
 
 if __name__ == "__main__":

--- a/l10n.toml
+++ b/l10n.toml
@@ -8,24 +8,24 @@ locales = [
 
 [[paths]]
   reference = "components/ui/tabcounter/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/components/ui/tabcounter/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "components/ui/tabcounter/src/main/res/values-{android_locale}/strings.xml"
 
 [[paths]]
   reference = "components/browser/errorpages/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/components/browser/errorpages/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "components/browser/errorpages/src/main/res/values-{android_locale}/strings.xml"
 
 [[paths]]
   reference = "components/browser/toolbar/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/components/browser/toolbar/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "components/browser/toolbar/src/main/res/values-{android_locale}/strings.xml"
 
 [[paths]]
   reference = "components/feature/tabs/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/components/feature/tabs/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "components/feature/tabs/src/main/res/values-{android_locale}/strings.xml"
 
 [[paths]]
   reference = "components/feature/downloads/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/components/feature/downloads/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "components/feature/downloads/src/main/res/values-{android_locale}/strings.xml"
 
 [[paths]]
   reference = "components/feature/contextmenu/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/components/feature/contextmenu/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "components/feature/contextmenu/src/main/res/values-{android_locale}/strings.xml"


### PR DESCRIPTION
l10n_base is actually in the way of creating a l10n-only cross-product repo,
it turns out. It's not really needed for Android projects anyway, removing it.