### PR TITLE
Closes #1567: Don't show private sessions in awesomebar

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -24,8 +24,8 @@ class SessionSuggestionProvider(
         val suggestions = mutableListOf<AwesomeBar.Suggestion>()
 
         sessionManager.sessions.forEach { session ->
-            if (session.url.contains(text, ignoreCase = true) ||
-                session.title.contains(text, ignoreCase = true)
+            if ((session.url.contains(text, ignoreCase = true) ||
+                    session.title.contains(text, ignoreCase = true)) && !session.private
             ) {
                 suggestions.add(
                     AwesomeBar.Suggestion(

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -88,6 +88,23 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
+    fun `Provider only returns non-private Sessions`() = runBlocking {
+        val sessionManager = SessionManager(mock())
+        val session = Session("https://www.mozilla.org")
+        val privateSession = Session("https://mozilla.org/firefox", true)
+        sessionManager.add(privateSession)
+        sessionManager.add(session)
+        sessionManager.add(privateSession)
+
+        val useCase: TabsUseCases.SelectTabUseCase = mock()
+
+        val provider = SessionSuggestionProvider(sessionManager, useCase)
+        val suggestions = provider.onInputChanged("mozilla")
+
+        assertEquals(1, suggestions.size)
+    }
+
+    @Test
     fun `Clicking suggestion invokes SelectTabUseCase`() = runBlocking {
         val sessionManager = SessionManager(mock())
         val session = Session("https://www.mozilla.org")


### PR DESCRIPTION
We've been showing private sessions in the awesome bar which doesn't seem like our intended behaviour (it may give the impression that we're also saving the session).

I've added a filter check if the session is private, but would we also want to provide an external session filter (similar to `TabsFeature#filterTabs`)?