### PR TITLE
Closes #1489: Fix backspace issue when suggestion strip is off

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@ permalink: /changelog/
   * Mozilla App Services (FxA: 0.11.5, Sync Logins: 0.11.5, Places: 0.11.5)
   * Third Party Libs (Sentry: 1.7.14, Okhttp: 3.12.0)
 
+* **ui-autocomplete**
+  * Fixing bug [#1489](https://github.com/mozilla-mobile/android-components/issues/1489).
+
 # 0.35.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.34.0...v0.35.0),


### PR DESCRIPTION
I also added a workaround for [an issue with Sony keyboards](https://bugzilla.mozilla.org/show_bug.cgi?id=1344464) that was missing from the fennec port. 

https://github.com/mozilla-mobile/focus-android/issues/3892