### PR TITLE
Bug 1519374 - Rename build worker types into mobile-X-b-andrcmp

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -52,9 +52,9 @@ tasks:
         else: mobile-1-decision
 
       build_worker_type:
-        $if: 'is_repo_trusted && tasks_for in ["github-release", "cron"]'
-        then: gecko-focus
-        else: android-components-g
+        $if: 'is_repo_trusted'
+        then: mobile-3-b-andrcmp
+        else: mobile-1-b-andrcmp
 
       tasks_priority:
         $if: 'is_repo_trusted'
@@ -98,6 +98,7 @@ tasks:
               TASK_ID: ${decision_task_id}
               TASKS_PRIORITY: ${tasks_priority}
               SCHEDULER_ID: ${scheduler_id}
+              BUILD_WORKER_TYPE: ${build_worker_type}
               MOBILE_HEAD_REPOSITORY: ${repository}
               MOBILE_HEAD_BRANCH: ${head_branch}
               MOBILE_HEAD_REV: ${head_rev}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -180,7 +180,6 @@ tasks:
                   scopes:
                     - project:mobile:android-components:releng:beetmover:action:push-to-maven
                     - project:mobile:android-components:releng:beetmover:bucket:${beetmover_bucket}
-                    - queue:create-task:${tasks_priority}:aws-provisioner-v1/github-worker      # Still used by non build tasks
                     - queue:create-task:${tasks_priority}:scriptworker-prov-v1/${beetmover_worker_type}
                   payload:
                     env:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -158,84 +158,86 @@ tasks:
                 then: ''
                 else: '--staging'
 
-              nightly_or_release_definition:
-                scopes:
-                  $flatten:
-                    - project:mobile:android-components:releng:beetmover:action:push-to-maven
-                    - queue:create-task:${tasks_priority}:aws-provisioner-v1/github-worker      # Still used by non build tasks
-                    - $if: 'is_repo_trusted'
-                      then:
-                        - queue:create-task:${tasks_priority}:scriptworker-prov-v1/mobile-beetmover-v1
-                      else:
-                        - queue:create-task:${tasks_priority}:scriptworker-prov-v1/mobile-beetmover-dev
-                payload:
-                  env:
-                    MOBILE_TRIGGERED_BY: ${user}
-                  features:
-                    chainOfTrust: true
-                  artifacts:
-                    public/task-graph.json:
-                      type: file
-                      path: /build/android-components/task-graph.json
-                      expires: ${expires_in}
-                    public/actions.json:
-                      type: file
-                      path: /build/android-components/actions.json
-                      expires: ${expires_in}
-                    public/parameters.yml:
-                      type: file
-                      path: /build/android-components/parameters.yml
-                      expires: ${expires_in}
-            in:
-              - $if: 'tasks_for == "github-release"'
+              beetmover_worker_type:
+                $if: 'is_repo_trusted'
+                then: mobile-beetmover-v1
+                else: mobile-beetmover-dev
+
+              beetmover_bucket:
+                $if: 'tasks_for == "github-release"'
                 then:
-                  $let:
-                    tag: ${event.release.tag_name}
-                  in:
+                  $if: 'is_repo_trusted'
+                  then: maven-production
+                  else: maven-staging
+                else:
+                  $if: 'is_repo_trusted'
+                  then: maven-snapshot-production
+                  else: maven-snapshot-staging
+
+            in:
+              $let:
+                nightly_or_release_definition:
+                  scopes:
+                    - project:mobile:android-components:releng:beetmover:action:push-to-maven
+                    - project:mobile:android-components:releng:beetmover:bucket:${beetmover_bucket}
+                    - queue:create-task:${tasks_priority}:aws-provisioner-v1/github-worker      # Still used by non build tasks
+                    - queue:create-task:${tasks_priority}:scriptworker-prov-v1/${beetmover_worker_type}
+                  payload:
+                    env:
+                      MOBILE_TRIGGERED_BY: ${user}
+                      BEETMOVER_WORKER_TYPE: ${beetmover_worker_type}
+                    features:
+                      chainOfTrust: true
+                    artifacts:
+                      public/task-graph.json:
+                        type: file
+                        path: /build/android-components/task-graph.json
+                        expires: ${expires_in}
+                      public/actions.json:
+                        type: file
+                        path: /build/android-components/actions.json
+                        expires: ${expires_in}
+                      public/parameters.yml:
+                        type: file
+                        path: /build/android-components/parameters.yml
+                        expires: ${expires_in}
+              in:
+                - $if: 'tasks_for == "github-release"'
+                  then:
+                    $let:
+                      tag: ${event.release.tag_name}
+                    in:
+                      $mergeDeep:
+                        - {$eval: 'default_task_definition'}
+                        - {$eval: 'nightly_or_release_definition'}
+                        - payload:
+                            command:
+                              - >-
+                                git fetch ${repository} --tags
+                                && git config advice.detachedHead false
+                                && git checkout ${tag}
+                                && ./gradlew --no-daemon --version
+                                && python automation/taskcluster/decision_task_publish.py --version "${tag}"
+                                ${command_staging_flag}
+                          metadata:
+                            name: Android Components - Decision task (${tag})
+                            description: Build and publish release versions.
+                - $if: 'tasks_for == "cron"'
+                  then:
                     $mergeDeep:
                       - {$eval: 'default_task_definition'}
                       - {$eval: 'nightly_or_release_definition'}
-                      - priority: ${tasks_priority}
-                        scopes:
-                          $if: 'is_repo_trusted'
-                          then:
-                            - project:mobile:android-components:releng:beetmover:bucket:maven-production
-                          else:
-                            - project:mobile:android-components:releng:beetmover:bucket:maven-staging
-                        payload:
+                      - payload:
                           command:
                             - >-
-                              git fetch ${repository} --tags
+                              git fetch ${repository} ${head_branch}
                               && git config advice.detachedHead false
-                              && git checkout ${tag}
+                              && git checkout ${head_rev}
                               && ./gradlew --no-daemon --version
-                              && python automation/taskcluster/decision_task_publish.py --version "${tag}"
+                              && python automation/taskcluster/decision_task_publish.py --snapshot
                               ${command_staging_flag}
+                        extra:
+                          cron: {$json: {$eval: 'cron'}}
                         metadata:
-                          name: Android Components - Decision task (${tag})
-                          description: Build and publish release versions.
-              - $if: 'tasks_for == "cron"'
-                then:
-                  $mergeDeep:
-                    - {$eval: 'default_task_definition'}
-                    - {$eval: 'nightly_or_release_definition'}
-                    - scopes:
-                        $if: 'is_repo_trusted'
-                        then:
-                          - project:mobile:android-components:releng:beetmover:bucket:maven-snapshot-production
-                        else:
-                          - project:mobile:android-components:releng:beetmover:bucket:maven-snapshot-staging
-                      payload:
-                        command:
-                          - >-
-                            git fetch ${repository} ${head_branch}
-                            && git config advice.detachedHead false
-                            && git checkout ${head_rev}
-                            && ./gradlew --no-daemon --version
-                            && python automation/taskcluster/decision_task_publish.py --snapshot
-                            ${command_staging_flag}
-                      extra:
-                        cron: {$json: {$eval: 'cron'}}
-                      metadata:
-                        name: Android Components - Decision task for Snapshot release
-                        description: Schedules the snapshot release of Android components.
+                          name: Android Components - Decision task for Snapshot release
+                          description: Schedules the snapshot release of Android components.

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -22,6 +22,7 @@ REPO_URL = os.environ.get('MOBILE_HEAD_REPOSITORY')
 BRANCH = os.environ.get('MOBILE_HEAD_BRANCH')
 COMMIT = os.environ.get('MOBILE_HEAD_REV')
 PR_TITLE = os.environ.get('GITHUB_PULL_TITLE', '')
+BUILD_WORKER_TYPE = os.environ.get('BUILD_WORKER_TYPE')
 
 # If we see this text inside a pull request title then we will not execute any tasks for this PR.
 SKIP_TASKS_TRIGGER = '[ci skip]'
@@ -40,7 +41,7 @@ def create_raw_task(name, description, full_command, scopes = []):
     deadline = taskcluster.fromNow('1 day')
 
     return {
-        "workerType": 'android-components-g',
+        "workerType": BUILD_WORKER_TYPE,
         "taskGroupId": TASK_ID,
         "expires": taskcluster.stringDate(expires),
         "retries": 5,

--- a/automation/taskcluster/decision_task_publish.py
+++ b/automation/taskcluster/decision_task_publish.py
@@ -66,7 +66,7 @@ def generate_build_task(version, artifact_info, is_snapshot):
         for gradle_task in BUILD_GRADLE_TASK_NAMES
     )
 
-    return taskcluster.slugId(), BUILDER.build_task(
+    return taskcluster.slugId(), BUILDER.craft_build_ish_task(
         name='Android Components - Module {} ({})'.format(module_name, version),
         description='Building and testing module {}'.format(module_name),
         command=(
@@ -112,7 +112,7 @@ def generate_beetmover_task(build_task_id, version, artifact, artifact_name, is_
         "project:mobile:android-components:releng:beetmover:bucket:{}".format(bucket_name),
         "project:mobile:android-components:releng:beetmover:action:push-to-maven",
     ]
-    return taskcluster.slugId(), BUILDER.beetmover_task(
+    return taskcluster.slugId(), BUILDER.craft_beetmover_task(
         name="Android Components - Publish Module :{} via beetmover".format(artifact_name),
         description="Publish release module {} to {}".format(artifact_name, bucket_public_url),
         version=version,
@@ -128,11 +128,10 @@ def generate_raw_task(name, description, command_to_run):
     checkout = ("export TERM=dumb && git fetch {} {} && "
                 "git config advice.detachedHead false && "
                 "git checkout {} && ".format(REPO_URL, BRANCH, HEAD_REV))
-    return taskcluster.slugId(), BUILDER.raw_task(
+    return taskcluster.slugId(), BUILDER.craft_build_ish_task(
         name=name,
         description=description,
-        command=(checkout +
-                 command_to_run)
+        command=(checkout + command_to_run)
     )
 
 

--- a/automation/taskcluster/decision_task_publish.py
+++ b/automation/taskcluster/decision_task_publish.py
@@ -30,6 +30,7 @@ BUILDER = lib.tasks.TaskBuilder(
     owner="skaspari@mozilla.com",
     source='{}/raw/{}/.taskcluster.yml'.format(REPO_URL, HEAD_REV),
     scheduler_id=os.environ.get('SCHEDULER_ID'),
+    build_worker_type=os.environ.get('BUILD_WORKER_TYPE'),
     tasks_priority=os.environ.get('TASKS_PRIORITY'),
 )
 
@@ -40,7 +41,7 @@ def _get_gradle_module_name(name):
     return ':{}'.format(name)
 
 
-def generate_build_task(version, artifact_info, is_snapshot, is_staging):
+def generate_build_task(version, artifact_info, is_snapshot):
     checkout = ("export TERM=dumb && git fetch {} {} --tags && "
                 "git config advice.detachedHead false && "
                 "git checkout {}".format(REPO_URL, BRANCH, HEAD_REV))
@@ -77,8 +78,7 @@ def generate_build_task(version, artifact_info, is_snapshot, is_staging):
             'chainOfTrust': True,
         },
         scopes=[],
-        artifacts=artifacts,
-        is_staging=is_staging
+        artifacts=artifacts
     )
 
 
@@ -185,7 +185,7 @@ def release(version, is_snapshot, is_staging):
     for artifact_info in artifacts_info:
         build_task_id = generate_and_append_task_to_task_graph(
             queue, task_graph, generate_build_task,
-            generate_args=(version, artifact_info, is_snapshot, is_staging)
+            generate_args=(version, artifact_info, is_snapshot)
         )
 
         generate_and_append_task_to_task_graph(

--- a/automation/taskcluster/decision_task_publish.py
+++ b/automation/taskcluster/decision_task_publish.py
@@ -31,6 +31,7 @@ BUILDER = lib.tasks.TaskBuilder(
     source='{}/raw/{}/.taskcluster.yml'.format(REPO_URL, HEAD_REV),
     scheduler_id=os.environ.get('SCHEDULER_ID'),
     build_worker_type=os.environ.get('BUILD_WORKER_TYPE'),
+    beetmover_worker_type=os.environ.get('BEETMOVER_WORKER_TYPE'),
     tasks_priority=os.environ.get('TASKS_PRIORITY'),
 )
 
@@ -119,7 +120,6 @@ def generate_beetmover_task(build_task_id, version, artifact, artifact_name, is_
         dependencies=[build_task_id],
         upstreamArtifacts=upstream_artifacts,
         scopes=scopes,
-        is_staging=is_staging,
         is_snapshot=is_snapshot
     )
 

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -8,7 +8,7 @@ import taskcluster
 
 
 class TaskBuilder(object):
-    def __init__(self, task_id, repo_url, branch, commit, owner, source, scheduler_id, build_worker_type, tasks_priority='lowest'):
+    def __init__(self, task_id, repo_url, branch, commit, owner, source, scheduler_id, build_worker_type, beetmover_worker_type, tasks_priority='lowest'):
         self.task_id = task_id
         self.repo_url = repo_url
         self.branch = branch
@@ -17,6 +17,7 @@ class TaskBuilder(object):
         self.source = source
         self.scheduler_id = scheduler_id
         self.build_worker_type = build_worker_type
+        self.beetmover_worker_type = beetmover_worker_type
         self.tasks_priority = tasks_priority
 
     def raw_task(self, name, description, command, dependencies=[],
@@ -109,13 +110,13 @@ class TaskBuilder(object):
 
     def beetmover_task(self, name, description, version, artifact_id,
                        dependencies=[], upstreamArtifacts=[], scopes=[],
-                       is_staging=False, is_snapshot=False):
+                       is_snapshot=False):
         created = datetime.datetime.now()
         expires = taskcluster.fromNow('1 year')
         deadline = taskcluster.fromNow('1 day')
 
         return {
-            "workerType": "mobile-beetmover-dev" if is_staging else "mobile-beetmover-v1",
+            "workerType": self.beetmover_worker_type,
             "taskGroupId": self.task_id,
             "schedulerId": self.scheduler_id,
             "expires": taskcluster.stringDate(expires),

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -8,7 +8,7 @@ import taskcluster
 
 
 class TaskBuilder(object):
-    def __init__(self, task_id, repo_url, branch, commit, owner, source, scheduler_id, tasks_priority='lowest'):
+    def __init__(self, task_id, repo_url, branch, commit, owner, source, scheduler_id, build_worker_type, tasks_priority='lowest'):
         self.task_id = task_id
         self.repo_url = repo_url
         self.branch = branch
@@ -16,6 +16,7 @@ class TaskBuilder(object):
         self.owner = owner
         self.source = source
         self.scheduler_id = scheduler_id
+        self.build_worker_type = build_worker_type
         self.tasks_priority = tasks_priority
 
     def raw_task(self, name, description, command, dependencies=[],
@@ -61,8 +62,7 @@ class TaskBuilder(object):
         }
 
     def build_task(self, name, description, command, dependencies=[],
-                   artifacts={}, scopes=[], routes=[], features={},
-                   is_staging=False):
+                   artifacts={}, scopes=[], routes=[], features={}):
         created = datetime.datetime.now()
         expires = taskcluster.fromNow('1 year')
         deadline = taskcluster.fromNow('1 day')
@@ -73,8 +73,7 @@ class TaskBuilder(object):
         })
 
         return {
-            # TODO: Use mobile-X-build workerType
-            "workerType": 'android-components-g' if is_staging else 'gecko-focus',
+            "workerType": self.build_worker_type,
             "taskGroupId": self.task_id,
             "schedulerId": self.scheduler_id,
             "expires": taskcluster.stringDate(expires),


### PR DESCRIPTION
Follows #1536 and #1638 up

`mobile-X-b-components` maps what exists on Firefox (e.g.: https://tools.taskcluster.net/aws-provisioner/gecko-1-b-android/view). It stands for: 

* `mobile` refers to the mobile projects. On Firefox, the name is `gecko`. We use it for the decision workers already. See #1588
* `X` is a trust level. It maps the levels in Gecko: 1 is the least trusted, 3 is the most. See #1588
* `b` means "build", like on Gecko.
* `components` refers to the project. For other mobile projects, we would have `fenix`, `focus`, `ref-browser`.

Please note the whole name is limited to 22 characters. 

Note: I didn't put `-g` like we had in `android-components-g`. The reasons are:
* `mobile-X-b-components` is already 22-char-long. Putting `-g` in would mean we had to truncate components somehow. I couldn't find an appealing mix of strings.
* If I'm not mistaken, all mobile build/lint tasks run on gradle, for now. Moreover, they all load the same docker image. Therefore, `-g` doesn't discriminate worker types. 

@ncalexan @grigoryk @pocmo @MihaiTabara @mitchhentges: What do you think about it?

Please do not merge until we agree on the name. I need to create the level 3 worker type before then.
