### PR TITLE
[glean] 1522160: Enforce the use of the glean. category only for internal use

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -4,7 +4,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-String GLEAN_PARSER_VERSION = "0.10.0"
+String GLEAN_PARSER_VERSION = "0.11.0"
 
 /* This script runs a given Python module as a "main" module, like
  * `python -m module`. However, it first checks that the installed
@@ -84,6 +84,13 @@ ext.gleanGenerateMetricsAPI = {
             args "-s"
             args "namespace=$namespace"
             args "$projectDir/metrics.yaml"
+
+            // If we're building the Glean library itself (rather than an
+            // application using Glean) pass the --allow-reserved flag so we can
+            // use metrics in the "glean..." category
+            if (project.name == 'service-glean') {
+                args "--allow-reserved"
+            }
 
             // Only show the output if something went wrong.
             ignoreExitValue = true


### PR DESCRIPTION
This is the last part of 1522160.

Through the changes to glean_parser [here](https://github.com/mozilla/glean_parser/pull/27), this enforces that categories starting with `glean.` can only be used internally.  This passes the special argument `--allow-reserved` only when then Glean library itself is being built, not when glean is being imported as a library into another library or application.
