### PR TITLE
Closes #1712: Added docs for customizing BrowserMenu. [skip ci]

### DIFF
--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -14,15 +14,23 @@ implementation "org.mozilla.components:browser-menu:{latest-version}"
 
 ### BrowserMenu
 
-There are multiple properties that you customize of the menu browser
-by just adding them into your dimens.xml file.
+There are multiple properties that you customize of the menu browser by just adding them into your dimens.xml file.
 
 ```xml
 <resources xmlns:tools="http://schemas.android.com/tools">
+
+   <!--Change how rounded the corners of the menu should be-->
     <dimen name="mozac_browser_menu_corner_radius">4dp</dimen>
+
+    <!--Change how much shadow the menu should have-->
     <dimen name="mozac_browser_menu_elevation">4dp</dimen>
+
+    <!--Change the width of the menu-->
     <dimen name="mozac_browser_menu_width">250dp</dimen>
+
+    <!--Change the top and bottom padding of the menu-->
     <dimen name="mozac_browser_menu_padding_vertical">8dp</dimen>
+
 </resources>
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,9 @@ permalink: /changelog/
 * **feature-prompts**, **browser-engine-gecko***
   * Added support for [Window.prompt](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt).
 
+* **browser-menu**
+  * Added [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/menu/README.md#browsermenu) for customizing `BrowserMenu`.
+
 # 0.38.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.37.0...v0.38.0),


### PR DESCRIPTION
We already had [dimens](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/menu/src/main/res/values/dimens.xml) for styling the BrowserMenu, this PR add docs to make them visible and  explain how to use them.

