### PR TITLE
[glean] 1512664: Don't record metrics or send pings if not initialized

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
@@ -40,6 +40,12 @@ interface CommonMetricData {
     }
 
     fun shouldRecord(logger: Logger): Boolean {
+        // Don't record metrics if we aren't initialized
+        if (!Glean.isInitialized()) {
+            logger.error("Glean must be initialized before metrics are recorded")
+            return false
+        }
+
         // Silently drop if metrics are turned off globally or locally
         if (!Glean.getMetricsEnabled() || disabled) {
             return false

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/CounterMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/CounterMetricTypeTest.kt
@@ -27,6 +27,7 @@ class CounterMetricTypeTest {
 
     @Before
     fun setUp() {
+        Glean.initialized = true
         CountersStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -28,6 +28,7 @@ class EventMetricTypeTest {
 
     @Before
     fun setUp() {
+        Glean.initialized = true
         EventsStorageEngine.clearAllStores()
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
@@ -27,6 +27,7 @@ class StringMetricTypeTest {
 
     @Before
     fun setUp() {
+        Glean.initialized = true
         StringsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
@@ -28,6 +28,7 @@ class UuidMetricTypeTest {
 
     @Before
     fun setUp() {
+        Glean.initialized = true
         UuidsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()


### PR DESCRIPTION
`Glean.initialize` makes sure that upload and storage engines work properly. Unfortunately, the API is not checking whether or not glean was initialized. We need a way to enforce and write the relevant test coverage.

I don't think we want the main metric APIs to throw exceptions ever, so this just spits out error logs if trying to record metrics before initialization.