### PR TITLE
Use SupervisorJob and not Job in fxaccounts and logins

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
 import org.mozilla.fxaclient.internal.FirefoxAccount as InternalFxAcct
 import org.mozilla.fxaclient.internal.FxaException.Unauthorized as Unauthorized
@@ -26,7 +26,7 @@ interface FirefoxAccountShaped {
  */
 class FirefoxAccount internal constructor(private val inner: InternalFxAcct) : AutoCloseable, FirefoxAccountShaped {
 
-    private val job = Job()
+    private val job = SupervisorJob()
     private val scope = CoroutineScope(Dispatchers.IO) + job
 
     /**

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
 import mozilla.appservices.logins.DatabaseLoginsStorage
 import mozilla.appservices.logins.LoginsStorage
@@ -207,7 +207,7 @@ interface AsyncLoginsStorage : AutoCloseable {
  */
 @Suppress("TooManyFunctions")
 open class AsyncLoginsStorageAdapter<T : LoginsStorage>(private val wrapped: T) : AsyncLoginsStorage, AutoCloseable {
-    private val job = Job()
+    private val job = SupervisorJob()
     private val scope = CoroutineScope(Dispatchers.IO) + job
 
     override fun lock(): Deferred<Unit> {


### PR DESCRIPTION
It seems like there's [no way to recover](https://github.com/Kotlin/kotlinx.coroutines/issues/753#issuecomment-432390224) from a `scope.async` where the scope is based on a Job. This is annoying, since we want callers to be able to catch errors thrown from our `async` blocks in FxA and Logins, and continue.

Thankfully, the fix is easy, it seems like if we just use SupervisorJob instead of Job, things work the way we want. This makes that change.

I looked for other uses of the same pattern and it's not clear if the other uses of Job want this behavior or the 'fail hard' behavior so I left them as is.

CC @sashei, @csadilek