### PR TITLE
Closes #1469: Added support for input type color

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -262,6 +262,26 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onColorPrompt(
+        session: GeckoSession,
+        title: String?,
+        defaultColor: String?,
+        callback: TextCallback
+    ) {
+
+        val onConfirm: (String) -> Unit = {
+            callback.confirm(it)
+        }
+        val onDismiss: () -> Unit = {
+            callback.dismiss()
+        }
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Color(defaultColor ?: "", onConfirm, onDismiss)
+            )
+        }
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession?,
         title: String?,
@@ -269,14 +289,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback?
     ) = Unit
-
-    override fun onColorPrompt(
-        session: GeckoSession?,
-        title: String?,
-        value: String?,
-        callback: TextCallback?
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1469
-
     override fun onTextPrompt(
         session: GeckoSession?,
         title: String?,

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -236,7 +236,6 @@ class GeckoPromptDelegateTest {
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
         gecko.onDateTimePrompt(null, "", 0, null, null, null, mock())
-        gecko.onColorPrompt(null, "", "", null)
         gecko.onTextPrompt(null, "", "", null, null)
         gecko.onPopupRequest(null, "")
         gecko.onDateTimePrompt(null, "", DATETIME_TYPE_TIME, null, "", "", mock())
@@ -636,5 +635,60 @@ class GeckoPromptDelegateTest {
         authRequest = request as PromptRequest.Authentication
 
         assertEquals(authRequest.level, NONE)
+    }
+
+    @Test
+    fun `Calling onColorPrompt must provide a Color PromptRequest`() {
+
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var onConfirmWasCalled = false
+        var onDismissWasCalled = false
+
+        val geckoCallback = object : GeckoSession.PromptDelegate.TextCallback {
+
+            override fun confirm(text: String?) {
+                onConfirmWasCalled = true
+            }
+
+            override fun dismiss() {
+                onDismissWasCalled = true
+            }
+
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onColorPrompt(mock(), "title", "#e66465", geckoCallback)
+        assertTrue(request is PromptRequest.Color)
+
+        var colorRequest = request as PromptRequest.Color
+
+        with(colorRequest) {
+
+            assertEquals(defaultColor, "#e66465")
+
+            onConfirm("#f6b73c")
+            assertTrue(onConfirmWasCalled)
+
+            onDismiss()
+            assertTrue(onDismissWasCalled)
+        }
+
+        promptDelegate.onColorPrompt(mock(), null, null, geckoCallback)
+        colorRequest = request as PromptRequest.Color
+
+        with(colorRequest) {
+            assertEquals(defaultColor, "")
+        }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -259,6 +259,26 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onColorPrompt(
+        session: GeckoSession,
+        title: String?,
+        defaultColor: String?,
+        callback: TextCallback
+    ) {
+
+        val onConfirm: (String) -> Unit = {
+            callback.confirm(it)
+        }
+        val onDismiss: () -> Unit = {
+            callback.dismiss()
+        }
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Color(defaultColor ?: "", onConfirm, onDismiss)
+            )
+        }
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession,
         title: String?,
@@ -266,13 +286,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback
     ) = Unit
-
-    override fun onColorPrompt(
-        session: GeckoSession,
-        title: String?,
-        value: String?,
-        callback: TextCallback
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1469
 
     override fun onTextPrompt(
         session: GeckoSession,

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -238,7 +238,6 @@ class GeckoPromptDelegateTest {
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(mock(), "", "", null, mock())
         gecko.onDateTimePrompt(mock(), "", 0, null, null, null, mock())
-        gecko.onColorPrompt(mock(), "", "", mock())
         gecko.onTextPrompt(mock(), "", "", null, mock())
         gecko.onPopupRequest(mock(), "")
         gecko.onDateTimePrompt(mock(), "", DATETIME_TYPE_TIME, null, "", "", mock())
@@ -639,5 +638,60 @@ class GeckoPromptDelegateTest {
         authRequest = request as PromptRequest.Authentication
 
         assertEquals(authRequest.level, NONE)
+    }
+
+    @Test
+    fun `Calling onColorPrompt must provide a Color PromptRequest`() {
+
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var onConfirmWasCalled = false
+        var onDismissWasCalled = false
+
+        val geckoCallback = object : GeckoSession.PromptDelegate.TextCallback {
+
+            override fun confirm(text: String?) {
+                onConfirmWasCalled = true
+            }
+
+            override fun dismiss() {
+                onDismissWasCalled = true
+            }
+
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onColorPrompt(mock(), "title", "#e66465", geckoCallback)
+        assertTrue(request is PromptRequest.Color)
+
+        var colorRequest = request as PromptRequest.Color
+
+        with(colorRequest) {
+
+            assertEquals(defaultColor, "#e66465")
+
+            onConfirm("#f6b73c")
+            assertTrue(onConfirmWasCalled)
+
+            onDismiss()
+            assertTrue(onDismissWasCalled)
+        }
+
+        promptDelegate.onColorPrompt(mock(), null, null, geckoCallback)
+        colorRequest = request as PromptRequest.Color
+
+        with(colorRequest) {
+            assertEquals(defaultColor, "")
+        }
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -210,6 +210,26 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onColorPrompt(
+        session: GeckoSession,
+        title: String?,
+        defaultColor: String?,
+        callback: TextCallback
+    ) {
+
+        val onConfirm: (String) -> Unit = {
+            callback.confirm(it)
+        }
+        val onDismiss: () -> Unit = {
+            callback.dismiss()
+        }
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Color(defaultColor ?: "", onConfirm, onDismiss)
+            )
+        }
+    }
+
     override fun onAuthPrompt(
         session: GeckoSession,
         title: String?,
@@ -267,13 +287,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback?
     ) = Unit
-
-    override fun onColorPrompt(
-        session: GeckoSession?,
-        title: String?,
-        value: String?,
-        callback: TextCallback?
-    ) = Unit // Related issue: https://github.com/mozilla-mobile/android-components/issues/1469
 
     override fun onTextPrompt(
         session: GeckoSession?,

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -232,7 +232,6 @@ class GeckoPromptDelegateTest {
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onButtonPrompt(null, "", "", null, null)
         gecko.onDateTimePrompt(null, "", 0, null, null, null, mock())
-        gecko.onColorPrompt(null, "", "", null)
         gecko.onTextPrompt(null, "", "", null, null)
         gecko.onPopupRequest(null, "")
         gecko.onDateTimePrompt(null, "", DATETIME_TYPE_TIME, null, "", "", mock())
@@ -633,5 +632,60 @@ class GeckoPromptDelegateTest {
         authRequest = request as PromptRequest.Authentication
 
         assertEquals(authRequest.level, NONE)
+    }
+
+    @Test
+    fun `Calling onColorPrompt must provide a Color PromptRequest`() {
+
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest? = null
+        var onConfirmWasCalled = false
+        var onDismissWasCalled = false
+
+        val geckoCallback = object : GeckoSession.PromptDelegate.TextCallback {
+
+            override fun confirm(text: String?) {
+                onConfirmWasCalled = true
+            }
+
+            override fun dismiss() {
+                onDismissWasCalled = true
+            }
+
+            override fun getCheckboxValue() = false
+            override fun setCheckboxValue(value: Boolean) = Unit
+            override fun hasCheckbox() = false
+            override fun getCheckboxMessage() = ""
+        }
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest
+            }
+        })
+
+        promptDelegate.onColorPrompt(mock(), "title", "#e66465", geckoCallback)
+        assertTrue(request is PromptRequest.Color)
+
+        var colorRequest = request as PromptRequest.Color
+
+        with(colorRequest) {
+
+            assertEquals(defaultColor, "#e66465")
+
+            onConfirm("#f6b73c")
+            assertTrue(onConfirmWasCalled)
+
+            onDismiss()
+            assertTrue(onDismissWasCalled)
+        }
+
+        promptDelegate.onColorPrompt(mock(), null, null, geckoCallback)
+        colorRequest = request as PromptRequest.Color
+
+        with(colorRequest) {
+            assertEquals(defaultColor, "")
+        }
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -122,4 +122,16 @@ sealed class PromptRequest {
             HOST, PROXY
         }
     }
+
+    /**
+     * Value type that represents a request for a selecting one or multiple files.
+     * @property defaultColor true if the user can select more that one file false otherwise.
+     * @property onConfirm callback to notify that the user has selected a single file.
+     * @property onDismiss callback to notify that the user has canceled the file selection.
+     */
+    data class Color(
+        val defaultColor: String,
+        val onConfirm: (String) -> Unit,
+        val onDismiss: () -> Unit
+    ) : PromptRequest()
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -77,5 +77,16 @@ class PromptRequestTest {
         assertFalse(promptRequest.isCrossOrigin)
         promptRequest.onConfirm("", "")
         promptRequest.onDismiss()
+
+        val onConfirm: (String) -> Unit = {
+        }
+        val onDismiss: () -> Unit = {
+        }
+
+        val colorRequest = PromptRequest.Color("defaultColor", onConfirm, onDismiss)
+        assertEquals(colorRequest.defaultColor, "defaultColor")
+
+        colorRequest.onConfirm("")
+        colorRequest.onDismiss()
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ColorPickerDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ColorPickerDialogFragment.kt
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.os.Bundle
+import android.support.annotation.VisibleForTesting
+import android.support.v7.app.AlertDialog
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+
+private const val KEY_SELECTED_COLOR = "KEY_SELECTED_COLOR"
+
+/**
+ * [android.support.v4.app.DialogFragment] implementation for a color picker dialog.
+ */
+internal class ColorPickerDialogFragment : PromptDialogFragment() {
+
+    private lateinit var selectColorTexView: TextView
+
+    @VisibleForTesting
+    internal var selectedColor: Int
+        get() = safeArguments.getInt(KEY_SELECTED_COLOR)
+        set(value) {
+            safeArguments.putInt(KEY_SELECTED_COLOR, value)
+        }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireContext())
+            .setCancelable(true)
+            .setNegativeButton(R.string.mozac_feature_prompts_cancel) { _, _ ->
+                feature?.onCancel(sessionId)
+            }
+            .setPositiveButton(R.string.mozac_feature_prompts_set_date) { _, _ ->
+                onPositiveClickAction()
+            }
+            .setView(createDialogContentView())
+        return builder.create()
+    }
+
+    override fun onCancel(dialog: DialogInterface?) {
+        super.onCancel(dialog)
+        feature?.onCancel(sessionId)
+    }
+
+    companion object {
+        fun newInstance(sessionId: String, defaultColor: String): ColorPickerDialogFragment {
+            val fragment = ColorPickerDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putString(KEY_SESSION_ID, sessionId)
+                putInt(KEY_SELECTED_COLOR, defaultColor.toColor())
+            }
+
+            fragment.arguments = arguments
+
+            return fragment
+        }
+    }
+
+    @SuppressLint("InflateParams")
+    internal fun createDialogContentView(): View {
+        val inflater = LayoutInflater.from(requireContext())
+        val view = inflater.inflate(R.layout.mozac_feature_prompts_color_picker_dialogs, null)
+
+        initSelectedColor(view)
+        initRecyclerView(view, inflater)
+
+        return view
+    }
+
+    private fun onPositiveClickAction() {
+        feature?.onConfirm(sessionId, selectedColor.toHexColor())
+    }
+
+    fun onColorChange(newColor: Int) {
+        selectedColor = newColor
+        selectColorTexView.changeColor(newColor)
+    }
+
+    /**
+     * RecyclerView adapter for displaying color items.
+     */
+    internal class ColorAdapter(
+        private val fragment: ColorPickerDialogFragment,
+        private val inflater: LayoutInflater
+    ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+        @Suppress("MagicNumber")
+        internal val defaultColors = arrayOf(
+            Color.rgb(215, 57, 32),
+            Color.rgb(255, 134, 5),
+            Color.rgb(255, 203, 19),
+            Color.rgb(95, 173, 71),
+            Color.rgb(33, 161, 222),
+            Color.rgb(16, 36, 87),
+            Color.rgb(91, 32, 103),
+            Color.rgb(212, 221, 228),
+            Color.WHITE
+        )
+
+        override fun getItemCount(): Int = defaultColors.size
+
+        override fun onCreateViewHolder(parent: ViewGroup, type: Int): RecyclerView.ViewHolder {
+            val view = inflater.inflate(R.layout.mozac_feature_prompts_color_item, parent, false)
+            return ColorViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+
+            with(holder as ColorViewHolder) {
+                val color = defaultColors[position]
+                bind(color, fragment)
+            }
+        }
+    }
+
+    /**
+     * View holder for a color item.
+     */
+    internal class ColorViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        fun bind(color: Int, fragment: ColorPickerDialogFragment) {
+
+            with(itemView) {
+                changeColor(color)
+                tag = color
+
+                setOnClickListener {
+                    val newColor = it.tag as Int
+                    fragment.onColorChange(newColor)
+                }
+            }
+        }
+    }
+
+    private fun initSelectedColor(view: View) {
+        selectColorTexView = view.findViewById(R.id.selected_color)
+        selectColorTexView.changeColor(selectedColor)
+    }
+
+    private fun initRecyclerView(view: View, inflater: LayoutInflater) {
+        view.findViewById<RecyclerView>(R.id.recyclerView).apply {
+            layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
+            adapter = ColorAdapter(this@ColorPickerDialogFragment, inflater)
+        }
+    }
+}
+
+private fun View.changeColor(newColor: Int) {
+    background.setColorFilter(newColor, PorterDuff.Mode.MULTIPLY)
+}
+
+internal fun String.toColor(): Int {
+    return try {
+        Color.parseColor(this)
+    } catch (e: IllegalArgumentException) {
+        0
+    }
+}
+
+@Suppress("MagicNumber")
+internal fun Int.toHexColor(): String {
+    return String.format("#%06x", 0xffffff and this)
+}

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/DatePickerDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/DatePickerDialogFragment.kt
@@ -84,7 +84,7 @@ internal class DatePickerDialogFragment : PromptDialogFragment(), DatePicker.OnD
     }
 
     private fun onPositiveClickAction() {
-        feature?.onSelect(sessionId, selectedDate)
+        feature?.onConfirm(sessionId, selectedDate)
     }
 
     companion object {

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.prompt.PromptRequest.Color
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
@@ -75,10 +76,8 @@ class PromptFeature(
 
     init {
         if (activity == null && fragment == null) {
-            throw IllegalStateException(
-                "activity and fragment references " +
-                    "must not be both null, at least one must be initialized."
-            )
+            throw IllegalStateException("activity and fragment references " +
+                "must not be both null, at least one must be initialized.")
         }
     }
 
@@ -280,6 +279,7 @@ class PromptFeature(
             when (it) {
                 is Alert -> it.onDismiss()
                 is Authentication -> it.onDismiss()
+                is Color -> it.onDismiss()
             }
             true
         }
@@ -319,16 +319,17 @@ class PromptFeature(
     }
 
     /**
-     * Event that is called when the user is requesting to select a date from the date picker dialog.
+     * Event that is called when the user confirm the action on the dialog.
      * This consumes the [PromptFeature] value from the [Session] indicated by [sessionId].
      * @param sessionId that requested to show the dialog.
-     * @param selectedDate the selected date from the dialog.
+     * @param value an optional value provided by the dialog as a result of confirming the action.
      */
-    internal fun onSelect(sessionId: String, selectedDate: Date) {
+    internal fun onConfirm(sessionId: String, value: Any? = null) {
         val session = sessionManager.findSessionById(sessionId) ?: return
         session.promptRequest.consume {
             when (it) {
-                is PromptRequest.Date -> it.onSelect(selectedDate)
+                is PromptRequest.Date -> it.onSelect(value as Date)
+                is PromptRequest.Color -> it.onConfirm(value as String)
             }
             true
         }
@@ -445,6 +446,12 @@ class PromptFeature(
                         password,
                         onlyShowPassword
                     )
+                }
+            }
+
+            is PromptRequest.Color -> {
+                with(promptRequest) {
+                    ColorPickerDialogFragment.newInstance(session.id, defaultColor)
                 }
             }
 

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_color_item.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_color_item.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+          android:id="@+id/color_item"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:textAppearance="?android:attr/textAppearanceListItemSmall"
+          android:gravity="center_vertical"
+          android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+          android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+          android:background="@android:drawable/editbox_background"
+          android:minHeight="?android:attr/listPreferredItemHeightSmall"/>

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_color_picker_dialogs.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_color_picker_dialogs.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="16dp"
+        android:orientation="vertical">
+
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="?android:attr/listPreferredItemPaddingLeft"
+            android:paddingStart="?android:attr/listPreferredItemPaddingLeft"
+            android:paddingEnd="?android:attr/listPreferredItemPaddingLeft"
+            android:orientation="horizontal">
+
+        <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="?android:attr/textAppearanceLarge"
+                android:text="@string/mozac_feature_prompts_choose_a_color"/>
+
+        <TextView
+                android:id="@+id/selected_color"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:textAppearance="?android:attr/textAppearanceListItemSmall"
+                android:layout_gravity="center_vertical|center_horizontal"
+                android:layout_marginStart="5dp"
+                android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+                android:background="@android:drawable/editbox_background"
+                android:minHeight="?android:attr/listPreferredItemHeightSmall"/>
+
+    </LinearLayout>
+
+
+    <android.support.v7.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+</LinearLayout>
+

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <!-- Text for a button that clears the selected input in the date/time picker. -->
     <string name="mozac_feature_prompts_clear">Clear</string>
 
-    <!-- Text for for title of an authentication dialog. -->
+    <!-- Text for the title of an authentication dialog. -->
     <string name="mozac_feature_prompt_sign_in">Sign In</string>
 
     <!-- Text for username field in an authentication dialog. -->
@@ -29,4 +29,8 @@
 
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Password</string>
+
+    <!-- Title of a color picker dialog, this text is shown above a color picker. -->
+    <string name="mozac_feature_prompts_choose_a_color">Choose a color</string>
+
 </resources>

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ColorPickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ColorPickerDialogFragmentTest.kt
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.content.Context
+import android.content.DialogInterface
+import android.support.v7.app.AlertDialog
+import android.support.v7.widget.RecyclerView
+import android.view.ContextThemeWrapper
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.feature.prompts.ColorPickerDialogFragment.ColorAdapter
+import mozilla.components.feature.prompts.ColorPickerDialogFragment.ColorViewHolder
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ColorPickerDialogFragmentTest {
+
+    private val context: Context
+        get() = ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext(),
+            android.support.v7.appcompat.R.style.Theme_AppCompat
+        )
+
+    @Test
+    fun `build dialog`() {
+
+        val fragment = spy(
+            ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+
+        dialog.show()
+
+        assertEquals(fragment.sessionId, "sessionId")
+        assertEquals(fragment.selectedColor.toHexColor(), "#e66465")
+    }
+
+    @Test
+    fun `clicking on positive button notifies the feature`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        fragment.onColorChange("#4f4663".toColor())
+
+        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        positiveButton.performClick()
+
+        verify(mockFeature).onConfirm("sessionId", "#4f4663")
+    }
+
+    @Test
+    fun `clicking on negative button notifies the feature`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val negativeButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_NEGATIVE)
+        negativeButton.performClick()
+
+        verify(mockFeature).onCancel("sessionId")
+    }
+
+    @Test
+    fun `touching outside of the dialog must notify the feature onCancel`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        fragment.onCancel(null)
+
+        verify(mockFeature).onCancel("sessionId")
+    }
+
+    @Test
+    fun `will show a color item`() {
+
+        val fragment = spy(
+            ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
+        )
+        doReturn(context).`when`(fragment).requireContext()
+
+        val adapter = getAdapterFrom(fragment)
+        val holder = adapter.onCreateViewHolder(LinearLayout(context), 0) as ColorViewHolder
+        val labelView = holder.itemView as TextView
+        adapter.bindViewHolder(holder, 0)
+
+        val selectedColor = adapter.defaultColors.first()
+        assertEquals(labelView.tag as Int, selectedColor)
+    }
+
+    @Test
+    fun `clicking on a item will update the selected color`() {
+
+        val fragment = spy(
+            ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
+        )
+        doReturn(context).`when`(fragment).requireContext()
+
+        val adapter = getAdapterFrom(fragment)
+        val holder = adapter.onCreateViewHolder(LinearLayout(context), 0) as ColorViewHolder
+        val colorItem = holder.itemView as TextView
+        adapter.bindViewHolder(holder, 0)
+
+        colorItem.performClick()
+
+        val selectedColor = adapter.defaultColors.first()
+        assertEquals(fragment.selectedColor, selectedColor)
+    }
+
+    private fun getAdapterFrom(fragment: ColorPickerDialogFragment): ColorAdapter {
+        val view = fragment.createDialogContentView()
+        val recyclerViewId = R.id.recyclerView
+
+        return view.findViewById<RecyclerView>(recyclerViewId).adapter as ColorAdapter
+    }
+}

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/DatePickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/DatePickerDialogFragmentTest.kt
@@ -85,7 +85,7 @@ class DatePickerDialogFragmentTest {
 
         val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
-        verify(mockFeature).onSelect("sessionId", initialDate)
+        verify(mockFeature).onConfirm("sessionId", initialDate)
 
         val neutralButton = dialog.getButton(BUTTON_NEUTRAL)
         neutralButton.performClick()

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -25,6 +25,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.prompt.PromptRequest.Color
 import mozilla.components.concept.engine.prompt.PromptRequest.Alert
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level.NONE
@@ -315,7 +316,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(promptRequest)
 
-        promptFeature.onSelect("unknown_sessionId", Date())
+        promptFeature.onConfirm("unknown_sessionId", Date())
 
         assertFalse(session.promptRequest.isConsumed())
         assertNull(selectedDate)
@@ -338,7 +339,7 @@ class PromptFeatureTest {
         session.promptRequest = Consumable.from(promptRequest)
 
         val date = Date()
-        promptFeature.onSelect(session.id, Date())
+        promptFeature.onConfirm(session.id, Date())
 
         assertTrue(session.promptRequest.isConsumed())
         assertEquals(selectedDate, date)
@@ -704,6 +705,36 @@ class PromptFeatureTest {
         promptFeature.onCancel(session.id)
 
         assertTrue(session.promptRequest.isConsumed())
+        assertTrue(onDismissWasCalled)
+    }
+
+    @Test
+    fun `Calling onConfirm with a Color request will consume promptRequest`() {
+        val session = getSelectedSession()
+
+        var onConfirmWasCalled = false
+        var onDismissWasCalled = false
+
+        val promptRequest = Color(
+            "#e66465",
+            {
+                onConfirmWasCalled = true
+            }) {
+            onDismissWasCalled = true
+        }
+
+        promptFeature.start()
+
+        session.promptRequest = Consumable.from(promptRequest)
+
+        promptFeature.onConfirm(session.id, "#f6b73c")
+
+        assertTrue(session.promptRequest.isConsumed())
+        assertTrue(onConfirmWasCalled)
+
+        session.promptRequest = Consumable.from(promptRequest)
+
+        promptFeature.onCancel(session.id)
         assertTrue(onDismissWasCalled)
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ permalink: /changelog/
 
 * **feature-prompts**, **browser-engine-gecko***
   * Added support for Authentication dialogs.
+  * Added support for [input type color fields](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color).
 
 # 0.37.0
 


### PR DESCRIPTION
[Demo](https://drive.google.com/file/d/18ooClEXrYazSMqa46LZQELMjiD3Fllgn/view?usp=sharing)
[How to test](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color)