### PR TITLE
[glean] Automatically discover the applicationId in glean

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -56,13 +56,10 @@ class SampleApplication : Application() {
 
         // Initialize the Glean library. Ideally, this is the first thing that
         // must be done right after enabling logging.
-        Glean.initialize(applicationContext, Configuration(applicationId = "YOUR_APPLICATION_NAME_HERE"))
+        Glean.initialize(applicationContext)
     }
 }
 ```
-
-**Important:** the `applicationId` will be used to properly route data in the pipeline, so it must be unique.
-The `glean` value is reserved for testing.
 
 Once initialized, if collection is enabled, glean will automatically start collecting [baseline metrics](metrics.yaml)
 and sending its [pings](docs/pings.md).

--- a/components/service/glean/docs/pings.md
+++ b/components/service/glean/docs/pings.md
@@ -44,3 +44,13 @@ This object contains experiments keyed by the experiment `id`. Each listed exper
 }
 ```
 
+## Ping submission
+The pings glean generates are submitted to the Mozilla servers at specific paths, in order to provide
+additional metadata without the need of unpacking the ping payload. A typical submission URL looks like
+`"<server-address>/submit/<application-id>/<doc-type>/<glean-schema-version>/<ping-uuid>"`, with:
+ 
+- `<server-address>`: the address of the server that receives the pings;
+- `<application-id>`: a unique application id, automatically detected by glean; this is the value returned by [`Context.getPackageName()`](http://developer.android.com/reference/android/content/Context.html#getPackageName());
+- `<doc-type>`: the name of the ping; this can be one of the pings available out of the box with glean, or a custom ping;
+- `<glean-schema-version>`: the version of the glean ping schema;
+- `<ping-uuid>`: a unique identifier for this ping.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -42,6 +42,10 @@ open class GleanInternalAPI {
     internal var initialized = false
     private var metricsEnabled = true
 
+    // The application id detected by glean to be used as part of the submission
+    // endpoint.
+    internal lateinit var applicationId: String
+
     /**
      * Initialize glean.
      *
@@ -53,7 +57,10 @@ open class GleanInternalAPI {
      * @param configuration A Glean [Configuration] object with global settings.
      * @raises Exception if called more than once
      */
-    fun initialize(applicationContext: Context, configuration: Configuration) {
+    fun initialize(
+        applicationContext: Context,
+        configuration: Configuration = Configuration()
+    ) {
         if (isInitialized()) {
             throw IllegalStateException("Glean may not be initialized multiple times")
         }
@@ -63,6 +70,7 @@ open class GleanInternalAPI {
         this.configuration = configuration
         httpPingUploader = HttpPingUploader(configuration)
         initialized = true
+        applicationId = applicationContext.packageName
 
         initializeCoreMetrics(applicationContext)
 
@@ -131,7 +139,7 @@ open class GleanInternalAPI {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun makePath(docType: String, uuid: UUID): String {
-        return "/submit/${configuration.applicationId}/$docType/${Glean.SCHEMA_VERSION}/$uuid"
+        return "/submit/$applicationId/$docType/${Glean.SCHEMA_VERSION}/$uuid"
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -9,7 +9,6 @@ import mozilla.components.service.glean.BuildConfig
 /**
  * The Configuration class describes how to configure the Glean.
  *
- * @property applicationId a unique identifier for the application (e.g. "reference-browser")
  * @property serverEndpoint the server pings are sent to
  * @property userAgent the user agent used when sending pings
  * @property connectionTimeout the timeout, in milliseconds, to use when connecting to
@@ -19,7 +18,6 @@ import mozilla.components.service.glean.BuildConfig
  * @property maxEvents the number of events to store before the events ping is sent
  */
 data class Configuration(
-    val applicationId: String,
     val serverEndpoint: String = "https://incoming.telemetry.mozilla.org",
     val userAgent: String = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)",
     val connectionTimeout: Int = 10000,

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean
 import android.os.SystemClock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.storages.EventsStorageEngine
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -29,6 +30,8 @@ class EventMetricTypeTest {
     @Before
     fun setUp() {
         Glean.initialized = true
+        Glean.applicationId = "test"
+        Glean.configuration = Configuration()
         EventsStorageEngine.clearAllStores()
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -32,7 +32,7 @@ import java.net.MalformedURLException
 class HttpPingUploaderTest {
     private val testPath: String = "/some/random/path/not/important"
     private val testPing: String = "{ 'ping': 'test' }"
-    private val testDefaultConfig = Configuration(applicationId = "test").copy(
+    private val testDefaultConfig = Configuration().copy(
         userAgent = "Glean/Test 25.0.2",
         connectionTimeout = 3050,
         readTimeout = 7050

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -3,10 +3,10 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
 import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.checkPingSchema
-import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.FakeDispatchersInTest
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.EventMetricType
@@ -33,8 +33,7 @@ class EventsStorageEngineTest {
     fun setUp() {
         Glean.initialized = false
         Glean.initialize(
-            applicationContext = ApplicationProvider.getApplicationContext(),
-            configuration = Configuration(applicationId = "test")
+            applicationContext = ApplicationProvider.getApplicationContext()
         )
         assert(Glean.initialized)
         EventsStorageEngine.clearAllStores()
@@ -204,7 +203,8 @@ class EventsStorageEngineTest {
             }
 
             val request = server.takeRequest()
-            assert(request.path.startsWith("/submit/test/events/${Glean.SCHEMA_VERSION}/"))
+            val applicationId = ApplicationProvider.getApplicationContext<Context>().packageName
+            assert(request.path.startsWith("/submit/$applicationId/events/${Glean.SCHEMA_VERSION}/"))
             val eventsJsonData = request.body.readUtf8()
             val eventsJson = JSONObject(eventsJsonData)
             val eventsArray = eventsJson.getJSONArray("events")!!

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -6,7 +6,6 @@ package org.mozilla.samples.glean
 
 import android.app.Application
 import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
 
@@ -20,7 +19,7 @@ class GleanApplication : Application() {
 
         // Initialize the Glean library. Ideally, this is the first thing that
         // must be done right after enabling logging.
-        Glean.initialize(applicationContext, Configuration(applicationId = "glean"))
+        Glean.initialize(applicationContext)
 
         // Set a sample value for a metric.
         GleanMetrics.Basic.os.set("Android")


### PR DESCRIPTION
This changes the glean initialization so that a default `applicationId` is discovered and provided as the default
parameter for the configuration. This additionally fixes tests and the documentation.

This leaves the configuration option in place for supporting applications that might need to tweak this id value (e.g. Focus/Klar like)