### PR TITLE
Closes #1400: Add close button to custom tabs...

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -532,3 +532,20 @@ class SessionManager(
         )
     }
 }
+
+/**
+ * Tries to find a session with the provided session ID and runs the block if found.
+ *
+ * @return True if the session was found and run successfully.
+ */
+fun SessionManager.runWithSession(
+    sessionId: String?,
+    block: SessionManager.(Session) -> Boolean
+): Boolean {
+    sessionId?.let {
+        findSessionById(sessionId)?.let { session ->
+            return block(session)
+        }
+    }
+    return false
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
@@ -22,6 +22,7 @@ import android.support.customtabs.CustomTabsIntent.KEY_MENU_ITEM_TITLE
 import android.support.customtabs.CustomTabsIntent.EXTRA_TINT_ACTION_BUTTON
 import android.support.customtabs.CustomTabsIntent.EXTRA_REMOTEVIEWS
 import android.support.customtabs.CustomTabsIntent.EXTRA_TOOLBAR_ITEMS
+import android.util.DisplayMetrics
 
 import mozilla.components.support.utils.SafeBundle
 import mozilla.components.support.utils.SafeIntent
@@ -54,6 +55,7 @@ class CustomTabConfig internal constructor(
         internal const val BOTTOM_TOOLBAR_OPTION = "hasBottomToolbar"
         internal const val EXIT_ANIMATION_OPTION = "hasExitAnimation"
         internal const val PAGE_TITLE_OPTION = "hasPageTitle"
+        private const val MAX_CLOSE_BUTTON_SIZE_DP = 24
 
         /**
          * Checks if the provided intent is a custom tab intent.
@@ -70,10 +72,11 @@ class CustomTabConfig internal constructor(
          *
          * @param intent the intent, wrapped as a SafeIntent, which is processed
          * to extract configuration data.
+         * @param displayMetrics needed in-order to verify that icons of a max size are only provided.
          * @return the CustomTabConfig instance.
          */
         @Suppress("ComplexMethod")
-        fun createFromIntent(intent: SafeIntent): CustomTabConfig {
+        fun createFromIntent(intent: SafeIntent, displayMetrics: DisplayMetrics? = null): CustomTabConfig {
             val id = UUID.randomUUID().toString()
 
             val options = mutableListOf<String>()
@@ -87,7 +90,11 @@ class CustomTabConfig internal constructor(
 
             val closeButtonIcon = run {
                 val icon = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
-                if (icon != null) {
+                val density = displayMetrics?.density ?: 1f
+                if (icon != null &&
+                    icon.width / density <= MAX_CLOSE_BUTTON_SIZE_DP &&
+                    icon.height / density <= MAX_CLOSE_BUTTON_SIZE_DP
+                ) {
                     options.add(CLOSE_BUTTON_OPTION)
                     icon
                 } else {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
@@ -54,7 +54,6 @@ class CustomTabConfig internal constructor(
         internal const val BOTTOM_TOOLBAR_OPTION = "hasBottomToolbar"
         internal const val EXIT_ANIMATION_OPTION = "hasExitAnimation"
         internal const val PAGE_TITLE_OPTION = "hasPageTitle"
-        private const val MAX_CLOSE_BUTTON_SIZE_DP = 24
 
         /**
          * Checks if the provided intent is a custom tab intent.
@@ -88,7 +87,7 @@ class CustomTabConfig internal constructor(
 
             val closeButtonIcon = run {
                 val icon = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
-                if (icon != null && icon.width <= MAX_CLOSE_BUTTON_SIZE_DP && icon.height <= MAX_CLOSE_BUTTON_SIZE_DP) {
+                if (icon != null) {
                     options.add(CLOSE_BUTTON_OPTION)
                     icon
                 } else {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -11,10 +11,12 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.never
@@ -1069,5 +1071,34 @@ class SessionManagerTest {
         manager.remove(regular1)
         assertEquals(manager.defaultSession?.invoke(), manager.selectedSession)
         assertEquals("http://www.mozilla.com", manager.selectedSession?.url)
+    }
+
+    @Test
+    fun `SessionManager#runWithSession executes the block when session found`() {
+        val sessionManager = spy(SessionManager(mock()))
+
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(mock())
+
+        val executed = sessionManager.runWithSession("123") { true }
+
+        assertTrue(executed)
+    }
+
+    @Test
+    fun `SessionManager#runWithSession with null session ID`() {
+        val sessionManager = spy(SessionManager(mock()))
+
+        val executed = sessionManager.runWithSession(null) { true }
+
+        assertFalse(executed)
+    }
+
+    @Test
+    fun `SessionManager#runWithSession with null session`() {
+        val sessionManager = spy(SessionManager(mock()))
+
+        val executed = sessionManager.runWithSession("123") { true }
+
+        assertFalse(executed)
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
@@ -65,18 +65,6 @@ class CustomTabConfigTest {
     }
 
     @Test
-    fun createFromIntentWithMaxOversizedCloseButton() {
-        val size = 64
-        val builder = CustomTabsIntent.Builder()
-        val closeButtonIcon = Bitmap.createBitmap(IntArray(size * size), size, size, Bitmap.Config.ARGB_8888)
-        builder.setCloseButtonIcon(closeButtonIcon)
-
-        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
-        assertNull(customTabConfig.closeButtonIcon)
-        assertFalse(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
-    }
-
-    @Test
     fun createFromIntentWithInvalidCloseButton() {
         val customTabsIntent = CustomTabsIntent.Builder().build()
         // Intent is a parcelable but not a Bitmap

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
@@ -10,6 +10,8 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
 import android.support.customtabs.CustomTabsIntent
+import android.util.DisplayMetrics
+import mozilla.components.support.test.mock
 import mozilla.components.support.utils.SafeIntent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -61,6 +63,33 @@ class CustomTabConfigTest {
         assertEquals(closeButtonIcon, customTabConfig.closeButtonIcon)
         assertEquals(size, customTabConfig.closeButtonIcon?.width)
         assertEquals(size, customTabConfig.closeButtonIcon?.height)
+        assertTrue(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
+    }
+
+    @Test
+    fun createFromIntentWithMaxOversizedCloseButton() {
+        val size = 64
+        val builder = CustomTabsIntent.Builder()
+        val closeButtonIcon = Bitmap.createBitmap(IntArray(size * size), size, size, Bitmap.Config.ARGB_8888)
+        builder.setCloseButtonIcon(closeButtonIcon)
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)))
+        assertNull(customTabConfig.closeButtonIcon)
+        assertFalse(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
+    }
+
+    @Test
+    fun createFromIntentUsingDisplayMetricsForCloseButton() {
+        val size = 64
+        val builder = CustomTabsIntent.Builder()
+        val displayMetrics: DisplayMetrics = mock()
+        val closeButtonIcon = Bitmap.createBitmap(IntArray(size * size), size, size, Bitmap.Config.ARGB_8888)
+        builder.setCloseButtonIcon(closeButtonIcon)
+
+        displayMetrics.density = 3f
+
+        val customTabConfig = CustomTabConfig.createFromIntent(SafeIntent((builder.build().intent)), displayMetrics)
+        assertEquals(closeButtonIcon, customTabConfig.closeButtonIcon)
         assertTrue(customTabConfig.options.contains(CustomTabConfig.CLOSE_BUTTON_OPTION))
     }
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -24,7 +24,6 @@ import mozilla.components.support.base.android.Padding
 import mozilla.components.support.ktx.android.content.res.pxToDp
 import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.support.ktx.android.view.isVisible
-import mozilla.components.support.ktx.android.view.setPadding
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 
 /**

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -59,7 +59,7 @@ import mozilla.components.ui.icons.R.drawable.mozac_ic_lock
  *
  */
 @SuppressLint("ViewConstructor") // This view is only instantiated in code
-@Suppress("LargeClass")
+@Suppress("LargeClass", "TooManyFunctions")
 internal class DisplayToolbar(
     context: Context,
     val toolbar: BrowserToolbar

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -59,7 +59,7 @@ import mozilla.components.ui.icons.R.drawable.mozac_ic_lock
  *
  */
 @SuppressLint("ViewConstructor") // This view is only instantiated in code
-@Suppress("LargeClass", "TooManyFunctions")
+@Suppress("LargeClass")
 internal class DisplayToolbar(
     context: Context,
     val toolbar: BrowserToolbar

--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -22,11 +22,14 @@ android {
 }
 
 dependencies {
+    implementation project(':browser-menu')
     implementation project(':browser-session')
     implementation project(':browser-toolbar')
     implementation project(':concept-engine')
     implementation project(':support-base')
+    implementation project(':support-ktx')
     implementation project(':support-utils')
+    implementation project(':ui-icons')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -75,6 +75,19 @@ class CustomTabsToolbarFeature(
 
     override fun stop() {}
 
+    /**
+     * Removes the current Custom Tabs session when the back button is pressed and returns true.
+     * Should be called when the back button is pressed.
+     */
+    fun onBackPressed(): Boolean {
+        val result = sessionManager.runWithSession(sessionId) {
+            remove(it)
+            true
+        }
+        closeListener.invoke()
+        return result
+    }
+
     internal fun Drawable.isSmallerThan(maxSize: Int): Boolean = with(context.resources) {
         pxToDp(minimumWidth) <= maxSize && pxToDp(minimumHeight) <= maxSize
     }

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -6,11 +6,18 @@
 
 package mozilla.components.feature.customtabs
 
+import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.support.v4.content.ContextCompat
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.runWithSession
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.ktx.android.content.res.pxToDp
 
 /**
  * Initializes and resets the Toolbar for a Custom Tab based on the CustomTabConfig.
@@ -18,19 +25,30 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 class CustomTabsToolbarFeature(
     private val sessionManager: SessionManager,
     private val toolbar: BrowserToolbar,
-    private val sessionId: String? = null
+    private val sessionId: String? = null,
+    private val closeListener: () -> Unit
 ) : LifecycleAwareFeature {
+    private val context = toolbar.context
+    private var initialized = false
 
     override fun start() {
-        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
-        session?.let { initialize(it) }
+        if (initialized) {
+            return
+        }
+        initialized = sessionManager.runWithSession(sessionId) { initialize(it) }
     }
 
-    internal fun initialize(session: Session) {
+    internal fun initialize(session: Session): Boolean {
         session.customTabConfig?.let { config ->
+            // Don't allow clickable toolbar so a custom tab can't switch to edit mode.
+            toolbar.onUrlClicked = { false }
             // Change the toolbar colour
             updateToolbarColor(config.toolbarColor)
+            // Add navigation close action
+            addCloseButton(config.closeButtonIcon)
+            return true
         }
+        return false
     }
 
     internal fun updateToolbarColor(toolbarColor: Int?) {
@@ -40,9 +58,30 @@ class CustomTabsToolbarFeature(
         }
     }
 
+    internal fun addCloseButton(bitmap: Bitmap?) {
+        val drawableIcon = bitmap?.let { icon ->
+            BitmapDrawable(context.resources, icon).also {
+                if (it.isSmallerThan(MAX_CLOSE_BUTTON_SIZE_DP)) return@also
+            }
+        } ?: ContextCompat.getDrawable(context, R.drawable.mozac_ic_close)
+
+        drawableIcon?.let {
+            val button = Toolbar.ActionButton(
+                it, context.getString(R.string.mozac_feature_customtabs_exit_button)
+            ) { closeListener.invoke() }
+            toolbar.addNavigationAction(button)
+        }
+    }
+
     override fun stop() {}
 
+    internal fun Drawable.isSmallerThan(maxSize: Int): Boolean = with(context.resources) {
+        pxToDp(minimumWidth) <= maxSize && pxToDp(minimumHeight) <= maxSize
+    }
+
     companion object {
+        internal const val MAX_CLOSE_BUTTON_SIZE_DP = 24
+
         @Suppress("MagicNumber")
         internal fun getReadableTextColor(backgroundColor: Int): Int {
             val greyValue = greyscaleFromRGB(backgroundColor)

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -9,7 +9,6 @@ package mozilla.components.feature.customtabs
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
-import android.graphics.drawable.Drawable
 import android.support.v4.content.ContextCompat
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -17,7 +16,6 @@ import mozilla.components.browser.session.runWithSession
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import mozilla.components.support.ktx.android.content.res.pxToDp
 
 /**
  * Initializes and resets the Toolbar for a Custom Tab based on the CustomTabConfig.
@@ -59,11 +57,10 @@ class CustomTabsToolbarFeature(
     }
 
     internal fun addCloseButton(bitmap: Bitmap?) {
-        val drawableIcon = bitmap?.let { icon ->
-            BitmapDrawable(context.resources, icon).also {
-                if (it.isSmallerThan(MAX_CLOSE_BUTTON_SIZE_DP)) return@also
-            }
-        } ?: ContextCompat.getDrawable(context, R.drawable.mozac_ic_close)
+        val drawableIcon = bitmap?.let { BitmapDrawable(context.resources, it) } ?: ContextCompat.getDrawable(
+            context,
+            R.drawable.mozac_ic_close
+        )
 
         drawableIcon?.let {
             val button = Toolbar.ActionButton(
@@ -86,10 +83,6 @@ class CustomTabsToolbarFeature(
         }
         closeListener.invoke()
         return result
-    }
-
-    internal fun Drawable.isSmallerThan(maxSize: Int): Boolean = with(context.resources) {
-        pxToDp(minimumWidth) <= maxSize && pxToDp(minimumHeight) <= maxSize
     }
 
     companion object {

--- a/components/feature/customtabs/src/main/res/values/strings.xml
+++ b/components/feature/customtabs/src/main/res/values/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<resources>
+    <string name="mozac_feature_customtabs_share_dialog_title">Share via</string>
+    <string name="mozac_feature_customtabs_exit_button">Return to previous app</string>
+    <string name="mozac_feature_customtabs_share_button">Share…</string>
+</resources>

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -153,6 +153,24 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
+    fun `onBackPressed removes session`() {
+        val sessionId = "123"
+        val session: Session = mock()
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        val sessionManager: SessionManager = mock()
+        var closeExecuted = false
+        `when`(session.customTabConfig).thenReturn(mock())
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
+
+        val feature = spy(CustomTabsToolbarFeature(sessionManager, toolbar, sessionId) { closeExecuted = true })
+
+        val result = feature.onBackPressed()
+
+        assertTrue(result)
+        assertTrue(closeExecuted)
+    }
+
+    @Test
     fun isSmallerThan() {
         val toolbar = spy(BrowserToolbar(RuntimeEnvironment.application))
         val drawable: Drawable = mock()

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -7,7 +7,6 @@
 package mozilla.components.feature.customtabs
 
 import android.graphics.Color
-import android.graphics.drawable.Drawable
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -168,24 +167,5 @@ class CustomTabsToolbarFeatureTest {
 
         assertTrue(result)
         assertTrue(closeExecuted)
-    }
-
-    @Test
-    fun isSmallerThan() {
-        val toolbar = spy(BrowserToolbar(RuntimeEnvironment.application))
-        val drawable: Drawable = mock()
-        with(CustomTabsToolbarFeature(mock(), toolbar, "") {}) {
-            `when`(drawable.minimumWidth).thenReturn(84)
-            `when`(drawable.minimumHeight).thenReturn(84)
-            assertFalse(drawable.isSmallerThan(CustomTabsToolbarFeature.MAX_CLOSE_BUTTON_SIZE_DP))
-
-            `when`(drawable.minimumWidth).thenReturn(24)
-            `when`(drawable.minimumHeight).thenReturn(24)
-            assertTrue(drawable.isSmallerThan(CustomTabsToolbarFeature.MAX_CLOSE_BUTTON_SIZE_DP))
-
-            `when`(drawable.minimumWidth).thenReturn(24)
-            `when`(drawable.minimumHeight).thenReturn(84)
-            assertFalse(drawable.isSmallerThan(CustomTabsToolbarFeature.MAX_CLOSE_BUTTON_SIZE_DP))
-        }
     }
 }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.intent
 
+import android.content.Context
 import android.content.Intent
 import android.text.TextUtils
 import mozilla.components.browser.session.Session
@@ -32,6 +33,7 @@ class IntentProcessor(
     private val sessionUseCases: SessionUseCases,
     private val sessionManager: SessionManager,
     private val searchUseCases: SearchUseCases,
+    private val context: Context,
     private val useDefaultHandlers: Boolean = true,
     private val openNewTab: Boolean = true
 ) {
@@ -44,7 +46,8 @@ class IntentProcessor(
 
             CustomTabConfig.isCustomTabIntent(safeIntent) -> {
                 val session = Session(url, false, Source.CUSTOM_TAB).apply {
-                    this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent)
+                    val displayMetrics = context.resources.displayMetrics
+                    this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
                 }
                 sessionManager.add(session)
                 sessionUseCases.loadUrl.invoke(url, session)

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
@@ -54,7 +54,8 @@ class IntentProcessorTest {
         val engine = mock(Engine::class.java)
         val sessionManager = spy(SessionManager(engine))
         val useCases = SessionUseCases(sessionManager)
-        val handler = IntentProcessor(useCases, sessionManager, searchUseCases)
+        val handler =
+            IntentProcessor(useCases, sessionManager, searchUseCases, RuntimeEnvironment.application)
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
 
@@ -77,7 +78,14 @@ class IntentProcessorTest {
 
     @Test
     fun processWithDefaultHandlersUsingSelectedSession() {
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, true, false)
+        val handler = IntentProcessor(
+            sessionUseCases,
+            sessionManager,
+            searchUseCases,
+            RuntimeEnvironment.application,
+            true,
+            false
+        )
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
         `when`(intent.dataString).thenReturn("http://mozilla.org")
@@ -91,7 +99,14 @@ class IntentProcessorTest {
         `when`(sessionManager.selectedSession).thenReturn(null)
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
 
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, true, false)
+        val handler = IntentProcessor(
+            sessionUseCases,
+            sessionManager,
+            searchUseCases,
+            RuntimeEnvironment.application,
+            true,
+            false
+        )
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
         `when`(intent.dataString).thenReturn("http://mozilla.org")
@@ -102,7 +117,13 @@ class IntentProcessorTest {
 
     @Test
     fun processWithoutDefaultHandlers() {
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, useDefaultHandlers = false)
+        val handler = IntentProcessor(
+            sessionUseCases,
+            sessionManager,
+            searchUseCases,
+            RuntimeEnvironment.application,
+            useDefaultHandlers = false
+        )
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
         `when`(intent.dataString).thenReturn("http://mozilla.org")
@@ -113,7 +134,13 @@ class IntentProcessorTest {
 
     @Test
     fun processWithCustomHandlers() {
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, useDefaultHandlers = false)
+        val handler = IntentProcessor(
+            sessionUseCases,
+            sessionManager,
+            searchUseCases,
+            RuntimeEnvironment.application,
+            useDefaultHandlers = false
+        )
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_SEND)
 
@@ -140,7 +167,7 @@ class IntentProcessorTest {
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
         val useCases = SessionUseCases(sessionManager)
 
-        val handler = IntentProcessor(useCases, sessionManager, searchUseCases)
+        val handler = IntentProcessor(useCases, sessionManager, searchUseCases, RuntimeEnvironment.application)
 
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_VIEW)
@@ -162,7 +189,7 @@ class IntentProcessorTest {
     fun `load URL on ACTION_SEND if text contains URL`() {
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
 
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases)
+        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, RuntimeEnvironment.application)
 
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_SEND)
@@ -192,7 +219,7 @@ class IntentProcessorTest {
         val searchTerms = "mozilla android"
         val searchUrl = "http://search-url.com?$searchTerms"
 
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases)
+        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, RuntimeEnvironment.application)
 
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_SEND)
@@ -210,7 +237,7 @@ class IntentProcessorTest {
 
     @Test
     fun `processor handles ACTION_SEND with empty text`() {
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases)
+        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, RuntimeEnvironment.application)
 
         val intent = mock(Intent::class.java)
         `when`(intent.action).thenReturn(Intent.ACTION_SEND)

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/toolbar/TabsToolbarFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/toolbar/TabsToolbarFeature.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.tabs.toolbar
 
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.runWithSession
 import mozilla.components.concept.toolbar.Toolbar
 
 /**
@@ -14,13 +15,21 @@ import mozilla.components.concept.toolbar.Toolbar
 class TabsToolbarFeature(
     toolbar: Toolbar,
     sessionManager: SessionManager,
+    sessionId: String? = null,
     showTabs: () -> Unit
 ) {
     init {
-        val tabsAction = TabCounterToolbarButton(
-            sessionManager,
-            showTabs)
-
-        toolbar.addBrowserAction(tabsAction)
+        run {
+            sessionManager.runWithSession(sessionId) {
+                it.isCustomTabSession()
+            }.also { isCustomTab ->
+                if (isCustomTab) return@run
+            }
+            val tabsAction = TabCounterToolbarButton(
+                sessionManager,
+                showTabs
+            )
+            toolbar.addBrowserAction(tabsAction)
+        }
     }
 }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabsToolbarFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabsToolbarFeatureTest.kt
@@ -4,22 +4,49 @@
 
 package mozilla.components.feature.tabs.toolbar
 
+import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Test
-import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class TabsToolbarFeatureTest {
     @Test
     fun `feature adds "tabs" button to toolbar`() {
         val toolbar: Toolbar = mock()
         val sessionManager: SessionManager = mock()
         TabsToolbarFeature(toolbar, sessionManager) {}
+
+        verify(toolbar).addBrowserAction(any())
+    }
+
+    @Test
+    fun `feature does not add tabs button when session is a customtab`() {
+        val toolbar: Toolbar = mock()
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
+        `when`(session.isCustomTabSession()).thenReturn(true)
+
+        TabsToolbarFeature(toolbar, sessionManager, "123") {}
+
+        verify(toolbar, never()).addBrowserAction(any())
+    }
+
+    @Test
+    fun `feature adds tab button when session found but not a customtab`() {
+        val toolbar: Toolbar = mock()
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
+        `when`(session.isCustomTabSession()).thenReturn(false)
+
+        TabsToolbarFeature(toolbar, sessionManager, "123") {}
 
         verify(toolbar).addBrowserAction(any())
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,7 +65,10 @@ permalink: /changelog/
   * Added support for JavaScript alerts on SystemEngineView.
   * [Improving use of internal Webview](https://github.com/mozilla-mobile/android-components/commit/59240f7a71a9f63fc51c1ff65e604f6735196a0e).
 
-* **feature-prompts**, **browser-engine-gecko***
+* **feature-customtabs**
+  * Added a close button to a custom tab with back button handling.
+
+* **feature-prompts**, **browser-engine-gecko**
   * Added support for Authentication dialogs.
   * Added support for [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) and [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time) pickers.
   * Added support for [input type color fields](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color).

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -67,7 +67,7 @@ class BrowserFragment : Fragment(), BackHandler {
             this.addDomainProvider(components.shippedDomainsProvider)
         }
 
-        tabsToolbarFeature = TabsToolbarFeature(layout.toolbar, components.sessionManager, ::showTabs)
+        tabsToolbarFeature = TabsToolbarFeature(layout.toolbar, components.sessionManager, sessionId, ::showTabs)
 
         AwesomeBarFeature(layout.awesomeBar, layout.toolbar, layout.engineView)
             .addHistoryProvider(components.historyStorage, components.sessionUseCases.loadUrl)
@@ -111,7 +111,7 @@ class BrowserFragment : Fragment(), BackHandler {
             components.sessionManager,
             layout.toolbar,
             sessionId
-        )
+        ) { activity?.finish() }
 
         // Observe the lifecycle for supported features
         lifecycle.addObservers(

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -137,12 +137,17 @@ class BrowserFragment : Fragment(), BackHandler {
         }
     }
 
+    @Suppress("ReturnCount")
     override fun onBackPressed(): Boolean {
         if (toolbarFeature.handleBackPressed()) {
             return true
         }
 
         if (sessionFeature.handleBackPressed()) {
+            return true
+        }
+
+        if (customTabsToolbarFeature.onBackPressed()) {
             return true
         }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -84,7 +84,14 @@ open class DefaultComponents(private val applicationContext: Context) {
     val defaultSearchUseCase by lazy { { searchTerms: String -> searchUseCases.defaultSearch.invoke(searchTerms) } }
 
     // Intent
-    val sessionIntentProcessor by lazy { IntentProcessor(sessionUseCases, sessionManager, searchUseCases) }
+    val sessionIntentProcessor by lazy {
+        IntentProcessor(
+            sessionUseCases,
+            sessionManager,
+            searchUseCases,
+            applicationContext
+        )
+    }
 
     // Menu
     val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }


### PR DESCRIPTION
Also makes the toolbar unclickable so it can't be switching into
edit mode, and removes all other actions.

Moved the custom tab back button bitmap checking to the feature from the
CustomTabConfig since we needed to know the DisplayMetrics for the
current screen to properly compare it to the max dp value.