### PR TITLE
Introduce simple, generic API for collecting "facts" emmitted by components.

### DIFF
--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -2,8 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import org.yaml.snakeyaml.Yaml
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'org.yaml:snakeyaml:1.23'
+    }
+}
+
+def generatedSrcDir = new File(buildDir, "generated/components/src/main/java")
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -22,6 +36,13 @@ android {
         }
     }
 
+    sourceSets {
+        main {
+            java {
+                srcDirs += generatedSrcDir
+            }
+        }
+    }
 }
 
 dependencies {
@@ -35,6 +56,40 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+}
+
+
+preBuild.finalizedBy("generateComponentEnum")
+
+
+/**
+ * Generates a "Components" enum listing all published components.
+ */
+task generateComponentEnum {
+    doLast {
+        generatedSrcDir.mkdirs()
+
+        def file = new File(generatedSrcDir, "Component.kt")
+        file.delete()
+        file.createNewFile()
+
+        file << "package mozilla.components.support.base" << "\n"
+        file << "\n"
+        file << "// Automatically generated file. DO NOT MODIFY" << "\n"
+        file << "\n"
+        file << "enum class Component {" << "\n"
+
+        def buildconfig = new Yaml().load(new File(rootDir, '.buildconfig.yml').newInputStream())
+        file << buildconfig.projects.findAll { project ->
+            project.value.publish
+        }.collect { project ->
+            "    " + project.key.replace("-", "_").toUpperCase(Locale.US)
+        }.join(", \n")
+
+        file << "\n"
+        file << "}\n"
+        file << "\n"
+    }
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/Action.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/Action.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+/**
+ * A user or system action that causes [Fact] instances to be emitted.
+ */
+enum class Action {
+    /**
+     * The user has clicked on something.
+     */
+    CLICK,
+
+    /**
+     * The user has toggled something.
+     *
+     * Other than a click this action is performed on items that have a distinct number of states. For example clicking
+     * a checkbox or switch widget could emit a [Fact] with a [TOGGLE] action instead of a [CLICK] action.
+     */
+    TOGGLE,
+
+    /**
+     * The user has committed an input (e.g. entered text into an input field and then pressed enter).
+     */
+    COMMIT,
+
+    /**
+     * A generic interaction that can be caused by a previous action (e.g. the user clicks on a button which causes a
+     * [Fact] with ][CLICK] action to be emitted. This click may causes something to load which emits a follow-up a
+     * [Fact] with [INTERACTION] action,
+     */
+    INTERACTION
+}

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/Fact.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/Fact.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+import mozilla.components.support.base.Component
+
+/**
+ * A fact describing a generic event that has occurred in a component.
+ *
+ * @property component Component that emitted this fact.
+ * @property action A user or system action that caused this fact (e.g. Action.CLICK).
+ * @property item An item that caused the action or that the action was performed on (e.g. "toolbar").
+ * @property value An optional value providing more context.
+ * @property metadata A key/value map for facts where additional richer context is needed.
+ */
+data class Fact(
+    val component: Component,
+    val action: Action,
+    val item: String,
+    val value: String? = null,
+    val metadata: Map<String, Any>? = null
+)
+
+/**
+ * Collect this fact through the [Facts] singleton.
+ */
+fun Fact.collect() = Facts.collect(this)

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/FactProcessor.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/FactProcessor.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+/**
+ * A [FactProcessor] receives [Fact] instances from the [Facts] singleton to process them further.
+ */
+interface FactProcessor {
+    /**
+     * Passes the given [Fact] to the [FactProcessor] for processing.
+     */
+    fun process(fact: Fact)
+}
+
+/**
+ * Registers this [FactProcessor] to collect [Fact] instances from the [Facts] singleton.
+ */
+fun FactProcessor.register() = Facts.registerProcessor(this)

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/Facts.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/Facts.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+import android.support.annotation.VisibleForTesting
+
+/**
+ * Global API for collecting [Fact] objects and forwarding them to [FactProcessor] instances.
+ */
+object Facts {
+    private val processors = mutableListOf<FactProcessor>()
+
+    /**
+     * Registers a new [FactProcessor].
+     */
+    fun registerProcessor(processor: FactProcessor): Facts {
+        processors.add(processor)
+        return this
+    }
+
+    /**
+     * Collects a [Fact] and forwards it to all registered [FactProcessor] instances.
+     */
+    fun collect(fact: Fact) {
+        processors.forEach { it.process(fact) }
+    }
+
+    @VisibleForTesting
+    internal fun clearProcessors() {
+        processors.clear()
+    }
+}

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/processor/LogFactProcessor.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/processor/LogFactProcessor.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts.processor
+
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.FactProcessor
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * A [FactProcessor] implementation that prints collected [Fact] instances to the log.
+ */
+class LogFactProcessor(
+    private val logger: Logger = Logger("Facts")
+) : FactProcessor {
+
+    override fun process(fact: Fact) {
+        logger.debug(fact.toString())
+    }
+}

--- a/components/support/base/src/test/java/mozilla/components/support/base/facts/FactProcessorTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/facts/FactProcessorTest.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+class FactProcessorTest {
+    @Before
+    @After
+    fun cleanUp() {
+        Facts.clearProcessors()
+    }
+
+    @Test
+    fun `register extension method regsiters processor on Facts singleton`() {
+        val processor: FactProcessor = mock()
+        processor.register()
+
+        val fact = Fact(
+            Component.SUPPORT_TEST,
+            Action.CLICK,
+            "test"
+        )
+
+        fact.collect()
+
+        Mockito.verify(processor).process(fact)
+    }
+}

--- a/components/support/base/src/test/java/mozilla/components/support/base/facts/FactTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/facts/FactTest.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.verify
+
+class FactTest {
+    @Before
+    @After
+    fun cleanUp() {
+        Facts.clearProcessors()
+    }
+
+    @Test
+    fun `Collect extension method forwards Fact to Facts singleton`() {
+        val processor: FactProcessor = mock()
+        Facts.registerProcessor(processor)
+
+        val fact = Fact(
+            Component.SUPPORT_TEST,
+            Action.CLICK,
+            "test"
+        )
+
+        fact.collect()
+
+        verify(processor).process(fact)
+    }
+
+    @Test
+    fun `Accessing values`() {
+        val fact = Fact(
+            Component.SUPPORT_TEST,
+            Action.CLICK,
+            "test-item",
+            "test-value",
+            mapOf(
+                "key1" to "value1",
+                "key2" to "value2"
+            )
+        )
+
+        assertEquals(Component.SUPPORT_TEST, fact.component)
+        assertEquals(Action.CLICK, fact.action)
+        assertEquals("test-item", fact.item)
+        assertEquals("test-value", fact.value)
+
+        assertNotNull(fact.metadata)
+        assertEquals(2, fact.metadata!!.size)
+        assertTrue(fact.metadata!!.contains("key1"))
+        assertTrue(fact.metadata!!.contains("key2"))
+        assertEquals("value1", fact.metadata!!["key1"])
+        assertEquals("value2", fact.metadata!!["key2"])
+    }
+}

--- a/components/support/base/src/test/java/mozilla/components/support/base/facts/FactsTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/facts/FactsTest.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.verify
+
+class FactsTest {
+    @Before
+    @After
+    fun cleanUp() {
+        Facts.clearProcessors()
+    }
+
+    @Test
+    fun `Collecting fact without processor`() {
+        Facts.collect(Fact(
+            Component.SUPPORT_TEST,
+            Action.CLICK,
+            "test"
+        ))
+    }
+
+    @Test
+    fun `Collected fact is forwarded to processors`() {
+        val processor1: FactProcessor = mock()
+        val processor2: FactProcessor = mock()
+
+        Facts
+            .registerProcessor(processor1)
+            .registerProcessor(processor2)
+
+        val fact1 = Fact(
+            Component.SUPPORT_TEST,
+            Action.CLICK,
+            "test")
+
+        Facts.collect(fact1)
+
+        verify(processor1).process(fact1)
+        verify(processor2).process(fact1)
+
+        val fact2 = Fact(
+            Component.SUPPORT_BASE,
+            Action.TOGGLE,
+            "test")
+
+        Facts.collect(fact2)
+
+        verify(processor1).process(fact2)
+        verify(processor2).process(fact2)
+    }
+}

--- a/components/support/base/src/test/java/mozilla/components/support/base/facts/processor/LogFactProcessorTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/facts/processor/LogFactProcessorTest.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts.processor
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.test.mock
+import org.junit.Test
+import org.mockito.Mockito.verify
+
+class LogFactProcessorTest {
+    @Test
+    fun `Processor forwards Fact objects to the log`() {
+        val logger: Logger = mock()
+        val processor = LogFactProcessor(logger)
+
+        val fact = Fact(
+            Component.SUPPORT_TEST,
+            Action.CLICK,
+            "test")
+
+        processor.process(fact)
+
+        verify(logger).debug(fact.toString())
+    }
+}


### PR DESCRIPTION
@csadilek I'd like to get your feedback here.

This is about #42: Having a way for components to emit telemetry events.

I think we want:
* The app to be in control about what gets send/collected
* Not depend on the telemetry library directly from all components (which is also impossible now that we have two of them)
* Have events that are independent from telemetry (There are some use cases that make it interesting to evaluate the events for other reasons, e.g.: A "contextual hints" FEATURE will need to answer questions like "did the user use the share feature in the past? did the user load a url at least 3 times?" and the answers can be derived from the events we observed)

I followed a similar approach like we did with "logs". There's a class that collects them and processors that can do something with them.

Since the events are generic we would need a way to translate between the generic event and a telemetry event. I want to look into this as soon as we have glean and some events in the reference browser. I expect this to not be super hard since the events follow a similar structure.

The word `event` is already quite overloaded. And I want to avoid that someone thinks those are events you listen to in order to implement app logic. So I tried to find something else. I came up with `Fact`, `FactCollector`, `FactProcessor`. Components emit facts. Something collects them. And something else processes them.

To simplify testing in this PR I made the FactCollector something that we pass down to our components that need it. I wanted to avoid having a singleton that every component accesses. However the current approach seems to be super verbose. I have to pass this thing around everywhere and it's pretty painful and makes our interfaces more verbose. I now tend more to using a Singleton again. It will make testing a bit more effortful - but it's still doable.

What do you think?