### PR TITLE
Closes #1606: Add Pocket Client on FireTV telemetry events ping

### DIFF
--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
@@ -20,6 +20,7 @@ import org.mozilla.telemetry.ping.TelemetryEventPingBuilder;
 import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder;
 import org.mozilla.telemetry.ping.TelemetryPing;
 import org.mozilla.telemetry.ping.TelemetryPingBuilder;
+import org.mozilla.telemetry.ping.TelemetryPocketEventPingBuilder;
 import org.mozilla.telemetry.schedule.TelemetryScheduler;
 import org.mozilla.telemetry.storage.TelemetryStorage;
 
@@ -95,6 +96,7 @@ public class Telemetry {
                 // ping type and then falling back on the legacy ping type.
                 final TelemetryPingBuilder mobileEventBuilder = pingBuilders.get(TelemetryMobileEventPingBuilder.TYPE);
                 final TelemetryPingBuilder focusEventBuilder = pingBuilders.get(TelemetryEventPingBuilder.TYPE);
+                final TelemetryPingBuilder pocketEventBuilder = pingBuilders.get(TelemetryPocketEventPingBuilder.TYPE);
                 final EventsMeasurement measurement;
                 final String addedPingType;
                 if (mobileEventBuilder != null) {
@@ -103,11 +105,13 @@ public class Telemetry {
                 } else if (focusEventBuilder != null) {
                     measurement = ((TelemetryEventPingBuilder) focusEventBuilder).getEventsMeasurement();
                     addedPingType = focusEventBuilder.getType();
+                } else if (pocketEventBuilder != null) {
+                    measurement = ((TelemetryPocketEventPingBuilder) pocketEventBuilder).getEventsMeasurement();
+                    addedPingType = pocketEventBuilder.getType();
                 } else {
                     throw new IllegalStateException("Expect either TelemetryEventPingBuilder or " +
                             "TelemetryMobileEventPingBuilder to be added to queue events");
                 }
-
                 measurement.add(event);
                 if (measurement.getEventCount() >= configuration.getMaximumNumberOfEventsPerPing()) {
                     queuePing(addedPingType);

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/PocketIdMeasurement.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/measurement/PocketIdMeasurement.java
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.measurement;
+
+import android.content.SharedPreferences;
+
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+
+import java.util.UUID;
+
+/**
+ * A unique, randomly generated UUID for this pocket client for fire-tv instance.
+ * This is distinct from the telemetry clientId. The clientId should not be able to be tied to the pocketId in any way.
+ */
+public class PocketIdMeasurement extends TelemetryMeasurement {
+    private static final String FIELD_NAME = "pocketId";
+
+    private static final String PREFERENCE_POCKET_ID = "pocket_id";
+
+    private TelemetryConfiguration configuration;
+    private String pocketId;
+
+    public PocketIdMeasurement(TelemetryConfiguration configuration) {
+        super(FIELD_NAME);
+
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Object flush() {
+        if (pocketId == null) {
+            pocketId = generateClientId(configuration);
+        }
+
+        return pocketId;
+    }
+
+    private static synchronized String generateClientId(final TelemetryConfiguration configuration) {
+        final SharedPreferences preferences = configuration.getSharedPreferences();
+
+        if (preferences.contains(PREFERENCE_POCKET_ID)) {
+            // We already generated a pocket id in the past. Let's use it.
+            return preferences.getString(PREFERENCE_POCKET_ID, /* unused default value */ null);
+        }
+
+        final String pocketId = UUID.randomUUID().toString();
+
+        preferences.edit()
+                .putString(PREFERENCE_POCKET_ID, pocketId)
+                .apply();
+
+        return pocketId;
+    }
+}

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPingBuilder.java
@@ -30,9 +30,13 @@ public abstract class TelemetryPingBuilder {
         this.type = type;
         this.measurements = new LinkedList<>();
 
-        // All pings contain a version and a client id
+        // All pings contain a version and a client id (with exception below)
         addMeasurement(new VersionMeasurement(version));
-        addMeasurement(new ClientIdMeasurement(configuration));
+
+        // Fire-tv pocket telemetry ping should not include client-id (see #1606)
+        if (!type.equals(TelemetryPocketEventPingBuilder.TYPE)) {
+            addMeasurement(new ClientIdMeasurement(configuration));
+        }
     }
 
     public TelemetryConfiguration getConfiguration() {

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPingBuilder.java
@@ -32,15 +32,18 @@ public abstract class TelemetryPingBuilder {
 
         // All pings contain a version and a client id (with exception below)
         addMeasurement(new VersionMeasurement(version));
-
-        // Fire-tv pocket telemetry ping should not include client-id (see #1606)
-        if (!type.equals(TelemetryPocketEventPingBuilder.TYPE)) {
+        if (shouldIncludeClientId()) {
             addMeasurement(new ClientIdMeasurement(configuration));
         }
     }
 
     public TelemetryConfiguration getConfiguration() {
         return configuration;
+    }
+
+    // Fire-tv pocket telemetry ping should not include client-id (see #1606)
+    protected boolean shouldIncludeClientId() {
+        return true;
     }
 
     @NonNull

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
@@ -6,6 +6,7 @@ package org.mozilla.telemetry.ping;
 
 import org.mozilla.telemetry.config.TelemetryConfiguration;
 import org.mozilla.telemetry.measurement.CreatedTimestampMeasurement;
+import org.mozilla.telemetry.measurement.DeviceMeasurement;
 import org.mozilla.telemetry.measurement.EventsMeasurement;
 import org.mozilla.telemetry.measurement.LocaleMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemMeasurement;
@@ -34,6 +35,7 @@ public class TelemetryPocketEventPingBuilder extends TelemetryPingBuilder {
         addMeasurement(new ProcessStartTimestampMeasurement(configuration));
         addMeasurement(new SequenceMeasurement(configuration, this));
         addMeasurement(new LocaleMeasurement());
+        addMeasurement(new DeviceMeasurement());
         addMeasurement(new OperatingSystemMeasurement());
         addMeasurement(new OperatingSystemVersionMeasurement());
         addMeasurement(new CreatedTimestampMeasurement());
@@ -48,11 +50,6 @@ public class TelemetryPocketEventPingBuilder extends TelemetryPingBuilder {
 
     public EventsMeasurement getEventsMeasurement() {
         return eventsMeasurement;
-    }
-
-    @Override
-    public boolean canBuild() {
-        return eventsMeasurement.getEventCount() >= getConfiguration().getMinimumEventsForUpload();
     }
 
     @Override

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
@@ -41,6 +41,11 @@ public class TelemetryPocketEventPingBuilder extends TelemetryPingBuilder {
         addMeasurement(eventsMeasurement = new EventsMeasurement(configuration));
     }
 
+    @Override
+    protected boolean shouldIncludeClientId() {
+        return false;
+    }
+
     public EventsMeasurement getEventsMeasurement() {
         return eventsMeasurement;
     }

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.ping;
+
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+import org.mozilla.telemetry.measurement.CreatedTimestampMeasurement;
+import org.mozilla.telemetry.measurement.EventsMeasurement;
+import org.mozilla.telemetry.measurement.LocaleMeasurement;
+import org.mozilla.telemetry.measurement.OperatingSystemMeasurement;
+import org.mozilla.telemetry.measurement.OperatingSystemVersionMeasurement;
+import org.mozilla.telemetry.measurement.ProcessStartTimestampMeasurement;
+import org.mozilla.telemetry.measurement.SequenceMeasurement;
+import org.mozilla.telemetry.measurement.SettingsMeasurement;
+import org.mozilla.telemetry.measurement.TimezoneOffsetMeasurement;
+
+/**
+ * A telemetry ping builder for events of type "fire-tv-events".
+ *
+ * See the schema for more details:
+ *   https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/dc458113a7a523e60a9ba50e1174a3b1e0cfdc24/schemas/pocket/fire-tv-events/fire-tv-events.1.schema.json
+ */
+public class TelemetryPocketEventPingBuilder extends TelemetryPingBuilder {
+    public static final String TYPE = "fire-tv-events";
+    private static final int VERSION = 1;
+
+    private EventsMeasurement eventsMeasurement;
+
+    public TelemetryPocketEventPingBuilder(TelemetryConfiguration configuration) {
+        super(configuration, TYPE, VERSION);
+
+        addMeasurement(new ProcessStartTimestampMeasurement(configuration));
+        addMeasurement(new SequenceMeasurement(configuration, this));
+        addMeasurement(new LocaleMeasurement());
+        addMeasurement(new OperatingSystemMeasurement());
+        addMeasurement(new OperatingSystemVersionMeasurement());
+        addMeasurement(new CreatedTimestampMeasurement());
+        addMeasurement(new TimezoneOffsetMeasurement());
+        addMeasurement(new SettingsMeasurement(configuration));
+        addMeasurement(eventsMeasurement = new EventsMeasurement(configuration));
+    }
+
+    public EventsMeasurement getEventsMeasurement() {
+        return eventsMeasurement;
+    }
+
+    @Override
+    public boolean canBuild() {
+        return eventsMeasurement.getEventCount() >= getConfiguration().getMinimumEventsForUpload();
+    }
+
+    @Override
+    protected String getUploadPath(final String documentId) {
+        return super.getUploadPath(documentId) + "?v=4";
+    }
+}

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryPocketEventPingBuilder.java
@@ -10,9 +10,9 @@ import org.mozilla.telemetry.measurement.EventsMeasurement;
 import org.mozilla.telemetry.measurement.LocaleMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemVersionMeasurement;
+import org.mozilla.telemetry.measurement.PocketIdMeasurement;
 import org.mozilla.telemetry.measurement.ProcessStartTimestampMeasurement;
 import org.mozilla.telemetry.measurement.SequenceMeasurement;
-import org.mozilla.telemetry.measurement.SettingsMeasurement;
 import org.mozilla.telemetry.measurement.TimezoneOffsetMeasurement;
 
 /**
@@ -30,6 +30,7 @@ public class TelemetryPocketEventPingBuilder extends TelemetryPingBuilder {
     public TelemetryPocketEventPingBuilder(TelemetryConfiguration configuration) {
         super(configuration, TYPE, VERSION);
 
+        addMeasurement(new PocketIdMeasurement(configuration));
         addMeasurement(new ProcessStartTimestampMeasurement(configuration));
         addMeasurement(new SequenceMeasurement(configuration, this));
         addMeasurement(new LocaleMeasurement());
@@ -37,7 +38,6 @@ public class TelemetryPocketEventPingBuilder extends TelemetryPingBuilder {
         addMeasurement(new OperatingSystemVersionMeasurement());
         addMeasurement(new CreatedTimestampMeasurement());
         addMeasurement(new TimezoneOffsetMeasurement());
-        addMeasurement(new SettingsMeasurement(configuration));
         addMeasurement(eventsMeasurement = new EventsMeasurement(configuration));
     }
 


### PR DESCRIPTION
To understand video impressions, clicks, views, and duration for Pocket on Firefox for Fire TV.

Note: `pocketId` is distinct from the telemetry `clientId`. The `clientId` should not be able to be tied to the `pocketId` in any way.