### PR TITLE
[glean] Mention the data-review process in the glean README [ci skip]

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -3,6 +3,22 @@
 A client-side telemetry SDK for collecting metrics and sending them to Mozilla's telemetry service
 (eventually replacing [service-telemetry](../telemetry/README.md)).
 
+- [Before using the library](#before-using-the-library)
+- [Usage](#usage)
+    - [Setting up the dependency](#setting-up-the-dependency)
+    - [Integrating with the build system](#integrating-with-the-build-system)
+    - [Initializing glean](#initializing-glean)
+    - [Defining metrics](#defining-metrics)
+- [License](#license)
+
+## Before using the library
+Products using glean to collect telemetry **must**:
+
+- add documentation for any new metric collected with the library in its repository (see [an example](https://github.com/mozilla-mobile/android-components/blob/df429df1a193516f796f2330863af384cce820bc/components/service/glean/docs/pings.md));
+- go through data review for the newly collected data by following [this process](https://wiki.mozilla.org/Firefox/Data_Collection);
+- provide a way for users to turn data collection off (e.g. providing settings to control
+  `Glean.setMetricsEnabled()`).
+
 ## Usage
 
 ### Setting up the dependency
@@ -69,6 +85,10 @@ and sending its [pings](docs/pings.md).
 The metrics that your application collects must be defined in a ``metrics.yaml``
 file. The format of that file is documented
 [here](https://mozilla.github.io/glean_parser/metrics-yaml.html).
+
+**Important**: as stated [here](#before-using-the-library), any new data collection requires
+documentation and data-review. This is also required for any new metric automatically collected
+by glean.
 
 ## License
 

--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -16,6 +16,8 @@ baseline:
       - baseline
     bugs:
       - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
@@ -39,6 +41,8 @@ baseline:
       The name of the operating system.
     bugs:
       - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
@@ -51,6 +55,8 @@ baseline:
       The version of the operating system.
     bugs:
       - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
@@ -63,6 +69,8 @@ baseline:
       The manufacturer and model of the device.
     bugs:
       - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
@@ -75,6 +83,8 @@ baseline:
       The architecture of the device, (e.g. "arm", "x86").
     bugs:
       - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
@@ -108,6 +118,8 @@ glean.internal.metrics:
     lifetime: user
     bugs:
       - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
 


### PR DESCRIPTION
This additionally adds links to the data-review related to the fields in the `ping_info` section of the pings.