### PR TITLE
Update Dockerfile to create smaller image..

### DIFF
--- a/automation/docker/Dockerfile
+++ b/automation/docker/Dockerfile
@@ -66,17 +66,13 @@ RUN curl -L https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_S
     && rm sdk.zip \
     && mkdir -p /build/android-sdk/.android/ \
     && touch /build/android-sdk/.android/repositories.cfg \
-    && yes | sdkmanager --licenses \
-    && sdkmanager --verbose "platform-tools" \
-        "platforms;android-${ANDROID_PLATFORM_VERSION}" \
-        "build-tools;${ANDROID_BUILD_TOOLS}" \
-        "extras;android;m2repository" \
-        "extras;google;m2repository"
+    && yes | sdkmanager --licenses
+
 #----------------------------------------------------------------------------------------------------------------------
 #-- Project -----------------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
 
-RUN git clone $PROJECT_REPOSITORY
+RUN git clone --depth=1 $PROJECT_REPOSITORY
 
 WORKDIR /build/android-components
 
@@ -85,13 +81,9 @@ RUN ./gradlew clean \
     && ./gradlew androidDependencies \
     && ./gradlew --stop \
     && ./gradlew --no-daemon assemble \
-    && ./gradlew --no-daemon test \
+    && ./gradlew --no-daemon -Pcoverage test \
     && ./gradlew --no-daemon detekt \
     && ./gradlew --no-daemon ktlint \
-    && ./gradlew --no-daemon docs
+    && ./gradlew --no-daemon docs \
+    && ./gradlew clean
 
-#----------------------------------------------------------------------------------------------------------------------
-# -- Cleanup ----------------------------------------------------------------------------------------------------------
-#----------------------------------------------------------------------------------------------------------------------
-
-RUN apt-get clean


### PR DESCRIPTION
There are three major changes:

* Do not download any SDK bits with `sdkmanager`. Gradle will download whatever it needs itself nowadays. This will make sure that we do not download things that we won't need.
* Use `--depth=1` to not clone the whole git history that we do not need.
* Run `clean` after executing all the gradle commands. There's no need to keep all the build artifacts around. They will be outdated pretty fast and are just huuuuuge. If we want build artifacts then they should be setup as a gradle build cache in a worker cache (instead of the build folders)

The image size dropped from 6 GB to 3 GB on docker hub (And 11.2 GB to 5.16 GB locally according to `docker images`).