### PR TITLE
[glean] Require an 'app_id' for initializing glean

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -56,10 +56,13 @@ class SampleApplication : Application() {
 
         // Initialize the Glean library. Ideally, this is the first thing that
         // must be done right after enabling logging.
-        Glean.initialize(applicationContext)
+        Glean.initialize(applicationContext, Configuration(applicationId = "YOUR_APPLICATION_NAME_HERE"))
     }
 }
 ```
+
+**Important:** the `applicationId` will be used to properly route data in the pipeline, so it must be unique.
+The `glean` value is reserved for testing.
 
 Once initialized, if collection is enabled, glean will automatically start collecting [baseline metrics](metrics.yaml)
 and sending its [pings](docs/pings.md).

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -33,7 +33,7 @@ open class GleanInternalAPI {
     // Include our singletons of StorageEngineManager and PingMaker
     private lateinit var storageEngineManager: StorageEngineManager
     private lateinit var pingMaker: PingMaker
-    private lateinit var configuration: Configuration
+    internal lateinit var configuration: Configuration
     // `internal` so this can be modified for testing
     internal lateinit var httpPingUploader: HttpPingUploader
 
@@ -54,7 +54,7 @@ open class GleanInternalAPI {
      * @param configuration A Glean [Configuration] object with global settings.
      * @raises Exception if called more than once
      */
-    fun initialize(applicationContext: Context, configuration: Configuration = Configuration()) {
+    fun initialize(applicationContext: Context, configuration: Configuration) {
         if (isInitialized()) {
             throw IllegalStateException("Glean may not be initialized multiple times")
         }
@@ -132,7 +132,7 @@ open class GleanInternalAPI {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun makePath(docType: String, uuid: UUID): String {
-        return "/submit/glean/$docType/${Glean.SCHEMA_VERSION}/$uuid"
+        return "/submit/${configuration.applicationId}/$docType/${Glean.SCHEMA_VERSION}/$uuid"
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -9,6 +9,7 @@ import mozilla.components.service.glean.BuildConfig
 /**
  * The Configuration class describes how to configure the Glean.
  *
+ * @property applicationId a unique identifier for the application (e.g. "reference-browser")
  * @property serverEndpoint the server pings are sent to
  * @property userAgent the user agent used when sending pings
  * @property connectionTimeout the timeout, in milliseconds, to use when connecting to
@@ -17,6 +18,7 @@ import mozilla.components.service.glean.BuildConfig
  *           the [serverEndpoint]
  */
 data class Configuration(
+    val applicationId: String,
     val serverEndpoint: String = "https://incoming.telemetry.mozilla.org",
     val userAgent: String = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)",
     val connectionTimeout: Int = 10000,

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.HttpPingUploader
 import mozilla.components.service.glean.storages.EventsStorageEngine
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
@@ -44,7 +45,8 @@ class GleanTest {
     fun setup() {
         Glean.initialized = false
         Glean.initialize(
-            applicationContext = ApplicationProvider.getApplicationContext()
+            applicationContext = ApplicationProvider.getApplicationContext(),
+            configuration = Configuration(applicationId = "test")
         )
     }
 
@@ -105,7 +107,8 @@ class GleanTest {
     fun `test path generation`() {
         val uuid = UUID.randomUUID()
         val path = Glean.makePath("test", uuid)
-        assertEquals(path, "/submit/glean/test/${Glean.SCHEMA_VERSION}/$uuid")
+        assertEquals("test", Glean.configuration.applicationId)
+        assertEquals(path, "/submit/test/test/${Glean.SCHEMA_VERSION}/$uuid")
     }
 
     @Test
@@ -164,7 +167,7 @@ class GleanTest {
             assertNotNull(metricsJson.opt("ping_info"))
             assertNotNull(metricsJson.getJSONObject("ping_info").opt("experiments"))
             assert(
-                metricsPath.startsWith("/submit/glean/metrics/${Glean.SCHEMA_VERSION}/")
+                metricsPath.startsWith("/submit/test/metrics/${Glean.SCHEMA_VERSION}/")
             )
         } finally {
             Glean.httpPingUploader = realClient
@@ -187,7 +190,8 @@ class GleanTest {
 
         // Try to init Glean: it should not crash.
         Glean.initialize(
-            applicationContext = ApplicationProvider.getApplicationContext()
+            applicationContext = ApplicationProvider.getApplicationContext(),
+            configuration = Configuration(applicationId = "test")
         )
 
         // Clean up after this, so that other tests don't fail.
@@ -217,7 +221,8 @@ class GleanTest {
     @Test(expected = IllegalStateException::class)
     fun `Don't initialize twice`() {
         Glean.initialize(
-            applicationContext = ApplicationProvider.getApplicationContext()
+            applicationContext = ApplicationProvider.getApplicationContext(),
+            configuration = Configuration(applicationId = "test")
         )
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -32,7 +32,7 @@ import java.net.MalformedURLException
 class HttpPingUploaderTest {
     private val testPath: String = "/some/random/path/not/important"
     private val testPing: String = "{ 'ping': 'test' }"
-    private val testDefaultConfig = Configuration().copy(
+    private val testDefaultConfig = Configuration(applicationId = "test").copy(
         userAgent = "Glean/Test 25.0.2",
         connectionTimeout = 3050,
         readTimeout = 7050

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -20,7 +20,7 @@ class GleanApplication : Application() {
 
         // Initialize the Glean library. Ideally, this is the first thing that
         // must be done right after enabling logging.
-        Glean.initialize(applicationContext, Configuration())
+        Glean.initialize(applicationContext, Configuration(applicationId = "glean"))
 
         // Set a sample value for a metric.
         GleanMetrics.Basic.os.set("Android")


### PR DESCRIPTION
We need the concept of 'app_id' to tell data streams apart on the pipeline side. This PR adds the field and
changes the glean initialization so that the application is required to provide one.