### PR TITLE
[glean] 1510552 Send the event ping

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -16,11 +16,13 @@ import mozilla.components.service.glean.BuildConfig
  *           the [serverEndpoint]
  * @property readTimeout the timeout, in milliseconds, to use when connecting to
  *           the [serverEndpoint]
+ * @property maxEvents the number of events to store before the events ping is sent
  */
 data class Configuration(
     val applicationId: String,
     val serverEndpoint: String = "https://incoming.telemetry.mozilla.org",
     val userAgent: String = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)",
     val connectionTimeout: Int = 10000,
-    val readTimeout: Int = 30000
+    val readTimeout: Int = 30000,
+    val maxEvents: Int = 500
 )

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.storages
 
+import mozilla.components.service.glean.Glean
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.SystemClock
@@ -70,6 +71,9 @@ internal object EventsStorageEngine : StorageEngine {
             for (storeName in stores) {
                 val storeData = eventStores.getOrPut(storeName) { mutableListOf() }
                 storeData.add(event.copy())
+                if (storeData.size == Glean.configuration.maxEvents) {
+                    Glean.sendPing(storeName, "events")
+                }
             }
         }
     }


### PR DESCRIPTION
This sets up the event ping to send when (a) going to background and (b) when the event storage engine of a particular store exceeds `MAX_EVENTS` items.

This includes a refactor of the `Glean` object into a class and a singleton instance to make it easier to create one-off instances for testing.

This also rewrites an unrelated test to send pings to a testing webserver rather than catching the contents in a mock.  I wasn't aware we already had this infrastructure when I wrote that original test and I think it's much better to mock less.