### PR TITLE
[glean]  Implement the `duration` field

### DIFF
--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -8,7 +8,7 @@ the following fields:
 | Field name | Type | Description |
 |---|---|---|
 | `sessions` | Counter | The number of foreground sessions since the last upload |
-| `durations` | Timespan | The combined duration of all the foreground sessions since the last upload |
+| `duration` | Timespan | The duration, in seconds, of the last foreground session |
 | `os` | String | The name of the operating system (e.g. "linux", "android", "ios") |
 | `os_version` | String | The version of the operating system |
 | `device` | String | Manufacturer and model |

--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -21,16 +21,19 @@ baseline:
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
-  # durations:
-  #   type: timespan
-  #   description: |
-  #     The combined duration of all the foreground sessions since the last upload.
-  #   send_in_pings:
-  #     - baseline
-  #   bugs:
-  #     - 1497894
-  #   notification_emails:
-  #     - telemetry-client-dev@mozilla.com
+  duration:
+    type: timespan
+    description: |
+      The duration of the last foreground session.
+    time_unit: second
+    send_in_pings:
+      - baseline
+    bugs:
+      - 1497894, 1519120
+    reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
 
   os:
     type: string

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
@@ -20,6 +20,9 @@ internal class GleanLifecycleObserver : LifecycleObserver {
      */
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onEnterBackground() {
+        // We're going to background, so store how much time we spent
+        // on foreground.
+        Baseline.duration.stopAndSum()
         Glean.handleEvent(Glean.PingEvent.Background)
     }
 
@@ -34,5 +37,9 @@ internal class GleanLifecycleObserver : LifecycleObserver {
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun onEnterForeground() {
         Baseline.sessions.add()
+        // Note that this is sending the length of the last foreground session
+        // because it belongs to the baseline ping and that ping is sent every
+        // time the app goes to background.
+        Baseline.duration.start()
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -64,7 +64,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
     /**
      * Implementor's provided function to serialize 'user' lifetime data as needed by the data type.
      *
-     * @param userPreferences [SharedPreference.Editor] for writing preferences as needed by type.
+     * @param userPreferences [SharedPreferences.Editor] for writing preferences as needed by type.
      * @param storeName The metric store name where the data is stored in [SharedPreferences].
      * @param value The value to be stored, passed as a [ScalarType] to be handled correctly by the
      *              implementor.
@@ -149,7 +149,7 @@ abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
      * @return the [ScalarType] recorded in the requested store
      */
     @Synchronized
-    open fun getSnapshot(storeName: String, clearStore: Boolean): GenericDataStorage<ScalarType>? {
+    fun getSnapshot(storeName: String, clearStore: Boolean): GenericDataStorage<ScalarType>? {
         val allLifetimes: GenericDataStorage<ScalarType> = mutableMapOf()
 
         // Make sure data with "user" lifetime is loaded before getting the snapshot.

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -80,9 +80,9 @@ class TimespansStorageEngineTest {
         )).thenReturn(sharedPreferences)
 
         storageEngine.applicationContext = context
-        val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
+        val snapshot = storageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
         assertEquals(1, snapshot!!.size)
-        assertEquals(expectedValue, snapshot["telemetry.valid"])
+        assertEquals(Pair("nanosecond", expectedValue), snapshot["telemetry.valid"])
     }
 
     @Test
@@ -107,9 +107,9 @@ class TimespansStorageEngineTest {
         doReturn(expectedTimespanNanos).`when`(spiedEngine).getElapsedNanos()
         spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
 
-        val snapshot = spiedEngine.getSnapshot(storeName = "store1", clearStore = false)
+        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
-        assertEquals(expectedTimespanNanos, snapshot["telemetry.single_elapsed_test"])
+        assertEquals(Pair("nanosecond", expectedTimespanNanos), snapshot["telemetry.single_elapsed_test"])
     }
 
     @Test
@@ -137,9 +137,9 @@ class TimespansStorageEngineTest {
         doReturn(expectedChunkNanos * 2).`when`(spiedEngine).getElapsedNanos()
         spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
 
-        val snapshot = spiedEngine.getSnapshot(storeName = "store1", clearStore = false)
+        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
-        assertEquals(expectedChunkNanos * 2, snapshot["telemetry.single_elapsed_test"])
+        assertEquals(Pair("nanosecond", expectedChunkNanos * 2), snapshot["telemetry.single_elapsed_test"])
     }
 
     @Test
@@ -186,9 +186,12 @@ class TimespansStorageEngineTest {
         doReturn(expectedChunkNanos).`when`(spiedEngine).getElapsedNanos()
         spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
 
-        val snapshot = spiedEngine.getSnapshot(storeName = "store1", clearStore = false)
+        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
-        assertEquals(expectedChunkNanos, snapshot["telemetry.single_elapsed_test"])
+        assertEquals(
+            Pair("nanosecond", expectedChunkNanos),
+            snapshot["telemetry.single_elapsed_test"]
+        )
     }
 
     @Test
@@ -214,7 +217,7 @@ class TimespansStorageEngineTest {
         doReturn(20.toLong()).`when`(spiedEngine).getElapsedNanos()
         spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
 
-        val snapshot = spiedEngine.getSnapshot(storeName = "store1", clearStore = false)
+        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertNull(snapshot)
     }
 
@@ -247,9 +250,9 @@ class TimespansStorageEngineTest {
             doReturn(expectedLengthInNanos).`when`(spiedEngine).getElapsedNanos()
             spiedEngine.stopAndSum(metric, res)
 
-            val snapshot = spiedEngine.getSnapshot(storeName = "store1", clearStore = true)
+            val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
             assertEquals(1, snapshot!!.size)
-            assertEquals(expectedTimespan, snapshot["telemetry.resolution_test"])
+            assertEquals(Pair(res.name.toLowerCase(), expectedTimespan), snapshot["telemetry.resolution_test"])
         }
     }
 
@@ -284,8 +287,11 @@ class TimespansStorageEngineTest {
 
         // Since the sum of the short-lived timespans is >= our resolution, we
         // expect the accumulated value to be in the snapshot.
-        val snapshot = spiedEngine.getSnapshot(storeName = "store1", clearStore = true)
+        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
         assertEquals(1, snapshot!!.size)
-        assertEquals(expectedTimespanSeconds, snapshot["telemetry.many_short_lived_test"])
+        assertEquals(
+            Pair("second", expectedTimespanSeconds),
+            snapshot["telemetry.many_short_lived_test"]
+        )
     }
 }


### PR DESCRIPTION
This field counts how much time user spent on foreground since the application started. Moreover,
this changes the `sessions` field to have an `application` lifetime rather than `ping`. This
additionally tries to use the `LifecycleRegistry` to interact with `GleanLifecycleObserver` and trigger
background pings.