### PR TITLE
Update version link in components guide [ci skip]

### DIFF
--- a/docs/contribute/components_inside_app.md
+++ b/docs/contribute/components_inside_app.md
@@ -22,7 +22,7 @@ Even if you are able to reproduce the scenario *inside* the repository you may s
 
 #### Setup version number
 
-In the *android-components* repository update the version number [in the configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt#L7) so that the app will be required to "download" this new version. Try to avoid picking a version number that was or will be officially released. Otherwise you may "pollute" your gradle cache with unofficial releases. To follow [the Maven convention](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version) you may want to use a `-SNAPSHOT` suffix.
+In the *android-components* repository update the version number [in the configuration](https://github.com/mozilla-mobile/android-components/blob/master/.buildconfig.yml#L1) so that the app will be required to "download" this new version. Try to avoid picking a version number that was or will be officially released. Otherwise you may "pollute" your gradle cache with unofficial releases. To follow [the Maven convention](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version) you may want to use a `-SNAPSHOT` suffix.
 
 #### Publish to local maven repository
 


### PR DESCRIPTION
We've moved the location of where to update the android components version - let's update the docs!