### PR TITLE
Closes #472: Register view bound observer once view is attached

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
@@ -39,7 +39,8 @@ interface Observable<T> {
     /**
      * Registers an observer to get notified about changes.
      *
-     * The observer will automatically unsubscribe if the provided view gets detached.
+     * The observer will only be notified if the view is attached and will be unregistered/
+     * registered if the attached state changes.
      *
      * @param observer the observer to register.
      * @param view the view the provided observer is bound to.

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -46,12 +46,6 @@ class ObserverRegistry<T> : Observable<T> {
     }
 
     override fun register(observer: T, view: View) {
-        if (!view.isAttachedToWindow) {
-            return
-        }
-
-        register(observer)
-
         val viewObserver = ViewBoundObserver(
                 view,
                 registry = this,
@@ -60,6 +54,10 @@ class ObserverRegistry<T> : Observable<T> {
         viewObservers[observer] = viewObserver
 
         view.addOnAttachStateChangeListener(viewObserver)
+
+        if (view.isAttachedToWindow) {
+            register(observer)
+        }
     }
 
     override fun unregister(observer: T) {
@@ -161,6 +159,8 @@ class ObserverRegistry<T> : Observable<T> {
             view.removeOnAttachStateChangeListener(this)
         }
 
-        override fun onViewAttachedToWindow(view: View) = Unit
+        override fun onViewAttachedToWindow(view: View) {
+            registry.register(observer)
+        }
     }
 }

--- a/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
@@ -234,6 +234,33 @@ class ObserverRegistryTest {
     }
 
     @Test
+    fun `observer will get added once view is attached`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val view = View(RuntimeEnvironment.application)
+
+        val registry = ObserverRegistry<TestObserver>()
+        val observer = TestObserver()
+
+        assertFalse(view.isAttachedToWindow)
+        registry.register(observer, view)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertFalse(observer.notified)
+
+        activity.windowManager.addView(view, WindowManager.LayoutParams(100, 100))
+        assertTrue(view.isAttachedToWindow)
+
+        registry.notifyObservers {
+            somethingChanged()
+        }
+
+        assertTrue(observer.notified)
+    }
+
+    @Test
     fun `observer will get unregistered if view gets detached`() {
         val activity = Robolectric.buildActivity(Activity::class.java).create().get()
         val view = View(RuntimeEnvironment.application)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

@pocmo came across this issue and thought about a third way this could work (other than throwing or always subscribing). Basically, binding an observer to a view makes it dependent on the attached state. So, it only observes when the view, it is bound to, is attached. I think this would have solved the problem you ran into at the time? Because once the view was attached you would have received notifications.
