### PR TITLE
Issue #1640: WIP: add isDisplayed(Boolean) and friends

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,6 +8,8 @@ object Versions {
     const val coroutines = "1.0.1"
 
     const val androidx_test = "1.0.0"
+    const val espresso = "3.1.0"
+    const val espresso_runner = "1.1.0"
     const val junit = "4.12"
     const val robolectric = "4.0.2"
     const val mockito = "2.23.0"
@@ -41,6 +43,10 @@ object Dependencies {
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
 
     const val testing_androidx = "androidx.test:core:${Versions.androidx_test}"
+    const val testing_espresso_core = "androidx.test.espresso:espresso-core:${Versions.espresso}"
+    const val testing_espresso_runner = "androidx.test:runner:${Versions.espresso_runner}"
+    const val testing_espresso_rules = "androidx.test:rules:${Versions.espresso_runner}"
+
     const val testing_junit = "junit:junit:${Versions.junit}"
     const val testing_robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
     const val testing_mockito = "org.mockito:mockito-core:${Versions.mockito}"

--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     implementation Dependencies.testing_mockito
     implementation Dependencies.testing_robolectric
 
+    implementation Dependencies.testing_espresso_core
+    implementation Dependencies.testing_espresso_runner
+    implementation Dependencies.testing_espresso_rules
+
     testImplementation Dependencies.support_compat
     testImplementation project(':support-ktx')
 }

--- a/components/support/test/src/main/java/mozilla/components/support/test/espresso/Matchers.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/espresso/Matchers.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.test.espresso
+
+import android.view.View
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matcher
+import android.support.test.espresso.matcher.ViewMatchers.isChecked as espressoIsChecked
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed as espressoIsDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.isEnabled as espressoIsEnabled
+import android.support.test.espresso.matcher.ViewMatchers.isSelected as espressoIsSelected
+
+/**
+ * The [espressoIsChecked] function that can also handle unchecked state through the boolean argument.
+ */
+fun isChecked(isChecked: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsChecked(), isChecked)
+
+/**
+ * The [espressoIsDisplayed] function that can also handle not selected state through the boolean argument.
+ */
+fun isDisplayed(isDisplayed: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsDisplayed(), isDisplayed)
+
+/**
+ * The [espressoIsEnabled] function that can also handle disabled state through the boolean argument.
+ */
+fun isEnabled(isEnabled: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsEnabled(), isEnabled)
+
+/**
+ * The [espressoIsSelected] function that can also handle not selected state through the boolean argument.
+ */
+fun isSelected(isSelected: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsSelected(), isSelected)
+
+private fun maybeInvertMatcher(matcher: Matcher<View>, useUnmodifiedMatcher: Boolean): Matcher<View> = when {
+    useUnmodifiedMatcher -> matcher
+    else -> not(matcher)
+}


### PR DESCRIPTION
This is taken nearly verbatim from functional code in firefox-tv:
  https://github.com/mozilla-mobile/firefox-tv/blob/6b36f79c030b186feba68562fb999415031cae68/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/Matchers.kt#L17

I'm stuck trying to import espresso: it doesn't seem to want to work. I wonder if it only works in 1) an android application or 2) androidTest dependency. Please suggest a better approach or take this on for yourself!

Note: I was wondering if this should be its own module because anyone who includes this dep has to take a dep on espresso too but didn't want to put in the effort to create a new module if it was unnecessary and I'm concerned about the mental overload of having so many module dependencies.