### PR TITLE
Adds pyyaml to docker image

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -88,7 +88,7 @@ tasks:
             - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
           payload:
             maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
-            image: mozillamobile/android-components:1.14
+            image: mozillamobile/android-components:1.15
             command:
               - /bin/bash
               - --login

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -207,7 +207,6 @@ tasks:
                               git fetch ${repository} --tags
                               && git config advice.detachedHead false
                               && git checkout ${tag}
-                              && pip install pyyaml
                               && ./gradlew --no-daemon --version
                               && python automation/taskcluster/decision_task_publish.py --version "${tag}"
                               ${command_staging_flag}

--- a/automation/docker/Dockerfile
+++ b/automation/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update -qq \
 RUN pip install --upgrade pip
 RUN pip install 'taskcluster>=4,<5'
 RUN pip install arrow
+RUN pip install pyyaml
 
 RUN locale-gen en_US.UTF-8
 

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -58,7 +58,7 @@ def create_raw_task(name, description, full_command, scopes = []):
                 'taskclusterProxy': True
             },
             "maxRunTime": 7200,
-            "image": "mozillamobile/android-components:1.14",
+            "image": "mozillamobile/android-components:1.15",
             "command": [
                 "/bin/bash",
                 "--login",

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -42,7 +42,7 @@ class TaskBuilder(object):
             "payload": {
                 "features": features,
                 "maxRunTime": 7200,
-                "image": "mozillamobile/android-components:1.14",
+                "image": "mozillamobile/android-components:1.15",
                 "command": [
                     "/bin/bash",
                     "--login",
@@ -90,7 +90,7 @@ class TaskBuilder(object):
             "payload": {
                 "features": features,
                 "maxRunTime": 7200,
-                "image": "mozillamobile/android-components:1.14",
+                "image": "mozillamobile/android-components:1.15",
                 "command": [
                     "/bin/bash",
                     "--login",


### PR DESCRIPTION
Multiple tasks now need `pyyaml`, so might as well add it to the shared docker image