### PR TITLE
[glean] 1512947: Upgrade JetBrains Python plugin to 0.0.26..

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -23,7 +23,7 @@ of the main `build.gradle` file.
 
 ```Groovy
 plugins {
-    id "com.jetbrains.python.envs" version "0.0.25"
+    id "com.jetbrains.python.envs" version "0.0.26"
 }
 ```
 

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 plugins {
-    id "com.jetbrains.python.envs" version "0.0.25"
+    id "com.jetbrains.python.envs" version "0.0.26"
 }
 
 apply plugin: 'com.android.library'

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -53,24 +53,6 @@ envs {
     conda "Miniconda3", "Miniconda3-latest", "64", ["glean_parser==${GLEAN_PARSER_VERSION}"]
 }
 
-// Setup the python environment before the build starts.
-
-task createBuildDir {
-    description = "Make sure the build dir exists before creating the Python Environments"
-    onlyIf {
-        !file(buildDir).exists()
-    }
-    doLast {
-        println "Creating build directory:" + buildDir.getPath()
-        buildDir.mkdir()
-    }
-}
-
-// Make sure that a build directory exists before attempting to download
-// the Python environment in the preBuild step. This will fail if the directory
-// doesn't exist. This is an issue with the gradle-python-envs plugin:
-// https://github.com/JetBrains/gradle-python-envs/issues/26
-preBuild.dependsOn(createBuildDir)
 preBuild.finalizedBy("build_envs")
 
 // Generate the Metrics API

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 plugins {
-    id "com.jetbrains.python.envs" version "0.0.25"
+    id "com.jetbrains.python.envs" version "0.0.26"
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
This allows us to remove the workaround to forcibly create the build directory first.