### PR TITLE
Issue #1541: feature-session-bundling: New component that saves sessions in grouped bundles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ _Combined components to implement feature-specific use cases._
 
 * ⚪ [**Session**](components/feature/session/README.md) - A component that connects an (concept) engine implementation with the browser session and storage modules.
 
+* 🔴 [**Session-Bundling**](components/feature/session-bundling/README.md) - A session storage implementation that saves the state of sessions in grouped bundles (e.g. by time) in a database.
+
 * 🔴 [**Sync**](components/feature/sync/README.md) -A component that provides synchronization orchestration for groups of (concept) SyncableStore objects.
 
 * 🔴 [**Tabs**](components/feature/tabs/README.md) - A component that connects a tabs tray implementation with the session and toolbar modules.

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/AutoSave.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/AutoSave.kt
@@ -1,0 +1,211 @@
+package mozilla.components.browser.session.storage
+
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.OnLifecycleEvent
+import android.arch.lifecycle.ProcessLifecycleOwner
+import android.os.SystemClock
+import android.support.annotation.VisibleForTesting
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.session.SelectionAwareSessionObserver
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.support.base.log.logger.Logger
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+class AutoSave(
+    private val sessionManager: SessionManager,
+    private val sessionStorage: Storage,
+    private val minimumIntervalMs: Long
+) {
+    interface Storage {
+        fun save(snapshot: SessionManager.Snapshot): Boolean
+    }
+
+    internal val logger = Logger("SessionStorage/AutoSave")
+    internal var saveJob: Job? = null
+    private var lastSaveTimestamp: Long = now()
+
+    /**
+     * Saves the state periodically when the app is in the foreground.
+     *
+     * @param interval The interval in which the state should be saved to disk.
+     * @param unit The time unit of the [interval] parameter.
+     */
+    fun periodicallyInForeground(
+        interval: Long = 300,
+        unit: TimeUnit = TimeUnit.SECONDS,
+        scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+        lifecycle: Lifecycle = ProcessLifecycleOwner.get().lifecycle
+    ): AutoSave {
+        lifecycle.addObserver(
+            AutoSavePeriodically(
+                this,
+                scheduler,
+                interval,
+                unit
+            )
+        )
+        return this
+    }
+
+    /**
+     * Saves the state automatically when the app goes to the background.
+     */
+    fun whenGoingToBackground(
+        lifecycle: Lifecycle = ProcessLifecycleOwner.get().lifecycle
+    ): AutoSave {
+        lifecycle.addObserver(AutoSaveBackground(this))
+        return this
+    }
+
+    /**
+     * Saves the state automatically when the sessions change, e.g. sessions get added and removed.
+     */
+    fun whenSessionsChange(): AutoSave {
+        AutoSaveSessionChange(
+            this,
+            sessionManager
+        ).observeSelected()
+        return this
+    }
+
+    /**
+     * Triggers saving the current state to disk.
+     *
+     * This method will not schedule a new save job if a job is already in flight. Additionally it will obey the
+     * interval passed to [SessionStorage.autoSave]; job may get delayed.
+     *
+     * @param delaySave Whether to delay the save job to obey the interval passed to [SessionStorage.autoSave].
+     */
+    @Synchronized
+    internal fun triggerSave(delaySave: Boolean = true): Job {
+        val currentJob = saveJob
+
+        if (currentJob != null && currentJob.isActive) {
+            logger.debug("Skipping save, other job already in flight")
+            return currentJob
+        }
+
+        val now = now()
+        val delayMs = lastSaveTimestamp + minimumIntervalMs - now
+        lastSaveTimestamp = now
+
+        GlobalScope.launch(Dispatchers.IO) {
+            if (delaySave && delayMs > 0) {
+                logger.debug("Delaying save (${delayMs}ms)")
+                delay(delayMs)
+            }
+
+            val start = now()
+
+            try {
+                val snapshot = sessionManager.createSnapshot()
+                if (snapshot != null) {
+                    sessionStorage.save(snapshot)
+                }
+            } finally {
+                val took = now() - start
+                logger.debug("Saved state to disk [${took}ms]")
+            }
+        }.also {
+            saveJob = it
+            return it
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun now() = SystemClock.elapsedRealtime()
+
+    companion object {
+        // Minimum interval between saving states.
+        const val DEFAULT_INTERVAL_MILLISECONDS = 2000L
+    }
+}
+
+/**
+ * [LifecycleObserver] to start/stop a task that saves the state at a periodic interval.
+ */
+private class AutoSavePeriodically(
+    private val autoSave: AutoSave,
+    private val scheduler: ScheduledExecutorService,
+    private val interval: Long,
+    private val unit: TimeUnit
+) : LifecycleObserver {
+    private var scheduledFuture: ScheduledFuture<*>? = null
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    fun start() {
+        scheduledFuture = scheduler.scheduleAtFixedRate(
+            {
+                autoSave.logger.info("Save: Periodic")
+                autoSave.triggerSave()
+            },
+            interval,
+            interval,
+            unit
+        )
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun stop() {
+        scheduledFuture?.cancel(false)
+    }
+}
+
+/**
+ * [LifecycleObserver] to save the state when the app goes to the background.
+ */
+private class AutoSaveBackground(
+    private val autoSave: AutoSave
+) : LifecycleObserver {
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun stop() {
+        autoSave.logger.info("Save: Background")
+
+        runBlocking {
+            // Since the app is going to the background and can get killed at any time, we do not want to delay saving
+            // the state to disk.
+            autoSave.triggerSave(delaySave = false).join()
+        }
+    }
+}
+
+/**
+ * [SelectionAwareSessionObserver] to save the state whenever sessions change.
+ */
+private class AutoSaveSessionChange(
+    private val autoSave: AutoSave,
+    sessionManager: SessionManager
+) : SelectionAwareSessionObserver(sessionManager) {
+    override fun onSessionSelected(session: Session) {
+        super.onSessionSelected(session)
+        autoSave.logger.info("Save: Session selected")
+        autoSave.triggerSave()
+    }
+
+    override fun onLoadingStateChanged(session: Session, loading: Boolean) {
+        if (!loading) {
+            autoSave.logger.info("Save: Load finished")
+            autoSave.triggerSave()
+        }
+    }
+
+    override fun onSessionAdded(session: Session) {
+        autoSave.logger.info("Save: Session added")
+        autoSave.triggerSave()
+    }
+
+    override fun onSessionRemoved(session: Session) {
+        autoSave.logger.info("Save: Session removed")
+        autoSave.triggerSave()
+    }
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SessionStorage.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SessionStorage.kt
@@ -4,45 +4,20 @@
 
 package mozilla.components.browser.session.storage
 
-import android.arch.lifecycle.Lifecycle
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
-import android.arch.lifecycle.ProcessLifecycleOwner
 import android.content.Context
-import android.os.SystemClock
 import android.support.annotation.CheckResult
 import android.support.annotation.VisibleForTesting
 import android.support.annotation.WorkerThread
 import android.util.AtomicFile
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import mozilla.components.browser.session.SelectionAwareSessionObserver
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
-import mozilla.components.support.base.log.logger.Logger
-import org.json.JSONArray
 import org.json.JSONException
-import org.json.JSONObject
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
 private const val STORE_FILE_NAME_FORMAT = "mozilla_components_session_storage_%s.json"
-
-// Current version of the format used [SessionStorage].
-private const val VERSION = 1
-
-// Minimum interval between saving states.
-private const val DEFAULT_INTERVAL_MILLISECONDS = 2000L
 
 private val sessionFileLock = Any()
 
@@ -52,12 +27,14 @@ private val sessionFileLock = Any()
 class SessionStorage(
     private val context: Context,
     private val engine: Engine
-) {
+) : AutoSave.Storage {
+    private val serializer = SnapshotSerializer()
+
     /**
      * Reads the saved state from disk. Returns null if no state was found on disk or if reading the file failed.
      */
     fun restore(): SessionManager.Snapshot? {
-        return readSnapshotFromDisk(getFileForEngine(context, engine), engine)
+        return readSnapshotFromDisk(getFileForEngine(context, engine), serializer, engine)
     }
 
     /**
@@ -71,13 +48,13 @@ class SessionStorage(
      * Saves the given state to disk.
      */
     @WorkerThread
-    fun save(snapshot: SessionManager.Snapshot): Boolean {
+    override fun save(snapshot: SessionManager.Snapshot): Boolean {
         if (snapshot.isEmpty()) {
             clear()
             return true
         }
 
-        return saveSnapshotToDisk(getFileForEngine(context, engine), snapshot)
+        return saveSnapshotToDisk(getFileForEngine(context, engine), serializer, snapshot)
     }
 
     /**
@@ -86,232 +63,48 @@ class SessionStorage(
     @CheckResult
     fun autoSave(
         sessionManager: SessionManager,
-        interval: Long = DEFAULT_INTERVAL_MILLISECONDS,
+        interval: Long = AutoSave.DEFAULT_INTERVAL_MILLISECONDS,
         unit: TimeUnit = TimeUnit.MILLISECONDS
     ): AutoSave {
         return AutoSave(sessionManager, this, unit.toMillis(interval))
     }
 }
 
-class AutoSave(
-    private val sessionManager: SessionManager,
-    private val sessionStorage: SessionStorage,
-    private val minimumIntervalMs: Long
-) {
-    internal val logger = Logger("SessionStorage/AutoSave")
-    internal var saveJob: Job? = null
-    private var lastSaveTimestamp: Long = now()
-
-    /**
-     * Saves the state periodically when the app is in the foreground.
-     *
-     * @param interval The interval in which the state should be saved to disk.
-     * @param unit The time unit of the [interval] parameter.
-     */
-    fun periodicallyInForeground(
-        interval: Long = 300,
-        unit: TimeUnit = TimeUnit.SECONDS,
-        scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
-        lifecycle: Lifecycle = ProcessLifecycleOwner.get().lifecycle
-    ): AutoSave {
-        lifecycle.addObserver(AutoSavePeriodically(this, scheduler, interval, unit))
-        return this
-    }
-
-    /**
-     * Saves the state automatically when the app goes to the background.
-     */
-    fun whenGoingToBackground(
-        lifecycle: Lifecycle = ProcessLifecycleOwner.get().lifecycle
-    ): AutoSave {
-        lifecycle.addObserver(AutoSaveBackground(this))
-        return this
-    }
-
-    /**
-     * Saves the state automatically when the sessions change, e.g. sessions get added and removed.
-     */
-    fun whenSessionsChange(): AutoSave {
-        AutoSaveSessionChange(
-            this,
-            sessionManager
-        ).observeSelected()
-        return this
-    }
-
-    /**
-     * Triggers saving the current state to disk.
-     *
-     * This method will not schedule a new save job if a job is already in flight. Additionally it will obey the
-     * interval passed to [SessionStorage.autoSave]; job may get delayed.
-     *
-     * @param delaySave Whether to delay the save job to obey the interval passed to [SessionStorage.autoSave].
-     */
-    @Synchronized
-    internal fun triggerSave(delaySave: Boolean = true): Job {
-        val currentJob = saveJob
-
-        if (currentJob != null && currentJob.isActive) {
-            logger.debug("Skipping save, other job already in flight")
-            return currentJob
-        }
-
-        val now = now()
-        val delayMs = lastSaveTimestamp + minimumIntervalMs - now
-        lastSaveTimestamp = now
-
-        GlobalScope.launch(Dispatchers.IO) {
-            if (delaySave && delayMs > 0) {
-                logger.debug("Delaying save (${delayMs}ms)")
-                delay(delayMs)
-            }
-
-            val start = now()
-
-            try {
-                val snapshot = sessionManager.createSnapshot()
-                if (snapshot != null) {
-                    sessionStorage.save(snapshot)
-                }
-            } finally {
-                val took = now() - start
-                logger.debug("Saved state to disk [${took}ms]")
-            }
-        }.also {
-            saveJob = it
-            return it
-        }
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun now() = SystemClock.elapsedRealtime()
-}
-
-/**
- * [LifecycleObserver] to start/stop a task that saves the state at a periodic interval.
- */
-private class AutoSavePeriodically(
-    private val autoSave: AutoSave,
-    private val scheduler: ScheduledExecutorService,
-    private val interval: Long,
-    private val unit: TimeUnit
-) : LifecycleObserver {
-    private var scheduledFuture: ScheduledFuture<*>? = null
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun start() {
-        scheduledFuture = scheduler.scheduleAtFixedRate(
-            {
-                autoSave.logger.info("Save: Periodic")
-                autoSave.triggerSave()
-            },
-            interval,
-            interval,
-            unit
-        )
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun stop() {
-        scheduledFuture?.cancel(false)
-    }
-}
-
-/**
- * [LifecycleObserver] to save the state when the app goes to the background.
- */
-private class AutoSaveBackground(
-    private val autoSave: AutoSave
-) : LifecycleObserver {
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun stop() {
-        autoSave.logger.info("Save: Background")
-
-        runBlocking {
-            // Since the app is going to the background and can get killed at any time, we do not want to delay saving
-            // the state to disk.
-            autoSave.triggerSave(delaySave = false).join()
-        }
-    }
-}
-
-/**
- * [SelectionAwareSessionObserver] to save the state whenever sessions change.
- */
-private class AutoSaveSessionChange(
-    private val autoSave: AutoSave,
-    sessionManager: SessionManager
-) : SelectionAwareSessionObserver(sessionManager) {
-    override fun onSessionSelected(session: Session) {
-        super.onSessionSelected(session)
-        autoSave.logger.info("Save: Session selected")
-        autoSave.triggerSave()
-    }
-
-    override fun onLoadingStateChanged(session: Session, loading: Boolean) {
-        if (!loading) {
-            autoSave.logger.info("Save: Load finished")
-            autoSave.triggerSave()
-        }
-    }
-
-    override fun onSessionAdded(session: Session) {
-        autoSave.logger.info("Save: Session added")
-        autoSave.triggerSave()
-    }
-
-    override fun onSessionRemoved(session: Session) {
-        autoSave.logger.info("Save: Session removed")
-        autoSave.triggerSave()
-    }
-}
-
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @Suppress("ReturnCount")
-internal fun readSnapshotFromDisk(file: AtomicFile, engine: Engine): SessionManager.Snapshot? {
+internal fun readSnapshotFromDisk(
+    file: AtomicFile,
+    serializer: SnapshotSerializer,
+    engine: Engine
+): SessionManager.Snapshot? {
     synchronized(sessionFileLock) {
-        val tuples: MutableList<SessionManager.Snapshot.Item> = mutableListOf()
-        var selectedSessionIndex = 0
 
         try {
             file.openRead().use {
                 val json = it.bufferedReader().use { reader -> reader.readText() }
 
-                val jsonRoot = JSONObject(json)
-                selectedSessionIndex = jsonRoot.getInt(Keys.SELECTED_SESSION_INDEX_KEY)
-                val sessionStateTuples = jsonRoot.getJSONArray(Keys.SESSION_STATE_TUPLES_KEY)
-                for (i in 0 until sessionStateTuples.length()) {
-                    val sessionStateTupleJson = sessionStateTuples.getJSONObject(i)
-                    val session = deserializeSession(sessionStateTupleJson.getJSONObject(Keys.SESSION_KEY))
-                    val state = engine.createSessionState(sessionStateTupleJson.getJSONObject(Keys.ENGINE_SESSION_KEY))
+                val snapshot = serializer.fromJSON(engine, json)
 
-                    tuples.add(SessionManager.Snapshot.Item(session, engineSession = null, engineSessionState = state))
+                if (snapshot.isEmpty()) {
+                    return null
                 }
+
+                return snapshot
             }
         } catch (_: IOException) {
             return null
         } catch (_: JSONException) {
             return null
         }
-
-        if (tuples.isEmpty()) {
-            return null
-        }
-
-        // If we see an illegal selected index on disk, reset it to 0.
-        if (tuples.getOrNull(selectedSessionIndex) == null) {
-            selectedSessionIndex = 0
-        }
-
-        return SessionManager.Snapshot(
-            sessions = tuples,
-            selectedSessionIndex = selectedSessionIndex
-        )
     }
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-internal fun saveSnapshotToDisk(file: AtomicFile, snapshot: SessionManager.Snapshot): Boolean {
+internal fun saveSnapshotToDisk(
+    file: AtomicFile,
+    serializer: SnapshotSerializer,
+    snapshot: SessionManager.Snapshot
+): Boolean {
     require(snapshot.sessions.isNotEmpty()) {
         "SessionsSnapshot must not be empty"
     }
@@ -323,29 +116,10 @@ internal fun saveSnapshotToDisk(file: AtomicFile, snapshot: SessionManager.Snaps
         var outputStream: FileOutputStream? = null
 
         return try {
-            val json = JSONObject()
-            json.put(Keys.VERSION_KEY, VERSION)
-            json.put(Keys.SELECTED_SESSION_INDEX_KEY, snapshot.selectedSessionIndex)
-
-            val sessions = JSONArray()
-            snapshot.sessions.forEachIndexed { index, sessionWithState ->
-                val sessionJson = JSONObject()
-                sessionJson.put(Keys.SESSION_KEY, serializeSession(sessionWithState.session))
-
-                val engineSessionState = if (sessionWithState.engineSessionState != null) {
-                    sessionWithState.engineSessionState.toJSON()
-                } else {
-                    sessionWithState.engineSession?.saveState()?.toJSON() ?: JSONObject()
-                }
-
-                sessionJson.put(Keys.ENGINE_SESSION_KEY, engineSessionState)
-
-                sessions.put(index, sessionJson)
-            }
-            json.put(Keys.SESSION_STATE_TUPLES_KEY, sessions)
+            val json = serializer.toJSON(snapshot)
 
             outputStream = file.startWrite()
-            outputStream.write(json.toString().toByteArray())
+            outputStream.write(json.toByteArray())
             file.finishWrite(outputStream)
             true
         } catch (_: IOException) {
@@ -367,48 +141,4 @@ private fun removeSnapshotFromDisk(context: Context, engine: Engine) {
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal fun getFileForEngine(context: Context, engine: Engine): AtomicFile {
     return AtomicFile(File(context.filesDir, String.format(STORE_FILE_NAME_FORMAT, engine.name()).toLowerCase()))
-}
-
-@Throws(JSONException::class)
-private fun serializeSession(session: Session): JSONObject {
-    return JSONObject().apply {
-        put(Keys.SESSION_URL_KEY, session.url)
-        put(Keys.SESSION_SOURCE_KEY, session.source.name)
-        put(Keys.SESSION_UUID_KEY, session.id)
-        put(Keys.SESSION_PARENT_UUID_KEY, session.parentId ?: "")
-    }
-}
-
-@Throws(JSONException::class)
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-internal fun deserializeSession(json: JSONObject): Session {
-    val source = try {
-        Session.Source.valueOf(json.getString(Keys.SESSION_SOURCE_KEY))
-    } catch (e: IllegalArgumentException) {
-        Session.Source.NONE
-    }
-    val session = Session(
-        json.getString(Keys.SESSION_URL_KEY),
-        // Currently, snapshot cannot contain private sessions.
-        false,
-        source,
-        json.getString(Keys.SESSION_UUID_KEY)
-    )
-    session.parentId = json.getString(Keys.SESSION_PARENT_UUID_KEY).takeIf { it != "" }
-    return session
-}
-
-private object Keys {
-    const val SELECTED_SESSION_INDEX_KEY = "selectedSessionIndex"
-    const val SESSION_STATE_TUPLES_KEY = "sessionStateTuples"
-
-    const val SESSION_SOURCE_KEY = "source"
-    const val SESSION_URL_KEY = "url"
-    const val SESSION_UUID_KEY = "uuid"
-    const val SESSION_PARENT_UUID_KEY = "parentUuid"
-
-    const val SESSION_KEY = "session"
-    const val ENGINE_SESSION_KEY = "engineSession"
-
-    const val VERSION_KEY = "version"
 }

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.storage
+
+import android.support.annotation.VisibleForTesting
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+// Current version of the format used.
+private const val VERSION = 1
+
+/**
+ * Helper to transform [SessionManager.Snapshot] instances to JSON and back.
+ */
+class SnapshotSerializer {
+    fun toJSON(snapshot: SessionManager.Snapshot): String {
+        val json = JSONObject()
+        json.put(Keys.VERSION_KEY, VERSION)
+        json.put(Keys.SELECTED_SESSION_INDEX_KEY, snapshot.selectedSessionIndex)
+
+        val sessions = JSONArray()
+        snapshot.sessions.forEachIndexed { index, sessionWithState ->
+            val sessionJson = JSONObject()
+            sessionJson.put(Keys.SESSION_KEY, serializeSession(sessionWithState.session))
+
+            val engineSessionState = if (sessionWithState.engineSessionState != null) {
+                sessionWithState.engineSessionState.toJSON()
+            } else {
+                sessionWithState.engineSession?.saveState()?.toJSON() ?: JSONObject()
+            }
+
+            sessionJson.put(Keys.ENGINE_SESSION_KEY, engineSessionState)
+
+            sessions.put(index, sessionJson)
+        }
+        json.put(Keys.SESSION_STATE_TUPLES_KEY, sessions)
+
+        return json.toString()
+    }
+
+    fun fromJSON(engine: Engine, json: String): SessionManager.Snapshot {
+        val tuples: MutableList<SessionManager.Snapshot.Item> = mutableListOf()
+
+        val jsonRoot = JSONObject(json)
+        val selectedSessionIndex = jsonRoot.getInt(Keys.SELECTED_SESSION_INDEX_KEY)
+
+        val sessionStateTuples = jsonRoot.getJSONArray(Keys.SESSION_STATE_TUPLES_KEY)
+        for (i in 0 until sessionStateTuples.length()) {
+            val sessionStateTupleJson = sessionStateTuples.getJSONObject(i)
+            val session = deserializeSession(sessionStateTupleJson.getJSONObject(Keys.SESSION_KEY))
+            val state = engine.createSessionState(sessionStateTupleJson.getJSONObject(Keys.ENGINE_SESSION_KEY))
+
+            tuples.add(SessionManager.Snapshot.Item(session, engineSession = null, engineSessionState = state))
+        }
+
+        return SessionManager.Snapshot(
+            sessions = tuples,
+            selectedSessionIndex = selectedSessionIndex
+        )
+    }
+}
+
+@Throws(JSONException::class)
+private fun serializeSession(session: Session): JSONObject {
+    return JSONObject().apply {
+        put(Keys.SESSION_URL_KEY, session.url)
+        put(Keys.SESSION_SOURCE_KEY, session.source.name)
+        put(Keys.SESSION_UUID_KEY, session.id)
+        put(Keys.SESSION_PARENT_UUID_KEY, session.parentId ?: "")
+    }
+}
+
+@Throws(JSONException::class)
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal fun deserializeSession(json: JSONObject): Session {
+    val source = try {
+        Session.Source.valueOf(json.getString(Keys.SESSION_SOURCE_KEY))
+    } catch (e: IllegalArgumentException) {
+        Session.Source.NONE
+    }
+    val session = Session(
+        json.getString(Keys.SESSION_URL_KEY),
+        // Currently, snapshot cannot contain private sessions.
+        false,
+        source,
+        json.getString(Keys.SESSION_UUID_KEY)
+    )
+    session.parentId = json.getString(Keys.SESSION_PARENT_UUID_KEY).takeIf { it != "" }
+    return session
+}
+
+private object Keys {
+    const val SELECTED_SESSION_INDEX_KEY = "selectedSessionIndex"
+    const val SESSION_STATE_TUPLES_KEY = "sessionStateTuples"
+
+    const val SESSION_SOURCE_KEY = "source"
+    const val SESSION_URL_KEY = "url"
+    const val SESSION_UUID_KEY = "uuid"
+    const val SESSION_PARENT_UUID_KEY = "parentUuid"
+
+    const val SESSION_KEY = "session"
+    const val ENGINE_SESSION_KEY = "engineSession"
+
+    const val VERSION_KEY = "version"
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class SessionStorageTest {
-
     @Test
     fun `Restored snapshot should contain sessions of saved snapshot`() {
         val session1 = Session("http://mozilla.org", id = "session1")
@@ -399,7 +398,7 @@ class SessionStorageTest {
             selectedSessionIndex = 0
         )
 
-        saveSnapshotToDisk(file, snapshot)
+        saveSnapshotToDisk(file, SnapshotSerializer(), snapshot)
 
         verify(file).failWrite(any())
     }
@@ -409,7 +408,7 @@ class SessionStorageTest {
         val file: AtomicFile = mock()
         doThrow(FileNotFoundException::class.java).`when`(file).openRead()
 
-        val snapshot = readSnapshotFromDisk(file, engine = mock())
+        val snapshot = readSnapshotFromDisk(file, engine = mock(), serializer = SnapshotSerializer())
         assertNull(snapshot)
     }
 
@@ -421,7 +420,7 @@ class SessionStorageTest {
         stream.bufferedWriter().write("{ name: 'Foo")
         file.finishWrite(stream)
 
-        val snapshot = readSnapshotFromDisk(file, engine = mock())
+        val snapshot = readSnapshotFromDisk(file, engine = mock(), serializer = SnapshotSerializer())
         assertNull(snapshot)
     }
 

--- a/components/feature/session-bundling/README.md
+++ b/components/feature/session-bundling/README.md
@@ -1,0 +1,78 @@
+# [Android Components](../../../README.md) > Feature > Session-Bundling
+
+A session storage implementation that saves the state of sessions in grouped bundles (e.g. by time) in a database.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-session-bundling:{latest-version}"
+```
+
+### Setting up
+
+When creating a `SessionBundleStorage` instance provide a bundle lifetime:
+
+```Kotlin
+val storage = SessionBundleStorage(
+    applicationContext,
+    bundleLifetime = Pair(1, TimeUnit.HOURS))
+```
+
+The provided lifetime will control how long a session bundle is active. The last session bundle will only be restored if it is not older than the provided lifetime. In case that no recent bundle could be found a new empty session bundle will be created.
+
+### Saving state automatically
+
+An app can call `save(SessionManager.Snapshot)` at any time to save a snapshot in the current session bundle. However in most scenarios it is recommended to setup the automatic saving of state:
+
+```Kotlin
+storage.autoSave(sessionManager)
+    .periodicallyInForeground() // interval can be configured
+    .whenGoingToBackground()    // app goes to the background
+    .whenSessionsChange()       // New sessions, pages load, etc.
+```
+
+### Restoring state
+
+Calling `restore()` will restore the last active session bundle if it is still active (lifetime has not expired) or null if no active session bundle is available. This bundle can be used to restore the state of the bundle:
+
+```Kotlin
+val bundle = storage.restore()
+
+bundle?.restoreSnapshot(engine)?.let { snapshot -> restore(snapshot) }
+```
+
+### Working with bundles
+
+The `SessionBundleStorage` class offers multiple methods for accessing and using `SessionBundle` instances:
+
+```Kotlin
+// LiveData list of the last 20 bundles
+val bundles: LiveData<List<SessionBundle>> = storage.bundles(20)
+
+// DataSource.Factory of all saved bundles. A consuming app can transform the
+// data source into a LiveData<PagedList> of when using RxJava2 into a
+// Flowable<PagedList> or `Observable<PagedList>`, that can be observed.
+// Together with Android's paging library this can be used to create a
+// dynamically updating RecyclerView.
+val factory: DataSource.Factory<Int, SessionBundle> = storage.pagedBundles()
+
+// Retrieve the bundle currently used for saving the state
+val current = storage.current()
+
+// Use a specific bundle for saving state
+storage.use(bundle)
+
+// Remove a bundle or all bundles from the storage
+storage.remove(bundle)
+storage.removeAll()
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/session-bundling/build.gradle
+++ b/components/feature/session-bundling/build.gradle
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+
+android {
+    compileSdkVersion Config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas".toString())
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':concept-engine')
+
+    implementation project(':browser-session')
+
+    implementation "android.arch.paging:runtime:1.0.1"
+
+    implementation "android.arch.persistence.room:runtime:1.1.1"
+    kapt "android.arch.persistence.room:compiler:1.1.1"
+    androidTestImplementation "android.arch.persistence.room:testing:1.1.1"
+
+    implementation "android.arch.lifecycle:extensions:1.1.1"
+    kapt "android.arch.lifecycle:compiler:1.1.1"
+
+    testImplementation project(':support-test')
+
+    implementation Dependencies.kotlin_stdlib
+
+    testImplementation Dependencies.testing_androidx
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.kotlin_coroutines
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(Config.componentsGroupId, archivesBaseName, gradle.componentDescriptions[archivesBaseName])

--- a/components/feature/session-bundling/proguard-rules.pro
+++ b/components/feature/session-bundling/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/session-bundling/schemas/mozilla.components.feature.session.bundling.db.BundleDatabase/1.json
+++ b/components/feature/session-bundling/schemas/mozilla.components.feature.session.bundling.db.BundleDatabase/1.json
@@ -1,0 +1,45 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "66b0ab6f143f2da6517902e22ef3c3b2",
+    "entities": [
+      {
+        "tableName": "bundles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `state` TEXT NOT NULL, `saved_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "saved_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"66b0ab6f143f2da6517902e22ef3c3b2\")"
+    ]
+  }
+}

--- a/components/feature/session-bundling/src/main/AndroidManifest.xml
+++ b/components/feature/session-bundling/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.session.bundling" />

--- a/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/SessionBundle.kt
+++ b/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/SessionBundle.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling
+
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+
+/**
+ * A bundle of sessions and their state.
+ */
+interface SessionBundle {
+    /**
+     * Restore a [SessionManager.Snapshot] from this bundle. The returned snapshot can be used with [SessionManager] to
+     * restore the sessions and their state.
+     */
+    fun restoreSnapshot(engine: Engine): SessionManager.Snapshot?
+}

--- a/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/SessionBundleStorage.kt
+++ b/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/SessionBundleStorage.kt
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.Transformations
+import android.arch.paging.DataSource
+import android.content.Context
+import android.support.annotation.CheckResult
+import android.support.annotation.VisibleForTesting
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.storage.AutoSave
+import mozilla.components.feature.session.bundling.db.BundleDatabase
+import mozilla.components.feature.session.bundling.db.BundleEntity
+import mozilla.components.feature.session.bundling.ext.toBundleEntity
+import java.util.concurrent.TimeUnit
+
+/**
+ * A [Session] storage implementation that saves snapshots as a [SessionBundle].
+ *
+ * @param bundleLifetime The lifetime of a bundle controls whether a bundle will be restored or whether this bundle is
+ * considered expired and a new bundle will be used.
+ */
+class SessionBundleStorage(
+    context: Context,
+    private val bundleLifetime: Pair<Long, TimeUnit>
+) : AutoSave.Storage {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal var databaseInitializer = {
+        BundleDatabase.get(context)
+    }
+
+    private val database by lazy { databaseInitializer() }
+    private var lastBundle: BundleEntity? = null
+
+    /**
+     * Restores the last [SessionBundle] if there is one without expired lifetime.
+     */
+    @Synchronized
+    fun restore(): SessionBundle? {
+        val since = now() - bundleLifetime.second.toMillis(bundleLifetime.first)
+
+        return database
+            .bundleDao()
+            .getLastBundle(since)
+            .also { lastBundle = it }
+    }
+
+    /**
+     * Saves the [SessionManager.Snapshot] as a bundle. If a bundle was restored previously then this bundle will be
+     * updated with the data from the snapshot. If no bundle was restored a new bundle will be created.
+     */
+    @Synchronized
+    override fun save(snapshot: SessionManager.Snapshot): Boolean {
+        var bundle = lastBundle
+
+        if (bundle == null) {
+            bundle = snapshot.toBundleEntity().also { lastBundle = it }
+            bundle.id = database.bundleDao().insertBundle(bundle)
+        } else {
+            bundle.updateFrom(snapshot)
+            database.bundleDao().updateBundle(bundle)
+        }
+
+        return true
+    }
+
+    /**
+     * Removes the given [SessionBundle] permanently. If this is the active bundle then a new one will be created the
+     * next time a [SessionManager.Snapshot] is saved.
+     */
+    @Synchronized
+    fun remove(bundle: SessionBundle) {
+        if (bundle == lastBundle) {
+            lastBundle = null
+        }
+
+        val entity = bundle as? BundleEntity
+        entity?.let { database.bundleDao().deleteBundle(it) }
+    }
+
+    /**
+     * Removes all saved [SessionBundle] instances permanently.
+     */
+    @Synchronized
+    fun removeAll() {
+        lastBundle = null
+        database.clearAllTables()
+    }
+
+    /**
+     * Returns the currently used [SessionBundle] for saving [SessionManager.Snapshot] instances. Or null if no bundle
+     * is in use currently.
+     */
+    @Synchronized
+    fun current(): SessionBundle? {
+        return lastBundle
+    }
+
+    /**
+     * Explicitly uses the given [SessionBundle] (even if not active) to save [SessionManager.Snapshot] instances to.
+     */
+    @Synchronized
+    fun use(bundle: SessionBundle) {
+        lastBundle = bundle as BundleEntity
+    }
+
+    /**
+     * Returns the last saved [SessionBundle] instances (up to [limit]) as a [LiveData] list.
+     */
+    fun bundles(limit: Int = 20): LiveData<List<SessionBundle>> {
+        return Transformations.map(
+            database
+            .bundleDao()
+            .getBundles(limit)
+        ) { list ->
+            list.map { it as SessionBundle }
+        }
+    }
+
+    /**
+     * Returns all saved [SessionBundle] instances as a [DataSource.Factory].
+     *
+     * A consuming app can transform the data source into a `LiveData<PagedList>` of when using RxJava2 into a
+     * `Flowable<PagedList>` or `Observable<PagedList>`, that can be observed.
+     *
+     * - https://developer.android.com/topic/libraries/architecture/paging/data
+     * - https://developer.android.com/topic/libraries/architecture/paging/ui
+     */
+    fun bundlesPaged(): DataSource.Factory<Int, SessionBundle> {
+        return database
+            .bundleDao()
+            .getBundlesPaged()
+            .map { entity -> entity as SessionBundle }
+    }
+
+    /**
+     * Starts configuring automatic saving of the state.
+     */
+    @CheckResult
+    fun autoSave(
+        sessionManager: SessionManager,
+        interval: Long = AutoSave.DEFAULT_INTERVAL_MILLISECONDS,
+        unit: TimeUnit = TimeUnit.MILLISECONDS
+    ): AutoSave {
+        return AutoSave(sessionManager, this, unit.toMillis(interval))
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun now() = System.currentTimeMillis()
+}

--- a/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/db/BundleDao.kt
+++ b/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/db/BundleDao.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling.db
+
+import android.arch.lifecycle.LiveData
+import android.arch.paging.DataSource
+import android.arch.persistence.room.Dao
+import android.arch.persistence.room.Delete
+import android.arch.persistence.room.Insert
+import android.arch.persistence.room.Query
+import android.arch.persistence.room.Update
+
+/**
+ * Internal dao for accessing and modifying the bundles in the database.
+ */
+@Dao
+internal interface BundleDao {
+    @Insert
+    fun insertBundle(bundle: BundleEntity): Long
+
+    @Update
+    fun updateBundle(bundle: BundleEntity)
+
+    @Delete
+    fun deleteBundle(bundle: BundleEntity)
+
+    @Query("SELECT * FROM bundles ORDER BY saved_at DESC LIMIT :limit")
+    fun getBundles(limit: Int = 20): LiveData<List<BundleEntity>>
+
+    @Query("SELECT * FROM bundles")
+    fun getBundlesPaged(): DataSource.Factory<Int, BundleEntity>
+
+    @Query("SELECT * FROM bundles WHERE saved_at >= :since ORDER BY saved_at DESC LIMIT 1")
+    fun getLastBundle(since: Long): BundleEntity?
+}

--- a/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/db/BundleDatabase.kt
+++ b/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/db/BundleDatabase.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling.db
+
+import android.arch.persistence.room.Database
+import android.arch.persistence.room.Room
+import android.arch.persistence.room.RoomDatabase
+import android.content.Context
+
+/**
+ * Internal database for saving bundles.
+ */
+@Database(entities = [BundleEntity::class], version = 1)
+internal abstract class BundleDatabase : RoomDatabase() {
+    abstract fun bundleDao(): BundleDao
+
+    companion object {
+        @Volatile private var instance: BundleDatabase? = null
+
+        @Synchronized
+        fun get(context: Context): BundleDatabase {
+            instance?.let { return it }
+
+            return Room.databaseBuilder(
+                context,
+                BundleDatabase::class.java,
+                "bundle_database"
+            ).allowMainThreadQueries().build().also { instance = it }
+        }
+    }
+}

--- a/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/db/BundleEntity.kt
+++ b/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/db/BundleEntity.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling.db
+
+import android.arch.persistence.room.ColumnInfo
+import android.arch.persistence.room.Entity
+import android.arch.persistence.room.PrimaryKey
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.storage.SnapshotSerializer
+import mozilla.components.concept.engine.Engine
+import mozilla.components.feature.session.bundling.SessionBundle
+import org.json.JSONException
+import java.io.IOException
+
+/**
+ * Internal entity representing a session bundle as it gets saved to the database. This class implements [SessionBundle]
+ * which only exposes the part of the API we want to make public.
+ */
+@Entity(tableName = "bundles")
+internal data class BundleEntity(
+    @PrimaryKey(autoGenerate = true) var id: Long?,
+    var state: String,
+    @ColumnInfo(name = "saved_at") var savedAt: Long
+) : SessionBundle {
+    /**
+     * Updates this entity with the value from the given snapshot.
+     */
+    fun updateFrom(snapshot: SessionManager.Snapshot): BundleEntity {
+        state = SnapshotSerializer().toJSON(snapshot)
+        savedAt = System.currentTimeMillis()
+        return this
+    }
+
+    /**
+     * Re-create the [SessionManager.Snapshot] from the state saved in the database.
+     */
+    override fun restoreSnapshot(engine: Engine): SessionManager.Snapshot? {
+        return try {
+            SnapshotSerializer().fromJSON(engine, state)
+        } catch (e: IOException) {
+            null
+        } catch (e: JSONException) {
+            null
+        }
+    }
+}

--- a/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/ext/Snapshot.kt
+++ b/components/feature/session-bundling/src/main/java/mozilla/components/feature/session/bundling/ext/Snapshot.kt
@@ -1,0 +1,10 @@
+package mozilla.components.feature.session.bundling.ext
+
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.session.bundling.db.BundleEntity
+
+internal fun SessionManager.Snapshot.toBundleEntity() = BundleEntity(
+    id = null,
+    state = "",
+    savedAt = System.currentTimeMillis()
+)

--- a/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/SessionBundleStorageTest.kt
+++ b/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/SessionBundleStorageTest.kt
@@ -1,0 +1,203 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling
+
+import android.arch.lifecycle.LiveData
+import android.arch.paging.DataSource
+import android.arch.persistence.db.SupportSQLiteOpenHelper
+import android.arch.persistence.room.DatabaseConfiguration
+import android.arch.persistence.room.InvalidationTracker
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.session.bundling.db.BundleDao
+import mozilla.components.feature.session.bundling.db.BundleDatabase
+import mozilla.components.feature.session.bundling.db.BundleEntity
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import java.util.concurrent.TimeUnit
+
+class SessionBundleStorageTest {
+    @Test
+    fun `restore loads last bundle using lifetime`() {
+        val dao: BundleDao = mock()
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { mockDatabase(dao) }
+        })
+        doReturn(1234567890L).`when`(storage).now()
+
+        val bundle = storage.restore()
+
+        assertNull(bundle)
+        verify(dao).getLastBundle(1227367890L) // since 2 hours ago
+    }
+
+    @Test
+    fun `current returns restored bundle`() {
+        val bundle: BundleEntity = mock()
+
+        val dao = object : BundleDao {
+            override fun insertBundle(bundle: BundleEntity): Long = TODO()
+            override fun updateBundle(bundle: BundleEntity) = TODO()
+            override fun deleteBundle(bundle: BundleEntity) = TODO()
+            override fun getBundles(limit: Int): LiveData<List<BundleEntity>> = TODO()
+            override fun getBundlesPaged(): DataSource.Factory<Int, BundleEntity> = TODO()
+
+            override fun getLastBundle(since: Long): BundleEntity? = bundle
+        }
+
+        val database = mockDatabase(dao)
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { database }
+        })
+
+        assertNull(storage.current())
+        assertEquals(bundle, storage.restore())
+        assertEquals(bundle, storage.current())
+    }
+
+    @Test
+    fun `save will create new bundle`() {
+        val dao: BundleDao = mock()
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { mockDatabase(dao) }
+        })
+
+        val snapshot = SessionManager.Snapshot(
+            listOf(SessionManager.Snapshot.Item(session = Session("https://www.mozilla.org"))),
+            selectedSessionIndex = 0)
+
+        assertNull(storage.current())
+
+        storage.save(snapshot)
+
+        verify(dao).insertBundle(any())
+
+        assertNotNull(storage.current())
+    }
+
+    @Test
+    fun `save will update existing bundle`() {
+        val bundle: BundleEntity = mock()
+
+        val dao: BundleDao = mock()
+        doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
+
+        val database = mockDatabase(dao)
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { database }
+        })
+
+        storage.restore()
+
+        val snapshot = SessionManager.Snapshot(
+            listOf(SessionManager.Snapshot.Item(session = Session("https://www.mozilla.org"))),
+            selectedSessionIndex = 0)
+
+        storage.save(snapshot)
+
+        verify(bundle).updateFrom(snapshot)
+        verify(dao).updateBundle(bundle)
+    }
+
+    @Test
+    fun `remove will remove existing bundle`() {
+        val bundle: BundleEntity = mock()
+
+        val dao: BundleDao = mock()
+        doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
+
+        val database = mockDatabase(dao)
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { database }
+        })
+
+        storage.restore()
+
+        assertNotNull(storage.current())
+
+        storage.remove(bundle)
+
+        assertNull(storage.current())
+
+        verify(dao).deleteBundle(bundle)
+    }
+
+    @Test
+    fun `removeAll will remove all bundles`() {
+        val bundle: BundleEntity = mock()
+
+        val dao: BundleDao = mock()
+        doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
+
+        val database = mockDatabase(dao)
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { database }
+        })
+
+        storage.restore()
+
+        assertNotNull(storage.current())
+
+        storage.removeAll()
+
+        assertNull(storage.current())
+        verify(storage).removeAll()
+    }
+
+    @Test
+    fun `Use will override current bundle`() {
+        val bundle: BundleEntity = mock()
+
+        val dao: BundleDao = mock()
+        doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
+
+        val database = mockDatabase(dao)
+
+        val storage = spy(SessionBundleStorage(mock(), Pair(2, TimeUnit.HOURS)).apply {
+            databaseInitializer = { database }
+        })
+
+        storage.restore()
+
+        assertEquals(bundle, storage.current())
+
+        val newBundle: BundleEntity = mock()
+
+        storage.use(newBundle)
+
+        assertEquals(newBundle, storage.current())
+
+        val snapshot = SessionManager.Snapshot(
+            listOf(SessionManager.Snapshot.Item(session = Session("https://www.mozilla.org"))),
+            selectedSessionIndex = 0)
+
+        storage.save(snapshot)
+
+        verify(newBundle).updateFrom(snapshot)
+        verify(dao).updateBundle(newBundle)
+    }
+
+    private fun mockDatabase(bundleDao: BundleDao) = object : BundleDatabase() {
+        override fun bundleDao() = bundleDao
+
+        override fun createOpenHelper(config: DatabaseConfiguration?): SupportSQLiteOpenHelper = mock()
+        override fun createInvalidationTracker(): InvalidationTracker = mock()
+        override fun clearAllTables() = Unit
+    }
+}

--- a/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/db/BundleEntityTest.kt
+++ b/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/db/BundleEntityTest.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.bundling.db
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.support.test.mock
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BundleEntityTest {
+    @Test
+    fun `updateFrom updates state and time`() {
+        val bundle = BundleEntity(0, "", 0)
+
+        val snapshot = SessionManager.Snapshot(
+            listOf(SessionManager.Snapshot.Item(session = Session("https://www.mozilla.org"))),
+            selectedSessionIndex = 0)
+
+        bundle.updateFrom(snapshot)
+
+        assertTrue(bundle.savedAt > 0)
+
+        val json = JSONObject(bundle.state)
+
+        assertEquals(1, json.get("version"))
+        assertEquals(0, json.get("selectedSessionIndex"))
+
+        val sessions = json.getJSONArray("sessionStateTuples")
+        assertEquals(1, sessions.length())
+    }
+
+    @Test
+    fun `restoreSnapshot restores snapshot from state`() {
+        val bundle = BundleEntity(0, "", 0)
+
+        val snapshot = SessionManager.Snapshot(
+            listOf(SessionManager.Snapshot.Item(session = Session("https://www.mozilla.org"))),
+            selectedSessionIndex = 0)
+
+        bundle.updateFrom(snapshot)
+
+        val restoredSnapshot = bundle.restoreSnapshot(mock())
+
+        assertNotNull(restoredSnapshot!!)
+
+        assertFalse(restoredSnapshot.isEmpty())
+        assertEquals(1, restoredSnapshot.sessions.size)
+        assertEquals("https://www.mozilla.org", restoredSnapshot.sessions[0].session.url)
+    }
+}

--- a/components/feature/session-bundling/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/session-bundling/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@ permalink: /changelog/
   * Mozilla App Services (FxA: 0.12.1, Sync Logins: 0.12.1, Places: 0.12.1)
   * Third Party Libs (Sentry: 1.7.14, Okhttp: 3.12.0)
 
+* **feature-session-bundling**
+  * 🆕 New component that saves the state of sessions (`SessionManager.Snapshot`) in grouped bundles (e.g. by time).
+
 # 0.36.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.35.0...v0.36.0),

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ setupProject(':feature-customtabs', 'components/feature/customtabs', 'Component 
 setupProject(':feature-intent', 'components/feature/intent', 'Combining various feature components for intent processing.')
 setupProject(':feature-search', 'components/feature/search', 'Feature implementation connecting an engine implementation with the search module.')
 setupProject(':feature-session', 'components/feature/session', 'Feature implementation connecting an engine implementation with the session module.')
+setupProject(':feature-session-bundling', 'components/feature/session-bundling', 'A session storage implementation that saves the state of sessions in grouped bundles (e.g. by time) in a database')
 setupProject(':feature-sync', 'components/feature/sync', 'Feature implementation that enables syncing of syncable components.')
 setupProject(':feature-tabs', 'components/feature/tabs', 'Feature implementation connecting a tabs tray implementation with the session and toolbar modules.')
 setupProject(':feature-toolbar', 'components/feature/toolbar', 'Feature implementation connecting a toolbar implementation with the session module.')


### PR DESCRIPTION
*I'm currently writing tests for this. But I wanted to share this for review already.*

This is the absolute small MVP for session bundling. Sessions are saved as a bundle in a database. You can define a lifetime and during that lifetime a bundle will be restored and re-used. Otherwise a new bundle will be started. I added some APIs to build UI for listing and restoring other bundles. Once released I want to build a little prototype UI in the reference browser.

The previous refactoring was helpful. Now I could just move `AutoSave` out and re-use all that logic for a new "session storage" implementation. I did the same with the code that de/serializes the snapshots and with that I had almost all building blocks for implementing a different session storage.

