### PR TITLE
Bug 1517732 - Expose routes.statuses because taskcluster-github now a…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -34,6 +34,8 @@ tasks:
           - queue:create-task:aws-provisioner-v1/github-worker
           - queue:scheduler-id:${scheduler_id}
           - secrets:get:project/mobile/android-components/public-tokens
+        routes:
+          - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
           maxRunTime: 3600
           image: mozillamobile/android-components:1.11


### PR DESCRIPTION
…dds it

It was added in https://github.com/taskcluster/taskcluster-github/pull/323