### PR TITLE
Issue #1085: FirefoxAccount no longer needs to be a Deferred type..

### DIFF
--- a/components/service/firefox-accounts/README.md
+++ b/components/service/firefox-accounts/README.md
@@ -25,8 +25,6 @@ implementation "org.mozilla.components:service-firefox-accounts:{latest-version}
 
 ### Start coding
 
-> This tutorial is for version 0.15 of the FxA client.
-
 First you need some OAuth information. Generate a `client_id`, `redirectUrl` and find out the scopes for your application.
 See Firefox Account documentation for that.
 

--- a/samples/firefox-accounts/README.md
+++ b/samples/firefox-accounts/README.md
@@ -27,7 +27,7 @@ To restore an account from an existing state in shared preferences:
 ```kotlin
 // Inside a `launch` or `async` block:
 getSharedPreferences(FXA_STATE_PREFS_KEY, Context.MODE_PRIVATE).getString(FXA_STATE_KEY, "").let {
-	FirefoxAccount.fromJSONString(it).await()
+	FirefoxAccount.fromJSONString(it)
 }
 ```
 

--- a/samples/sync-logins/src/main/java/org/mozilla/samples/sync/logins/MainActivity.kt
+++ b/samples/sync-logins/src/main/java/org/mozilla/samples/sync/logins/MainActivity.kt
@@ -13,12 +13,10 @@ import android.widget.ArrayAdapter
 import android.widget.ListView
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.SyncError
 import mozilla.components.feature.sync.FirefoxSyncFeature
 import mozilla.components.service.fxa.Config
@@ -57,7 +55,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
     private lateinit var listView: ListView
     private lateinit var adapter: ArrayAdapter<String>
     private lateinit var activityContext: MainActivity
-    private lateinit var whenAccount: Deferred<FirefoxAccount>
+    private lateinit var account: FirefoxAccount
 
     private lateinit var job: Job
     override val coroutineContext: CoroutineContext
@@ -79,18 +77,11 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
         adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1)
         listView.adapter = adapter
         activityContext = this
-
-        whenAccount = async {
-            getAuthenticatedAccount()?.let {
-                return@async it
-            }
-
-            FirefoxAccount(Config.release(CLIENT_ID, REDIRECT_URL))
-        }
+        account = getAuthenticatedAccount() ?: FirefoxAccount(Config.release(CLIENT_ID, REDIRECT_URL))
 
         findViewById<View>(R.id.buttonWebView).setOnClickListener {
             launch {
-                val url = whenAccount.await().beginOAuthFlow(scopes, wantsKeys).await()
+                val url = account.beginOAuthFlow(scopes, wantsKeys).await()
                 openWebView(url)
             }
         }
@@ -109,7 +100,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
 
     override fun onDestroy() {
         super.onDestroy()
-        runBlocking { whenAccount.await().close() }
+        account.close()
         job.cancel()
     }
 
@@ -123,8 +114,6 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
 
     override fun onLoginComplete(code: String, state: String, fragment: LoginFragment) {
         launch {
-            val account = whenAccount.await()
-
             account.completeOAuthFlow(code, state).await()
             account.toJSONString().let {
                 getSharedPreferences(FXA_STATE_PREFS_KEY, Context.MODE_PRIVATE)


### PR DESCRIPTION
This is just some cleanup we forgot after applying the changes for #1085. Now that creating a `Config` and `toJSONString`/`fromJSONString` are no longer async we don't need to use a `Deferred` for `FirefoxAccount`.

It gets rid of a bunch of unneeded `await` calls and also removes the potential deadlocking code on `onDestroy`.

The reference browser is already updated.

More improvements on the way in:
https://github.com/mozilla/application-services/issues/483
