### PR TITLE
[glean] Document the pings available out of the box [ci skip]

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -61,7 +61,8 @@ class SampleApplication : Application() {
 }
 ```
 
-Once initialized, glean will automatically start collecting and sending its [core metrics](metrics.yaml).
+Once initialized, if collection is enabled, glean will automatically start collecting [baseline metrics](metrics.yaml)
+and sending its [pings](docs/pings.md).
 
 ## License
 

--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -1,0 +1,18 @@
+# The `baseline` ping
+This ping is intended to provide metrics that are managed by the library itself, and not explicitly
+set by the application or included in the application's `metrics.yaml` file.
+
+The `baseline` ping is automatically sent when the application is moved to the *background* and it includes
+the following fields:
+
+| Field name | Type | Description |
+|---|---|---|
+| `sessions` | Counter | The number of foreground sessions since the last upload |
+| `durations` | Timespan | The combined duration of all the foreground sessions since the last upload |
+| `os` | String | The name of the operating system (e.g. "linux", "android", "ios") |
+| `os_version` | String | The version of the operating system |
+| `device` | String | Manufacturer and model |
+| `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
+| `timezone` | Number | The timezone of the device, as an offset from UTC |
+| `accessibility_services` | StringList | List of accessibility services enabled on the device |
+| `locale` | String | The locale of the application |

--- a/components/service/glean/docs/pings.md
+++ b/components/service/glean/docs/pings.md
@@ -1,0 +1,46 @@
+# glean pings
+
+If data collection is enabled, glean provides a set of pings that are assembled out of the box
+without any developer intervention.
+Every glean ping is in JSON format and contains a [common section](#the-common-information-section)
+with shared information data included under the `ping_info` key.
+The following is a list of the pings along with the conditions that triggers them.
+
+- [`baseline` ping](baseline.md)
+- `events` ping (TBD)
+- `metrics` ping (TBD)
+
+## The `ping_info` section
+The following fields are always included in the `ping_info` section, for every ping.
+
+| Field name | Type | Description |
+|---|---|---|
+| `ping_type` | String | The name of the ping type (e.g. "baseline", "metrics") |
+| `app_build` | String | TBD |
+| `telemetry_sdk_build` | String | The version of the glean library |
+| `client_id` | UUID |  A UUID identifying a profile and allowing user-oriented correlation of data |
+| `seq` | Counter | A running counter of the number of times pings of this type have been sent |
+| `experiments` | Object | A dictionary of [active experiments](#the-experiments-object) |
+| `start_time` | Datetime | The time of the start of collection of the data in the ping |
+| `end_time` | Datetime | The time of the end of collection of the data in the ping. This is also the time this ping was generated and is likely well before ping transmission time |
+| `profile_age` | Datetime | TBD |
+
+All the metrics surviving application restarts (e.g. `client_id`, `seq`, ...) are removed once the
+application using glean is uninstalled.
+
+### The `experiments` object
+This object contains experiments keyed by the experiment `id`. Each listed experiment contains the
+`branch` the client is enrolled in and may contain a string to string map with additional data in the
+`extra` key. Both the `id` and `branch` are truncated to 30 characters.
+
+```json
+{
+  "<id>": {
+    "branch": "branch-id",
+    "extra": {
+      "some-key": "a-value"
+    }
+  }
+}
+```
+


### PR DESCRIPTION
This adds documentation for the baseline ping and the metric it collects out of the box. This
additionally lays out the structure for the remaining documentation, so that all pings docs have a similar
structure.