### PR TITLE
Closes #1633: Add Bitmap.withRoundedCorners.

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/graphics/Bitmap.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/graphics/Bitmap.kt
@@ -5,6 +5,11 @@
 package mozilla.components.support.ktx.android.graphics
 
 import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Shader.TileMode
+import android.support.annotation.CheckResult
 import android.util.Base64
 import java.io.ByteArrayOutputStream
 
@@ -16,4 +21,27 @@ fun Bitmap.toDataUri(): String {
     compress(Bitmap.CompressFormat.PNG, 100, stream)
     val encodedImage = Base64.encodeToString(stream.toByteArray(), Base64.DEFAULT)
     return "data:image/png;base64," + encodedImage
+}
+
+/**
+ * Returns a new bitmap that is the receiver Bitmap with four rounded corners;
+ * the receiver is unmodified.
+ *
+ * This operation is expensive: it requires allocating an identical Bitmap and copying
+ * all of the Bitmap's pixels. Consider these theoretically cheaper alternatives:
+ * - android:background= a drawable with rounded corners
+ * - Wrap your bitmap's ImageView with a layout that masks your view with rounded corners (e.g. CardView)
+ */
+@CheckResult
+fun Bitmap.withRoundedCorners(cornerRadiusPx: Float): Bitmap {
+    val roundedBitmap = Bitmap.createBitmap(width, height, config)
+    val canvas = Canvas(roundedBitmap)
+    val paint = Paint().apply {
+        isAntiAlias = true
+        shader = BitmapShader(this@withRoundedCorners, TileMode.CLAMP, TileMode.CLAMP)
+    }
+
+    canvas.drawRoundRect(0.0f, 0.0f, width.toFloat(), height.toFloat(),
+            cornerRadiusPx, cornerRadiusPx, paint)
+    return roundedBitmap
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/graphics/BitmapKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/graphics/BitmapKtTest.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.graphics
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BitmapKtTest {
+
+    @Ignore // TODO: convert to integration test. Robolectric's shadows are incomplete and cause this to fail.
+    @Test
+    fun `WHEN withRoundedCorners is called THEN returned bitmap's corners should be transparent and center with color`() {
+        val dimen = 200
+        val fillColor = Color.RED
+
+        val bitmap = Bitmap.createBitmap(dimen, dimen, Bitmap.Config.ARGB_8888).apply {
+            eraseColor(fillColor)
+        }
+        val roundedBitmap = bitmap.withRoundedCorners(40f)
+
+        fun assertCornersAreTransparent() {
+            val cornerLocations = listOf(0, dimen - 1)
+
+            cornerLocations.forEach { x ->
+                cornerLocations.forEach { y ->
+                    assertEquals(Color.TRANSPARENT, roundedBitmap.getPixel(x, y))
+                }
+            }
+        }
+
+        fun assertCenterIsFilled() {
+            val center = dimen / 2
+            assertEquals(fillColor, roundedBitmap.getPixel(center, center))
+        }
+
+        assertNotSame(bitmap, roundedBitmap)
+        assertCornersAreTransparent()
+        assertCenterIsFilled()
+    }
+}


### PR DESCRIPTION
I verified this was working correctly by adding code locally to the
sample browser.

![screenshot_1546288023](https://user-images.githubusercontent.com/759372/50567282-f8ac2f00-0cf7-11e9-95c8-d5a18cd01168.png)
