### PR TITLE
Temporarily disable intermittent failing test until fixed

### DIFF
--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.provider.SearchEngineProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -112,6 +113,7 @@ class SearchEngineManagerTest {
         }
     }
 
+    @Ignore
     @Test
     fun `locale update broadcast will trigger reload`() {
         runBlocking {


### PR DESCRIPTION
I'm seeing a lot of build failures due to this test. How do we feel about temporarily disabling this test until we get this fixed? (I'd like to work on it next sprint.)