### PR TITLE
Switch to android.net.Uri in domain matching logic

### DIFF
--- a/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
+++ b/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
@@ -10,7 +10,10 @@ import mozilla.components.concept.storage.VisitType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class InMemoryHistoryStorageTest {
     @Test
     fun `store can be used to track visit information`() = runBlocking {

--- a/components/feature/toolbar/build.gradle
+++ b/components/feature/toolbar/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.kotlin_coroutines
 }
 

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -24,7 +24,10 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import kotlinx.coroutines.runBlocking
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ToolbarAutocompleteFeatureTest {
     class TestToolbar : Toolbar {
         override var url: String = ""

--- a/components/support/utils/build.gradle
+++ b/components/support/utils/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_robolectric
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
@@ -5,8 +5,8 @@
 
 package mozilla.components.support.utils
 
+import android.net.Uri
 import java.net.MalformedURLException
-import java.net.URL
 
 data class DomainMatch(val url: String, val matchedSegment: String)
 
@@ -31,7 +31,7 @@ private fun basicMatch(query: String, urls: Sequence<String>): String? {
         }
 
         val url = try {
-            URL(rawUrl)
+            Uri.parse(rawUrl)
         } catch (e: MalformedURLException) {
             null
         }
@@ -62,17 +62,19 @@ private fun matchSegment(query: String, rawUrl: String): String? {
         return rawUrl
     }
 
-    val url = URL(rawUrl)
-    if (url.host.startsWith(query)) {
-        return url.host + url.path + url.port.orEmpty()
-    }
+    val url = Uri.parse(rawUrl)
+    url.host?.let { host ->
+        if (host.startsWith(query)) {
+            return host + url.path + url.port.orEmpty()
+        }
 
-    val strippedHost = url.host.noCommonSubdomains()
+        val strippedHost = host.noCommonSubdomains()
 
-    return if (strippedHost != url.host) {
-        strippedHost + url.port.orEmpty() + url.path
-    } else {
-        url.host + url.port.orEmpty() + url.path
+        return if (strippedHost != url.host) {
+            strippedHost + url.port.orEmpty() + url.path
+        } else {
+            host + url.port.orEmpty() + url.path
+        }
     }
 }
 

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
@@ -7,7 +7,10 @@ package mozilla.components.support.utils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class DomainMatcherTest {
     @Test
     fun `should perform basic domain matching for a given query`() {
@@ -18,7 +21,7 @@ class DomainMatcherTest {
                 "https://mobile.twitter.com", "https://m.youtube.com",
                 "https://en.Wikipedia.org/Wiki/Mozilla",
                 "http://192.168.254.254:8000", "http://192.168.254.254:8000/admin",
-                "about:config"
+                "about:config", "about:crashes"
         )
         // Full url matching.
         assertEquals(
@@ -64,6 +67,20 @@ class DomainMatcherTest {
         assertEquals(
                 DomainMatch("http://192.168.254.254:8000/admin", "192.168.254.254:8000/admin"),
                 segmentAwareDomainMatch("192.168.254.254:8000/a", urls)
+        )
+
+        // About urls.
+        assertEquals(
+                DomainMatch("about:config", "about:config"),
+                segmentAwareDomainMatch("abo", urls)
+        )
+        assertEquals(
+                DomainMatch("about:config", "about:config"),
+                segmentAwareDomainMatch("about:", urls)
+        )
+        assertEquals(
+                DomainMatch("about:crashes", "about:crashes"),
+                segmentAwareDomainMatch("about:cr", urls)
         )
 
         assertNull(segmentAwareDomainMatch("nomatch", urls))


### PR DESCRIPTION
It's more forgiving than java.net.URI, which is what we want here. One downside of android.net.Uri is that it will vary by API version, so we might get different behaviours. 

This is intended to help with https://github.com/mozilla-mobile/reference-browser/issues/396,
although I wasn't able to add a failing unit test that would match that crash. @pocmo do you know what toolbar input crashed r-b for you?