### PR TITLE
Closes #1397: Add custom tab toolbar color support..

### DIFF
--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -22,8 +22,11 @@ android {
 }
 
 dependencies {
+    implementation project(':browser-session')
+    implementation project(':browser-toolbar')
     implementation project(':concept-engine')
     implementation project(':support-base')
+    implementation project(':support-utils')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -1,0 +1,67 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.customtabs
+
+import android.graphics.Color
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+
+/**
+ * Initializes and resets the Toolbar for a Custom Tab based on the CustomTabConfig.
+ */
+class CustomTabsToolbarFeature(
+    private val sessionManager: SessionManager,
+    private val toolbar: BrowserToolbar,
+    private val sessionId: String? = null
+) : LifecycleAwareFeature {
+
+    override fun start() {
+        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
+        session?.let { initialize(it) }
+    }
+
+    internal fun initialize(session: Session) {
+        session.customTabConfig?.let { config ->
+            // Change the toolbar colour
+            updateToolbarColor(config.toolbarColor)
+        }
+    }
+
+    internal fun updateToolbarColor(toolbarColor: Int?) {
+        toolbarColor?.let { color ->
+            toolbar.setBackgroundColor(color)
+            toolbar.textColor = getReadableTextColor(color)
+        }
+    }
+
+    override fun stop() {}
+
+    companion object {
+        @Suppress("MagicNumber")
+        internal fun getReadableTextColor(backgroundColor: Int): Int {
+            val greyValue = greyscaleFromRGB(backgroundColor)
+            // 186 chosen rather than the seemingly obvious 128 because of gamma.
+            return if (greyValue < 186) {
+                Color.WHITE
+            } else {
+                Color.BLACK
+            }
+        }
+
+        @Suppress("MagicNumber")
+        private fun greyscaleFromRGB(color: Int): Int {
+            val red = Color.red(color)
+            val green = Color.green(color)
+            val blue = Color.blue(color)
+            // Magic weighting taken from a stackoverflow post, supposedly related to how
+            // humans perceive color.
+            return (0.299 * red + 0.587 * green + 0.114 * blue).toInt()
+        }
+    }
+}

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -1,0 +1,97 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.customtabs
+
+import android.graphics.Color
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CustomTabsToolbarFeatureTest {
+
+    @Test
+    fun `start with no sessionId invokes nothing`() {
+        val sessionManager: SessionManager = spy(SessionManager(mock()))
+        val session: Session = mock()
+
+        val feature = spy(CustomTabsToolbarFeature(sessionManager, mock()))
+
+        feature.start()
+
+        verify(sessionManager, never()).findSessionById(anyString())
+        verify(feature, never()).initialize(session)
+    }
+
+    @Test
+    fun `start calls initialize with the sessionId`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
+
+        val feature = spy(CustomTabsToolbarFeature(sessionManager, mock(), ""))
+
+        feature.start()
+
+        verify(feature).initialize(session)
+    }
+
+    @Test
+    fun `initialize updates toolbar`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        `when`(session.customTabConfig).thenReturn(mock())
+
+        val feature = spy(CustomTabsToolbarFeature(sessionManager, mock(), ""))
+
+        feature.initialize(session)
+
+        verify(feature).updateToolbarColor(anyInt())
+    }
+
+    @Test
+    fun `updateToolbarColor changes background and textColor`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        val toolbar: BrowserToolbar = mock()
+        `when`(session.customTabConfig).thenReturn(mock())
+
+        val feature = spy(CustomTabsToolbarFeature(sessionManager, toolbar, ""))
+
+        feature.updateToolbarColor(null)
+
+        verify(toolbar, never()).setBackgroundColor(anyInt())
+        verify(toolbar, never()).textColor = anyInt()
+
+        feature.updateToolbarColor(123)
+
+        verify(toolbar).setBackgroundColor(anyInt())
+        verify(toolbar).textColor = anyInt()
+    }
+
+    @Test
+    fun getReadableTextColor() {
+        // White text color for a black background
+        val white = CustomTabsToolbarFeature.getReadableTextColor(0)
+        assertEquals(Color.WHITE, white)
+
+        // Black text color for a white background
+        val black = CustomTabsToolbarFeature.getReadableTextColor(0xFFFFFF)
+        assertEquals(Color.BLACK, black)
+    }
+}

--- a/components/feature/customtabs/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/customtabs/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)
+

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -40,10 +40,6 @@ class ToolbarPresenter(
         activeSession?.let { session ->
             toolbar.url = session.url
 
-            session.customTabConfig?.toolbarColor?.let {
-                toolbar.asView().setBackgroundColor(it)
-            }
-
             updateToolbarSecurity(session.securityInfo)
 
             // TODO Apply remaining configurations: https://github.com/mozilla-mobile/android-components/issues/306

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,18 @@ permalink: /changelog/
   * Mozilla App Services (FxA: 0.12.1, Sync Logins: 0.12.1, Places: 0.12.1)
   * Third Party Libs (Sentry: 1.7.14, Okhttp: 3.12.0)
 
+* **feature-customtabs**
+  * Added a new feature `CustomTabsToolbarFeature` which will handle setting up the `BrowserToolbar` with the configurations available in that session:
+
+  ```kotlin
+  CustomTabsToolbarFeature(
+    sessionManager,
+    browserToolbar,
+    sessionId
+  ).also { lifecycle.addObserver(it) }
+  ```
+  Note: this constructor API is still a work-in-progress and will change as more Custom Tabs support is added to it next release.
+
 * **feature-session-bundling**
   * 🆕 New component that saves the state of sessions (`SessionManager.Snapshot`) in grouped bundles (e.g. by time).
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -18,6 +18,7 @@ import kotlinx.android.synthetic.main.fragment_browser.*
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
+import mozilla.components.feature.customtabs.CustomTabsToolbarFeature
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.session.CoordinateScrollingFeature
 import mozilla.components.feature.prompts.PromptFeature
@@ -39,6 +40,7 @@ class BrowserFragment : Fragment(), BackHandler {
     private lateinit var contextMenuFeature: ContextMenuFeature
     private lateinit var promptFeature: PromptFeature
     private lateinit var windowFeature: WindowFeature
+    private lateinit var customTabsToolbarFeature: CustomTabsToolbarFeature
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_browser, container, false)
@@ -99,14 +101,20 @@ class BrowserFragment : Fragment(), BackHandler {
                 view))
 
         promptFeature = PromptFeature(
-            null, this,
-            components.sessionManager,
-            requireFragmentManager()
+            fragment = this,
+            sessionManager = components.sessionManager,
+            fragmentManager = requireFragmentManager()
         ) { _, permissions, requestCode ->
             requestPermissions(permissions, requestCode)
         }
 
         windowFeature = WindowFeature(components.engine, components.sessionManager)
+
+        customTabsToolbarFeature = CustomTabsToolbarFeature(
+            components.sessionManager,
+            toolbar,
+            sessionId
+        )
 
         // Observe the lifecycle for supported features
         lifecycle.addObservers(
@@ -116,7 +124,8 @@ class BrowserFragment : Fragment(), BackHandler {
             scrollFeature,
             contextMenuFeature,
             promptFeature,
-            windowFeature
+            windowFeature,
+            customTabsToolbarFeature
         )
     }
 


### PR DESCRIPTION
I ended up finishing most of the requirements for a custom tabs toolbar in https://github.com/mozilla-mobile/reference-browser/issues/209 all at once. This PR only contains the minimum required for setting up the feature and toolbar background color, the rest will come through in a follow up PR when I'm done writing tests for them.