### PR TITLE
Closes #1645: Default behaviour for window requests in engine-gecko..

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -272,6 +272,13 @@ class GeckoEngineSession(
             session: GeckoSession,
             request: NavigationDelegate.LoadRequest
         ): GeckoResult<AllowOrDeny> {
+            // TODO use onNewSession and create window request:
+            // https://github.com/mozilla-mobile/android-components/issues/1503
+            if (request.target == GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW) {
+                geckoSession.loadUri(request.uri)
+                return GeckoResult.fromValue(AllowOrDeny.DENY)
+            }
+
             val response = settings.requestInterceptor?.onLoadRequest(
                 this@GeckoEngineSession,
                 request.uri
@@ -281,7 +288,6 @@ class GeckoEngineSession(
                     is InterceptionResponse.Url -> loadUrl(url)
                 }
             }
-
             return GeckoResult.fromValue(if (response != null) AllowOrDeny.DENY else AllowOrDeny.ALLOW)
         }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -43,6 +43,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
+import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
@@ -1397,6 +1398,19 @@ class GeckoEngineSessionTest {
         verify(geckoSession).close()
     }
 
+    @Test
+    fun `Handle new window load requests`() {
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+        captureDelegates()
+
+        val result = navigationDelegate.value.onLoadRequest(geckoSession,
+                mockLoadRequest("sample:about", GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW))
+
+        assertNotNull(result)
+        assertEquals(result!!.poll(0), AllowOrDeny.DENY)
+        verify(geckoSession).loadUri("sample:about")
+    }
+
     private fun mockGeckoSession(): GeckoSession {
         val session = mock(GeckoSession::class.java)
         `when`(session.settings).thenReturn(
@@ -1404,7 +1418,7 @@ class GeckoEngineSessionTest {
         return session
     }
 
-    private fun mockLoadRequest(uri: String): GeckoSession.NavigationDelegate.LoadRequest {
+    private fun mockLoadRequest(uri: String, target: Int = 0): GeckoSession.NavigationDelegate.LoadRequest {
         val constructor = GeckoSession.NavigationDelegate.LoadRequest::class.java.getDeclaredConstructor(
             String::class.java,
             String::class.java,
@@ -1412,6 +1426,6 @@ class GeckoEngineSessionTest {
             Int::class.java)
         constructor.isAccessible = true
 
-        return constructor.newInstance(uri, uri, 0, 0)
+        return constructor.newInstance(uri, uri, target, 0)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -273,6 +273,13 @@ class GeckoEngineSession(
             session: GeckoSession,
             request: NavigationDelegate.LoadRequest
         ): GeckoResult<AllowOrDeny> {
+            // TODO use onNewSession and create window request:
+            // https://github.com/mozilla-mobile/android-components/issues/1503
+            if (request.target == GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW) {
+                geckoSession.loadUri(request.uri)
+                return GeckoResult.fromValue(AllowOrDeny.DENY)
+            }
+
             val response = settings.requestInterceptor?.onLoadRequest(
                 this@GeckoEngineSession,
                 request.uri
@@ -282,7 +289,6 @@ class GeckoEngineSession(
                     is InterceptionResponse.Url -> loadUrl(url)
                 }
             }
-
             return GeckoResult.fromValue(if (response != null) AllowOrDeny.DENY else AllowOrDeny.ALLOW)
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -43,6 +43,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
+import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
@@ -1397,6 +1398,19 @@ class GeckoEngineSessionTest {
         verify(geckoSession).close()
     }
 
+    @Test
+    fun `Handle new window load requests`() {
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+        captureDelegates()
+
+        val result = navigationDelegate.value.onLoadRequest(geckoSession,
+                mockLoadRequest("sample:about", GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW))
+
+        assertNotNull(result)
+        assertEquals(result!!.poll(0), AllowOrDeny.DENY)
+        verify(geckoSession).loadUri("sample:about")
+    }
+
     private fun mockGeckoSession(): GeckoSession {
         val session = mock(GeckoSession::class.java)
         `when`(session.settings).thenReturn(
@@ -1404,7 +1418,7 @@ class GeckoEngineSessionTest {
         return session
     }
 
-    private fun mockLoadRequest(uri: String): GeckoSession.NavigationDelegate.LoadRequest {
+    private fun mockLoadRequest(uri: String, target: Int = 0): GeckoSession.NavigationDelegate.LoadRequest {
         val constructor = GeckoSession.NavigationDelegate.LoadRequest::class.java.getDeclaredConstructor(
             String::class.java,
             String::class.java,
@@ -1412,6 +1426,6 @@ class GeckoEngineSessionTest {
             Int::class.java)
         constructor.isAccessible = true
 
-        return constructor.newInstance(uri, uri, 0, 0)
+        return constructor.newInstance(uri, uri, target, 0)
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -261,6 +261,13 @@ class GeckoEngineSession(
             session: GeckoSession,
             request: NavigationDelegate.LoadRequest
         ): GeckoResult<AllowOrDeny> {
+            // TODO use onNewSession and create window request:
+            // https://github.com/mozilla-mobile/android-components/issues/1503
+            if (request.target == GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW) {
+                geckoSession.loadUri(request.uri)
+                return GeckoResult.fromValue(AllowOrDeny.DENY)
+            }
+
             val response = settings.requestInterceptor?.onLoadRequest(
                 this@GeckoEngineSession,
                 request.uri
@@ -270,7 +277,6 @@ class GeckoEngineSession(
                     is InterceptionResponse.Url -> loadUrl(url)
                 }
             }
-
             return GeckoResult.fromValue(if (response != null) AllowOrDeny.DENY else AllowOrDeny.ALLOW)
         }
 


### PR DESCRIPTION
This makes sure `target="_blank"` and `window.open` at least work (open in same tab) until we can support window requests (see #1503).