### PR TITLE
Issue 1195: Remove webview if EngineView instance is reused....

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -69,9 +69,10 @@ class SystemEngineView @JvmOverloads constructor(
      * Render the content of the given session.
      */
     override fun render(session: EngineSession) {
-        this.session = session as SystemEngineSession
+        removeAllViews()
 
-        (session.webView?.parent as? SystemEngineView)?.removeView(session.webView)
+        this.session = session as SystemEngineSession
+        (session.webView.parent as? SystemEngineView)?.removeView(session.webView)
         addView(initWebView(session.webView))
     }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -1033,6 +1033,7 @@ class SystemEngineViewTest {
         engineView.render(SystemEngineSession(getApplicationContext()))
         assertFalse(engineView.onLongClick(null))
     }
+
     @Test
     fun `Calling onJsAlert must provide an Alert PromptRequest`() {
         val context = getApplicationContext<Context>()
@@ -1188,6 +1189,18 @@ class SystemEngineViewTest {
             assertEquals(jsAlertCount, 0)
             assertTrue(shouldShowMoreDialogs)
         }
+    }
+
+    @Test
+    fun `render removes webview from previous session`() {
+        val engineView = SystemEngineView(getApplicationContext())
+
+        val session1 = SystemEngineSession(getApplicationContext())
+        val session2 = SystemEngineSession(getApplicationContext())
+        engineView.render(session1)
+        engineView.render(session2)
+
+        assertNull(session1.webView.parent)
     }
 
     private fun Date.add(timeUnit: Int, amountOfTime: Int): Date {


### PR DESCRIPTION
FireTV is using a cached single instance of SystemEngineView. There are cases though where it uses different sessions i.e. settings->clear all data will create a new session with a new webview.

This makes sure we remove the old webview from the engine view so it can get gc'ed in this case. Our code (samples, and r-b) should not be affected. 

