### PR TITLE
[ci-skip] Bug 1512631 - part 13: Do not use gecko-focus on push on mozilla-mobile

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -52,7 +52,7 @@ tasks:
         else: mobile-1-decision
 
       build_worker_type:
-        $if: 'is_repo_trusted'
+        $if: 'is_repo_trusted && tasks_for in ["github-release", "cron"]'
         then: gecko-focus
         else: android-components-g
 


### PR DESCRIPTION
Follow #1588 up 

Fixes https://github.com/mozilla-mobile/android-components/commit/0cad9cc124cff6d65d995895f60989bb07ef1641#commitcomment-31870938

