### PR TITLE
Improvements around FirefoxSyncFeature state management and ergonomics.

### DIFF
--- a/components/feature/sync/src/test/java/mozilla/components/feature/sync/FirefoxSyncFeatureTest.kt
+++ b/components/feature/sync/src/test/java/mozilla/components/feature/sync/FirefoxSyncFeatureTest.kt
@@ -5,10 +5,10 @@
 package mozilla.components.feature.sync
 
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.SyncError
 import mozilla.components.concept.storage.SyncOk
+import mozilla.components.concept.storage.SyncStatus
 import mozilla.components.concept.storage.SyncableStore
 import mozilla.components.service.fxa.AccessTokenInfo
 import mozilla.components.service.fxa.FirefoxAccountShaped
@@ -16,11 +16,14 @@ import mozilla.components.service.fxa.OAuthScopedKey
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.Assert.assertTrue
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import java.lang.Exception
-import java.util.concurrent.Executors
 
 class FirefoxSyncFeatureTest {
     data class TestAuthType(
@@ -34,19 +37,15 @@ class FirefoxSyncFeatureTest {
         return TestAuthType(this.kid, this.fxaAccessToken, this.syncKey, this.tokenServerUrl)
     }
 
-    private val testContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-
     @Test
     fun `sync with no stores`() = runBlocking {
-        val feature = FirefoxSyncFeature(testContext) { it.into() }
-        val results = feature.sync(mock()).await()
+        val feature = FirefoxSyncFeature(mapOf()) { it.into() }
+        val results = feature.sync(mock())
         assertTrue(results.isEmpty())
     }
 
     @Test
     fun `sync with configured stores`() = runBlocking {
-        val feature = FirefoxSyncFeature(testContext) { it.into() }
-
         val mockAccount: FirefoxAccountShaped = mock()
         `when`(mockAccount.getTokenServerEndpointURL()).thenReturn("dummyUrl")
 
@@ -57,15 +56,15 @@ class FirefoxSyncFeatureTest {
 
         // Single store, different result types.
         val testStore: SyncableStore<TestAuthType> = mock()
-        feature.addSyncable("testStore", testStore)
+        val feature = FirefoxSyncFeature(mapOf("testStore" to testStore)) { it.into() }
 
         `when`(testStore.sync(any())).thenReturn(SyncOk)
-        var results = feature.sync(mockAccount).await()
+        var results = feature.sync(mockAccount)
         assertTrue(results["testStore"]!!.status is SyncOk)
         assertEquals(1, results.size)
 
         `when`(testStore.sync(any())).thenReturn(SyncError(Exception("test")))
-        results = feature.sync(mockAccount).await()
+        results = feature.sync(mockAccount)
         var error = results["testStore"]!!.status
         assertTrue(error is SyncError)
         assertEquals("test", (error as SyncError).exception.message)
@@ -73,15 +72,70 @@ class FirefoxSyncFeatureTest {
 
         // Multiple stores, different result types.
         val anotherStore: SyncableStore<TestAuthType> = mock()
-        feature.addSyncable("goodStore", anotherStore)
+        val anotherFeature = FirefoxSyncFeature(mapOf(
+            Pair("testStore", testStore),
+            Pair("goodStore", anotherStore))
+        ) { it.into() }
 
         `when`(anotherStore.sync(any())).thenReturn(SyncOk)
 
-        results = feature.sync(mockAccount).await()
+        results = anotherFeature.sync(mockAccount)
         assertEquals(2, results.size)
         error = results["testStore"]!!.status
         assertTrue(error is SyncError)
         assertEquals("test", (error as SyncError).exception.message)
         assertTrue(results["goodStore"]!!.status is SyncOk)
+    }
+
+    @Test
+    fun `sync status can be observed`() = runBlocking {
+        val mockAccount: FirefoxAccountShaped = mock()
+        `when`(mockAccount.getTokenServerEndpointURL()).thenReturn("dummyUrl")
+
+        val mockAccessTokenInfo = AccessTokenInfo(
+                key = OAuthScopedKey("kid", "k"), token = "token", expiresAt = 0
+        )
+        `when`(mockAccount.getAccessToken(any())).thenReturn(CompletableDeferred((mockAccessTokenInfo)))
+
+        val verifier = object {
+            private val blocks = mutableListOf<() -> Unit>()
+
+            fun addVerifyBlock(block: () -> Unit) {
+                blocks.add(block)
+            }
+
+            fun verify() {
+                blocks.forEach { it() }
+            }
+        }
+
+        // A store that runs verifications during a sync.
+        val testStore = object : SyncableStore<TestAuthType> {
+            override suspend fun sync(authInfo: TestAuthType): SyncStatus {
+                verifier.verify()
+                return SyncOk
+            }
+        }
+        val syncStatusObserver: SyncStatusObserver = mock()
+
+        val feature = FirefoxSyncFeature(mapOf("testStore" to testStore)) { it.into() }
+
+        // These assertions will run while sync is in progress.
+        verifier.addVerifyBlock {
+            assertTrue(feature.syncRunning())
+            verify(syncStatusObserver, times(1)).onStarted()
+            verify(syncStatusObserver, never()).onIdle()
+        }
+
+        feature.register(syncStatusObserver)
+        verify(syncStatusObserver, never()).onStarted()
+        verify(syncStatusObserver, never()).onIdle()
+        assertFalse(feature.syncRunning())
+
+        feature.sync(mockAccount)
+
+        verify(syncStatusObserver, times(1)).onStarted()
+        verify(syncStatusObserver, times(1)).onIdle()
+        assertFalse(feature.syncRunning())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,14 @@ permalink: /changelog/
 * **sample-browser**
   * Added in-memory browsing history as one of the AwesomeBar data providers.
 
+* **feature-sync**
+  * Simplified error handling. Errors are wrapped in a SyncResult, exceptions are no longer thrown.
+  * `FirefoxSyncFeature`'s constructor now takes a map of `Syncable` instances. That is, the internal list of `Syncables` is no longer mutable.
+  * `sync` is now a `suspend` function. Callers are expected to manage scoping themselves.
+  * Ability to observe "sync is running" and "sync is idle" events vs `SyncStatusObserver` interface.
+  * Ability to query for current sync state (running or idle).
+  * See included `sample-sync-history` application for example usage of these observers.
+
 # 0.34.2
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.34.1...v0.34.2)

--- a/samples/sync-history/src/main/res/layout/activity_main.xml
+++ b/samples/sync-history/src/main/res/layout/activity_main.xml
@@ -48,10 +48,18 @@
         android:text="" />
 
     <TextView
-        android:id="@+id/historySyncResult"
+        android:id="@+id/historySyncStatus"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/fxaStatusView"
+        android:layout_gravity="center"
+        android:text="" />
+
+    <TextView
+        android:id="@+id/historySyncResult"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/historySyncStatus"
         android:layout_gravity="center"
         android:text="" />
 

--- a/samples/sync-history/src/main/res/values/strings.xml
+++ b/samples/sync-history/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="app_name">Firefox Sync History Demo</string>
     <string name="sign_in">FxA sign in</string>
     <string name="signed_in">Signed in: %1$s</string>
+    <string name="sync_idle">Sync is idle</string>
     <string name="syncing">Syncing&#8230;</string>
     <string name="sync_error">Sync error: %1$s</string>
     <plurals name="visited_url_count">


### PR DESCRIPTION
This patch includes a few changes:
- it changes 'sync' to be a 'suspend' function, dropping requirement for a CoroutineContext.
  We are starting to understand what we care about vis-a-vis scopes, so let's make this
  more flexible so that realistic usage patterns may emerge at the consumer level (reference browser).
- it introduces a mutex, which guards sync operation exposed by this feauture.
  We don't want multiple sync operations to be running at once, so the feature shouldn't
  expose that footgun to its users.
- doesn't throw AuthException, instead wrapping it in SyncError. This makes dealing with outcomes
  of sync a bit simpler.
  We still have work to do around unifying errors coming out of PlacesConnection, as some
  of those could be auth-related.
- introduces sync start/stop listeners that can be registered and unregistered. This allows
  for much simpler UI code which needs to reflect sync's internal state.

Sample apps that use the feature are updated accordingly.