### PR TITLE
[glean] Remove the "sessions" field from the baseline ping

### DIFF
--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -7,7 +7,6 @@ the following fields:
 
 | Field name | Type | Description |
 |---|---|---|
-| `sessions` | Counter | The number of foreground sessions since the last upload |
 | `duration` | Timespan | The duration, in seconds, of the last foreground session |
 | `os` | String | The name of the operating system (e.g. "linux", "android", "ios") |
 | `os_version` | String | The version of the operating system |

--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -8,19 +8,6 @@ baseline:
   ## TODO: Some metrics are commented out below until we implement them as part
   ## of 1497894 and its dependent bugs
 
-  sessions:
-    type: counter
-    description: |
-      The number of foreground sessions since the last ping upload.
-    send_in_pings:
-      - baseline
-    bugs:
-      - 1497894
-    reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
-    notification_emails:
-      - telemetry-client-dev@mozilla.com
-
   duration:
     type: timespan
     description: |

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
@@ -27,7 +27,7 @@ internal class GleanLifecycleObserver : LifecycleObserver {
     }
 
     /**
-     * Updates the baseline.sessions metric when entering the foreground.
+     * Updates the baseline.duration metric when entering the foreground.
      * We use ON_RESUME here because there are a number of paths by which
      * the application can re-enter the foreground, e.g. from a cold start
      * or warm start, etc., all of which eventually call ON_RESUME.
@@ -36,7 +36,6 @@ internal class GleanLifecycleObserver : LifecycleObserver {
      */
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun onEnterForeground() {
-        Baseline.sessions.add()
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -15,7 +15,6 @@ import mozilla.components.service.glean.net.HttpPingUploader
 import mozilla.components.service.glean.storages.EventsStorageEngine
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StringsStorageEngine
-import mozilla.components.service.glean.metrics.Baseline
 import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -234,15 +233,6 @@ class GleanTest {
                 assertNotNull(baselineStringMetrics.get(metric))
             }
 
-            val expectedBaselineCounterMetrics = arrayOf(
-                "baseline.sessions"
-            )
-            val baselineCounterMetrics = baselineMetricsObject.getJSONObject("counter")!!
-            assertEquals(expectedBaselineCounterMetrics.size, baselineCounterMetrics.length())
-            for (metric in expectedBaselineCounterMetrics) {
-                assertNotNull(baselineCounterMetrics.get(metric))
-            }
-
             val baselineTimespanMetrics = baselineMetricsObject.getJSONObject("timespan")!!
             assertEquals(1, baselineTimespanMetrics.length())
             assertNotNull(baselineTimespanMetrics.get("baseline.duration"))
@@ -351,8 +341,6 @@ class GleanTest {
         Glean.httpPingUploader = HttpPingUploader(testConfig)
 
         try {
-            Baseline.sessions.add()
-
             Glean.handleEvent(Glean.PingEvent.Background)
 
             val requests: MutableMap<String, String> = mutableMapOf()


### PR DESCRIPTION
This removes the "sessions" field, since it was not adding any useful insight to the data we already
collect. This is due to the fact that the container ping is generated and sent every time we go to
background, so the value of this field would always be 1.