### PR TITLE
[glean] Pin the Miniconda3 version to 4.5.11

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -50,7 +50,7 @@ envs {
 
     // Setup a miniconda environment. conda is used because it works
     // non-interactively on Windows, unlike the other options
-    conda "Miniconda3", "Miniconda3-latest", "64", ["glean_parser==${GLEAN_PARSER_VERSION}"]
+    conda "Miniconda3", "Miniconda3-4.5.11", "64", ["glean_parser==${GLEAN_PARSER_VERSION}"]
 }
 
 preBuild.finalizedBy("build_envs")


### PR DESCRIPTION
The latest version, 4.5.12, is breaking ssl for glean on Windows.