### PR TITLE
BrowserMenuItemToolbar: Allow overriding isVisible lambda..

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -20,7 +20,7 @@ import mozilla.components.support.ktx.android.content.res.pxToDp
 class BrowserMenuItemToolbar(
     private val items: List<Button>
 ) : BrowserMenuItem {
-    override val visible: () -> Boolean = { true }
+    override var visible: () -> Boolean = { true }
 
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_toolbar
 


### PR DESCRIPTION
This allows consumers to create in-menu toolbars that are not always visible.