### PR TITLE
Remove ErrorPage dependency

### DIFF
--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     // We expose this as API because we are using Observable in our public API and do not want every
     // consumer to have to manually import "base".
     api project(':support-base')
-    api project(':browser-errorpages')
 
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric


### PR DESCRIPTION
This was from a previous patch which had an ErrorType that existed in
the errorpages feature but was later hidden internally within all the
engine implementations.