### PR TITLE
Closes #1398: Add menu items to Custom Tab Toolbar

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
@@ -12,7 +12,7 @@ import android.content.Context
  * @param items List of BrowserMenuItem objects to compose the menu from.
  */
 class BrowserMenuBuilder(
-    private val items: List<BrowserMenuItem>
+    val items: List<BrowserMenuItem>
 ) {
     fun build(context: Context): BrowserMenu {
         val adapter = BrowserMenuAdapter(context, items)

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
@@ -80,6 +80,6 @@ class ContextTest {
         verify(context).startActivity(argCaptor.capture())
 
         assertTrue(result)
-        assertEquals(FLAG_ACTIVITY_NEW_TASK, argCaptor.firstValue.flags)
+        assertEquals(FLAG_ACTIVITY_NEW_TASK, argCaptor.value.flags)
     }
 }

--- a/components/support/test/src/main/java/mozilla/components/support/test/ArgumentCaptor.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/ArgumentCaptor.kt
@@ -24,7 +24,7 @@ class KArgumentCaptor<out T : Any?>(
      * The first captured value of the argument.
      * @throws IndexOutOfBoundsException if the value is not available.
      */
-    val firstValue: T
+    val value: T
         get() = captor.value
 
     val allValues: List<T>

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -109,7 +109,8 @@ class BrowserFragment : Fragment(), BackHandler {
         customTabsToolbarFeature = CustomTabsToolbarFeature(
             components.sessionManager,
             layout.toolbar,
-            sessionId
+            sessionId,
+            components.menuBuilder
         ) { activity?.finish() }
 
         // Observe the lifecycle for supported features

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -105,9 +105,7 @@ open class DefaultComponents(private val applicationContext: Context) {
                 SimpleBrowserMenuItem("Settings") {
                     Toast.makeText(applicationContext, "Settings", Toast.LENGTH_SHORT).show()
                 },
-
                 BrowserMenuDivider(),
-
                 SimpleBrowserMenuItem("Clear Data") {
                     sessionUseCases.clearData.invoke()
                 },


### PR DESCRIPTION
Also renamed `firstValue` in the captor to just `value`.