### PR TITLE
Closes #1544: Added support for image and text in browser menus

### DIFF
--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -74,9 +74,6 @@ To customize the menu you could use separate properties 1 or full access to the 
     <!--Icon-->
 
     <!--Label-->
-           <!--Change the label's layout_height-->
-            <dimen name="mozac_browser_menu_item_image_text_label_layout_height">48dp</dimen> <!--Default value-->
-
            <!--Change the separation between the label and the icon-->
             <dimen name="mozac_browser_menu_item_image_text_label_padding_start">20dp</dimen> <!--Default value-->
 
@@ -86,20 +83,26 @@ To customize the menu you could use separate properties 1 or full access to the 
 
 2) For full customization, override the default style of menu by adding this style item in your `style.xml` file, and customize to your liking.
 ```xml
-    <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="">
-        <item name="android:layout_width">@dimen/mozac_browser_menu_item_image_text_icon_layout_width</item>
-        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_icon_layout_height</item>
+
+    <!--Change the appearance of all text menu items-->
+    <style name="Mozac.Browser.Menu.Item.Text" parent="@android:style/TextAppearance.Material.Menu">
+        <item name="android:background">?android:attr/selectableItemBackground</item>
+        <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:lines">1</item>
+        <item name="android:focusable">true</item>
+        <item name="android:clickable">true</item>
     </style>
 
-    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="@android:style/TextAppearance.Material.Menu">
+    <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="">
+        <item name="android:layout_width">@dimen/mozac_browser_menu_item_image_text_icon_width</item>
+        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_icon_height</item>
+    </style>
+
+    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="Mozac.Browser.Menu.Item.Text">
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_label_layout_height</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>
-        <item name="android:lines">1</item>
-        <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
-        <item name="android:clickable">true</item>
-        <item name="android:ellipsize">end</item>
-        <item name="android:focusable">true</item>
     </style>
 ```
 ## License

--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -13,6 +13,7 @@ implementation "org.mozilla.components:browser-menu:{latest-version}"
 ```
 
 ### BrowserMenu
+Sample code can be found in [Sample Toolbar app](https://github.com/mozilla-mobile/android-components/tree/master/samples/toolbar).
 
 There are multiple properties that you customize of the menu browser by just adding them into your dimens.xml file.
 
@@ -20,32 +21,38 @@ There are multiple properties that you customize of the menu browser by just add
 <resources xmlns:tools="http://schemas.android.com/tools">
 
    <!--Change how rounded the corners of the menu should be-->
-    <dimen name="mozac_browser_menu_corner_radius">4dp</dimen>
+    <dimen name="mozac_browser_menu_corner_radius" tools:ignore="UnusedResources">4dp</dimen>
 
     <!--Change how much shadow the menu should have-->
-    <dimen name="mozac_browser_menu_elevation">4dp</dimen>
+    <dimen name="mozac_browser_menu_elevation" tools:ignore="UnusedResources">4dp</dimen>
 
     <!--Change the width of the menu-->
-    <dimen name="mozac_browser_menu_width">250dp</dimen>
+    <dimen name="mozac_browser_menu_width" tools:ignore="UnusedResources">250dp</dimen>
 
     <!--Change the top and bottom padding of the menu-->
-    <dimen name="mozac_browser_menu_padding_vertical">8dp</dimen>
+    <dimen name="mozac_browser_menu_padding_vertical" tools:ignore="UnusedResources">8dp</dimen>
 
 </resources>
 ```
 
 ### BrowserMenuDivider
+```kotlin
+
+    BrowserMenuDivider()
+
+```
+
 To customize the divider you could use a 1. Quick customization or a 2. Full customization:
 
 1) If you just want to change the height of the divider, add this item your ``dimes.xml`` file, and your
 prefer height size.
 
 ```xml
-    <dimen name="mozac_browser_menu_item_divider_height">YOUR_HEIGHT</dimen>
+    <dimen name="mozac_browser_menu_item_divider_height" tools:ignore="UnusedResources">YOUR_HEIGHT</dimen>
 ```
 2) For full customization, override the default style of the divider by adding this style item in your `style.xml` file, and customize to your liking.
 ```xml
-        <style name="Mozac.Browser.Menu.Item.Divider.Horizontal">
+        <style name="Mozac.Browser.Menu.Item.Divider.Horizontal" tools:ignore="UnusedResources">
             <item name="android:background">YOUR_BACKGROUND</item>
             <item name="android:layout_width">match_parent</item>
             <item name="android:layout_height">YOUR_HEIGHT</item>
@@ -53,6 +60,17 @@ prefer height size.
 ```
 
 ### BrowserMenuImageText
+```kotlin
+    BrowserMenuImageText(
+       label = "Share",
+       imageResource = R.drawable.mozac_ic_share,
+       contentDescription = "Sharing menu item",
+       iconTintColorResource = R.color.photonBlue90
+    ) {
+        Toast.makeText(applicationContext, "Share", Toast.LENGTH_SHORT).show()
+    }
+```
+
 To customize the menu you could use separate properties 1 or full access to the style of the menu 2:
 
 1) If you just want to change a specify property, just add one these dimen items to your ``dimes.xml`` file.
@@ -61,21 +79,21 @@ To customize the menu you could use separate properties 1 or full access to the 
 
     <!--Menu Item -->
        <!--Change the text_size for ALL menu items NOT only for the BrowserMenuImageText -->
-        <dimen name="mozac_browser_menu_item_text_size">16sp</dimen>
+        <dimen name="mozac_browser_menu_item_text_size" tools:ignore="UnusedResources">16sp</dimen>
     <!--Menu Item -->
 
     <!--Icon-->
        <!--Change the icon's width-->
-        <dimen name="mozac_browser_menu_item_image_text_icon_width">24dp</dimen> <!--Default value-->
+        <dimen name="mozac_browser_menu_item_image_text_icon_width" tools:ignore="UnusedResources">24dp</dimen> <!--Default value-->
 
        <!--Change the icon's height-->
-        <dimen name="mozac_browser_menu_item_image_text_icon_height">24dp</dimen> <!--Default value-->
+        <dimen name="mozac_browser_menu_item_image_text_icon_height" tools:ignore="UnusedResources">24dp</dimen> <!--Default value-->
 
     <!--Icon-->
 
     <!--Label-->
            <!--Change the separation between the label and the icon-->
-            <dimen name="mozac_browser_menu_item_image_text_label_padding_start">20dp</dimen> <!--Default value-->
+            <dimen name="mozac_browser_menu_item_image_text_label_padding_start" tools:ignore="UnusedResources">20dp</dimen> <!--Default value-->
 
     <!--Label-->
 
@@ -85,7 +103,7 @@ To customize the menu you could use separate properties 1 or full access to the 
 ```xml
 
     <!--Change the appearance of all text menu items-->
-    <style name="Mozac.Browser.Menu.Item.Text" parent="@android:style/TextAppearance.Material.Menu">
+    <style name="Mozac.Browser.Menu.Item.Text" parent="@android:style/TextAppearance.Material.Menu" tools:ignore="UnusedResources">
         <item name="android:background">?android:attr/selectableItemBackground</item>
         <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
         <item name="android:ellipsize">end</item>
@@ -94,12 +112,12 @@ To customize the menu you could use separate properties 1 or full access to the 
         <item name="android:clickable">true</item>
     </style>
 
-    <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="">
+    <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="" tools:ignore="UnusedResources">
         <item name="android:layout_width">@dimen/mozac_browser_menu_item_image_text_icon_width</item>
         <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_icon_height</item>
     </style>
 
-    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="Mozac.Browser.Menu.Item.Text">
+    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="Mozac.Browser.Menu.Item.Text" tools:ignore="UnusedResources">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>

--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -35,7 +35,7 @@ There are multiple properties that you customize of the menu browser by just add
 ```
 
 ### BrowserMenuDivider
-To customize the divider you can have a 1. Quick customization or a 2. Full customization:
+To customize the divider you could use a 1. Quick customization or a 2. Full customization:
 
 1) If you just want to change the height of the divider, add this item your ``dimes.xml`` file, and your
 prefer height size.
@@ -52,6 +52,56 @@ prefer height size.
         </style>
 ```
 
+### BrowserMenuImageText
+To customize the menu you could use separate properties 1 or full access to the style of the menu 2:
+
+1) If you just want to change a specify property, just add one these dimen items to your ``dimes.xml`` file.
+
+```xml
+
+    <!--Menu Item -->
+       <!--Change the text_size for ALL menu items NOT only for the BrowserMenuImageText -->
+        <dimen name="mozac_browser_menu_item_text_size">16sp</dimen>
+    <!--Menu Item -->
+
+    <!--Icon-->
+       <!--Change the icon's width-->
+        <dimen name="mozac_browser_menu_item_image_text_icon_width">24dp</dimen> <!--Default value-->
+
+       <!--Change the icon's height-->
+        <dimen name="mozac_browser_menu_item_image_text_icon_height">24dp</dimen> <!--Default value-->
+
+    <!--Icon-->
+
+    <!--Label-->
+           <!--Change the label's layout_height-->
+            <dimen name="mozac_browser_menu_item_image_text_label_layout_height">48dp</dimen> <!--Default value-->
+
+           <!--Change the separation between the label and the icon-->
+            <dimen name="mozac_browser_menu_item_image_text_label_padding_start">20dp</dimen> <!--Default value-->
+
+    <!--Label-->
+
+```
+
+2) For full customization, override the default style of menu by adding this style item in your `style.xml` file, and customize to your liking.
+```xml
+    <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="">
+        <item name="android:layout_width">@dimen/mozac_browser_menu_item_image_text_icon_layout_width</item>
+        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_icon_layout_height</item>
+    </style>
+
+    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="@android:style/TextAppearance.Material.Menu">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_label_layout_height</item>
+        <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>
+        <item name="android:lines">1</item>
+        <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
+        <item name="android:clickable">true</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:focusable">true</item>
+    </style>
+```
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.androidx_test_core
+
 }
 
 apply from: '../../../publish.gradle'

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.support.annotation.ColorRes
+import android.support.annotation.DrawableRes
+import android.support.v4.content.ContextCompat
+import android.support.v7.widget.AppCompatImageView
+import android.view.View
+import android.widget.TextView
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuItem
+import mozilla.components.browser.menu.R
+
+private const val NO_ID = -1
+
+/**
+ * A menu item for displaying text with an image icon.
+ *
+ * @param label The visible label of this menu item.
+ * @param imageResource ID of a drawable resource to be shown as icon.
+ * @param contentDescription The image's content description, used for accessibility support.
+ * @param iconTintColorResource Optional ID of color resource to tint the icon.
+ * @param listener Callback to be invoked when this menu item is clicked.
+ */
+class BrowserMenuImageText(
+    private val label: String,
+    @DrawableRes
+    private val imageResource: Int,
+    private val contentDescription: String,
+    @ColorRes
+    private val iconTintColorResource: Int = NO_ID,
+    private val listener: () -> Unit = {}
+) : BrowserMenuItem {
+
+    override var visible: () -> Boolean = { true }
+
+    override fun getLayoutResource() = R.layout.mozac_browser_menu_item_image_text
+
+    override fun bind(menu: BrowserMenu, view: View) {
+
+        bindText(view)
+
+        bindImage(view)
+
+        view.setOnClickListener {
+            listener.invoke()
+            menu.dismiss()
+        }
+    }
+
+    private fun bindText(view: View) {
+        val textView = view.findViewById<TextView>(R.id.text)
+        textView.text = label
+    }
+
+    private fun bindImage(view: View) {
+        val imageView = view.findViewById<AppCompatImageView>(R.id.image)
+
+        with(imageView) {
+            setImageResource(imageResource)
+            contentDescription = this@BrowserMenuImageText.contentDescription
+
+            if (iconTintColorResource != NO_ID) {
+                imageView.imageTintList = ContextCompat.getColorStateList(view.context, iconTintColorResource)
+            }
+        }
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
@@ -40,7 +40,6 @@ class BrowserMenuImageText(
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_image_text
 
     override fun bind(menu: BrowserMenu, view: View) {
-
         bindText(view)
 
         bindImage(view)

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_checkbox.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_checkbox.xml
@@ -3,18 +3,12 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <android.support.v7.widget.AppCompatCheckBox xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@android:style/TextAppearance.Material.Menu"
+    style="@style/Mozac.Browser.Menu.Item.Text"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
-    android:background="?android:attr/selectableItemBackground"
+    android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
     android:button="@null"
-    android:clickable="true"
     android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
     android:drawablePadding="12dp"
-    android:ellipsize="end"
-    android:focusable="true"
     android:gravity="center_vertical"
-    android:lines="1"
     android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:textSize="16sp" />
+    android:paddingEnd="16dp" />

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_text.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_text.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        style="@style/Mozac.Browser.Menu.Item.Container"
+        android:layout_width="match_parent"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+    <android.support.v7.widget.AppCompatImageView
+            android:id="@+id/image"
+            style="@style/Mozac.Browser.Menu.Item.ImageText.Icon"
+            tools:src="@android:drawable/screen_background_dark"/>
+
+    <TextView
+            android:id="@+id/text"
+            style="@style/Mozac.Browser.Menu.Item.ImageText.Label"
+            android:gravity="center_vertical"
+            tools:text="Item"/>
+</LinearLayout>

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_simple.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_simple.xml
@@ -3,15 +3,9 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@android:style/TextAppearance.Material.Menu"
+    style="@style/Mozac.Browser.Menu.Item.Text"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
-    android:background="?android:attr/selectableItemBackground"
-    android:clickable="true"
-    android:ellipsize="end"
-    android:focusable="true"
+    android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
     android:gravity="center_vertical"
-    android:lines="1"
     android:paddingEnd="16dp"
-    android:paddingStart="16dp"
-    android:textSize="16sp" />
+    android:paddingStart="16dp" />

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_switch.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_switch.xml
@@ -3,14 +3,9 @@
   -  License, v. 2.0. If a copy of the MPL was not distributed with this
   -  file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <android.support.v7.widget.SwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@android:style/TextAppearance.Material.Menu"
+    style="@style/Mozac.Browser.Menu.Item.Text"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
-    android:background="?android:attr/selectableItemBackground"
-    android:ellipsize="end"
-    android:focusable="true"
-    android:lines="1"
+    android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
     android:orientation="vertical"
     android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:textSize="16sp" />
+    android:paddingEnd="16dp"/>

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -8,6 +8,29 @@
     <dimen name="mozac_browser_menu_width">250dp</dimen>
     <dimen name="mozac_browser_menu_padding_vertical">8dp</dimen>
 
-    <!--Item Divider -->
+    <!--Menu Item -->
+    <dimen name="mozac_browser_menu_item_text_size">16sp</dimen>
+    <dimen name="mozac_browser_menu_item_container_layout_height">48dp</dimen>
+    <dimen name="mozac_browser_menu_item_container_padding_start">24dp</dimen>
+    <dimen name="mozac_browser_menu_item_container_padding_end">24dp</dimen>
+    <!--Menu Item -->
+
+    <!--BrowserMenuDivider -->
     <dimen name="mozac_browser_menu_item_divider_height">1dp</dimen>
+    <!--BrowserMenuDivider -->
+
+    <!--BrowserMenuImageText-->
+
+    <!--Icon-->
+    <dimen name="mozac_browser_menu_item_image_text_icon_width">24dp</dimen>
+    <dimen name="mozac_browser_menu_item_image_text_icon_height">24dp</dimen>
+    <!--Icon-->
+
+    <!--Label-->
+    <dimen name="mozac_browser_menu_item_image_text_label_layout_height">48dp</dimen>
+    <dimen name="mozac_browser_menu_item_image_text_label_padding_start">20dp</dimen>
+    <!--Label-->
+
+    <!--BrowserMenuImageText-->
+
 </resources>

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -27,7 +27,6 @@
     <!--Icon-->
 
     <!--Label-->
-    <dimen name="mozac_browser_menu_item_image_text_label_layout_height">48dp</dimen>
     <dimen name="mozac_browser_menu_item_image_text_label_padding_start">20dp</dimen>
     <!--Label-->
 

--- a/components/browser/menu/src/main/res/values/style.xml
+++ b/components/browser/menu/src/main/res/values/style.xml
@@ -21,21 +21,25 @@
         <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
+    <style name="Mozac.Browser.Menu.Item.Text" parent="@android:style/TextAppearance.Material.Menu">
+        <item name="android:background">?android:attr/selectableItemBackground</item>
+        <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:lines">1</item>
+        <item name="android:focusable">true</item>
+        <item name="android:clickable">true</item>
+    </style>
+
     <!-- BrowserMenuImageText -->
     <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="">
         <item name="android:layout_width">@dimen/mozac_browser_menu_item_image_text_icon_width</item>
         <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_icon_height</item>
     </style>
 
-    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="@android:style/TextAppearance.Material.Menu">
+    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="Mozac.Browser.Menu.Item.Text">
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_label_layout_height</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>
-        <item name="android:lines">1</item>
-        <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
-        <item name="android:clickable">true</item>
-        <item name="android:ellipsize">end</item>
-        <item name="android:focusable">true</item>
     </style>
     <!-- BrowserMenuImageText -->
 </resources>

--- a/components/browser/menu/src/main/res/values/style.xml
+++ b/components/browser/menu/src/main/res/values/style.xml
@@ -13,4 +13,29 @@
         <item name="android:layout_height">@dimen/mozac_browser_menu_item_divider_height</item>
     </style>
     <!-- Item Divider -->
+
+    <style name="Mozac.Browser.Menu.Item.Container" parent="">
+        <item name="android:layout_height">@dimen/mozac_browser_menu_item_container_layout_height</item>
+        <item name="android:paddingStart">@dimen/mozac_browser_menu_item_container_padding_start</item>
+        <item name="android:paddingEnd">@dimen/mozac_browser_menu_item_container_padding_end</item>
+        <item name="android:background">?android:attr/selectableItemBackground</item>
+    </style>
+
+    <!-- BrowserMenuImageText -->
+    <style name="Mozac.Browser.Menu.Item.ImageText.Icon" parent="">
+        <item name="android:layout_width">@dimen/mozac_browser_menu_item_image_text_icon_width</item>
+        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_icon_height</item>
+    </style>
+
+    <style name="Mozac.Browser.Menu.Item.ImageText.Label" parent="@android:style/TextAppearance.Material.Menu">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">@dimen/mozac_browser_menu_item_image_text_label_layout_height</item>
+        <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>
+        <item name="android:lines">1</item>
+        <item name="android:textSize">@dimen/mozac_browser_menu_item_text_size</item>
+        <item name="android:clickable">true</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:focusable">true</item>
+    </style>
+    <!-- BrowserMenuImageText -->
 </resources>

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
@@ -1,0 +1,93 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.menu.item
+
+import android.content.Context
+import android.support.v7.widget.AppCompatImageView
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserMenuImageTextTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `browser menu ImageText should be inflated`() {
+        var onClickWasPress = false
+        val item = BrowserMenuImageText(
+            "label",
+            android.R.drawable.ic_menu_report_image,
+            "contentDescription",
+            android.R.color.black
+        ) {
+            onClickWasPress = true
+        }
+
+        val view = inflate(item)
+
+        view.performClick()
+        assertTrue(onClickWasPress)
+    }
+
+    @Test
+    fun `browser menu ImageText should have the right text, image, content description and iconTintColorResource`() {
+        val item = BrowserMenuImageText(
+            "label",
+            android.R.drawable.ic_menu_report_image,
+            "contentDescription",
+            android.R.color.black
+        ) {
+        }
+
+        val view = inflate(item)
+
+        val textView = view.findViewById<TextView>(R.id.text)
+        assertEquals(textView.text, "label")
+
+        val imageView = view.findViewById<AppCompatImageView>(R.id.image)
+
+        assertEquals(imageView.contentDescription, "contentDescription")
+
+        assertNotNull(imageView.drawable)
+
+        assertNotNull(imageView.imageTintList)
+    }
+
+    @Test
+    fun `browser menu ImageText with with no iconTintColorResource must not have an imageTintList`() {
+        val item = BrowserMenuImageText(
+            "label",
+            android.R.drawable.ic_menu_report_image,
+            "contentDescription")
+
+        val view = inflate(item)
+
+        val imageView = view.findViewById<AppCompatImageView>(R.id.image)
+
+        assertNull(imageView.imageTintList)
+    }
+
+    private fun inflate(item: BrowserMenuImageText): View {
+        val view = LayoutInflater.from(context).inflate(item.getLayoutResource(), null)
+        val mockMenu = mock(BrowserMenu::class.java)
+        item.bind(mockMenu, view)
+        return view
+    }
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
@@ -26,7 +26,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuImageTextTest {
 
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `browser menu ImageText should be inflated`() {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ permalink: /changelog/
 
 * **browser-menu**
   * Added [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/menu/README.md#browsermenu) for customizing `BrowserMenu`.
+  * Added `BrowserMenuDivider`.[For customization take a look at the docs.](https://github.com/mozilla-mobile/android-components/tree/master/components/browser/menu/README.md#BrowserMenuDivider)
+  * Added [BrowserMenuImageText](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/menu/README.md#BrowserMenuImageText) for show an icon next to text in menus.
   * Added support for showing a menu with DOWN and UP orientation (e.g. for supporting menus in bottom toolbars).
 
 * **concept-engine**, **browser-engine-gecko-***

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.BrowserMenuCheckbox
 import mozilla.components.browser.menu.item.BrowserMenuDivider
+import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
@@ -92,7 +93,12 @@ open class DefaultComponents(private val applicationContext: Context) {
     private val menuItems by lazy {
         listOf(
                 menuToolbar,
-                SimpleBrowserMenuItem("Share") {
+                BrowserMenuImageText(
+                    "Share",
+                    R.drawable.mozac_ic_share,
+                    contentDescription = "Sharing menu item",
+                    iconTintColorResource = R.color.photonBlue90
+                ) {
                     Toast.makeText(applicationContext, "Share", Toast.LENGTH_SHORT).show()
                 },
                 SimpleBrowserMenuItem("Settings") {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -15,7 +15,6 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.BrowserMenuCheckbox
 import mozilla.components.browser.menu.item.BrowserMenuDivider
-import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
@@ -93,12 +92,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     private val menuItems by lazy {
         listOf(
                 menuToolbar,
-                BrowserMenuImageText(
-                    "Share",
-                    R.drawable.mozac_ic_share,
-                    contentDescription = "Sharing menu item",
-                    iconTintColorResource = R.color.photonBlue90
-                ) {
+                SimpleBrowserMenuItem("Share") {
                     Toast.makeText(applicationContext, "Share", Toast.LENGTH_SHORT).show()
                 },
                 SimpleBrowserMenuItem("Settings") {

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/SampleToolbarHelpers.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/SampleToolbarHelpers.kt
@@ -22,7 +22,8 @@ enum class ToolbarConfiguration(val label: String) {
     DEFAULT("Default"),
     FOCUS_TABLET("Firefox Focus (Tablet)"),
     FOCUS_PHONE("Firefox Focus (Phone)"),
-    SEEDLING("Seedling")
+    SEEDLING("Seedling"),
+    CUSTOM_MENU("Custom Menu")
 }
 
 @Suppress("MagicNumber")

--- a/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -23,6 +23,8 @@ import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.BrowserMenuItem
+import mozilla.components.browser.menu.item.BrowserMenuDivider
+import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -54,6 +56,7 @@ class ToolbarActivity : AppCompatActivity() {
             ToolbarConfiguration.FOCUS_TABLET -> setupFocusTabletToolbar()
             ToolbarConfiguration.FOCUS_PHONE -> setupFocusPhoneToolbar()
             ToolbarConfiguration.SEEDLING -> setupSeedlingToolbar()
+            ToolbarConfiguration.CUSTOM_MENU -> setupCustomMenu()
         }
 
         recyclerView.adapter = ConfigurationAdapter(configuration)
@@ -142,6 +145,40 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
+    }
+
+    /**
+     * A custom browser menu.
+     */
+    private fun setupCustomMenu() {
+
+        toolbar.setBackgroundColor(
+            ContextCompat.getColor(this, mozilla.components.ui.colors.R.color.photonBlue80))
+
+        // //////////////////////////////////////////////////////////////////////////////////////////
+        // Create a menu with text and icons
+        // //////////////////////////////////////////////////////////////////////////////////////////
+
+        val share = BrowserMenuImageText(
+            "Share",
+            R.drawable.mozac_ic_share,
+            contentDescription = "Sharing menu item"
+        ) { /* Do nothing */ }
+
+        val search = BrowserMenuImageText(
+            "Search",
+            R.drawable.mozac_ic_search,
+            contentDescription = "Sharing menu item"
+        ) { /* Do nothing */ }
+
+        val builder = BrowserMenuBuilder(listOf(share, BrowserMenuDivider(), search))
+        toolbar.setMenuBuilder(builder)
+
+        // //////////////////////////////////////////////////////////////////////////////////////////
+        // Display a URL
+        // //////////////////////////////////////////////////////////////////////////////////////////
+
+        toolbar.url = "https://www.mozilla.org/"
     }
 
     /**

--- a/samples/toolbar/src/main/res/values/dimens.xml
+++ b/samples/toolbar/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <dimen tools:ignore="UnusedResources" name="mozac_browser_menu_corner_radius">20dp</dimen>
+</resources>


### PR DESCRIPTION
To avoid API break with consumers of `SimpleBrowserMenuItem`. I added `BrowserMenuImage`.

### Demo
![screenshot_20190117-103134](https://user-images.githubusercontent.com/773158/51329290-32dd3680-1a43-11e9-8461-7a43f7838592.png)
