### PR TITLE
Adds "arrow" as a python dependency to docker image 

### DIFF
--- a/automation/docker/Dockerfile
+++ b/automation/docker/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update -qq \
 
 RUN pip install --upgrade pip
 RUN pip install 'taskcluster>=4,<5'
+RUN pip install arrow
 
 RUN locale-gen en_US.UTF-8
 


### PR DESCRIPTION
We need `arrow` to parse `ISO8601` dates from `taskcluster`.
This blocks:
* [indexes in Taskcluster for `reference-browser`](https://github.com/mozilla-mobile/reference-browser/issues/369)
* [indexes in Taskcluster for `focus`](https://github.com/mozilla-mobile/focus-android/issues/2980)