### PR TITLE
Closes #1840: Add menu and security icon color attributes

### DIFF
--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     implementation project(':browser-menu')
     implementation project(':ui-icons')
+    implementation project(':ui-colors')
     implementation project(':support-ktx')
 
     implementation Dependencies.support_appcompat

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -59,9 +59,9 @@ class BrowserToolbar @JvmOverloads constructor(
      * Set/Get whether a site security icon (usually a lock or globe icon) should be next to the URL.
      */
     var displaySiteSecurityIcon: Boolean
-        get() = displayToolbar.iconView.isVisible()
+        get() = displayToolbar.siteSecurityIconView.isVisible()
         set(value) {
-            displayToolbar.iconView.visibility = if (value) View.VISIBLE else View.GONE
+            displayToolbar.siteSecurityIconView.visibility = if (value) View.VISIBLE else View.GONE
         }
 
     /**
@@ -208,7 +208,7 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     init {
-        context.obtainStyledAttributes(attrs, R.styleable.BrowserToolbar, defStyleAttr, 0).apply {
+        context.obtainStyledAttributes(attrs, R.styleable.BrowserToolbar, defStyleAttr, 0).run {
             attrs?.let {
                 hintColor = getColor(
                     R.styleable.BrowserToolbar_browserToolbarHintColor,
@@ -222,6 +222,15 @@ class BrowserToolbar @JvmOverloads constructor(
                     R.styleable.BrowserToolbar_browserToolbarTextSize,
                     textSize
                 ) / resources.displayMetrics.density
+                val inSecure = getColor(
+                    R.styleable.BrowserToolbar_browserToolbarInsecureColor,
+                    displayToolbar.securityIconColor.first
+                )
+                val secure = getColor(
+                    R.styleable.BrowserToolbar_browserToolbarSecureColor,
+                    displayToolbar.securityIconColor.second
+                )
+                displayToolbar.securityIconColor = Pair(inSecure, secure)
             }
             recycle()
         }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -222,6 +222,10 @@ class BrowserToolbar @JvmOverloads constructor(
                     R.styleable.BrowserToolbar_browserToolbarTextSize,
                     textSize
                 ) / resources.displayMetrics.density
+                displayToolbar.menuViewColor = getColor(
+                    R.styleable.BrowserToolbar_browserToolbarMenuColor,
+                    displayToolbar.menuViewColor
+                )
                 val inSecure = getColor(
                     R.styleable.BrowserToolbar_browserToolbarInsecureColor,
                     displayToolbar.securityIconColor.first

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -161,6 +161,12 @@ internal class DisplayToolbar(
 
     internal var securityIconColor = Pair(defaultColor, defaultColor)
 
+    internal var menuViewColor = defaultColor
+        set(value) {
+            field = value
+            menuView.setColorFilter(value)
+        }
+
     init {
         addView(siteSecurityIconView)
         addView(urlView)

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -10,5 +10,6 @@
     <attr name="browserToolbarTextSize" format="dimension"/>
     <attr name="browserToolbarSecureColor" format="color"/>
     <attr name="browserToolbarInsecureColor" format="color"/>
+    <attr name="browserToolbarMenuColor" format="color"/>
   </declare-styleable>
 </resources>

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -8,5 +8,7 @@
     <attr name="browserToolbarHintColor" format="color"/>
     <attr name="browserToolbarTextColor" format="color"/>
     <attr name="browserToolbarTextSize" format="dimension"/>
+    <attr name="browserToolbarSecureColor" format="color"/>
+    <attr name="browserToolbarInsecureColor" format="color"/>
   </declare-styleable>
 </resources>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -648,13 +648,13 @@ class BrowserToolbarTest {
     @Test
     fun `displaySiteSecurityIcon getter and setter`() {
         val toolbar = BrowserToolbar(RuntimeEnvironment.application)
-        assertEquals(toolbar.displayToolbar.iconView.isVisible(), toolbar.displaySiteSecurityIcon)
+        assertEquals(toolbar.displayToolbar.siteSecurityIconView.isVisible(), toolbar.displaySiteSecurityIcon)
 
         toolbar.displaySiteSecurityIcon = false
-        assertEquals(View.GONE, toolbar.displayToolbar.iconView.visibility)
+        assertEquals(View.GONE, toolbar.displayToolbar.siteSecurityIconView.visibility)
 
         toolbar.displaySiteSecurityIcon = true
-        assertEquals(View.VISIBLE, toolbar.displayToolbar.iconView.visibility)
+        assertEquals(View.VISIBLE, toolbar.displayToolbar.siteSecurityIconView.visibility)
     }
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -19,7 +19,7 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
 import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.support.test.mock
-import mozilla.components.ui.icons.R
+import mozilla.components.browser.toolbar.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -34,6 +34,7 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
@@ -564,7 +565,7 @@ class DisplayToolbarTest {
 
         val menuView = extractMenuView(displayToolbar)
         val browserActionView = extractActionView(displayToolbar, "Tabs")!!
-        val iconView = displayToolbar.iconView
+        val iconView = displayToolbar.siteSecurityIconView
         val urlView = displayToolbar.urlView
 
         val viewRect = Rect(view.left, view.top, view.right, view.bottom)
@@ -611,19 +612,30 @@ class DisplayToolbarTest {
     @Test
     fun `iconView changes image resource when site security changes`() {
         val toolbar = mock(BrowserToolbar::class.java)
-        val displayToolbar = DisplayToolbar(context, toolbar)
-        var shadowDrawable = shadowOf(displayToolbar.iconView.drawable)
+        val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
+        var shadowDrawable = shadowOf(displayToolbar.siteSecurityIconView.drawable)
         assertEquals(R.drawable.mozac_ic_globe, shadowDrawable.createdFromResId)
 
         displayToolbar.setSiteSecurity(SiteSecurity.SECURE)
 
-        shadowDrawable = shadowOf(displayToolbar.iconView.drawable)
+        shadowDrawable = shadowOf(displayToolbar.siteSecurityIconView.drawable)
         assertEquals(R.drawable.mozac_ic_lock, shadowDrawable.createdFromResId)
 
         displayToolbar.setSiteSecurity(SiteSecurity.INSECURE)
 
-        shadowDrawable = shadowOf(displayToolbar.iconView.drawable)
+        shadowDrawable = shadowOf(displayToolbar.siteSecurityIconView.drawable)
         assertEquals(R.drawable.mozac_ic_globe, shadowDrawable.createdFromResId)
+    }
+
+    @Test
+    fun `iconView changes image color filter on update`() {
+        val toolbar = mock(BrowserToolbar::class.java)
+        val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
+
+        displayToolbar.securityIconColor = Pair(R.color.photonBlue40, R.color.photonBlue40)
+
+        assertEquals(R.color.photonBlue40, displayToolbar.securityIconColor.first)
+        assertEquals(R.color.photonBlue40, displayToolbar.securityIconColor.second)
     }
 
     companion object {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,19 @@ permalink: /changelog/
 * **browser-engine-gecko-nightly**
   * Tweaked `NestedGeckoView` to "stick" to `AppBar` in nested scroll, like other Android apps. This is possible after a [fix](https://bugzilla.mozilla.org/show_bug.cgi?id=1515774) in APZ gesture detection.
 
+* **feature-browser**
+  * Added `BrowserToolbar` attributes to color the menu.
+  ```xml
+  <mozilla.components.browser.toolbar.BrowserToolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="56dp"
+      android:background="#aaaaaa"
+      app:browserToolbarMenuColor="@color/photonBlue50"
+      app:browserToolbarInsecureColor="@color/photonRed50"
+      app:browserToolbarSecureColor="@color/photonGreen50" />
+  ```
+
 * **feature-contextmenu**
   * Fixed Context Menus feature to work with Custom Tabs by passing in the session ID when applicable.
 

--- a/samples/browser/src/main/res/layout/fragment_browser.xml
+++ b/samples/browser/src/main/res/layout/fragment_browser.xml
@@ -19,7 +19,8 @@
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
-                android:background="#aaaaaa"/>
+                android:background="#aaaaaa"
+                app:browserToolbarSecureColor="@color/photonGreen50" />
 
         <mozilla.components.feature.findinpage.view.FindInPageBar
                 android:id="@+id/findInPage"


### PR DESCRIPTION
I've added some attributes to the `BrowserToolbar` to be able to colour the attributes.

The diff is a bit messy because I renamed the security icon value: `iconView` -> `siteSecurityIconView`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: N/A ~The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
