### PR TITLE
[glean] Fix 1518835: Clarify issues around character length vs. utf8 bytes.

### DIFF
--- a/components/service/glean/docs/pings.md
+++ b/components/service/glean/docs/pings.md
@@ -72,3 +72,11 @@ additional metadata without the need of unpacking the ping payload. A typical su
 - `<doc-type>`: the name of the ping; this can be one of the pings available out of the box with glean, or a custom ping;
 - `<glean-schema-version>`: the version of the glean ping schema;
 - `<ping-uuid>`: a unique identifier for this ping.
+
+## A note about string length
+In order to ensure that pings don't become accidentally large, most string
+values are automatically truncated. The current implementation truncates based
+on a maximum number of Unicode characters (defined in the API docs), since is
+the most expedient implementation-wise. Other or future implementations may
+perform this truncation based on the number of UTF8 bytes instead, which is
+ultimately what matters for ping size.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
@@ -8,11 +8,6 @@ import kotlinx.coroutines.launch
 import mozilla.components.service.glean.storages.EventsStorageEngine
 import mozilla.components.support.base.log.logger.Logger
 
-// Maximum length of any string value in the extra dictionary, in UTF8 byte sequence length.
-internal const val MAX_LENGTH_EXTRA_KEY_VALUE = 80
-// Maximum length of any passed value string, in UTF8 byte sequence length.
-internal const val MAX_LENGTH_EVENT_VALUE = 80
-
 /**
  * This implements the developer facing API for recording events.
  *
@@ -37,10 +32,10 @@ data class EventMetricType(
     private val logger = Logger("glean/EventMetricType")
 
     companion object {
-        // Maximum length of any string value in the extra dictionary, in UTF8 byte sequence length.
-        private const val MAX_LENGTH_EXTRA_KEY_VALUE = 80
-        // Maximum length of any passed value string, in UTF8 byte sequence length.
-        private const val MAX_LENGTH_VALUE = 80
+        // Maximum length of any string value in the extra dictionary, in characters
+        internal const val MAX_LENGTH_EXTRA_KEY_VALUE = 80
+        // Maximum length of any passed value string, in characters
+        internal const val MAX_LENGTH_VALUE = 80
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringListMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringListMetricType.kt
@@ -30,7 +30,7 @@ data class StringListMetricType(
     private val logger = Logger("glean/StringListMetricType")
 
     companion object {
-        // Maximum length of any passed value string, in UTF8 byte sequence length.
+        // Maximum length of any passed value string, in characters.
         const val MAX_STRING_LENGTH = 50
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -30,15 +30,15 @@ data class StringMetricType(
     private val logger = Logger("glean/StringMetricType")
 
     companion object {
-        // Maximum length of any passed value string, in UTF8 byte sequence length.
+        // Maximum length of any passed value string, in characters.
         private const val MAX_LENGTH_VALUE = 50
     }
 
     /**
      * Set a string value.
      *
-     * @param value This is a user defined string value. The maximum length of
-     * this string is defined the metrics.yaml file by max_length.
+     * @param value This is a user defined string value. If the length of the string
+     * exceeds [MAX_LENGTH_VALUE] characters, it will be truncated.
      */
     fun set(value: String) {
         // TODO report errors through other special metrics handled by the SDK. See bug 1499761.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/ExperimentsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/ExperimentsStorageEngine.kt
@@ -24,8 +24,7 @@ internal object ExperimentsStorageEngine : StorageEngine {
 
     private val logger = Logger("glean/ExperimentsStorageEngine")
 
-    // Maximum length of the experiment and branch names, in UTF8 byte
-    // sequence length
+    // Maximum length of the experiment and branch names, in characters.
     private const val MAX_ID_LENGTH = 30
 
     data class RecordedExperimentData(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -169,7 +169,7 @@ class EventMetricTypeTest {
         val secondEvent = snapshot.filter { e -> e.objectId == "buttonB" }.single()
         assertEquals("ui", secondEvent.category)
         assertEquals("click", secondEvent.name)
-        assertEquals(testValue.repeat(10).substring(0, MAX_LENGTH_EVENT_VALUE), secondEvent.value)
+        assertEquals(testValue.repeat(10).substring(0, EventMetricType.MAX_LENGTH_VALUE), secondEvent.value)
     }
 
     @Test
@@ -237,7 +237,7 @@ class EventMetricTypeTest {
             "'extra' keys must be correctly recorded and truncated",
             mapOf(
                 "extra1" to testValue,
-                "truncatedExtra" to (testValue.repeat(10)).substring(0, MAX_LENGTH_EXTRA_KEY_VALUE)
+                "truncatedExtra" to (testValue.repeat(10)).substring(0, EventMetricType.MAX_LENGTH_EXTRA_KEY_VALUE)
             ).equals(snapshot.first().extra))
     }
 }


### PR DESCRIPTION
Also cleans up some duplicate constants and an obsolete comment.