### PR TITLE
Closes #1504: Add support for alert popup in WebView

### DIFF
--- a/components/browser/engine-system/src/main/res/values/strings.xml
+++ b/components/browser/engine-system/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!-- Text for a title dialog on web page. -->
+    <string name="mozac_browser_engine_system_alert_title">The page at %1$s says:</string>
+</resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 [Milestone](https://github.com/mozilla-mobile/android-components/milestone/40?closed=1),
 [API reference](https://mozilla-mobile.github.io/android-components/api/0.38.0/index)
 
+* **browser-engine-system**
+  * Added support for js alerts on SystemEngineView.
+
 * Compiled against:
   * Android (SDK: 28, Support Libraries: 28.0.0)
   * Kotlin (Stdlib: 1.3.10, Coroutines: 1.0.1)


### PR DESCRIPTION
@jonalmeida, @csadilek and @pocmo. I want hear what do you think about this is this is an early implementation for preventing a page showing many JS alerts. This implementation is already provided by GeckoView for this reason we have to provide a similar one on SystemView.

Here a small [demo](https://drive.google.com/file/d/18G15NiBfMu44arAhCHTJ7lWmb1mj0q_n/view)