### PR TITLE
[glean] Don't fail if no metrics yaml is present

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -114,12 +114,17 @@ ext.gleanGenerateMetricsAPI = {
             }
         }
 
-        // This is an Android-Gradle plugin 3+-ism.  Culted from reading the source,
-        // searching for "registerJavaGeneratingTask", and finding
-        // https://github.com/GoogleCloudPlatform/endpoints-framework-gradle-plugin/commit/2f2b91476fb1c6647791e2c6fe531a47615a1e85.
-        // The added directory doesn't appear in the paths listed by the
-        // `sourceSets` task, for reasons unknown.
-        variant.registerJavaGeneratingTask(generateKotlinAPI, new File(sourceOutputDir))
+        // Only attach the generation task if the metrics file is available. We don't need to
+        // fail hard otherwise, as some 3rd party project might just want metrics included in
+        // glean and nothing more.
+        if (file("$projectDir/metrics.yaml").exists()) {
+            // This is an Android-Gradle plugin 3+-ism.  Culted from reading the source,
+            // searching for "registerJavaGeneratingTask", and finding
+            // https://github.com/GoogleCloudPlatform/endpoints-framework-gradle-plugin/commit/2f2b91476fb1c6647791e2c6fe531a47615a1e85.
+            // The added directory doesn't appear in the paths listed by the
+            // `sourceSets` task, for reasons unknown.
+            variant.registerJavaGeneratingTask(generateKotlinAPI, new File(sourceOutputDir))
+        }
     }
 }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/CountersStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/CountersStorageEngine.kt
@@ -43,8 +43,8 @@ internal open class CountersStorageEngineImplementation(
         amount: Int
     ) {
         // Use a custom combiner to add the amount to the existing counters rather than overwriting
-        super.recordScalar(metricData, amount) { currentValue, amount ->
-            currentValue?.let { it + amount } ?: amount
+        super.recordScalar(metricData, amount) { currentValue, newAmount ->
+            currentValue?.let { it + newAmount } ?: newAmount
         }
     }
 }


### PR DESCRIPTION
Consumer application might just need glean core metrics, without defining any custom metric on they own. For this reason, they wouldn't need any `metrics.yaml` file. This patch makes sure the application build process doesn't fail when using glean and no such file is present.

This additionally fixes a minor problem in the CountersStorageEngine.