### PR TITLE
Closes #1468: Adding support for html input types file for GeckoEngine.

### DIFF
--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_androidx
 
     testImplementation project(':support-test')
 }

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_androidx
 
     testImplementation project(':support-test')
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.browser.engine.gecko.prompt
 
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.prompt.Choice
@@ -22,6 +25,7 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULT
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
 import org.robolectric.RobolectricTestRunner
 import mozilla.components.support.ktx.kotlin.toDate
+import org.junit.Assert
 import org.junit.Assert.assertNotNull
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
@@ -220,7 +224,6 @@ class GeckoPromptDelegateTest {
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
         gecko.onDateTimePrompt(null, "", 0, null, null, null, mock())
-        gecko.onFilePrompt(null, "", 0, null, null)
         gecko.onColorPrompt(null, "", "", null)
         gecko.onAuthPrompt(null, "", "", null, null)
         gecko.onTextPrompt(null, "", "", null, null)
@@ -479,5 +482,64 @@ class GeckoPromptDelegateTest {
         calendar.time = date
         val year = calendar[YEAR].toString()
         assertEquals(dateString, year)
+    }
+
+    @Test
+    fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var onSingleFileSelectedWasCalled = false
+        var onMultipleFilesSelectedWasCalled = false
+        var onDismissWasCalled = false
+
+        val callback = object : GeckoSession.PromptDelegate.FileCallback {
+            override fun dismiss() {
+                onDismissWasCalled = true
+            }
+
+            override fun confirm(context: Context?, uri: Uri?) {
+                onSingleFileSelectedWasCalled = true
+            }
+
+            override fun confirm(context: Context?, uris: Array<out Uri>?) {
+                onMultipleFilesSelectedWasCalled = true
+            }
+
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onFilePrompt(null, "title", GeckoSession.PromptDelegate.FILE_TYPE_SINGLE, emptyArray(), callback)
+        assertTrue(request is PromptRequest.File)
+
+        val filePickerRequest = request as PromptRequest.File
+
+        filePickerRequest.onSingleFileSelected(context, mock())
+        assertTrue(onSingleFileSelectedWasCalled)
+
+        filePickerRequest.onMultipleFilesSelected(context, emptyArray())
+        assertTrue(onMultipleFilesSelectedWasCalled)
+
+        filePickerRequest.onDismiss()
+        assertTrue(onDismissWasCalled)
+
+        assertTrue(filePickerRequest.mimeTypes.isEmpty())
+        Assert.assertFalse(filePickerRequest.isMultipleFilesSelection)
+
+        promptDelegate.onFilePrompt(null, "title",
+            GeckoSession.PromptDelegate.FILE_TYPE_MULTIPLE, emptyArray(), callback)
+
+        assertTrue((request as PromptRequest.File) .isMultipleFilesSelection)
     }
 }

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_androidx
 
     testImplementation project(':support-test')
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.browser.engine.gecko.prompt
 
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.prompt.Choice
@@ -22,6 +25,7 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULT
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
 import org.robolectric.RobolectricTestRunner
 import mozilla.components.support.ktx.kotlin.toDate
+import org.junit.Assert
 import org.junit.Assert.assertNotNull
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
@@ -218,7 +222,6 @@ class GeckoPromptDelegateTest {
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
         gecko.onDateTimePrompt(null, "", 0, null, null, null, mock())
-        gecko.onFilePrompt(null, "", 0, null, null)
         gecko.onColorPrompt(null, "", "", null)
         gecko.onAuthPrompt(null, "", "", null, null)
         gecko.onTextPrompt(null, "", "", null, null)
@@ -477,5 +480,64 @@ class GeckoPromptDelegateTest {
         calendar.time = date
         val year = calendar[YEAR].toString()
         assertEquals(dateString, year)
+    }
+
+    @Test
+    fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var onSingleFileSelectedWasCalled = false
+        var onMultipleFilesSelectedWasCalled = false
+        var onDismissWasCalled = false
+
+        val callback = object : GeckoSession.PromptDelegate.FileCallback {
+            override fun dismiss() {
+                onDismissWasCalled = true
+            }
+
+            override fun confirm(context: Context?, uri: Uri?) {
+                onSingleFileSelectedWasCalled = true
+            }
+
+            override fun confirm(context: Context?, uris: Array<out Uri>?) {
+                onMultipleFilesSelectedWasCalled = true
+            }
+
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onFilePrompt(null, "title", GeckoSession.PromptDelegate.FILE_TYPE_SINGLE, emptyArray(), callback)
+        assertTrue(request is PromptRequest.File)
+
+        val filePickerRequest = request as PromptRequest.File
+
+        filePickerRequest.onSingleFileSelected(context, mock())
+        assertTrue(onSingleFileSelectedWasCalled)
+
+        filePickerRequest.onMultipleFilesSelected(context, emptyArray())
+        assertTrue(onMultipleFilesSelectedWasCalled)
+
+        filePickerRequest.onDismiss()
+        assertTrue(onDismissWasCalled)
+
+        assertTrue(filePickerRequest.mimeTypes.isEmpty())
+        Assert.assertFalse(filePickerRequest.isMultipleFilesSelection)
+
+        promptDelegate.onFilePrompt(null, "title",
+            GeckoSession.PromptDelegate.FILE_TYPE_MULTIPLE, emptyArray(), callback)
+
+        assertTrue((request as PromptRequest.File) .isMultipleFilesSelection)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.concept.engine.prompt
 
+import android.content.Context
+import android.net.Uri
+
 /**
  * Value type that represents a request for showing a native dialog for prompt web content.
  *
@@ -62,5 +65,21 @@ sealed class PromptRequest {
         val maximumDate: java.util.Date?,
         val onSelect: (java.util.Date) -> Unit,
         val onClear: () -> Unit
+    ) : PromptRequest()
+
+    /**
+     * Value type that represents a request for a selecting one or multiple files.
+     * @property mimeTypes a set of allowed mime types. Only these file types can be selected.
+     * @property isMultipleFilesSelection true if the user can select more that one file false otherwise.
+     * @property onSingleFileSelected callback to notify that the user has selected a single file.
+     * @property onMultipleFilesSelected callback to notify that the user has selected multiple files.
+     * @property onDismiss callback to notify that the user has canceled the file selection.
+     */
+    data class File(
+        val mimeTypes: Array<out String>,
+        val isMultipleFilesSelection: Boolean,
+        val onSingleFileSelected: (Context, Uri) -> Unit,
+        val onMultipleFilesSelected: (Context, Array<Uri>) -> Unit,
+        val onDismiss: () -> Unit
     ) : PromptRequest()
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -8,8 +8,10 @@ import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Date
 
@@ -44,5 +46,12 @@ class PromptRequestTest {
         assertNotNull(dateRequest.maximumDate)
         dateRequest.onSelect(Date())
         dateRequest.onClear()
+
+        val filePickerRequest = PromptRequest.File(emptyArray(), true, { _, _ -> }, { _, _ -> }) {}
+        assertTrue(filePickerRequest.mimeTypes.isEmpty())
+        assertTrue(filePickerRequest.isMultipleFilesSelection)
+        filePickerRequest.onSingleFileSelected(mock(), mock())
+        filePickerRequest.onMultipleFilesSelected(mock(), emptyArray())
+        filePickerRequest.onDismiss()
     }
 }

--- a/components/feature/prompts/README.md
+++ b/components/feature/prompts/README.md
@@ -5,7 +5,6 @@ A feature that will subscribe to the selected session and will handle all the co
 ## Usage
 
 ### Setting up the dependency
-
 Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
 
 ```Groovy
@@ -15,7 +14,22 @@ implementation "org.mozilla.components:feature-prompts:{latest-version}"
 ### PromptFeature
 
   ```kotlin
-  val promptFeature = PromptFeature(sessionManager, fragmentManager)
+
+  val onNeedToRequestPermissions : ( Session, Array<String>, Int) -> Unit = {
+    session, permissions, requestCode ->
+    /* You are in charge of triggering the request for the permissions needed,
+     * this way you can control, when you request the permissions,
+     * in case that you want to show an informative dialog,
+     * to clarify the use of these permissions.
+     */
+    this.requestPermissions(permissions, requestCode)
+  }
+
+  val promptFeature = PromptFeature(fragment = this,
+    sessionManager = sessionManager,
+    fragmentManager= fragmentManager,
+    onNeedToRequestPermissions = onNeedToRequestPermissions
+  )
 
   //It will start listing for new prompt requests for web content.
   promptFeature.start()
@@ -23,6 +37,23 @@ implementation "org.mozilla.components:feature-prompts:{latest-version}"
   //It will stop listing for future prompt requests for web content.
   promptFeature.stop()
 
+  /* There some requests that are not handled with dialogs, instead they are delegated to other apps
+   * to perform the request, an example is a file picker request, that delegates to the OS file picker.
+   * For this reason, you have to forward the results of these requests to the prompt feature by overriding,
+   * onActivityResult in your Activity or Fragment and forward its calls to promptFeature.onActivityResult.
+   */
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    promptFeature.onActivityResult(requestCode, resultCode, data)
+  }
+
+  /* Additionally, there are requests that need to have some runtime permission before they can be performed,
+   * like file pickers request that need access to read the selected files. As onActivityResult you need to override
+   * onRequestPermissionsResult in your Activity or Fragment and forward its
+   * calls to promptFeature.onRequestPermissionsResult.
+   */
+  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+    promptFeature.onActivityResult(requestCode, resultCode, data)
+  }
   ```
 
 ## License

--- a/components/feature/prompts/build.gradle
+++ b/components/feature/prompts/build.gradle
@@ -24,6 +24,7 @@ android {
 dependencies {
     implementation project(':browser-session')
     implementation project(':concept-engine')
+    implementation project(':support-ktx')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.support_design
@@ -33,7 +34,6 @@ dependencies {
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_androidx
     testImplementation project(':support-test')
-    testImplementation project(':support-ktx')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -4,7 +4,15 @@
 
 package mozilla.components.feature.prompts
 
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.app.Activity
+import android.app.Activity.RESULT_OK
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.support.annotation.VisibleForTesting
+import android.support.annotation.VisibleForTesting.PRIVATE
+import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
@@ -15,32 +23,64 @@ import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
+import mozilla.components.concept.engine.prompt.PromptRequest.File
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.MULTIPLE_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.MENU_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.SINGLE_CHOICE_DIALOG_TYPE
+import mozilla.components.support.ktx.android.content.isPermissionGranted
+import java.security.InvalidParameterException
 import java.util.Date
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal const val FRAGMENT_TAG = "mozac_feature_prompt_dialog"
 
+typealias OnNeedToRequestPermissions = (session: Session, permissions: Array<String>, requestCode: Int) -> Unit
+
 /**
  * Feature for displaying native dialogs for html elements like:
  * input type date,file,time,color, option, menu, authentication, confirmation and other alerts.
+ *
+ * There are some requests that are not handled with dialogs instead with intents like file choosers and others.
+ * For this reason, you have to keep the feature aware of flow of requesting data from other apps, overriding
+ * onActivityResult on your [Activity] or [Fragment] and forward its calls to [onActivityResult].
  *
  * This feature will subscribe to the currently selected [Session] and display a suitable native dialog based on
  * [Session.Observer.onPromptRequested] events. Once the dialog is closed or the user selects an item from the dialog
  * the related [PromptFeature] will be consumed.
  *
- * @property sessionManager The [SessionManager] instance in order to subscribe to the selected [Session].
+ * @property activity The [Activity] host of this feature, if the host is a [Fragment], just ignore this parameter
+ * and pass a [fragment] parameter. Never [fragment] and [activity] should be both null or you will get
+ * an [IllegalStateException].
+ * @property fragment The [Fragment] host of this feature, if the host is an [Activity], just ignore this parameter
+ * and pass [activity] parameter. Never [fragment] and [activity] should be both null or you will get
+ * an [IllegalStateException].
+ * @property sessionManager The [Fragment] instance in order to subscribe to the selected [Session].
  * @property fragmentManager The [FragmentManager] to be used when displaying a dialog (fragment).
+ * @property onNeedToRequestPermissions A callback to let you know that there are some permissions that need to be
+ * granted before performing a [PromptRequest]. You are in change of requesting these permissions and notify the feature
+ * calling [onRequestPermissionsResult] method.
  */
+
+@Suppress("TooManyFunctions")
 class PromptFeature(
+    private val activity: Activity? = null,
+    private val fragment: Fragment? = null,
     private val sessionManager: SessionManager,
-    private val fragmentManager: FragmentManager
+    private val fragmentManager: FragmentManager,
+    private val onNeedToRequestPermissions: OnNeedToRequestPermissions
+
 ) {
 
-    private val observer =
-        PromptRequestObserver(sessionManager, feature = this)
+    init {
+        if (activity == null && fragment == null) {
+            throw IllegalStateException("activity and fragment references " +
+                "must not be both null, at least one must be initialized.")
+        }
+    }
+
+    private val observer = PromptRequestObserver(sessionManager, feature = this)
+
+    private val context get() = activity ?: requireNotNull(fragment).requireContext()
 
     /**
      * Start observing the selected session and when needed show native dialogs.
@@ -64,46 +104,134 @@ class PromptFeature(
     }
 
     /**
+     * Forward the calls to onActivityResult on your [Activity] or [Fragment], to let the feature know, the results
+     * of intents for handling prompt requests, that need to be performed by other apps like file chooser requests.
+     *
+     * @param requestCode The code of the app that requested the intent.
+     * @param intent The result of the request.
+     */
+    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        if (requestCode == FILE_PICKER_REQUEST) {
+            sessionManager.selectedSession?.promptRequest?.consume {
+
+                val request = it as File
+
+                if (resultCode != RESULT_OK || intent == null) {
+                    request.onDismiss()
+                } else {
+                    handleFilePickerIntentResult(intent, request)
+                }
+                true
+            }
+        }
+    }
+
+    /**
+     * Forward the calls to onRequestPermissionsResult on your [Activity] or [Fragment], to let the feature know,
+     * the results for the requested permissions that are needed for performing a [PromptRequest].
+     *
+     * @param requestCode The code of the app that requested the intent.
+     * @param permissions List of permission requested.
+     * @see [onNeedToRequestPermissions].
+     */
+    fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        when (requestCode) {
+            FILE_PICKER_REQUEST -> {
+                if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+                    onPermissionsGranted()
+                } else {
+                    onPermissionsDeny()
+                }
+            }
+        }
+    }
+
+    /**
+     * Use in conjunction with [onNeedToRequestPermissions], to notify the feature that all the required permissions
+     * have been granted, and it can perform the pending [PromptRequest] in the selected session.
+     *
+     * If the required permission has not been completely granted [onNeedToRequestPermissions] will be called.
+     */
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun onPermissionsGranted() {
+        sessionManager.selectedSession?.apply {
+            promptRequest.consume { promptRequest ->
+                onPromptRequested(this, promptRequest)
+                false
+            }
+        }
+    }
+
+    /**
+     * Use in conjunction with [onNeedToRequestPermissions] to notify the feature that one or more required permissions
+     * have been denied.
+     */
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun onPermissionsDeny() {
+        sessionManager.selectedSession?.apply {
+            promptRequest.consume { request ->
+                if (request is File) {
+                    request.onDismiss()
+                }
+                true
+            }
+        }
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun handleFilePickerIntentResult(
+        intent: Intent,
+        request: File
+    ) {
+        intent.apply {
+
+            if (request.isMultipleFilesSelection) {
+                handleMultipleFileSelections(request, this)
+            } else {
+                handleSingleFileSelection(request, this)
+            }
+        }
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun handleSingleFileSelection(
+        request: File,
+        intent: Intent
+    ) {
+        intent.data?.apply {
+            request.onSingleFileSelected(context, this)
+        }
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun handleMultipleFileSelections(
+        request: File,
+        intent: Intent
+    ) {
+        intent.clipData?.apply {
+            val uris = Array<Uri>(itemCount) { index -> getItemAt(index).uri }
+            request.onMultipleFilesSelected(context, uris)
+        }
+    }
+
+    /**
      * Event that is triggered when a native dialog needs to be shown.
      * Displays suitable dialog for the type of the [promptRequest].
      *
      * @param session The session which requested the dialog.
      * @param promptRequest The session the request the dialog.
      */
+    @VisibleForTesting(otherwise = PRIVATE)
     internal fun onPromptRequested(session: Session, promptRequest: PromptRequest) {
 
-        val dialog = when (promptRequest) {
-
-            is SingleChoice -> {
-                ChoiceDialogFragment.newInstance(
-                    promptRequest.choices,
-                    session.id, SINGLE_CHOICE_DIALOG_TYPE
-                )
-            }
-
-            is MultipleChoice -> ChoiceDialogFragment.newInstance(
-                promptRequest.choices, session.id, MULTIPLE_CHOICE_DIALOG_TYPE
-            )
-
-            is MenuChoice -> ChoiceDialogFragment.newInstance(
-                promptRequest.choices, session.id, MENU_CHOICE_DIALOG_TYPE
-            )
-
-            is Alert -> {
-                with(promptRequest) {
-                    AlertDialogFragment.newInstance(session.id, title, message, hasShownManyDialogs)
-                }
-            }
-
-            is PromptRequest.Date -> {
-                with(promptRequest) {
-                    DatePickerDialogFragment.newInstance(session.id, title, initialDate, minimumDate, maximumDate)
-                }
+        // Requests that are handle with intents
+        when (promptRequest) {
+            is File -> {
+                handleFilePickerRequest(promptRequest, session)
+                return
             }
         }
-
-        dialog.feature = this
-        dialog.show(fragmentManager, FRAGMENT_TAG)
+        handleDialogsRequest(promptRequest, session)
     }
 
     /**
@@ -215,6 +343,84 @@ class PromptFeature(
         fragment.feature = this
     }
 
+    internal fun handleFilePickerRequest(
+        promptRequest: File,
+        session: Session
+    ) {
+        if (context.isPermissionGranted(READ_EXTERNAL_STORAGE)) {
+            val intent = buildFileChooserIntent(
+                promptRequest.isMultipleFilesSelection,
+                promptRequest.mimeTypes
+            )
+            startActivityForResult(intent, FILE_PICKER_REQUEST)
+        } else {
+            onNeedToRequestPermissions(session, arrayOf(READ_EXTERNAL_STORAGE), FILE_PICKER_REQUEST)
+        }
+    }
+
+    internal fun startActivityForResult(intent: Intent, code: Int) {
+        if (activity != null) {
+            activity.startActivityForResult(intent, code)
+        } else {
+            requireNotNull(fragment).startActivityForResult(intent, code)
+        }
+    }
+
+    internal fun buildFileChooserIntent(allowMultipleSelection: Boolean, mimeTypes: Array<out String>): Intent {
+        return with(Intent(Intent.ACTION_GET_CONTENT)) {
+            type = "*/*"
+            addCategory(Intent.CATEGORY_OPENABLE)
+            putExtra(Intent.EXTRA_LOCAL_ONLY, true)
+            if (mimeTypes.isNotEmpty()) {
+                putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
+            }
+            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultipleSelection)
+        }
+    }
+
+    private fun handleDialogsRequest(
+        promptRequest: PromptRequest,
+        session: Session
+    ) {
+        // Requests that are handled with dialogs
+        val dialog = when (promptRequest) {
+
+            is SingleChoice -> {
+                ChoiceDialogFragment.newInstance(
+                    promptRequest.choices,
+                    session.id, SINGLE_CHOICE_DIALOG_TYPE
+                )
+            }
+
+            is MultipleChoice -> ChoiceDialogFragment.newInstance(
+                promptRequest.choices, session.id, MULTIPLE_CHOICE_DIALOG_TYPE
+            )
+
+            is MenuChoice -> ChoiceDialogFragment.newInstance(
+                promptRequest.choices, session.id, MENU_CHOICE_DIALOG_TYPE
+            )
+
+            is Alert -> {
+                with(promptRequest) {
+                    AlertDialogFragment.newInstance(session.id, title, message, hasShownManyDialogs)
+                }
+            }
+
+            is PromptRequest.Date -> {
+                with(promptRequest) {
+                    DatePickerDialogFragment.newInstance(session.id, title, initialDate, minimumDate, maximumDate)
+                }
+            }
+
+            else -> {
+                throw InvalidParameterException("Not valid prompt request type")
+            }
+        }
+
+        dialog.feature = this
+        dialog.show(fragmentManager, FRAGMENT_TAG)
+    }
+
     /**
      * Observes [Session.Observer.onPromptRequested] of the selected session and notifies the feature whenever a prompt
      * needs to be shown.
@@ -228,5 +434,9 @@ class PromptFeature(
             feature.onPromptRequested(session, promptRequest)
             return false
         }
+    }
+
+    companion object {
+        const val FILE_PICKER_REQUEST = 1234
     }
 }

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -4,33 +4,52 @@
 
 package mozilla.components.feature.prompts
 
+import android.Manifest
+import android.app.Activity
+import android.app.Activity.RESULT_CANCELED
+import android.app.Activity.RESULT_OK
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_GET_CONTENT
+import android.content.Intent.EXTRA_ALLOW_MULTIPLE
+import android.content.Intent.EXTRA_MIME_TYPES
+import android.content.pm.PackageManager.PERMISSION_DENIED
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.net.Uri
+import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
-import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
+import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
+import mozilla.components.feature.prompts.PromptFeature.Companion.FILE_PICKER_REQUEST
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.grantPermission
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import java.util.UUID
 import java.util.Date
-import mozilla.components.concept.engine.prompt.PromptRequest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class PromptFeatureTest {
@@ -45,7 +64,7 @@ class PromptFeatureTest {
         mockFragmentManager = mockFragmentManager()
 
         mockSessionManager = Mockito.spy(SessionManager(engine))
-        promptFeature = PromptFeature(mockSessionManager, mockFragmentManager)
+        promptFeature = PromptFeature(null, mock(), mockSessionManager, mockFragmentManager) { _, _, _ -> }
     }
 
     @Test
@@ -88,7 +107,7 @@ class PromptFeatureTest {
         mockFragmentManager = mock()
         doReturn(fragment).`when`(mockFragmentManager).findFragmentByTag(any())
 
-        promptFeature = PromptFeature(mockSessionManager, mockFragmentManager)
+        promptFeature = PromptFeature(mock(), null, mockSessionManager, mockFragmentManager) { _, _, _ -> }
 
         promptFeature.start()
         verify(fragment).feature = promptFeature
@@ -109,15 +128,15 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(fragmentManager).beginTransaction()
         doReturn(transaction).`when`(transaction).remove(fragment)
 
-        val feature = PromptFeature(mockSessionManager, fragmentManager)
+        val feature = PromptFeature(null, mock(), mockSessionManager, fragmentManager) { _, _, _ -> }
 
         feature.start()
         verify(fragmentManager).beginTransaction()
         verify(transaction).remove(fragment)
     }
 
+    @Test
     fun `Already existing fragment will be removed if session does not exist anymore`() {
-        val sessionManager = SessionManager(mock())
         val fragment: ChoiceDialogFragment = mock()
         doReturn(UUID.randomUUID().toString()).`when`(fragment).sessionId
 
@@ -128,7 +147,7 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(fragmentManager).beginTransaction()
         doReturn(transaction).`when`(transaction).remove(fragment)
 
-        val feature = PromptFeature(sessionManager, fragmentManager)
+        val feature = PromptFeature(mock(), mock(), mockSessionManager, fragmentManager) { _, _, _ -> }
 
         feature.start()
         verify(fragmentManager).beginTransaction()
@@ -302,6 +321,7 @@ class PromptFeatureTest {
         promptFeature.onClear("unknown_sessionId")
         assertFalse(onClearWasCalled)
     }
+
     @Test
     fun `selecting a date will consume promptRequest`() {
         val session = getSelectedSession()
@@ -325,6 +345,264 @@ class PromptFeatureTest {
         assertTrue(onClearWasCalled)
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun `Initializing a PromptFeature without giving an activity or fragment reference will throw an exception`() {
+        promptFeature = PromptFeature(null, null, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+    }
+
+    @Test
+    fun `startActivityForResult must delegate its calls either to an activity or a fragment`() {
+        val mockActivity: Activity = mock()
+        val mockFragment: Fragment = mock()
+        val intent = Intent()
+        val code = 1
+
+        promptFeature = PromptFeature(mockActivity, null, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+
+        promptFeature.startActivityForResult(intent, code)
+        verify(mockActivity).startActivityForResult(intent, code)
+
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+
+        promptFeature.startActivityForResult(intent, code)
+        verify(mockFragment).startActivityForResult(intent, code)
+    }
+
+    @Test
+    fun `handleFilePickerRequest without the required permission will call onNeedToRequestPermissions`() {
+        val mockFragment: Fragment = mock()
+        val intent = Intent()
+        val code = 1
+        var onRequestPermissionWasCalled = false
+        val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ ->
+            onRequestPermissionWasCalled = true
+        }
+
+        doReturn(context).`when`(mockFragment).requireContext()
+
+        promptFeature.handleFilePickerRequest(filePickerRequest, mock())
+
+        assertTrue(onRequestPermissionWasCalled)
+        verify(mockFragment, never()).startActivityForResult(intent, code)
+    }
+
+    @Test
+    fun `handleFilePickerRequest with the required permission will call startActivityForResult`() {
+        val mockFragment: Fragment = mock()
+        var onRequestPermissionWasCalled = false
+        val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ ->
+            onRequestPermissionWasCalled = true
+        }
+
+        doReturn(context).`when`(mockFragment).requireContext()
+
+        grantPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
+
+        promptFeature.handleFilePickerRequest(filePickerRequest, mock())
+
+        assertFalse(onRequestPermissionWasCalled)
+        verify(mockFragment).startActivityForResult(any<Intent>(), anyInt())
+    }
+
+    @Test
+    fun `buildFileChooserIntent with allowMultipleFiles false and empty mimeTypes will create an intent without EXTRA_ALLOW_MULTIPLE and EXTRA_MIME_TYPES`() {
+
+        val intent = promptFeature.buildFileChooserIntent(false, emptyArray())
+
+        with(intent) {
+
+            assertEquals(action, ACTION_GET_CONTENT)
+
+            val mimeType = extras!!.get(EXTRA_MIME_TYPES)
+            assertNull(mimeType)
+
+            val allowMultipleFiles = extras!!.getBoolean(EXTRA_ALLOW_MULTIPLE)
+            assertFalse(allowMultipleFiles)
+        }
+    }
+
+    @Test
+    fun `buildFileChooserIntent with allowMultipleFiles true and not empty mimeTypes will create an intent with EXTRA_ALLOW_MULTIPLE and EXTRA_MIME_TYPES`() {
+
+        promptFeature = PromptFeature(null, mock(), mockSessionManager, mockFragmentManager) { _, _, _ -> }
+
+        val intent = promptFeature.buildFileChooserIntent(true, arrayOf("image/jpeg"))
+
+        with(intent) {
+
+            assertEquals(action, ACTION_GET_CONTENT)
+
+            val mimeTypes = extras!!.get(EXTRA_MIME_TYPES) as Array<*>
+            assertEquals(mimeTypes.first(), "image/jpeg")
+
+            val allowMultipleFiles = extras!!.getBoolean(EXTRA_ALLOW_MULTIPLE)
+            assertTrue(allowMultipleFiles)
+        }
+    }
+
+    @Test
+    fun `onPermissionsGranted will forward its call to onPromptRequested`() {
+        val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
+
+        val session = getSelectedSession()
+
+        session.promptRequest = Consumable.from(filePickerRequest)
+
+        stubContext()
+
+        promptFeature = spy(promptFeature)
+
+        promptFeature.onPermissionsGranted()
+
+        verify(mockSessionManager).selectedSession
+        verify(promptFeature).onPromptRequested(any(), any<PromptRequest.File>())
+        assertFalse(session.promptRequest.isConsumed())
+    }
+
+    @Test
+    fun `onPermissionsDeny will call onDismiss and consume the file PromptRequest of the actual session`() {
+
+        var onDismissWasCalled = false
+        val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {
+            onDismissWasCalled = true
+        }
+
+        val session = getSelectedSession()
+
+        stubContext()
+
+        session.promptRequest = Consumable.from(filePickerRequest)
+
+        promptFeature.onPermissionsDeny()
+
+        verify(mockSessionManager).selectedSession
+        assertTrue(onDismissWasCalled)
+        assertTrue(session.promptRequest.isConsumed())
+    }
+
+    @Test
+    fun `onActivityResult with RESULT_OK and isMultipleFilesSelection false will consume PromptRequest of the actual session`() {
+
+        var onSingleFileSelectionWasCalled = false
+
+        val onSingleFileSelection: (Context, Uri) -> Unit = { _, _ ->
+            onSingleFileSelectionWasCalled = true
+        }
+
+        val filePickerRequest =
+            PromptRequest.File(emptyArray(), false, onSingleFileSelection, { _, _ -> }) {
+            }
+
+        val session = getSelectedSession()
+        val intent = Intent()
+
+        intent.data = mock()
+        session.promptRequest = Consumable.from(filePickerRequest)
+
+        stubContext()
+
+        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_REQUEST, RESULT_OK, intent)
+
+        verify(mockSessionManager).selectedSession
+        assertTrue(onSingleFileSelectionWasCalled)
+        assertTrue(session.promptRequest.isConsumed())
+    }
+
+    @Test
+    fun `onActivityResult with RESULT_OK and isMultipleFilesSelection true will consume PromptRequest of the actual session`() {
+
+        var onMultipleFileSelectionWasCalled = false
+
+        val onMultipleFileSelection: (Context, Array<Uri>) -> Unit = { _, _ ->
+            onMultipleFileSelectionWasCalled = true
+        }
+
+        val filePickerRequest =
+            PromptRequest.File(emptyArray(), true, { _, _ -> }, onMultipleFileSelection) {}
+
+        val session = getSelectedSession()
+        val intent = Intent()
+
+        intent.clipData = mock()
+        val item = mock<ClipData.Item>()
+
+        doReturn(mock<Uri>()).`when`(item).uri
+
+        intent.clipData?.apply {
+            doReturn(1).`when`(this).itemCount
+            doReturn(item).`when`(this).getItemAt(0)
+        }
+
+        session.promptRequest = Consumable.from(filePickerRequest)
+
+        stubContext()
+
+        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_REQUEST, RESULT_OK, intent)
+
+        verify(mockSessionManager).selectedSession
+        assertTrue(onMultipleFileSelectionWasCalled)
+        assertTrue(session.promptRequest.isConsumed())
+    }
+
+    @Test
+    fun `onActivityResult with not RESULT_OK will consume PromptRequest of the actual session and call onDismiss `() {
+
+        var onDismissWasCalled = false
+
+        val filePickerRequest =
+            PromptRequest.File(emptyArray(), true, { _, _ -> }, { _, _ -> }) {
+                onDismissWasCalled = true
+            }
+
+        val session = getSelectedSession()
+        val intent = Intent()
+
+        session.promptRequest = Consumable.from(filePickerRequest)
+
+        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_REQUEST, RESULT_CANCELED, intent)
+
+        verify(mockSessionManager).selectedSession
+        assertTrue(onDismissWasCalled)
+        assertTrue(session.promptRequest.isConsumed())
+    }
+
+    @Test
+    fun `onRequestPermissionsResult with FILE_PICKER_REQUEST and PERMISSION_GRANTED will call onPermissionsGranted`() {
+
+        promptFeature = spy(promptFeature)
+
+        promptFeature.onRequestPermissionsResult(FILE_PICKER_REQUEST, emptyArray(), IntArray(1) { PERMISSION_GRANTED })
+
+        verify(promptFeature).onPermissionsGranted()
+    }
+
+    @Test
+    fun `onRequestPermissionsResult with FILE_PICKER_REQUEST and PERMISSION_DENIED will call onPermissionsDeny`() {
+
+        promptFeature = spy(promptFeature)
+
+        promptFeature.onRequestPermissionsResult(FILE_PICKER_REQUEST, emptyArray(), IntArray(1) { PERMISSION_DENIED })
+
+        verify(promptFeature).onPermissionsDeny()
+    }
+
+    @Test
+    fun `onRequestPermissionsResult with invalid request code will not call neither onPermissionsGranted nor onPermissionsDeny`() {
+
+        promptFeature = spy(promptFeature)
+
+        promptFeature.onRequestPermissionsResult(-1344, emptyArray(), IntArray(1) { PERMISSION_DENIED })
+
+        verify(promptFeature, never()).onPermissionsGranted()
+        verify(promptFeature, never()).onPermissionsDeny()
+    }
+
     private fun getSelectedSession(): Session {
         val session = Session("")
         mockSessionManager.add(session)
@@ -337,5 +615,14 @@ class PromptFeatureTest {
         val transaction: FragmentTransaction = mock()
         doReturn(transaction).`when`(fragmentManager).beginTransaction()
         return fragmentManager
+    }
+
+    private fun stubContext() {
+        val mockFragment: Fragment = mock()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        doReturn(context).`when`(mockFragment).requireContext()
+
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ -> }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,17 @@ permalink: /changelog/
 * **feature-customtabs**
  * Added support for opening speculative connections for a likely future navigation to a URL (`mayLaunchUrl`)
 
+* **feature-prompts**
+  * Added support for file picker requests.
+
+  There some requests that are not handled with dialogs, instead they are delegated to other apps
+  to perform the request, an example is a file picker request. As a result, now you have to override
+  `onActivityResult` on your `Activity` or `Fragment` and forward its calls to `promptFeature.onActivityResult`.
+
+  Additionally, there are requests that need some permission to be granted before they can be performed, like
+  file pickers that need access to read the selected files. Like `onActivityResult` you need to override
+  `onRequestPermissionsResult` and forward its calls to `promptFeature.onRequestPermissionsResult`.
+
 # 0.35.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.35.0...v0.35.1)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.samples.browser
 
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.content.Intent
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Bundle
 import android.support.v4.app.Fragment
@@ -95,7 +96,13 @@ class BrowserFragment : Fragment(), BackHandler {
                 components.tabsUseCases,
                 view))
 
-        promptFeature = PromptFeature(components.sessionManager, requireFragmentManager())
+        promptFeature = PromptFeature(
+            null, this,
+            components.sessionManager,
+            requireFragmentManager()
+        ) { _, permissions, requestCode ->
+            requestPermissions(permissions, requestCode)
+        }
 
         windowFeature = WindowFeature(components.engine, components.sessionManager)
     }
@@ -168,5 +175,10 @@ class BrowserFragment : Fragment(), BackHandler {
                 }
             }
         }
+        promptFeature.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        promptFeature.onActivityResult(requestCode, resultCode, data)
     }
 }


### PR DESCRIPTION
While working in this feature, I noticed somethings that are not working correctly on the GeckoView side:

- GeckoView is not giving us the mimeTypes from the input type file -> [Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1514364)
- GeckoView is not handling selected Uris coming from the Android File Chooser only Uris from the Android Gallery app. I did the same exercise with the webview implementation and it worked correctly  -> [Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1515440)

You can take a look at this feature [here](https://drive.google.com/file/d/1pIvDJOggMgSH5_nLr9ozN0wOYlsRwkdm/view).