### PR TITLE
WIP: [glean] 1518163: Add the a11y_services metric in the baseline ping.

### DIFF
--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -14,5 +14,5 @@ the following fields:
 | `device` | String | Manufacturer and model |
 | `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
 | `timezone` | Number | The timezone of the device, as an offset from UTC |
-| `accessibility_services` | StringList | List of accessibility services enabled on the device |
+| `a11y_services` | StringList | List of accessibility services enabled on the device |
 | `locale` | String | The locale of the application |

--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -102,14 +102,18 @@ baseline:
   #   notification_emails:
   #     - telemetry-client-dev@mozilla.com
 
-  # accessibility_services:
-  #   type: string_list
-  #   description: |
-  #     List of accessibility services enabled on the device.
-  #   bugs:
-  #     - 1497894
-  #   notification_emails:
-  #     - telemetry-client-dev@mozilla.com
+  a11y_services:
+    type: string_list
+    description: |
+      List of accessibility services enabled on the device.
+    send_in_pings:
+      - baseline
+    bugs:
+      - 1497894
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
 
 glean.internal.metrics:
   client_id:
@@ -125,4 +129,3 @@ glean.internal.metrics:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
-

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -7,7 +7,9 @@ package mozilla.components.service.glean
 import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.LifecycleRegistry
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
+import android.view.accessibility.AccessibilityManager
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -30,10 +32,14 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.anyObject
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -390,6 +396,30 @@ class GleanTest {
         assertEquals(
             "org-mozilla-test-app",
             Glean.sanitizeApplicationId("org-mozilla-test-app")
+        )
+    }
+
+    fun `Make sure a11y services are collected`() {
+        var applicationContext = RuntimeEnvironment.application.applicationContext
+        var accessibilityManager = applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+
+        var shadowAccessibilityManager = shadowOf(accessibilityManager)
+        shadowAccessibilityManager.setEnabled(true)
+
+        val serviceSpy1 = spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
+        doReturn("service1").`when`(serviceSpy1).loadDescription(anyObject())
+
+        val serviceSpy2 = spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
+        doReturn("service2").`when`(serviceSpy2).loadDescription(anyObject())
+
+        shadowAccessibilityManager.setEnabledAccessibilityServiceList(listOf(serviceSpy1, serviceSpy2))
+
+        assertEquals(
+            listOf("service1", "service2"),
+            Glean.getEnabledAccessibilityServices(
+                accessibilityManager,
+                applicationContext.packageManager
+            )
         )
     }
 }


### PR DESCRIPTION
This works, and I was able to test it in the sample app.  However, I'm uncertain how to write a test for it, since it doesn't seem that the accessibility service is enabled in the testing environment, and I can't figure out how to programmatically do that...