### PR TITLE
[glean]Prevent ping upload when metrics disabled or ping empty

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -146,15 +146,25 @@ open class GleanInternalAPI {
 
     /**
      * Collect and assemble the ping. Asynchronously submits the assembled
-     * payload to the designated server using [httpPingUploader].
+     * payload to the designated server using [httpPingUploader] but only
+     * if metrics are enabled, and there is ping data to send.
      */
     internal fun sendPing(store: String, docType: String) {
-        val pingContent = pingMaker.collect(store)
-        val uuid = UUID.randomUUID()
-        val path = makePath(docType, uuid)
-        // Asynchronously perform the HTTP upload off the main thread.
-        GlobalScope.launch(Dispatchers.IO) {
-            httpPingUploader.upload(path = path, data = pingContent)
+        // Do not send ping if metrics disabled
+        if (!getMetricsEnabled()) {
+            logger.debug("Attempt to send ping \"$store\" but metrics disabled, aborting send.")
+            return
+        }
+
+        // Build and send the ping on an async thread. Since the pingMaker.collect() function
+        // returns null if there is nothing to send we can use this to avoid sending an empty ping
+        pingMaker.collect(store)?.let { pingContent ->
+            val uuid = UUID.randomUUID()
+            val path = makePath(docType, uuid)
+            // Asynchronously perform the HTTP upload off the main thread.
+            GlobalScope.launch(Dispatchers.IO) {
+                httpPingUploader.upload(path = path, data = pingContent)
+            }
         }
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/PingMaker.kt
@@ -108,12 +108,20 @@ internal class PingMaker(
      * Collects the relevant data and assembles the requested ping.
      *
      * @param storage the name of the storage containing the data for the ping.
-     *        This usually matches with the name of the ping
-     * @return a string holding the data for the ping.
+     *        This usually matches with the name of the ping.
+     * @return a string holding the data for the ping, or null if there is no data to send.
      */
-    fun collect(storage: String): String {
+    fun collect(storage: String): String? {
         val jsonPing = storageManager.collect(storage)
+
+        // Return null if there is nothing in the jsonPing object so that this can be used by
+        // consuming functions (i.e. sendPing()) to indicate no ping data is available to send.
+        if (jsonPing.length() == 0) {
+            return null
+        }
+
         jsonPing.put("ping_info", getPingInfo(storage))
+
         return jsonPing.toString()
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -33,7 +33,8 @@ internal class StorageEngineManager(
      *
      * @param storeName the name of the storage of interest
      * @return a [JSONObject] containing the data collected from all the
-     *         storage engines.
+     *         storage engines or returns a completely empty, zero-length [JSONObject]
+     *         if the store is empty and there are no real metrics to send.
      */
     fun collect(storeName: String): JSONObject {
         val jsonPing = JSONObject()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -82,9 +83,10 @@ class PingMakerTest {
             "wontCollect" to MockStorageEngine(JSONObject(), "notThisPing")
         ), applicationContext = mockApplicationContext))
 
-        // Gather the data. We expect an empty ping with the "ping_info" information
+        // Gather the data, this should have everything in the 'test' ping which is the default
+        // storex
         val data = maker.collect("test")
-        assertTrue("We expect a non-empty JSON blob", "{}" != data)
+        assertNotNull("We expect a non-null JSON blob", data)
 
         // Parse the data so that we can easily check the other fields
         val jsonData = JSONObject(data)
@@ -92,5 +94,19 @@ class PingMakerTest {
         assertEquals(engine1Data, metricsData.getJSONArray("engine1"))
         assertEquals(engine2Data, metricsData.getJSONArray("engine2"))
         assertFalse(metricsData.has("wontCollect"))
+    }
+
+    @Test
+    fun `collect() must report an empty string when no data is stored`() {
+        val engine1Data = JSONArray(listOf("1", "2", "3"))
+        val engine2Data = JSONArray(listOf("a", "b", "c"))
+        val maker = PingMaker(StorageEngineManager(storageEngines = mapOf(
+            "engine1" to MockStorageEngine(engine1Data),
+            "engine2" to MockStorageEngine(engine2Data)
+        ), applicationContext = mockApplicationContext))
+
+        // Gather the data. We expect an empty string
+        val data = maker.collect("noSuchData")
+        assertNull("We expect an empty string", data)
     }
 }


### PR DESCRIPTION
Pings were previously still being uploaded even when metrics were disabled. Added a check to test for metrics being enabled before building and uploading ping.

Pings could also be uploaded if they contained no data.  In order to address this, the collect function was changed to return an empty string to be able to intelligently determine whether or not to send a ping.

Add log warning message when attempting to send an empty ping.

Add test cases ensuring pings aren't sent for metrics disabled, and empty pings
