### PR TITLE
Closes #1471: Add support for text prompts dialogs.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -300,7 +300,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         callback: ButtonCallback?
     ) = Unit
 
-
     override fun onPopupRequest(session: GeckoSession?, targetUri: String?): GeckoResult<AllowOrDeny> {
         return GeckoResult()
     } // Related issue: https://github.com/mozilla-mobile/android-components/issues/1473

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -265,6 +265,33 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onTextPrompt(
+        session: GeckoSession,
+        title: String?,
+        inputLabel: String?,
+        inputValue: String?,
+        callback: TextCallback
+    ) {
+        val hasShownManyDialogs = callback.hasCheckbox()
+        val onDismiss: () -> Unit = {
+            callback.dismiss()
+        }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.TextPrompt(
+                    title ?: "",
+                    inputLabel ?: "",
+                    inputValue ?: "",
+                    hasShownManyDialogs,
+                    onDismiss
+                ) { showMoreDialogs, valueInput ->
+                    callback.checkboxValue = showMoreDialogs
+                    callback.confirm(valueInput)
+                })
+        }
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession?,
         title: String?,
@@ -272,13 +299,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback?
     ) = Unit
-    override fun onTextPrompt(
-        session: GeckoSession?,
-        title: String?,
-        msg: String?,
-        value: String?,
-        callback: TextCallback?
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1471
+
 
     override fun onPopupRequest(session: GeckoSession?, targetUri: String?): GeckoResult<AllowOrDeny> {
         return GeckoResult()

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -236,7 +236,6 @@ class GeckoPromptDelegateTest {
         val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
-        gecko.onTextPrompt(null, "", "", null, null)
         gecko.onPopupRequest(null, "")
     }
 
@@ -845,6 +844,57 @@ class GeckoPromptDelegateTest {
 
         with(colorRequest) {
             assertEquals(defaultColor, "")
+        }
+    }
+
+    @Test
+    fun `onTextPrompt must provide an TextPrompt PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var dismissWasCalled = false
+        var confirmWasCalled = false
+        var setCheckboxValueWasCalled = false
+
+        val callback = object : GeckoSession.PromptDelegate.TextCallback {
+
+            override fun confirm(text: String?) {
+                confirmWasCalled = true
+            }
+
+            override fun setCheckboxValue(value: Boolean) {
+                setCheckboxValueWasCalled = true
+            }
+
+            override fun dismiss() {
+                dismissWasCalled = true
+            }
+
+            override fun getCheckboxValue(): Boolean = false
+            override fun hasCheckbox(): Boolean = false
+            override fun getCheckboxMessage(): String = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onTextPrompt(mock(), "title", "label", "value", callback)
+
+        with(request as PromptRequest.TextPrompt) {
+            assertEquals(title, "title")
+            assertEquals(inputLabel, "label")
+            assertEquals(inputValue, "value")
+
+            onDismiss()
+            assertTrue(dismissWasCalled)
+
+            onConfirm(true, "newInput")
+            assertTrue(setCheckboxValueWasCalled)
+            assertTrue(confirmWasCalled)
         }
     }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -96,7 +96,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is SingleChoice)
 
-        (promptRequestSingleChoice as SingleChoice).onSelect(mock())
+        (promptRequestSingleChoice as SingleChoice).onConfirm(mock())
         assertTrue(confirmWasCalled)
     }
 
@@ -141,7 +141,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is MultipleChoice)
 
-        (promptRequestSingleChoice as MultipleChoice).onSelect(arrayOf())
+        (promptRequestSingleChoice as MultipleChoice).onConfirm(arrayOf())
         assertTrue(confirmWasCalled)
     }
 
@@ -183,7 +183,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is PromptRequest.MenuChoice)
 
-        (promptRequestSingleChoice as PromptRequest.MenuChoice).onSelect(mock())
+        (promptRequestSingleChoice as PromptRequest.MenuChoice).onConfirm(mock())
         assertTrue(confirmWasCalled)
     }
 
@@ -224,7 +224,7 @@ class GeckoPromptDelegateTest {
         (alertRequest as PromptRequest.Alert).onDismiss()
         assertTrue(dismissWasCalled)
 
-        (alertRequest as PromptRequest.Alert).onShouldShowNoMoreDialogs(true)
+        (alertRequest as PromptRequest.Alert).onConfirm(true)
         assertTrue(setCheckboxValueWasCalled)
 
         assertEquals((alertRequest as PromptRequest.Alert).title, "title")
@@ -286,7 +286,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_DATE, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
 
@@ -331,7 +331,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2019-11-30".toDate("yyyy-MM-dd"))
         }
         val selectedDate = "2019-11-28".toDate("yyyy-MM-dd")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM-dd")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -359,7 +359,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_MONTH, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -401,7 +401,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2019-11".toDate("yyyy-MM"))
         }
         val selectedDate = "2019-11".toDate("yyyy-MM")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -429,7 +429,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_WEEK, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -471,7 +471,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2018-W26".toDate("yyyy-'W'ww"))
         }
         val selectedDate = "2018-W26".toDate("yyyy-'W'ww")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-'W'ww")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -500,7 +500,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_TIME, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -542,7 +542,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "18:00".toDate("HH:mm"))
         }
         val selectedDate = "17:00".toDate("HH:mm")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("HH:mm")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -574,7 +574,7 @@ class GeckoPromptDelegateTest {
             GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
         )
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -616,7 +616,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2018-06-14T00:00".toDate("yyyy-MM-dd'T'HH:mm"))
         }
         val selectedDate = "2018-06-12T19:30".toDate("yyyy-MM-dd'T'HH:mm")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM-dd'T'HH:mm")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -242,6 +242,33 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onTextPrompt(
+        session: GeckoSession,
+        title: String?,
+        inputLabel: String?,
+        inputValue: String?,
+        callback: TextCallback
+    ) {
+        val hasShownManyDialogs = callback.hasCheckbox()
+        val onDismiss: () -> Unit = {
+            callback.dismiss()
+        }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.TextPrompt(
+                    title ?: "",
+                    inputLabel ?: "",
+                    inputValue ?: "",
+                    hasShownManyDialogs,
+                    onDismiss
+                ) { showMoreDialogs, valueInput ->
+                    callback.checkboxValue = showMoreDialogs
+                    callback.confirm(valueInput)
+                })
+        }
+    }
+
     override fun onColorPrompt(
         session: GeckoSession,
         title: String?,
@@ -269,14 +296,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback
     ) = Unit
-
-    override fun onTextPrompt(
-        session: GeckoSession,
-        title: String?,
-        msg: String?,
-        value: String?,
-        callback: TextCallback
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1471
 
     override fun onPopupRequest(session: GeckoSession, targetUri: String?): GeckoResult<AllowOrDeny> {
         return GeckoResult()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -95,7 +95,7 @@ class GeckoPromptDelegateTest {
         assertTrue(promptRequestSingleChoice is SingleChoice)
         val request = promptRequestSingleChoice as SingleChoice
 
-        request.onSelect(request.choices.first())
+        request.onConfirm(request.choices.first())
         assertTrue(confirmWasCalled)
     }
 
@@ -141,7 +141,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is MultipleChoice)
 
-        (promptRequestSingleChoice as MultipleChoice).onSelect(arrayOf())
+        (promptRequestSingleChoice as MultipleChoice).onConfirm(arrayOf())
         assertTrue(confirmWasCalled)
     }
 
@@ -185,7 +185,7 @@ class GeckoPromptDelegateTest {
         assertTrue(promptRequestSingleChoice is PromptRequest.MenuChoice)
         val request = promptRequestSingleChoice as PromptRequest.MenuChoice
 
-        request.onSelect(request.choices.first())
+        request.onConfirm(request.choices.first())
         assertTrue(confirmWasCalled)
     }
 
@@ -226,7 +226,7 @@ class GeckoPromptDelegateTest {
         (alertRequest as PromptRequest.Alert).onDismiss()
         assertTrue(dismissWasCalled)
 
-        (alertRequest as PromptRequest.Alert).onShouldShowNoMoreDialogs(true)
+        (alertRequest as PromptRequest.Alert).onConfirm(true)
         assertTrue(setCheckboxValueWasCalled)
 
         assertEquals((alertRequest as PromptRequest.Alert).title, "title")
@@ -288,7 +288,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(mock(), "title", DATETIME_TYPE_DATE, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
 
@@ -333,7 +333,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2019-11-30".toDate("yyyy-MM-dd"))
         }
         val selectedDate = "2019-11-28".toDate("yyyy-MM-dd")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM-dd")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -361,7 +361,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(mock(), "title", DATETIME_TYPE_MONTH, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -403,7 +403,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2019-11".toDate("yyyy-MM"))
         }
         val selectedDate = "2019-11".toDate("yyyy-MM")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -431,7 +431,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(mock(), "title", DATETIME_TYPE_WEEK, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -473,7 +473,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2018-W26".toDate("yyyy-'W'ww"))
         }
         val selectedDate = "2018-W26".toDate("yyyy-'W'ww")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-'W'ww")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -502,7 +502,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(mock(), "title", DATETIME_TYPE_TIME, "", "", "", callback)
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -544,7 +544,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "18:00".toDate("HH:mm"))
         }
         val selectedDate = "17:00".toDate("HH:mm")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("HH:mm")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -576,7 +576,7 @@ class GeckoPromptDelegateTest {
             GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
         )
         assertTrue(dateRequest is PromptRequest.TimeSelection)
-        (dateRequest as PromptRequest.TimeSelection).onSelect(Date())
+        (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as PromptRequest.TimeSelection).title, "title")
     }
@@ -618,7 +618,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2018-06-14T00:00".toDate("yyyy-MM-dd'T'HH:mm"))
         }
         val selectedDate = "2018-06-12T19:30".toDate("yyyy-MM-dd'T'HH:mm")
-        (timeSelectionRequest as PromptRequest.TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM-dd'T'HH:mm")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as PromptRequest.TimeSelection).title, "title")
     }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -238,7 +238,6 @@ class GeckoPromptDelegateTest {
         val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(mock(), "", "", null, mock())
-        gecko.onTextPrompt(mock(), "", "", null, mock())
         gecko.onPopupRequest(mock(), "")
     }
 
@@ -850,6 +849,57 @@ class GeckoPromptDelegateTest {
 
         with(colorRequest) {
             assertEquals(defaultColor, "")
+        }
+    }
+
+    @Test
+    fun `onTextPrompt must provide an TextPrompt PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var dismissWasCalled = false
+        var confirmWasCalled = false
+        var setCheckboxValueWasCalled = false
+
+        val callback = object : GeckoSession.PromptDelegate.TextCallback {
+
+            override fun confirm(text: String?) {
+                confirmWasCalled = true
+            }
+
+            override fun setCheckboxValue(value: Boolean) {
+                setCheckboxValueWasCalled = true
+            }
+
+            override fun dismiss() {
+                dismissWasCalled = true
+            }
+
+            override fun getCheckboxValue(): Boolean = false
+            override fun hasCheckbox(): Boolean = false
+            override fun getCheckboxMessage(): String = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onTextPrompt(mock(), "title", "label", "value", callback)
+
+        with(request as PromptRequest.TextPrompt) {
+            assertEquals(title, "title")
+            assertEquals(inputLabel, "label")
+            assertEquals(inputValue, "value")
+
+            onDismiss()
+            assertTrue(dismissWasCalled)
+
+            onConfirm(true, "newInput")
+            assertTrue(setCheckboxValueWasCalled)
+            assertTrue(confirmWasCalled)
         }
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -263,7 +263,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
-
     override fun onTextPrompt(
         session: GeckoSession,
         title: String?,

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -263,6 +263,34 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+
+    override fun onTextPrompt(
+        session: GeckoSession,
+        title: String?,
+        inputLabel: String?,
+        inputValue: String?,
+        callback: TextCallback
+    ) {
+        val hasShownManyDialogs = callback.hasCheckbox()
+        val onDismiss: () -> Unit = {
+            callback.dismiss()
+        }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.TextPrompt(
+                    title ?: "",
+                    inputLabel ?: "",
+                    inputValue ?: "",
+                    hasShownManyDialogs,
+                    onDismiss
+                ) { showMoreDialogs, valueInput ->
+                    callback.checkboxValue = showMoreDialogs
+                    callback.confirm(valueInput)
+                })
+        }
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession?,
         title: String?,
@@ -270,14 +298,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback?
     ) = Unit
-
-    override fun onTextPrompt(
-        session: GeckoSession?,
-        title: String?,
-        msg: String?,
-        value: String?,
-        callback: TextCallback?
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1471
 
     override fun onPopupRequest(session: GeckoSession?, targetUri: String?): GeckoResult<AllowOrDeny> {
         return GeckoResult()

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -233,7 +233,6 @@ class GeckoPromptDelegateTest {
         val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
-        gecko.onTextPrompt(null, "", "", null, null)
         gecko.onPopupRequest(null, "")
     }
 
@@ -845,6 +844,57 @@ class GeckoPromptDelegateTest {
 
         with(colorRequest) {
             assertEquals(defaultColor, "")
+        }
+    }
+
+    @Test
+    fun `onTextPrompt must provide an TextPrompt PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var dismissWasCalled = false
+        var confirmWasCalled = false
+        var setCheckboxValueWasCalled = false
+
+        val callback = object : GeckoSession.PromptDelegate.TextCallback {
+
+            override fun confirm(text: String?) {
+                confirmWasCalled = true
+            }
+
+            override fun setCheckboxValue(value: Boolean) {
+                setCheckboxValueWasCalled = true
+            }
+
+            override fun dismiss() {
+                dismissWasCalled = true
+            }
+
+            override fun getCheckboxValue(): Boolean = false
+            override fun hasCheckbox(): Boolean = false
+            override fun getCheckboxMessage(): String = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onTextPrompt(mock(), "title", "label", "value", callback)
+
+        with(request as PromptRequest.TextPrompt) {
+            assertEquals(title, "title")
+            assertEquals(inputLabel, "label")
+            assertEquals(inputValue, "value")
+
+            onDismiss()
+            assertTrue(dismissWasCalled)
+
+            onConfirm(true, "newInput")
+            assertTrue(setCheckboxValueWasCalled)
+            assertTrue(confirmWasCalled)
         }
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -95,7 +95,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is SingleChoice)
 
-        (promptRequestSingleChoice as SingleChoice).onSelect(mock())
+        (promptRequestSingleChoice as SingleChoice).onConfirm(mock())
         assertTrue(confirmWasCalled)
     }
 
@@ -140,7 +140,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is MultipleChoice)
 
-        (promptRequestSingleChoice as MultipleChoice).onSelect(arrayOf())
+        (promptRequestSingleChoice as MultipleChoice).onConfirm(arrayOf())
         assertTrue(confirmWasCalled)
     }
 
@@ -180,7 +180,7 @@ class GeckoPromptDelegateTest {
 
         assertTrue(promptRequestSingleChoice is PromptRequest.MenuChoice)
 
-        (promptRequestSingleChoice as PromptRequest.MenuChoice).onSelect(mock())
+        (promptRequestSingleChoice as PromptRequest.MenuChoice).onConfirm(mock())
         assertTrue(confirmWasCalled)
     }
 
@@ -221,7 +221,7 @@ class GeckoPromptDelegateTest {
         (alertRequest as PromptRequest.Alert).onDismiss()
         assertTrue(dismissWasCalled)
 
-        (alertRequest as PromptRequest.Alert).onShouldShowNoMoreDialogs(true)
+        (alertRequest as PromptRequest.Alert).onConfirm(true)
         assertTrue(setCheckboxValueWasCalled)
 
         assertEquals((alertRequest as PromptRequest.Alert).title, "title")
@@ -283,7 +283,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_DATE, "", "", "", callback)
         assertTrue(dateRequest is TimeSelection)
-        (dateRequest as TimeSelection).onSelect(Date())
+        (dateRequest as TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as TimeSelection).title, "title")
 
@@ -328,7 +328,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2019-11-30".toDate("yyyy-MM-dd"))
         }
         val selectedDate = "2019-11-28".toDate("yyyy-MM-dd")
-        (timeSelectionRequest as TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM-dd")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as TimeSelection).title, "title")
     }
@@ -356,7 +356,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_MONTH, "", "", "", callback)
         assertTrue(dateRequest is TimeSelection)
-        (dateRequest as TimeSelection).onSelect(Date())
+        (dateRequest as TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as TimeSelection).title, "title")
     }
@@ -398,7 +398,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2019-11".toDate("yyyy-MM"))
         }
         val selectedDate = "2019-11".toDate("yyyy-MM")
-        (timeSelectionRequest as TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as TimeSelection).title, "title")
     }
@@ -426,7 +426,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_WEEK, "", "", "", callback)
         assertTrue(dateRequest is TimeSelection)
-        (dateRequest as TimeSelection).onSelect(Date())
+        (dateRequest as TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as TimeSelection).title, "title")
     }
@@ -468,7 +468,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2018-W26".toDate("yyyy-'W'ww"))
         }
         val selectedDate = "2018-W26".toDate("yyyy-'W'ww")
-        (timeSelectionRequest as TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-'W'ww")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as TimeSelection).title, "title")
     }
@@ -497,7 +497,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(null, "title", DATETIME_TYPE_TIME, "", "", "", callback)
         assertTrue(dateRequest is TimeSelection)
-        (dateRequest as TimeSelection).onSelect(Date())
+        (dateRequest as TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as TimeSelection).title, "title")
     }
@@ -539,7 +539,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "18:00".toDate("HH:mm"))
         }
         val selectedDate = "17:00".toDate("HH:mm")
-        (timeSelectionRequest as TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("HH:mm")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as TimeSelection).title, "title")
     }
@@ -571,7 +571,7 @@ class GeckoPromptDelegateTest {
             GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
         )
         assertTrue(dateRequest is TimeSelection)
-        (dateRequest as TimeSelection).onSelect(Date())
+        (dateRequest as TimeSelection).onConfirm(Date())
         assertTrue(confirmCalled)
         assertEquals((dateRequest as TimeSelection).title, "title")
     }
@@ -613,7 +613,7 @@ class GeckoPromptDelegateTest {
             assertEquals(maximumDate, "2018-06-14T00:00".toDate("yyyy-MM-dd'T'HH:mm"))
         }
         val selectedDate = "2018-06-12T19:30".toDate("yyyy-MM-dd'T'HH:mm")
-        (timeSelectionRequest as TimeSelection).onSelect(selectedDate)
+        (timeSelectionRequest as TimeSelection).onConfirm(selectedDate)
         assertNotNull(geckoDate?.toDate("yyyy-MM-dd'T'HH:mm")?.equals(selectedDate))
         assertEquals((timeSelectionRequest as TimeSelection).title, "title")
     }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -1060,14 +1060,14 @@ class SystemEngineViewTest {
         assertEquals(alertRequest.hasShownManyDialogs, false)
         assertEquals(alertRequest.message, "message")
 
-        alertRequest.onShouldShowNoMoreDialogs(true)
+        alertRequest.onConfirm(true)
         verify(mockJSResult).confirm()
         assertEquals(engineView.jsAlertCount, 1)
 
         alertRequest.onDismiss()
         verify(mockJSResult).cancel()
 
-        alertRequest.onShouldShowNoMoreDialogs(true)
+        alertRequest.onConfirm(true)
         assertEquals(engineView.shouldShowMoreDialogs, false)
 
         engineView.lastDialogShownAt = engineView.lastDialogShownAt.add(YEAR, -1)

--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -12,6 +12,20 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:browser-menu:{latest-version}"
 ```
 
+### BrowserMenu
+
+There are multiple properties that you customize of the menu browser
+by just adding them into your dimens.xml file.
+
+```xml
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <dimen name="mozac_browser_menu_corner_radius">4dp</dimen>
+    <dimen name="mozac_browser_menu_elevation">4dp</dimen>
+    <dimen name="mozac_browser_menu_width">250dp</dimen>
+    <dimen name="mozac_browser_menu_padding_vertical">8dp</dimen>
+</resources>
+```
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -15,23 +15,23 @@ sealed class PromptRequest {
     /**
      * Value type that represents a request for a single choice prompt.
      * @property choices All the possible options.
-     * @property onSelect A callback indicating which option was selected.
+     * @property onConfirm A callback indicating which option was selected.
      */
-    data class SingleChoice(val choices: Array<Choice>, val onSelect: (Choice) -> Unit) : PromptRequest()
+    data class SingleChoice(val choices: Array<Choice>, val onConfirm: (Choice) -> Unit) : PromptRequest()
 
     /**
      * Value type that represents a request for a multiple choice prompt.
      * @property choices All the possible options.
-     * @property onSelect A callback indicating witch options has been selected.
+     * @property onConfirm A callback indicating witch options has been selected.
      */
-    data class MultipleChoice(val choices: Array<Choice>, val onSelect: (Array<Choice>) -> Unit) : PromptRequest()
+    data class MultipleChoice(val choices: Array<Choice>, val onConfirm: (Array<Choice>) -> Unit) : PromptRequest()
 
     /**
      * Value type that represents a request for a menu choice prompt.
      * @property choices All the possible options.
-     * @property onSelect A callback indicating which option was selected.
+     * @property onConfirm A callback indicating which option was selected.
      */
-    data class MenuChoice(val choices: Array<Choice>, val onSelect: (Choice) -> Unit) : PromptRequest()
+    data class MenuChoice(val choices: Array<Choice>, val onConfirm: (Choice) -> Unit) : PromptRequest()
 
     /**
      * Value type that represents a request for an alert prompt.
@@ -39,19 +39,19 @@ sealed class PromptRequest {
      * @property message the body of the dialog.
      * @property hasShownManyDialogs tells if this page has shown multiple prompts within a short period of time.
      * @property onDismiss callback to let the page know the user dismissed the dialog.
-     * @property onShouldShowNoMoreDialogs tells the web page if it should continue showing alerts or not.
+     * @property onConfirm tells the web page if it should continue showing alerts or not.
      */
     data class Alert(
         val title: String,
         val message: String,
         val hasShownManyDialogs: Boolean = false,
         val onDismiss: () -> Unit,
-        val onShouldShowNoMoreDialogs: (Boolean) -> Unit
+        val onConfirm: (Boolean) -> Unit
     ) : PromptRequest()
 
     /**
      * Value type that represents a request for an alert prompt to enter a message.
-     * @property title of the dialog.
+     * @property title title of the dialog.
      * @property inputLabel the label of the field the user should fill.
      * @property inputValue the default value of the field.
      * @property hasShownManyDialogs tells if this page has shown multiple prompts within a short period of time.
@@ -74,7 +74,7 @@ sealed class PromptRequest {
      * @property minimumDate date allow to be selected.
      * @property maximumDate date allow to be selected.
      * @property type indicate which [Type] of selection de user wants.
-     * @property onSelect callback that is called when the date is selected.
+     * @property onConfirm callback that is called when the date is selected.
      * @property onClear callback that is called when the user requests the picker to be clear up.
      */
     class TimeSelection(
@@ -83,7 +83,7 @@ sealed class PromptRequest {
         val minimumDate: java.util.Date?,
         val maximumDate: java.util.Date?,
         val type: Type = Type.DATE,
-        val onSelect: (java.util.Date) -> Unit,
+        val onConfirm: (java.util.Date) -> Unit,
         val onClear: () -> Unit
     ) : PromptRequest() {
         enum class Type {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -50,6 +50,24 @@ sealed class PromptRequest {
     ) : PromptRequest()
 
     /**
+     * Value type that represents a request for an alert prompt to enter a message.
+     * @property title of the dialog.
+     * @property inputLabel the label of the field the user should fill.
+     * @property inputValue the default value of the field.
+     * @property hasShownManyDialogs tells if this page has shown multiple prompts within a short period of time.
+     * @property onDismiss callback to let the page know the user dismissed the dialog.
+     * @property onConfirm tells the web page if it should continue showing alerts or not.
+     */
+    data class TextPrompt(
+        val title: String,
+        val inputLabel: String,
+        val inputValue: String,
+        val hasShownManyDialogs: Boolean = false,
+        val onDismiss: () -> Unit,
+        val onConfirm: (Boolean, String) -> Unit
+    ) : PromptRequest()
+
+    /**
      * Value type that represents a request for a date prompt for picking a year, month, and day.
      * @property title of the dialog.
      * @property initialDate date that dialog should be set by default.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -23,15 +23,15 @@ class PromptRequestTest {
     fun `Create prompt requests`() {
 
         val single = SingleChoice(emptyArray()) {}
-        single.onSelect(Choice(id = "", label = ""))
+        single.onConfirm(Choice(id = "", label = ""))
         assertNotNull(single.choices)
 
         val multiple = MultipleChoice(emptyArray()) {}
-        multiple.onSelect(arrayOf(Choice(id = "", label = "")))
+        multiple.onConfirm(arrayOf(Choice(id = "", label = "")))
         assertNotNull(multiple.choices)
 
         val menu = MenuChoice(emptyArray()) {}
-        menu.onSelect(Choice(id = "", label = ""))
+        menu.onConfirm(Choice(id = "", label = ""))
         assertNotNull(menu.choices)
 
         val alert = Alert("title", "message", true, {}) {}
@@ -39,13 +39,13 @@ class PromptRequestTest {
         assertEquals(alert.message, "message")
         assertEquals(alert.hasShownManyDialogs, true)
         alert.onDismiss()
-        alert.onShouldShowNoMoreDialogs(true)
+        alert.onConfirm(true)
 
         assertEquals(alert.title, "title")
         assertEquals(alert.message, "message")
         assertEquals(alert.hasShownManyDialogs, true)
         alert.onDismiss()
-        alert.onShouldShowNoMoreDialogs(true)
+        alert.onConfirm(true)
 
         val textPrompt = PromptRequest.TextPrompt(
             "title",
@@ -73,7 +73,7 @@ class PromptRequestTest {
         assertNotNull(dateRequest.initialDate)
         assertNotNull(dateRequest.minimumDate)
         assertNotNull(dateRequest.maximumDate)
-        dateRequest.onSelect(Date())
+        dateRequest.onConfirm(Date())
         dateRequest.onClear()
 
         val filePickerRequest = PromptRequest.File(emptyArray(), true, { _, _ -> }, { _, _ -> }) {}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -41,6 +41,26 @@ class PromptRequestTest {
         alert.onDismiss()
         alert.onShouldShowNoMoreDialogs(true)
 
+        assertEquals(alert.title, "title")
+        assertEquals(alert.message, "message")
+        assertEquals(alert.hasShownManyDialogs, true)
+        alert.onDismiss()
+        alert.onShouldShowNoMoreDialogs(true)
+
+        val textPrompt = PromptRequest.TextPrompt(
+            "title",
+            "label",
+            "value",
+            true,
+            {}) { _, _ -> }
+
+        assertEquals(textPrompt.title, "title")
+        assertEquals(textPrompt.inputLabel, "label")
+        assertEquals(textPrompt.inputValue, "value")
+        assertEquals(textPrompt.hasShownManyDialogs, true)
+        textPrompt.onDismiss()
+        textPrompt.onConfirm(true, "")
+
         val dateRequest = PromptRequest.TimeSelection(
             "title",
             Date(),

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/AlertDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/AlertDialogFragment.kt
@@ -56,7 +56,7 @@ internal class AlertDialogFragment : PromptDialogFragment() {
         if (!userSelectionNoMoreDialogs) {
             feature?.onCancel(sessionId)
         } else {
-            feature?.onShouldMoreDialogsChecked(sessionId, userSelectionNoMoreDialogs)
+            feature?.onConfirm(sessionId, userSelectionNoMoreDialogs)
         }
     }
 

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/AuthenticationDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/AuthenticationDialogFragment.kt
@@ -64,7 +64,7 @@ internal class AuthenticationDialogFragment : PromptDialogFragment() {
     }
 
     private fun onPositiveClickAction() {
-        feature?.onConfirmAuthentication(sessionId, username, password)
+        feature?.onConfirm(sessionId, username to password)
     }
 
     @SuppressLint("InflateParams")

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ChoiceDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ChoiceDialogFragment.kt
@@ -80,7 +80,7 @@ internal class ChoiceDialogFragment : PromptDialogFragment() {
     }
 
     fun onSelect(selectedChoice: Choice) {
-        feature?.onSingleChoiceSelect(sessionId, selectedChoice)
+        feature?.onConfirm(sessionId, selectedChoice)
         dismiss()
     }
 
@@ -106,7 +106,7 @@ internal class ChoiceDialogFragment : PromptDialogFragment() {
                 feature?.onCancel(sessionId)
             }
             .setPositiveButton(R.string.mozac_feature_prompts_ok) { _, _ ->
-                feature?.onMultipleChoiceSelect(sessionId, mapSelectChoice.keys.toTypedArray())
+                feature?.onConfirm(sessionId, mapSelectChoice.keys.toTypedArray())
             }.setOnDismissListener {
                 feature?.onCancel(sessionId)
             }.create()

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.Color
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
@@ -282,6 +283,7 @@ class PromptFeature(
                 is Alert -> it.onDismiss()
                 is Authentication -> it.onDismiss()
                 is Color -> it.onDismiss()
+                is TextPrompt -> it.onDismiss()
             }
             true
         }
@@ -332,6 +334,7 @@ class PromptFeature(
             when (it) {
                 is PromptRequest.TimeSelection -> it.onSelect(value as Date)
                 is PromptRequest.Color -> it.onConfirm(value as String)
+                is TextPrompt -> it.onConfirm(noShowMoreDialogs, inputValue)
             }
             true
         }
@@ -450,6 +453,12 @@ class PromptFeature(
                         maximumDate,
                         selectionType
                     )
+                }
+            }
+
+            is PromptRequest.TextPrompt -> {
+                with(promptRequest) {
+                    TextPromptDialogFragment.newInstance(session.id, title, inputLabel, inputValue, hasShownManyDialogs)
                 }
             }
 

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TextPromptDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TextPromptDialogFragment.kt
@@ -74,12 +74,11 @@ internal class TextPromptDialogFragment : PromptDialogFragment(), TextWatcher {
     }
 
     override fun onCancel(dialog: DialogInterface?) {
-        super.onCancel(dialog)
         feature?.onCancel(sessionId)
     }
 
     private fun onPositiveClickAction() {
-        feature?.onConfirmTextPrompt(sessionId, userSelectionNoMoreDialogs, userSelectionEditText)
+        feature?.onConfirm(sessionId, userSelectionNoMoreDialogs to userSelectionEditText)
     }
 
     @SuppressLint("InflateParams")

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TextPromptDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TextPromptDialogFragment.kt
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.support.v7.app.AlertDialog
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.View.VISIBLE
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.TextView
+
+private const val KEY_MANY_ALERTS = "KEY_MANY_ALERTS"
+private const val KEY_USER_CHECK_BOX = "KEY_USER_CHECK_BOX"
+private const val KEY_USER_EDIT_TEXT = "KEY_USER_EDIT_TEXT"
+private const val KEY_LABEL_INPUT = "KEY_LABEL_INPUT"
+private const val KEY_DEFAULT_INPUT_VALUE = "KEY_DEFAULT_INPUT_VALUE"
+
+/**
+ * [android.support.v4.app.DialogFragment] implementation to display a
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt">Window.prompt()</a> with native dialogs.
+ */
+internal class TextPromptDialogFragment : PromptDialogFragment(), TextWatcher {
+
+    /**
+     * Tells if a checkbox should be shown for preventing this [sessionId] from showing more dialogs.
+     */
+    internal val hasShownManyDialogs: Boolean by lazy { safeArguments.getBoolean(KEY_MANY_ALERTS) }
+
+    /**
+     * Contains the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt#Parameters">default()</a>
+     * value provided by this [sessionId].
+     */
+    internal val defaultInputValue: String by lazy { safeArguments.getString(KEY_DEFAULT_INPUT_VALUE) }
+
+    /**
+     * Contains the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt#Parameters">message</a>
+     * value provided by this [sessionId].
+     */
+    internal val labelInput: String by lazy { safeArguments.getString(KEY_LABEL_INPUT) }
+
+    /**
+     * Stores the user's decision from the checkbox
+     * for preventing this [sessionId] from showing more dialogs.
+     */
+    internal var userSelectionNoMoreDialogs: Boolean
+        get() = safeArguments.getBoolean(KEY_USER_CHECK_BOX)
+        set(value) {
+            safeArguments.putBoolean(KEY_USER_CHECK_BOX, value)
+        }
+
+    private var userSelectionEditText: String
+        get() = safeArguments.getString(KEY_USER_EDIT_TEXT, defaultInputValue)
+        set(value) {
+            safeArguments.putString(KEY_USER_EDIT_TEXT, value)
+        }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireContext())
+            .setTitle(title)
+            .setCancelable(true)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                onPositiveClickAction()
+            }
+        return addLayout(builder).create()
+    }
+
+    override fun onCancel(dialog: DialogInterface?) {
+        super.onCancel(dialog)
+        feature?.onCancel(sessionId)
+    }
+
+    private fun onPositiveClickAction() {
+        feature?.onConfirmTextPrompt(sessionId, userSelectionNoMoreDialogs, userSelectionEditText)
+    }
+
+    @SuppressLint("InflateParams")
+    private fun addLayout(builder: AlertDialog.Builder): AlertDialog.Builder {
+        val inflater = LayoutInflater.from(requireContext())
+        val view = inflater.inflate(R.layout.mozac_feature_text_prompt, null)
+
+        val label = view.findViewById<TextView>(R.id.input_label)
+        val editText = view.findViewById<EditText>(R.id.input_value)
+
+        label.text = labelInput
+        editText.setText(defaultInputValue)
+        editText.addTextChangedListener(this)
+
+        if (hasShownManyDialogs) {
+            addCheckBox(view)
+        }
+
+        return builder.setView(view)
+    }
+
+    @SuppressLint("InflateParams")
+    private fun addCheckBox(view: View) {
+        if (hasShownManyDialogs) {
+            val checkBox = view.findViewById<CheckBox>(R.id.no_more_dialogs_check_box)
+            checkBox.setOnCheckedChangeListener { _, isChecked ->
+                userSelectionNoMoreDialogs = isChecked
+            }
+            checkBox.visibility = VISIBLE
+        }
+    }
+
+    override fun afterTextChanged(editable: Editable) {
+        userSelectionEditText = editable.toString()
+    }
+
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+
+    companion object {
+        /**
+         * A builder method for creating a [TextPromptDialogFragment]
+         * @param sessionId to create the dialog.
+         * @param title the title of the dialog.
+         * @param inputLabel
+         * @param defaultInputValue
+         * @param hasShownManyDialogs tells if this [sessionId] has shown many dialogs
+         * in a short period of time, if is true a checkbox will be part of the dialog, for the user
+         * to choose if wants to prevent this [sessionId] continuing showing dialogs.
+         */
+        fun newInstance(
+            sessionId: String,
+            title: String,
+            inputLabel: String,
+            defaultInputValue: String,
+            hasShownManyDialogs: Boolean
+        ): TextPromptDialogFragment {
+
+            val fragment = TextPromptDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putString(KEY_SESSION_ID, sessionId)
+                putString(KEY_TITLE, title)
+                putString(KEY_LABEL_INPUT, inputLabel)
+                putString(KEY_DEFAULT_INPUT_VALUE, defaultInputValue)
+                putBoolean(KEY_MANY_ALERTS, hasShownManyDialogs)
+            }
+
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+}

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_text_prompt.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_text_prompt.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="?android:attr/listPreferredItemPaddingLeft"
+            android:paddingStart="?android:attr/listPreferredItemPaddingLeft"
+            android:paddingEnd="?android:attr/listPreferredItemPaddingLeft">
+
+        <TextView
+                android:id="@+id/input_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="Please enter your name"
+                android:labelFor="@+id/input_value"
+                android:contentDescription="@string/mozac_feature_prompts_content_description_input_label"/>
+
+        <EditText
+                android:id="@+id/input_value"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:ignore="Autofill"
+                android:inputType="text"/>
+
+        <CheckBox
+                android:id="@+id/no_more_dialogs_check_box"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/mozac_feature_prompts_no_more_dialogs"
+                android:visibility="gone"
+                tools:visibility="visible"
+                android:textColor="#aaa"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -36,7 +36,10 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Password</string>
 
+    <!-- Text for a label for the field when prompt requesting a text is shown. -->
+    <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
+    <string name="mozac_feature_prompts_content_description_input_label">Label for entering a text input field</string>
+
     <!-- Title of a color picker dialog, this text is shown above a color picker. -->
     <string name="mozac_feature_prompts_choose_a_color">Choose a color</string>
-
 </resources>

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AlertDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AlertDialogFragmentTest.kt
@@ -123,7 +123,7 @@ class AlertDialogFragmentTest {
         val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
-        verify(mockFeature).onShouldMoreDialogsChecked("sessionId", true)
+        verify(mockFeature).onConfirm("sessionId", true)
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AuthenticationDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AuthenticationDialogFragmentTest.kt
@@ -152,7 +152,7 @@ class AuthenticationDialogFragmentTest {
         val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
         positiveButton.performClick()
 
-        verify(mockFeature).onConfirmAuthentication("sessionId", "username", "password")
+        verify(mockFeature).onConfirm("sessionId", "username" to "password")
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ChoiceDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ChoiceDialogFragmentTest.kt
@@ -283,7 +283,7 @@ class ChoiceDialogFragmentTest {
 
         holder.itemView.performClick()
 
-        verify(mockFeature).onSingleChoiceSelect("sessionId", choices.first())
+        verify(mockFeature).onConfirm("sessionId", choices.first())
         dialog.dismiss()
         verify(mockFeature).onCancel("sessionId")
     }
@@ -313,7 +313,7 @@ class ChoiceDialogFragmentTest {
 
         holder.itemView.performClick()
 
-        verify(mockFeature).onSingleChoiceSelect("sessionId", choices.first())
+        verify(mockFeature).onConfirm("sessionId", choices.first())
         dialog.dismiss()
         verify(mockFeature).onCancel("sessionId")
     }
@@ -346,7 +346,7 @@ class ChoiceDialogFragmentTest {
         val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
-        verify(mockFeature).onMultipleChoiceSelect("sessionId", fragment.mapSelectChoice.keys.toTypedArray())
+        verify(mockFeature).onConfirm("sessionId", fragment.mapSelectChoice.keys.toTypedArray())
 
         val negativeButton = dialog.getButton(BUTTON_NEGATIVE)
         negativeButton.performClick()
@@ -385,7 +385,7 @@ class ChoiceDialogFragmentTest {
         val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
-        verify(mockFeature).onMultipleChoiceSelect("sessionId", fragment.mapSelectChoice.keys.toTypedArray())
+        verify(mockFeature).onConfirm("sessionId", fragment.mapSelectChoice.keys.toTypedArray())
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -24,6 +24,7 @@ import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
 import mozilla.components.concept.engine.prompt.PromptRequest.Color
@@ -180,7 +181,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(singleChoiceRequest)
 
-        promptFeature.onSingleChoiceSelect(session.id, mock())
+        promptFeature.onConfirm(session.id, mock<Choice>())
 
         assertTrue(session.promptRequest.isConsumed())
     }
@@ -194,11 +195,11 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(singleChoiceRequest)
 
-        promptFeature.onSingleChoiceSelect("unknown_session", mock())
+        promptFeature.onConfirm("unknown_session", mock())
 
         assertFalse(session.promptRequest.isConsumed())
 
-        promptFeature.onMultipleChoiceSelect("unknown_session", arrayOf())
+        promptFeature.onConfirm("unknown_session", arrayOf<Choice>())
 
         assertFalse(session.promptRequest.isConsumed())
 
@@ -216,13 +217,13 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(menuChoiceRequest)
 
-        promptFeature.onSingleChoiceSelect(session.id, mock())
+        promptFeature.onConfirm(session.id, mock<Choice>())
 
         assertTrue(session.promptRequest.isConsumed())
     }
 
     @Test
-    fun `Selecting items o multiple choice dialog will consume promptRequest`() {
+    fun `Selecting items on multiple choice dialog will consume promptRequest`() {
         val session = getSelectedSession()
         val multipleChoiceRequest = MultipleChoice(arrayOf()) {}
 
@@ -230,7 +231,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(multipleChoiceRequest)
 
-        promptFeature.onMultipleChoiceSelect(session.id, arrayOf())
+        promptFeature.onConfirm(session.id, arrayOf<Choice>())
 
         assertTrue(session.promptRequest.isConsumed())
     }
@@ -250,7 +251,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onShouldMoreDialogsChecked(session.id, false)
+        promptFeature.onConfirm(session.id, false)
 
         assertTrue(session.promptRequest.isConsumed())
         assertTrue(onShowNoMoreAlertsWasCalled)
@@ -276,7 +277,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onShouldMoreDialogsChecked("unknown_session_id", false)
+        promptFeature.onConfirm("unknown_session_id", false)
 
         assertFalse(session.promptRequest.isConsumed())
         assertFalse(onShowNoMoreAlertsWasCalled)
@@ -324,7 +325,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onConfirmTextPrompt("unknown_session_id", false, "")
+        promptFeature.onConfirm("unknown_session_id", false to "")
 
         assertFalse(session.promptRequest.isConsumed())
         assertFalse(onConfirmWasCalled)
@@ -355,7 +356,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onConfirmTextPrompt(session.id, false, "")
+        promptFeature.onConfirm(session.id, false to "")
 
         assertTrue(session.promptRequest.isConsumed())
         assertTrue(onConfirmWasCalled)
@@ -436,7 +437,7 @@ class PromptFeatureTest {
             PromptRequest.TimeSelection.Type.TIME
         )
 
-        timeSelectionTypes.forEach { timeType ->
+        timeSelectionTypes.forEach { _ ->
 
             val session = getSelectedSession()
             var onClearWasCalled = false
@@ -753,7 +754,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onConfirmAuthentication(session.id, "", "")
+        promptFeature.onConfirm(session.id, "" to "")
 
         assertTrue(session.promptRequest.isConsumed())
         assertTrue(onConfirmWasCalled)
@@ -789,7 +790,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onConfirmAuthentication("unknown_session_id", "", "")
+        promptFeature.onConfirm("unknown_session_id", "" to "")
 
         assertFalse(session.promptRequest.isConsumed())
         assertFalse(onConfirmWasCalled)

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
@@ -108,7 +108,7 @@ class TextPromptDialogFragmentTest {
         val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
         positiveButton.performClick()
 
-        verify(mockFeature).onConfirmTextPrompt("sessionId", false, "defaultValue")
+        verify(mockFeature).onConfirm("sessionId", false to "defaultValue")
     }
 
     @Test
@@ -134,7 +134,7 @@ class TextPromptDialogFragmentTest {
         val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
-        verify(mockFeature).onConfirmTextPrompt("sessionId", true, "defaultValue")
+        verify(mockFeature).onConfirm("sessionId", true to "defaultValue")
     }
 
     @Test

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import android.content.DialogInterface
+import android.content.DialogInterface.BUTTON_POSITIVE
+import android.support.v7.app.AlertDialog
+import android.view.ContextThemeWrapper
+import android.widget.CheckBox
+import android.widget.TextView
+import mozilla.components.support.test.mock
+import mozilla.components.feature.prompts.R.id
+import mozilla.components.support.ktx.android.view.isVisible
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TextPromptDialogFragmentTest {
+
+    private val context: Context
+        get() = ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext(),
+            android.support.v7.appcompat.R.style.Theme_AppCompat
+        )
+
+    @Test
+    fun `build dialog`() {
+
+        val fragment = spy(
+            TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", true)
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+
+        dialog.show()
+
+        val titleTextView = dialog.findViewById<TextView>(android.support.v7.appcompat.R.id.alertTitle)
+        val inputLabel = dialog.findViewById<TextView>(id.input_label)
+        val inputValue = dialog.findViewById<TextView>(id.input_value)
+        val checkBox = dialog.findViewById<CheckBox>(id.no_more_dialogs_check_box)
+
+        assertEquals(fragment.sessionId, "sessionId")
+        assertEquals(fragment.title, "title")
+        assertEquals(fragment.labelInput, "label")
+        assertEquals(fragment.defaultInputValue, "defaultValue")
+        assertEquals(fragment.hasShownManyDialogs, true)
+
+        assertEquals(titleTextView.text, "title")
+        assertEquals(fragment.title, "title")
+        assertEquals(inputLabel.text, "label")
+        assertEquals(inputValue.text.toString(), "defaultValue")
+        assertTrue(checkBox.isVisible())
+
+        checkBox.isChecked = true
+        assertTrue(fragment.userSelectionNoMoreDialogs)
+
+        inputValue.text = "NewValue"
+        assertEquals(inputValue.text.toString(), "NewValue")
+    }
+
+    @Test
+    fun `TextPrompt with hasShownManyDialogs equals false should not have a checkbox`() {
+
+        val fragment = spy(
+            TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", false)
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+
+        dialog.show()
+
+        val checkBox = dialog.findViewById<CheckBox>(id.no_more_dialogs_check_box)
+
+        assertFalse(checkBox.isVisible())
+    }
+
+    @Test
+    fun `Clicking on positive button notifies the feature`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", false)
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        positiveButton.performClick()
+
+        verify(mockFeature).onConfirmTextPrompt("sessionId", false, "defaultValue")
+    }
+
+    @Test
+    fun `After checking no more dialogs checkbox feature onNoMoreDialogsChecked must be called`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", true)
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val checkBox = dialog.findViewById<CheckBox>(id.no_more_dialogs_check_box)
+
+        checkBox.isChecked = true
+
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
+        positiveButton.performClick()
+
+        verify(mockFeature).onConfirmTextPrompt("sessionId", true, "defaultValue")
+    }
+
+    @Test
+    fun `touching outside of the dialog must notify the feature onCancel`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", true)
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        fragment.onCancel(null)
+
+        verify(mockFeature).onCancel("sessionId")
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ permalink: /changelog/
 * **feature-awesomebar**
   * Added `ClipboardSuggestionProvider` - An `AwesomeBar.SuggestionProvider` implementation that returns a suggestions for an URL in the clipboard (if there's any).
 
+* **feature-prompts**, **browser-engine-gecko***
+  * Added support for [Window.prompt](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt).
+
 # 0.38.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.37.0...v0.38.0),
@@ -50,8 +53,8 @@ permalink: /changelog/
 
 * **feature-prompts**, **browser-engine-gecko***
   * Added support for Authentication dialogs.
-  * Added support for [input type color fields](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color).
   * Added support for [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) and [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time) pickers.
+  * Added support for [input type color fields](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color).
 
 * **browser-menu**
   * `BrowserMenuItemToolbar` now allows overriding the `visible` lambda.
@@ -486,7 +489,7 @@ permalink: /changelog/
 * **ui-autocomplete**
   * Fixed problem handling backspaces as described in [Issue 1489](https://github.com/mozilla-mobile/android-components/issues/1489)
 
-* **browser-search**  
+* **browser-search**
   * Updated search codes (see [Issue 1563](https://github.com/mozilla-mobile/android-components/issues/1563) for details)
 
 # 0.32.1


### PR DESCRIPTION
Added support for [Window.prompt()](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt#Parameters)

[Demo](https://drive.google.com/open?id=1wgbhk8qzgluGMHVDVP5Cx6-CZUnk_5-u)
