### PR TITLE
[glean] Update PingMaker.kt to remove format specifier not supported in Android SDK-21

### DIFF
--- a/components/service/glean/docs/pings.md
+++ b/components/service/glean/docs/pings.md
@@ -21,12 +21,30 @@ The following fields are always included in the `ping_info` section, for every p
 | `client_id` | UUID |  A UUID identifying a profile and allowing user-oriented correlation of data |
 | `seq` | Counter | A running counter of the number of times pings of this type have been sent |
 | `experiments` | Object | A dictionary of [active experiments](#the-experiments-object) |
-| `start_time` | Datetime | The time of the start of collection of the data in the ping |
-| `end_time` | Datetime | The time of the end of collection of the data in the ping. This is also the time this ping was generated and is likely well before ping transmission time |
+| `start_time` | Datetime | The time of the start of collection of the data in the ping | See [note](#a-note-about-time-formats) |
+| `end_time` | Datetime | The time of the end of collection of the data in the ping. This is also the time this ping was generated and is likely well before ping transmission time | See [note](#a-note-about-time-formats) |
 | `profile_age` | Datetime | TBD |
 
 All the metrics surviving application restarts (e.g. `client_id`, `seq`, ...) are removed once the
 application using glean is uninstalled.
+
+### A note about time formats
+Time formats are used and expected in ISO 8601 format.  Due to the minimum Android SDK version 21
+not having direct support of outputting or parsing these formats, there was difficulty in finding
+a way to output these formats with the `:` character properly encoded in the timezone offset.  So
+we get the following:
+
+```
+2018-12-19T12:36-0600
+```
+
+We require the following to comply with certain back-end services:
+
+```
+2018-12-19T12:36-06:00
+```
+
+Which is why the `:` is manually inserted in order to comply with the format and requirements.
 
 ### The `experiments` object
 This object contains experiments keyed by the experiment `id`. Each listed experiment contains the

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -12,6 +12,7 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.org.json.mergeWith
 import org.json.JSONException
 import org.json.JSONObject
+import java.lang.StringBuilder
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -29,8 +30,18 @@ internal class PingMaker(
      * @return a string containing the date and time.
      */
     private fun getISOTimeString(): String {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX", Locale.US)
-        return dateFormat.format(Date())
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ", Locale.US)
+        val timeString = StringBuilder(dateFormat.format(Date()))
+
+        // Due to limitations of SDK version 21, there isn't a way to properly output the time
+        // offset with a ':' character:
+        // 2018-12-19T12:36-0600    --  This is what we get
+        // 2018-12-19T12:36-06:00   -- This is what GCP will expect
+        //
+        // In order to satisfy time offset requirements of GCP, we manually insert the ":"
+        timeString.insert(timeString.length - 2, ":")
+
+        return timeString.toString()
     }
 
     /**

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
@@ -27,6 +28,7 @@ class PingMakerTest {
     private val mockApplicationContext = mock(Context::class.java)
 
     @Test
+    @Config(minSdk = 21)
     fun `"ping_info" must contain a non-empty start_time and end_time`() {
         val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
                 "engine2" to MockStorageEngine(JSONObject())
@@ -47,7 +49,7 @@ class PingMakerTest {
         DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(pingInfo.getString("end_time"))
         OffsetDateTime.parse(pingInfo.getString("start_time"))
         assertTrue(OffsetDateTime.parse(pingInfo.getString("start_time"))
-            >= OffsetDateTime.parse(pingInfo.getString("end_time")))
+            <= OffsetDateTime.parse(pingInfo.getString("end_time")))
     }
 
     @Test


### PR DESCRIPTION
SimpleDateFormat, prior to SDK 24 does not support format specifier 'X' to output the time zone offset.  Switched to use format specifier 'Z' which is supported, although slightly different in it's output.  Instead of hh:mm it outputs hhmm for the timezone offset.  In light of this, I had to alter the tests as DateTimeFormatter.ISO_OFFSET_DATE_TIME is strict in requiring the ':' even though the actual ISO8601 spec is not.  This should allow us to fully support the specified minimum SDK version for both android-components, and the reference browser.