### PR TITLE
Add support for hooking logs from app-services into the log system

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -192,6 +192,10 @@ projects:
     path: components/support/utils
     description: 'A collection of generic helper classes.'
     publish: true
+  support-rustlog:
+    path: components/support/rustlog
+    description: 'A bridge allowing log messages from Rust code to be sent to the log system in support-base'
+    publish: true
   lib-crash:
     path: components/lib/crash
     description: 'A generic crash reporter library that can report crashes to multiple services.'

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,9 +29,7 @@ object Versions {
     const val sentry = "1.7.14"
     const val okhttp = "3.12.1"
 
-    const val mozilla_fxa = "0.13.3"
-    const val mozilla_sync_logins = "0.13.3"
-    const val mozilla_places = "0.13.3"
+    const val mozilla_appservices = "0.14.0"
     const val servo = "0.0.1.20181017.aa95911"
 }
 
@@ -71,9 +69,10 @@ object Dependencies {
     const val tools_lintapi = "com.android.tools.lint:lint-api:${Versions.lint}"
     const val tools_linttests = "com.android.tools.lint:lint-tests:${Versions.lint}"
 
-    const val mozilla_fxa = "org.mozilla.fxaclient:fxaclient:${Versions.mozilla_fxa}"
-    const val mozilla_sync_logins = "org.mozilla.sync15:logins:${Versions.mozilla_sync_logins}"
-    const val mozilla_places = "org.mozilla.places:places:${Versions.mozilla_places}"
+    const val mozilla_fxa = "org.mozilla.fxaclient:fxaclient:${Versions.mozilla_appservices}"
+    const val mozilla_sync_logins = "org.mozilla.sync15:logins:${Versions.mozilla_appservices}"
+    const val mozilla_places = "org.mozilla.places:places:${Versions.mozilla_appservices}"
+    const val mozilla_rustlog = "org.mozilla.appservices:rustlog:${Versions.mozilla_appservices}"
     const val mozilla_servo = "org.mozilla.servoview:servoview-armv7:${Versions.servo}"
 
     const val thirdparty_okhttp = "com.squareup.okhttp3:okhttp:${Versions.okhttp}"

--- a/components/support/rustlog/build.gradle
+++ b/components/support/rustlog/build.gradle
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules-consumer.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Dependencies.mozilla_rustlog
+
+    implementation Dependencies.kotlin_stdlib
+    // Log.Priority is in the public api.
+    api project(':support-base')
+
+    testImplementation Dependencies.mozilla_rustlog
+
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/support/rustlog/proguard-rules-consumer.pro
+++ b/components/support/rustlog/proguard-rules-consumer.pro
@@ -1,0 +1,1 @@
+# ProGuard rules for consumers of this library.

--- a/components/support/rustlog/proguard-rules.pro
+++ b/components/support/rustlog/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /Users/sebastian/Library/Android/sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/support/rustlog/src/main/AndroidManifest.xml
+++ b/components/support/rustlog/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.support.rustlog" />

--- a/components/support/rustlog/src/main/java/mozilla/components/support/rustlog/RustLog.kt
+++ b/components/support/rustlog/src/main/java/mozilla/components/support/rustlog/RustLog.kt
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.rustlog
+
+import mozilla.appservices.rustlog.LogLevelFilter
+import mozilla.appservices.rustlog.RustLogAdapter
+import mozilla.components.support.base.log.Log
+
+object RustLog {
+
+    /**
+     * Enable the Rust log adapter.
+     *
+     * This does almost (see below) nothing if you are not in a megazord build.
+     * After calling this, logs emitted by Rust code are forwarded to any
+     * LogSinks attached to [Log].
+     *
+     * Megazording is required due to each dynamically loaded Rust library having
+     * its own internal/private version of the Rust logging framework. When
+     * megazording, this is still true, but there's only a single dynamically
+     * loaded library, and so it is redirected properly.
+     *
+     * Note that non-megazord versions of the Rust libraries will log directly to
+     * logcat by default (at DEBUG level), so while they cannot hook into the base
+     * component log system, they still have logs available for development use.
+     *
+     * (We say "almost" nothing, as calling this will hook up logging for the dynamic
+     * library containing the Rust log hooking (and only that), as well as logging
+     * a single message indicating that it completed initialization).
+     */
+    fun enable() {
+        RustLogAdapter.enable { level, tagStr, msgStr ->
+            Log.log(levelToPriority(level), tagStr, null, msgStr)
+            // Return true to keep open. Eventually we could intercept calls
+            // to disable that happen as the direct result of the above call
+            // (e.g. on this thread, before this function returns) and return
+            // false if any happen, but for now this is fine. (Exceptions thrown
+            // by a log sink will also close us)
+            true
+        }
+    }
+
+    /**
+     * Disable the rust log adapter.
+     */
+    fun disable() {
+        RustLogAdapter.disable()
+    }
+
+    /**
+     * Set the maximum level of logs that will be forwarded to [Log]. By
+     * default, the max level is DEBUG.
+     *
+     * This is somewhat redundant with [Log.logLevel] (and a stricter
+     * filter on Log.logLevel will take precedence here), however
+     * setting the max level here can improve performance a great deal,
+     * as it allows the Rust code to skip a great deal of work.
+     *
+     * This includes a `includePII` flag, which allows enabling logs at
+     * the trace level. It is ignored if level is not [Log.Priority.DEBUG].
+     * These trace level logs* may contain the personal information of users
+     * but can be very helpful for tracking down bugs.
+     *
+     * @param level The maximum (inclusive) level to include logs at.
+     * @param includePII If `level` is [Log.Priority.DEBUG], allow
+     *     debug logs to contain PII.
+     */
+    fun setMaxLevel(level: Log.Priority, includePII: Boolean = false) {
+        val levelFilter = when (level) {
+            Log.Priority.DEBUG -> {
+                if (includePII) {
+                    LogLevelFilter.TRACE
+                } else {
+                    LogLevelFilter.DEBUG
+                }
+            }
+            Log.Priority.INFO -> LogLevelFilter.INFO
+            Log.Priority.WARN -> LogLevelFilter.WARN
+            Log.Priority.ERROR -> LogLevelFilter.ERROR
+        }
+        RustLogAdapter.setMaxLevel(levelFilter)
+    }
+}
+
+internal fun levelToPriority(level: Int): Log.Priority {
+    return when {
+        level <= android.util.Log.DEBUG -> Log.Priority.DEBUG
+        level == android.util.Log.INFO -> Log.Priority.INFO
+        level == android.util.Log.WARN -> Log.Priority.WARN
+        else -> Log.Priority.ERROR
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,8 @@ permalink: /changelog/
         customTabsToolbarFeature
       )
     }
-  ```
+    ```
+
 * **feature-awesomebar**
   * Added ability to show one item per search suggestion ([#1779](https://github.com/mozilla-mobile/android-components/issues/1779))
   * Added ability to define custom hooks to be invoked when editing starts or is completed.
@@ -37,6 +38,30 @@ permalink: /changelog/
 
 * **browser-engine-system**
   * Preventing JavaScript `confirm()` and `prompt()` until providing proper implementation #1816.
+
+* **support-rustlog**
+  * 🆕 New component: This component allows consumers of [megazorded](https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html) Rust libraries produced by application-services to redirect their log output to the base component's log system as follows:
+  ```kotlin
+  import mozilla.components.support.rustlog.RustLog
+  import mozilla.components.support.base.log.Log
+  // In onCreate, any time after MyMegazordClass.init()
+  RustLog.enable()
+  // Note: By default this is enabled at level DEBUG, which can be adjusted.
+  // (It is recommended you do this for performance if you adjust
+  // `Log.logLevel`).
+  RustLog.setMaxLevel(Log.Priority.INFO)
+  // You can also enable "trace logs", which may include PII
+  // (but can assist debugging) as follows. It is recommended
+  // you not do this in builds you distribute to users.
+  RustLog.setMaxLevel(Log.Priority.DEBUG, true)
+  ```
+  * This is pointless to do when not using a megazord.
+    * Megazording is required due to each dynamically loaded Rust library having its own internal/private version of the Rust logging framework. When megazording, this is still true, but there's only a single dynamically loaded library, and so it's redirected properly. (This could probably be worked around, but it would take a great effort, and given that we expect most production use of these libraries will be using megazords, we accepted this limitation)
+    * This would be very annoying during initial development (and debugging the sample apps), so by default, we'll log (directly, e.g. not through the base component logger) to logcat when not megazorded.
+  * Note that you must call `MyMegazordClass.init()` *before* any uses of this class.
+
+* Mozilla App Services library updated to 0.14.0. See [release notes](https://github.com/mozilla/application-services/releases/tag/v0.14.0) for details.
+  * Important: Users consuming megazords must also update the application-services gradle plugin to version 0.3.0.
 
 # 0.39.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,6 +67,7 @@ if (localProperties != null) {
                 substitute module('org.mozilla.fxaclient:fxaclient') with project(':fxa-client-library')
                 substitute module('org.mozilla.sync15:logins') with project(':logins-library')
                 substitute module('org.mozilla.places:places') with project(':places-library')
+                substitute module('org.mozilla.appservices:rustlog') with project(':rustlog-library')
             }
         }
 


### PR DESCRIPTION
This adds a new component that allows logs emitted by rust code from https://github.com/mozilla/application-services to be directed to the `Log` object in the base component. Previously, they were always written to logcat.

It's worth noting that this only works if you're using a [megazord](https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html) build (Unfortunately, it's more or less impossible for us to make it work outside a megazord). Code running outside a megazord will continue to use logcat (realistically, we don't expect to ship non-megazords, so this basically means the android-components samples and the like).

I avoided doing anything fancy in `Log` to let it know about this type, although I could see an argument for having it be aware to automatically set the max level of RustLog or something, IDK (I don't think we want a hard dependency though, so there would need to be some annoying indirection that I punted on).

Anyway, I didn't really know where to put this. It's a lot less general purpose than the other stuff in `support`, but it doesn't really fit anywhere else either. LMK, I'm open to move it.

### Note:

This won't work until this is included in an app services release, which hasn't happened yet because it hasn't landed in app services yet (https://github.com/mozilla/application-services/pull/472).

Once it does I'll update the versions and add release notes.
