### PR TITLE
Closes #1744: Support "UP" and "DOWN" orientations in browser-menu

### DIFF
--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
 
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -7,8 +7,10 @@ package mozilla.components.browser.menu
 import android.annotation.SuppressLint
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.support.design.widget.CoordinatorLayout
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
@@ -25,7 +27,7 @@ class BrowserMenu internal constructor(
     private var currentPopup: PopupWindow? = null
 
     @SuppressLint("InflateParams")
-    fun show(anchor: View): PopupWindow {
+    fun show(anchor: View, orientation: Orientation = Orientation.DOWN): PopupWindow {
         val view = LayoutInflater.from(anchor.context).inflate(R.layout.mozac_browser_menu, null)
 
         adapter.menu = this
@@ -49,7 +51,8 @@ class BrowserMenu internal constructor(
             }
 
             val xOffset = if (anchor.isRTL) -anchor.width else 0
-            showAsDropDown(anchor, xOffset, -anchor.height)
+            val yOffset = determineVerticalOffset(orientation, view, anchor)
+            showAsDropDown(anchor, xOffset, yOffset)
         }.also {
             currentPopup = it
         }
@@ -61,5 +64,38 @@ class BrowserMenu internal constructor(
 
     companion object {
         private const val MENU_ELEVATION_DP = 8
+
+        /**
+         * Determines the orientation to be used for a menu based on the positioning of the [parent] in the layout.
+         */
+        fun determineMenuOrientation(parent: View): BrowserMenu.Orientation {
+            val params = parent.layoutParams
+            return if (params is CoordinatorLayout.LayoutParams) {
+                if (params.gravity and Gravity.BOTTOM == Gravity.BOTTOM) {
+                    BrowserMenu.Orientation.UP
+                } else {
+                    BrowserMenu.Orientation.DOWN
+                }
+            } else {
+                BrowserMenu.Orientation.DOWN
+            }
+        }
+    }
+
+    enum class Orientation {
+        UP,
+        DOWN
+    }
+}
+
+private fun determineVerticalOffset(orientation: BrowserMenu.Orientation, view: View, anchor: View): Int {
+    return if (orientation == BrowserMenu.Orientation.DOWN) {
+        // Menu should overlay anchor.
+        -anchor.height
+    } else {
+        // Measure menu and then position menu above (and overlapping) anchor
+        val spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        view.measure(spec, spec)
+        -view.measuredHeight
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -4,9 +4,15 @@
 
 package mozilla.components.browser.menu
 
+import android.content.Context
+import android.support.design.widget.CoordinatorLayout
 import android.support.v7.widget.RecyclerView
+import android.view.Gravity
+import android.view.View
 import android.widget.Button
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -14,21 +20,23 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @Test
     fun `show returns non-null popup window`() {
         val items = listOf(
-                SimpleBrowserMenuItem("Hello") {},
-                SimpleBrowserMenuItem("World") {})
+            SimpleBrowserMenuItem("Hello") {},
+            SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(context, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(RuntimeEnvironment.application)
+        val anchor = Button(context)
         val popup = menu.show(anchor)
 
         assertNotNull(popup)
@@ -37,14 +45,14 @@ class BrowserMenuTest {
     @Test
     fun `recyclerview adapter will have items for every menu item`() {
         val items = listOf(
-                SimpleBrowserMenuItem("Hello") {},
-                SimpleBrowserMenuItem("World") {})
+            SimpleBrowserMenuItem("Hello") {},
+            SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(context, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(RuntimeEnvironment.application)
+        val anchor = Button(context)
         val popup = menu.show(anchor)
 
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
@@ -58,14 +66,14 @@ class BrowserMenuTest {
     @Test
     fun `created popup window is displayed automatically`() {
         val items = listOf(
-                SimpleBrowserMenuItem("Hello") {},
-                SimpleBrowserMenuItem("World") {})
+            SimpleBrowserMenuItem("Hello") {},
+            SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(context, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(RuntimeEnvironment.application)
+        val anchor = Button(context)
         val popup = menu.show(anchor)
 
         assertTrue(popup.isShowing)
@@ -74,14 +82,14 @@ class BrowserMenuTest {
     @Test
     fun `dismissing the browser menu will dismiss the popup`() {
         val items = listOf(
-                SimpleBrowserMenuItem("Hello") {},
-                SimpleBrowserMenuItem("World") {})
+            SimpleBrowserMenuItem("Hello") {},
+            SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(context, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(RuntimeEnvironment.application)
+        val anchor = Button(context)
         val popup = menu.show(anchor)
 
         assertTrue(popup.isShowing)
@@ -89,5 +97,41 @@ class BrowserMenuTest {
         menu.dismiss()
 
         assertFalse(popup.isShowing)
+    }
+
+    @Test
+    fun `determineMenuOrientation returns Orientation-DOWN by default`() {
+        assertEquals(
+            BrowserMenu.Orientation.DOWN,
+            BrowserMenu.determineMenuOrientation(mock())
+        )
+    }
+
+    @Test
+    fun `determineMenuOrientation returns Orientation-UP for views with bottom gravity in CoordinatorLayout`() {
+        val params = CoordinatorLayout.LayoutParams(100, 100)
+        params.gravity = Gravity.BOTTOM
+
+        val view = View(context)
+        view.layoutParams = params
+
+        assertEquals(
+            BrowserMenu.Orientation.UP,
+            BrowserMenu.determineMenuOrientation(view)
+        )
+    }
+
+    @Test
+    fun `determineMenuOrientation returns Orientation-DOWN for views with top gravity in CoordinatorLayout`() {
+        val params = CoordinatorLayout.LayoutParams(100, 100)
+        params.gravity = Gravity.TOP
+
+        val view = View(context)
+        view.layoutParams = params
+
+        assertEquals(
+            BrowserMenu.Orientation.DOWN,
+            BrowserMenu.determineMenuOrientation(view)
+        )
     }
 }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -15,6 +15,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
+import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
@@ -111,7 +112,9 @@ internal class DisplayToolbar(
         visibility = View.GONE
 
         setOnClickListener {
-            menuBuilder?.build(context)?.show(this)
+            menuBuilder?.build(context)?.show(
+                anchor = this,
+                orientation = BrowserMenu.determineMenuOrientation(toolbar))
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ permalink: /changelog/
 
 * **browser-menu**
   * Added [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/menu/README.md#browsermenu) for customizing `BrowserMenu`.
+  * Added support for showing a menu with DOWN and UP orientation (e.g. for supporting menus in bottom toolbars).
 
 * **concept-engine**, **browser-engine-gecko-***
   * Added support for enabling tracking protection for specific session type:


### PR DESCRIPTION
This will add support for bottom toolbars with a menu.

This unblocks PR https://github.com/mozilla-mobile/reference-browser/pull/429.