### PR TITLE
Closes #1473: Adding support for pop-up dialog when opening a new window for GeckoEngine

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -275,17 +275,26 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onPopupRequest(session: GeckoSession, targetUri: String?): GeckoResult<AllowOrDeny> {
+        val geckoResult = GeckoResult<AllowOrDeny>()
+        val onAllow: () -> Unit = { geckoResult.complete(AllowOrDeny.ALLOW) }
+        val onDeny: () -> Unit = { geckoResult.complete(AllowOrDeny.DENY) }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Popup(targetUri ?: "", onAllow, onDeny)
+            )
+        }
+        return geckoResult
+    }
+
     override fun onButtonPrompt(
-        session: GeckoSession?,
+        session: GeckoSession,
         title: String?,
         msg: String?,
         btnMsg: Array<out String>?,
-        callback: ButtonCallback?
+        callback: ButtonCallback
     ) = Unit
-
-    override fun onPopupRequest(session: GeckoSession?, targetUri: String?): GeckoResult<AllowOrDeny> {
-        return GeckoResult()
-    } // Related issue: https://github.com/mozilla-mobile/android-components/issues/1473
 
     private fun GeckoChoice.toChoice(): Choice {
         val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -273,6 +273,19 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onPopupRequest(session: GeckoSession, targetUri: String?): GeckoResult<AllowOrDeny> {
+        val geckoResult = GeckoResult<AllowOrDeny>()
+        val onAllow: () -> Unit = { geckoResult.complete(AllowOrDeny.ALLOW) }
+        val onDeny: () -> Unit = { geckoResult.complete(AllowOrDeny.DENY) }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Popup(targetUri ?: "", onAllow, onDeny)
+            )
+        }
+        return geckoResult
+    }
+
     override fun onButtonPrompt(
         session: GeckoSession,
         title: String?,
@@ -280,10 +293,6 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         btnMsg: Array<out String>?,
         callback: ButtonCallback
     ) = Unit
-
-    override fun onPopupRequest(session: GeckoSession, targetUri: String?): GeckoResult<AllowOrDeny> {
-        return GeckoResult()
-    } // Related issue: https://github.com/mozilla-mobile/android-components/issues/1473
 
     private fun GeckoChoice.toChoice(): Choice {
         val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -37,6 +37,8 @@ import org.robolectric.RobolectricTestRunner
 import mozilla.components.support.ktx.kotlin.toDate
 import org.junit.Assert
 import org.junit.Assert.assertNotNull
+import org.mozilla.geckoview.AllowOrDeny
+import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
@@ -873,6 +875,47 @@ class GeckoPromptDelegateTest {
             assertTrue(setCheckboxValueWasCalled)
             assertTrue(confirmWasCalled)
         }
+    }
+
+    @Test
+    fun `onPopupRequest must provide a Popup PromptRequest`() {
+        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        var request: PromptRequest.Popup? = null
+        var onAllowWasCalled = false
+        var onDenyWasCalled = false
+
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+
+        mockSession.register(object : EngineSession.Observer {
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                request = promptRequest as PromptRequest.Popup
+            }
+        })
+
+        var geckoCallback = promptDelegate.onPopupRequest(mock(), "www.popuptest.com/")
+
+        val geckoThen: (AllowOrDeny?) -> GeckoResult<AllowOrDeny> = {
+            when (it!!) {
+                AllowOrDeny.ALLOW -> { onAllowWasCalled = true }
+                AllowOrDeny.DENY -> { onDenyWasCalled = true }
+            }
+            geckoCallback
+        }
+
+        geckoCallback.then(geckoThen)
+
+        with(request!!) {
+            assertEquals(targetUri, "www.popuptest.com/")
+
+            onAllow()
+            assertTrue(onAllowWasCalled)
+        }
+
+        geckoCallback = promptDelegate.onPopupRequest(mock(), "www.popuptest.com/")
+        geckoCallback.then(geckoThen)
+
+        request!!.onDeny()
+        assertTrue(onDenyWasCalled)
     }
 
     open class DefaultGeckoChoiceCallback : GeckoSession.PromptDelegate.ChoiceCallback {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -273,17 +273,26 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         }
     }
 
+    override fun onPopupRequest(session: GeckoSession, targetUri: String?): GeckoResult<AllowOrDeny> {
+        val geckoResult = GeckoResult<AllowOrDeny>()
+        val onAllow: () -> Unit = { geckoResult.complete(AllowOrDeny.ALLOW) }
+        val onDeny: () -> Unit = { geckoResult.complete(AllowOrDeny.DENY) }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.Popup(targetUri ?: "", onAllow, onDeny)
+            )
+        }
+        return geckoResult
+    }
+
     override fun onButtonPrompt(
-        session: GeckoSession?,
+        session: GeckoSession,
         title: String?,
         msg: String?,
         btnMsg: Array<out String>?,
-        callback: ButtonCallback?
+        callback: ButtonCallback
     ) = Unit
-
-    override fun onPopupRequest(session: GeckoSession?, targetUri: String?): GeckoResult<AllowOrDeny> {
-        return GeckoResult()
-    } // Related issue: https://github.com/mozilla-mobile/android-components/issues/1473
 
     private fun GeckoChoice.toChoice(): Choice {
         val choiceChildren = items?.map { it.toChoice() }?.toTypedArray()

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -158,4 +158,19 @@ sealed class PromptRequest {
         val onConfirm: (String) -> Unit,
         val onDismiss: () -> Unit
     ) : PromptRequest()
+
+    /**
+     * Value type that represents a request for showing a pop-pup prompt.
+     * This occurs when content attempts to open a new window,
+     * in a way that doesn't appear to be the result of user input.
+     *
+     * @property targetUri the uri that the page is trying to open.
+     * @property onAllow callback to notify that the user wants to open the [targetUri].
+     * @property onDeny callback to notify that the user doesn't want to open the [targetUri].
+     */
+    data class Popup(
+        val targetUri: String,
+        val onAllow: () -> Unit,
+        val onDeny: () -> Unit
+    ) : PromptRequest()
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt
@@ -116,5 +116,11 @@ class PromptRequestTest {
 
         colorRequest.onConfirm("")
         colorRequest.onDismiss()
+
+        val popupRequest = PromptRequest.Popup("http://mozilla.slack.com/", {}, {})
+
+        assertEquals(popupRequest.targetUri, "http://mozilla.slack.com/")
+        popupRequest.onAllow()
+        popupRequest.onDeny()
     }
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ConfirmDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ConfirmDialogFragment.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.app.Dialog
+import android.os.Bundle
+import android.support.v7.app.AlertDialog
+
+internal const val KEY_POSITIVE_BUTTON = "KEY_POSITIVE_BUTTON"
+internal const val KEY_NEGATIVE_BUTTON = "KEY_NEGATIVE_BUTTON"
+
+/**
+ * [android.support.v4.app.DialogFragment] implementation for a confirm dialog.
+ * The user has two possible options, allow the request or
+ * deny it (Positive and Negative buttons]. When the positive button is pressed the
+ * feature.onConfirm function will be called otherwise the feature.onCancel function will be called.
+ */
+internal class ConfirmDialogFragment : PromptDialogFragment() {
+
+    private val positiveButtonText: String by lazy { safeArguments.getString(KEY_POSITIVE_BUTTON)!! }
+    private val negativeButtonText: String by lazy { safeArguments.getString(KEY_NEGATIVE_BUTTON)!! }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireContext())
+            .setCancelable(false)
+            .setTitle(title)
+            .setMessage(message)
+            .setNegativeButton(negativeButtonText) { _, _ ->
+                feature?.onCancel(sessionId)
+            }
+            .setPositiveButton(positiveButtonText) { _, _ ->
+                onPositiveClickAction()
+            }
+        return builder.create()
+    }
+
+    private fun onPositiveClickAction() {
+        feature?.onConfirm(sessionId)
+    }
+
+    companion object {
+        fun newInstance(
+            sessionId: String? = null,
+            title: String,
+            message: String,
+            positiveButtonText: String,
+            negativeButtonText: String
+        ): ConfirmDialogFragment {
+
+            val fragment = ConfirmDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putString(KEY_SESSION_ID, sessionId)
+                putString(KEY_TITLE, title)
+                putString(KEY_MESSAGE, message)
+                putString(KEY_POSITIVE_BUTTON, positiveButtonText)
+                putString(KEY_NEGATIVE_BUTTON, negativeButtonText)
+            }
+
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+}

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -255,6 +255,7 @@ class PromptFeature(
                 is Authentication -> it.onDismiss()
                 is Color -> it.onDismiss()
                 is TextPrompt -> it.onDismiss()
+                is PromptRequest.Popup -> it.onDeny()
             }
             true
         }
@@ -266,8 +267,8 @@ class PromptFeature(
      * @param sessionId that requested to show the dialog.
      * @param value an optional value provided by the dialog as a result of confirming the action.
      */
-    @Suppress("UNCHECKED_CAST")
-    internal fun onConfirm(sessionId: String, value: Any) {
+    @Suppress("UNCHECKED_CAST", "ComplexMethod")
+    internal fun onConfirm(sessionId: String, value: Any? = null) {
         val session = sessionManager.findSessionById(sessionId) ?: return
         session.promptRequest.consume {
             when (it) {
@@ -276,6 +277,7 @@ class PromptFeature(
                 is Alert -> it.onConfirm(value as Boolean)
                 is SingleChoice -> it.onConfirm(value as Choice)
                 is MenuChoice -> it.onConfirm(value as Choice)
+                is PromptRequest.Popup -> it.onAllow()
 
                 is MultipleChoice -> {
                     it.onConfirm(value as Array<Choice>)
@@ -433,6 +435,22 @@ class PromptFeature(
             is PromptRequest.Color -> {
                 with(promptRequest) {
                     ColorPickerDialogFragment.newInstance(session.id, defaultColor)
+                }
+            }
+
+            is PromptRequest.Popup -> {
+                val title = context.getString(R.string.mozac_feature_prompts_popup_dialog_title)
+                val positiveLabel = context.getString(R.string.mozac_feature_prompts_allow)
+                val negativeLabel = context.getString(R.string.mozac_feature_prompts_deny)
+
+                with(promptRequest) {
+                    ConfirmDialogFragment.newInstance(
+                        sessionId = session.id,
+                        title = title,
+                        message = targetUri,
+                        positiveButtonText = positiveLabel,
+                        negativeButtonText = negativeLabel
+                    )
                 }
             }
 

--- a/components/feature/prompts/src/main/res/values/strings.xml
+++ b/components/feature/prompts/src/main/res/values/strings.xml
@@ -42,4 +42,13 @@
 
     <!-- Title of a color picker dialog, this text is shown above a color picker. -->
     <string name="mozac_feature_prompts_choose_a_color">Choose a color</string>
+
+    <!-- Text of a confirm button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_allow">Allow</string>
+
+    <!-- Text of a negative button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_deny">Deny</string>
+
+    <!-- Text of the title of a dialog when a page is requesting to open a new window. -->
+    <string name="mozac_feature_prompts_popup_dialog_title">Prevent this site from opening this pop-up window?</string>
 </resources>

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ConfirmDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ConfirmDialogFragmentTest.kt
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts
+
+import android.content.Context
+import android.content.DialogInterface
+import android.support.v7.app.AlertDialog
+import android.view.ContextThemeWrapper
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ConfirmDialogFragmentTest {
+
+    private val context: Context
+        get() = ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext(),
+            android.support.v7.appcompat.R.style.Theme_AppCompat
+        )
+
+    @Test
+    fun `build dialog`() {
+
+        val fragment = spy(
+            ConfirmDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                "message",
+                "positiveLabel",
+                "negativeLabel"
+            )
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+
+        dialog.show()
+
+        val titleTextView = dialog.findViewById<TextView>(android.support.v7.appcompat.R.id.alertTitle)
+        val messageTextView = dialog.findViewById<TextView>(android.R.id.message)
+
+        assertEquals(fragment.sessionId, "sessionId")
+        assertEquals(fragment.message, "message")
+
+        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        val negativeButton = dialog.getButton(DialogInterface.BUTTON_NEGATIVE)
+
+        assertEquals(titleTextView.text, "title")
+        assertEquals(messageTextView.text, "message")
+        assertEquals(positiveButton.text, "positiveLabel")
+        assertEquals(negativeButton.text, "negativeLabel")
+    }
+
+    @Test
+    fun `clicking on positive button notifies the feature`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            ConfirmDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                "message",
+                "positiveLabel",
+                "negativeLabel"
+            )
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        positiveButton.performClick()
+
+        verify(mockFeature).onConfirm("sessionId")
+    }
+
+    @Test
+    fun `clicking on negative button notifies the feature`() {
+
+        val mockFeature: PromptFeature = mock()
+
+        val fragment = spy(
+            ConfirmDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                "message",
+                "positiveLabel",
+                "negativeLabel"
+            )
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val negativeButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_NEGATIVE)
+        negativeButton.performClick()
+
+        verify(mockFeature).onCancel("sessionId")
+    }
+}

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -860,6 +860,51 @@ class PromptFeatureTest {
         assertTrue(onDismissWasCalled)
     }
 
+    @Test
+    fun `calling onConfirm for a Popup request will consume promptRequest`() {
+        val session = getSelectedSession()
+        var onConfirmWasCalled = false
+
+        val promptRequest = PromptRequest.Popup(
+            "http://www.popuptest.com/",
+            { onConfirmWasCalled = true }
+        ) {}
+
+        stubContext()
+
+        promptFeature.start()
+
+        session.promptRequest = Consumable.from(promptRequest)
+
+        promptFeature.onConfirm(session.id)
+
+        assertTrue(session.promptRequest.isConsumed())
+        assertTrue(onConfirmWasCalled)
+    }
+
+    @Test
+    fun `calling onCancel with a Popup request will consume promptRequest`() {
+        val session = getSelectedSession()
+        var onCancelWasCalled = false
+
+        val promptRequest = PromptRequest.Popup("http://www.popuptest.com/", { }) {
+            onCancelWasCalled = true
+        }
+
+        stubContext()
+
+        promptFeature.start()
+
+        session.promptRequest = Consumable.from(promptRequest)
+
+        promptFeature.onCancel(session.id)
+
+        assertTrue(session.promptRequest.isConsumed())
+        assertTrue(onCancelWasCalled)
+
+        session.promptRequest = Consumable.from(promptRequest)
+    }
+
     private fun getSelectedSession(): Session {
         val session = Session("")
         mockSessionManager.add(session)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,9 @@ permalink: /changelog/
 * **lib-publicsuffixlist**
   * The public suffix list shipping with this component is now updated automatically in the repository every day (if there are changes).
 
+* **feature-prompts**, **browser-engine-gecko***
+  * Added support for [Pop-up windows dialog](https://support.mozilla.org/en-US/kb/pop-blocker-settings-exceptions-troubleshooting#w_what-are-pop-ups).
+
 # 0.39.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.38.0...v0.39.0)


### PR DESCRIPTION
[Demo](https://drive.google.com/file/d/1Dm6dnhfdF5nHkNZyA1gjHNmSFRE32xV7/view?usp=sharing). To test you can use this [site](http://www.popuptest.com/)