### PR TITLE
Closes #1300: Intermittent failure in BrowserAwesomeBarTest [#5]

### DIFF
--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.awesomebar
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.awesomebar.AwesomeBar
@@ -190,12 +191,13 @@ class BrowserAwesomeBarTest {
 
                     try {
                         // We can only escape this by cancelling the coroutine
-                        while (true) {
+                        while (isActive) {
                             delay(10)
                         }
                     } finally {
                         firstProviderCallCancelled = true
                     }
+                    return emptyList()
                 }
             }
 


### PR DESCRIPTION
Basically this comment on `scheduleResumeAfterDelay`: `Continuation **must be scheduled** to resume even if it is already cancelled,...`

Made me think if it was possible we cancelled the `Job` in between calls to `delay` so instead of an infinite loop I am testing for `isActive`. Let's see if this makes a difference.

