### PR TITLE
Closes #1880: Clear download consumable when permission is denied

### DIFF
--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -17,11 +17,14 @@ import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.mock
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
@@ -196,6 +199,20 @@ class DownloadsFeatureTest {
         startDownload()
 
         verify(mockDialog, times(0)).show(mockFragmentManager, FRAGMENT_TAG)
+    }
+
+    @Test
+    fun `download is cleared when permissions denied`() {
+        feature.start()
+        feature.onPermissionsDenied()
+        assertNull(mockSessionManager.selectedSession)
+
+        val download = startDownload()
+        feature.onPermissionsDenied()
+
+        verify(mockDownloadManager, never()).download(download)
+        assertNotNull(mockSessionManager.selectedSession)
+        assertTrue(mockSessionManager.selectedSession!!.download.isConsumed())
     }
 
     private fun startDownload(): Download {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.downloads
 import android.Manifest.permission.INTERNET
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.support.v4.app.FragmentManager
+import android.support.v4.content.PermissionChecker
 import org.junit.Assert.assertTrue
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
@@ -121,9 +122,7 @@ class DownloadsFeatureTest {
     fun `when a download came and permissions aren't granted needToRequestPermissions must be called `() {
         var needToRequestPermissionCalled = false
 
-        feature.onNeedToRequestPermissions = { _, _ ->
-            needToRequestPermissionCalled = true
-        }
+        feature.onNeedToRequestPermissions = { needToRequestPermissionCalled = true }
 
         feature.start()
         val download = startDownload()
@@ -136,9 +135,7 @@ class DownloadsFeatureTest {
     fun `when a download came and permissions aren't granted needToRequestPermissions and after onPermissionsGranted the download must be triggered`() {
         var needToRequestPermissionCalled = false
 
-        feature.onNeedToRequestPermissions = { _, _ ->
-            needToRequestPermissionCalled = true
-        }
+        feature.onNeedToRequestPermissions = { needToRequestPermissionCalled = true }
 
         feature.start()
 
@@ -149,7 +146,8 @@ class DownloadsFeatureTest {
 
         grantPermissions()
 
-        feature.onPermissionsGranted()
+        feature.onPermissionsResult(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
+                intArrayOf(PermissionChecker.PERMISSION_GRANTED, PermissionChecker.PERMISSION_GRANTED))
         verify(mockDownloadManager).download(download)
     }
 
@@ -204,11 +202,13 @@ class DownloadsFeatureTest {
     @Test
     fun `download is cleared when permissions denied`() {
         feature.start()
-        feature.onPermissionsDenied()
+        feature.onPermissionsResult(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
+                intArrayOf(PermissionChecker.PERMISSION_GRANTED, PermissionChecker.PERMISSION_GRANTED))
         assertNull(mockSessionManager.selectedSession)
 
         val download = startDownload()
-        feature.onPermissionsDenied()
+        feature.onPermissionsResult(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
+                intArrayOf(PermissionChecker.PERMISSION_GRANTED, PermissionChecker.PERMISSION_DENIED))
 
         verify(mockDownloadManager, never()).download(download)
         assertNotNull(mockSessionManager.selectedSession)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@ permalink: /changelog/
 * **feature-customtabs**
   * Added a temporary workaround for Custom Tab intents not being recognized when using the Jetifier tool.
 
+* **feature-downloads**
+  * Introduced a new `onPermissionsDenied` method, which similar to `onPermissionsGranted`, should be invoked in response to permission requests. If the requested permissions were denied the feature will clear the pending download.
+
 # 0.40.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.39.0...v0.40.0)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,26 @@ permalink: /changelog/
   * Added a temporary workaround for Custom Tab intents not being recognized when using the Jetifier tool.
 
 * **feature-downloads**
-  * Introduced a new `onPermissionsDenied` method, which similar to `onPermissionsGranted`, should be invoked in response to permission requests. If the requested permissions were denied the feature will clear the pending download.
+  * ⚠️ **This is a breaking API change!**
+  * The required permissions are now passed to the `onNeedToRequestPermissions` callback.
+  ```kotlin
+  downloadsFeature = DownloadsFeature(
+      requireContext(),
+      sessionManager = components.sessionManager,
+      fragmentManager = childFragmentManager,
+      onNeedToRequestPermissions = { permissions ->
+          requestPermissions(permissions, REQUEST_CODE_DOWNLOAD_PERMISSIONS)
+      }
+  )
+  ```
+  * Removed the `onPermissionsGranted` method in favour of `onPermissionsResult` which handles both granted and denied permissions. This method should be invoked from `onRequestPermissionsResult`:
+  ```kotlin
+   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+      when (requestCode) {
+          REQUEST_CODE_DOWNLOAD_PERMISSIONS -> downloadsFeature.onPermissionsResult(permissions, grantResults)
+      }        
+    }
+  ```
 
 # 0.40.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -34,7 +34,6 @@ import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
-import mozilla.components.support.ktx.android.content.isPermissionGranted
 import org.mozilla.samples.browser.ext.components
 
 class BrowserFragment : Fragment(), BackHandler {
@@ -190,8 +189,6 @@ class BrowserFragment : Fragment(), BackHandler {
         }
     }
 
-    private fun isStoragePermissionAvailable() = requireContext().isPermissionGranted(WRITE_EXTERNAL_STORAGE)
-
     companion object {
         private const val SESSION_ID = "session_id"
         private const val PERMISSION_WRITE_STORAGE_REQUEST = 1
@@ -206,10 +203,10 @@ class BrowserFragment : Fragment(), BackHandler {
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         when (requestCode) {
             PERMISSION_WRITE_STORAGE_REQUEST -> {
-                if ((grantResults.isNotEmpty() && grantResults[0] == PERMISSION_GRANTED) &&
-                    isStoragePermissionAvailable()) {
-                    // permission was granted, yay!
+                if ((grantResults.isNotEmpty() && grantResults[0] == PERMISSION_GRANTED)) {
                     downloadsFeature.onPermissionsGranted()
+                } else {
+                    downloadsFeature.onPermissionsDenied()
                 }
             }
         }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -4,9 +4,7 @@
 
 package org.mozilla.samples.browser
 
-import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.content.Intent
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Bundle
 import android.support.design.widget.AppBarLayout
 import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
@@ -87,12 +85,11 @@ class BrowserFragment : Fragment(), BackHandler {
         downloadsFeature = DownloadsFeature(
             requireContext(),
             sessionManager = components.sessionManager,
-            fragmentManager = childFragmentManager
+            fragmentManager = childFragmentManager,
+            onNeedToRequestPermissions = { permissions ->
+                requestPermissions(permissions, REQUEST_CODE_DOWNLOAD_PERMISSIONS)
+            }
         )
-
-        downloadsFeature.onNeedToRequestPermissions = { _, _ ->
-            requestPermissions(arrayOf(WRITE_EXTERNAL_STORAGE), PERMISSION_WRITE_STORAGE_REQUEST)
-        }
 
         scrollFeature = CoordinateScrollingFeature(components.sessionManager, layout.engineView, layout.toolbar)
 
@@ -191,7 +188,7 @@ class BrowserFragment : Fragment(), BackHandler {
 
     companion object {
         private const val SESSION_ID = "session_id"
-        private const val PERMISSION_WRITE_STORAGE_REQUEST = 1
+        private const val REQUEST_CODE_DOWNLOAD_PERMISSIONS = 1
 
         fun create(sessionId: String? = null): BrowserFragment = BrowserFragment().apply {
             arguments = Bundle().apply {
@@ -202,13 +199,7 @@ class BrowserFragment : Fragment(), BackHandler {
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         when (requestCode) {
-            PERMISSION_WRITE_STORAGE_REQUEST -> {
-                if ((grantResults.isNotEmpty() && grantResults[0] == PERMISSION_GRANTED)) {
-                    downloadsFeature.onPermissionsGranted()
-                } else {
-                    downloadsFeature.onPermissionsDenied()
-                }
-            }
+            REQUEST_CODE_DOWNLOAD_PERMISSIONS -> downloadsFeature.onPermissionsResult(permissions, grantResults)
         }
         promptFeature.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }


### PR DESCRIPTION
@pocmo Maybe for tomorrow's release? We could do that in the app but it's nicer to have a symmetric API.  

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
