### PR TITLE
[glean] 1522160: Rename the baseline category to glean.baseline

### DIFF
--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -4,7 +4,7 @@
 
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
-baseline:
+glean.baseline:
   ## TODO: Some metrics are commented out below until we implement them as part
   ## of 1497894 and its dependent bugs
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -25,7 +25,7 @@ import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
-import mozilla.components.service.glean.metrics.Baseline
+import mozilla.components.service.glean.metrics.GleanBaseline
 import mozilla.components.service.glean.utils.StringUtils
 import mozilla.components.support.base.log.logger.Logger
 import java.io.File
@@ -234,11 +234,11 @@ open class GleanInternalAPI {
         }
 
         // Set the OS type
-        Baseline.os.set("Android")
+        GleanBaseline.os.set("Android")
 
         // Set the OS version
         // https://developer.android.com/reference/android/os/Build.VERSION
-        Baseline.osVersion.set(Build.VERSION.SDK_INT.toString())
+        GleanBaseline.osVersion.set(Build.VERSION.SDK_INT.toString())
 
         // Set the device string
         // https://developer.android.com/reference/android/os/Build
@@ -247,20 +247,20 @@ open class GleanInternalAPI {
         // similar names than we are for a manufacturer to have two devices with the similar names
         // (e.g. Galaxy S6 vs. Galaxy Note 6).
         @Suppress("MagicNumber")
-        Baseline.device.set(
+        GleanBaseline.device.set(
             StringUtils.safeSubstring(Build.MANUFACTURER, 0, 12) +
             '-' +
             StringUtils.safeSubstring(Build.MODEL, 0, 19)
         )
 
         // Set the CPU architecture
-        Baseline.architecture.set(Build.SUPPORTED_ABIS[0])
+        GleanBaseline.architecture.set(Build.SUPPORTED_ABIS[0])
 
         // Set the enabled accessibility services
         getEnabledAccessibilityServices(
             applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
         ) ?.let {
-            Baseline.a11yServices.set(it)
+            GleanBaseline.a11yServices.set(it)
         }
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
@@ -8,7 +8,7 @@ import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.LifecycleObserver
 import android.arch.lifecycle.OnLifecycleEvent
 import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.metrics.Baseline
+import mozilla.components.service.glean.metrics.GleanBaseline
 
 /**
  * Connects process lifecycle events from Android to Glean's handleEvent
@@ -22,7 +22,7 @@ internal class GleanLifecycleObserver : LifecycleObserver {
     fun onEnterBackground() {
         // We're going to background, so store how much time we spent
         // on foreground.
-        Baseline.duration.stopAndSum()
+        GleanBaseline.duration.stopAndSum()
         Glean.handleEvent(Glean.PingEvent.Background)
     }
 
@@ -39,6 +39,6 @@ internal class GleanLifecycleObserver : LifecycleObserver {
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.
-        Baseline.duration.start()
+        GleanBaseline.duration.start()
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -220,10 +220,10 @@ class GleanTest {
             checkPingSchema(baselineJson)
 
             val expectedBaselineStringMetrics = arrayOf(
-                "baseline.os",
-                "baseline.os_version",
-                "baseline.device",
-                "baseline.architecture"
+                "glean.baseline.os",
+                "glean.baseline.os_version",
+                "glean.baseline.device",
+                "glean.baseline.architecture"
             )
             val baselineMetricsObject = baselineJson.getJSONObject("metrics")!!
             val baselineStringMetrics = baselineMetricsObject.getJSONObject("string")!!
@@ -234,7 +234,7 @@ class GleanTest {
 
             val baselineTimespanMetrics = baselineMetricsObject.getJSONObject("timespan")!!
             assertEquals(1, baselineTimespanMetrics.length())
-            assertNotNull(baselineTimespanMetrics.get("baseline.duration"))
+            assertNotNull(baselineTimespanMetrics.get("glean.baseline.duration"))
         } finally {
             server.shutdown()
             lifecycleRegistry.removeObserver(gleanLifecycleObserver)


### PR DESCRIPTION
This is just a simple rename of metrics in the category `baseline` to `glean.baseline` (to make it clear these are internal, reserved metrics).