### PR TITLE
feature-customtabs: Execute warmup() on main thread.

### DIFF
--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':support-base')
 
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     api Dependencies.support_customtabs
 

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
@@ -9,6 +9,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.customtabs.CustomTabsService
 import android.support.customtabs.CustomTabsSessionToken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.engine.Engine
 import mozilla.components.support.base.log.logger.Logger
 
@@ -27,9 +29,12 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
     abstract val engine: Engine
 
     override fun warmup(flags: Long): Boolean {
-        // Just accessing the engine here will make sure that it is created and initialized.
-        logger.debug("Warm up for engine: ${engine.name()}")
-        return true
+        // We need to run this on the main thread since that's where GeckoRuntime expects to get initialized (if needed)
+        return runBlocking(Dispatchers.Main) {
+            // Just accessing the engine here will make sure that it is created and initialized.
+            logger.debug("Warm up for engine: ${engine.name()}")
+            true
+        }
     }
 
     override fun requestPostMessageChannel(sessionToken: CustomTabsSessionToken?, postMessageOrigin: Uri?): Boolean {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,9 @@ permalink: /changelog/
   val telemetry = Telemetry(configuration, storage, client, scheduler)
   ```
 
+* **feature-customtabs**
+  * Fixed a bug where a third-party app (like Gmail or Slack) could crash when calling warmup().
+
 # 0.36.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.35.0...v0.36.0),


### PR DESCRIPTION
This fixes https://github.com/mozilla-mobile/reference-browser/issues/366