### PR TITLE
Closes #496: Adding support for html input types file for SystemEngine

### DIFF
--- a/components/browser/engine-system/build.gradle
+++ b/components/browser/engine-system/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_androidx
 }
 
 apply from: '../../../publish.gradle'


### PR DESCRIPTION
[Here](https://drive.google.com/file/d/1LJZpB-cXxbofXZCM_M-d_u8Aylm1owf8/view). you can take a look at this feature.

To be able to test this feature, I had to comment the `sessionStorage.autoSave` on `DefaultComponents.kt`, because in the `systemUniversal` variant, the app gets frozen every time that leave and return to the app.

```kotlin
//            sessionStorage.autoSave(this)
//                .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
//                .whenGoingToBackground()
//                .whenSessionsChange()
```

 
  