### PR TITLE
Closes #1872: Make LoadUrlUseCase in ToolbarFeature customizable

### DIFF
--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -144,7 +144,7 @@ class SessionUseCasesTest {
         `when`(sessionManager.selectedSession).thenReturn(null)
         `when`(sessionManager.getOrCreateEngineSession(any())).thenReturn(mock())
 
-        val loadUseCase = SessionUseCases.LoadUrlUseCase(sessionManager) { url ->
+        val loadUseCase = SessionUseCases.DefaultLoadUrlUseCase(sessionManager) { url ->
             sessionCreatedForUrl = url
             Session(url).also { createdSession = it }
         }

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -25,6 +25,7 @@ android {
 
 dependencies {
     api project(':browser-session')
+    api project(':feature-session')
     implementation project(':concept-engine')
     implementation project(':concept-tabstray')
     implementation project(':concept-toolbar')

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.tabs
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.session.SessionUseCases.LoadUrlUseCase
 
 /**
  * Contains use cases related to the tabs feature.
@@ -42,13 +43,24 @@ class TabsUseCases(
 
     class AddNewTabUseCase internal constructor(
         private val sessionManager: SessionManager
-    ) {
+    ) : LoadUrlUseCase {
+
         /**
-         * Add a new tab and load the provided URL.
+         * Adds a new tab and loads the provided URL.
+         *
+         * @param url The URL to be loaded in the new tab.
+         */
+        override fun invoke(url: String) {
+            this.invoke(url, true, true, null)
+        }
+
+        /**
+         * Adds a new tab and loads the provided URL.
          *
          * @param url The URL to be loaded in the new tab.
          * @param selectTab True (default) if the new tab should be selected immediately.
          * @param startLoading True (default) if the new tab should start loading immediately.
+         * @param parent the parent session to use for the newly created session.
          */
         fun invoke(
             url: String,
@@ -69,12 +81,24 @@ class TabsUseCases(
 
     class AddNewPrivateTabUseCase internal constructor(
         private val sessionManager: SessionManager
-    ) {
+    ) : LoadUrlUseCase {
+
         /**
-         * Add a new private tab and load the provided URL.
+         * Adds a new private tab and loads the provided URL.
+         *
+         * @param url The URL to be loaded in the new private tab.
+         */
+        override fun invoke(url: String) {
+            this.invoke(url, true, true, null)
+        }
+
+        /**
+         * Adds a new private tab and loads the provided URL.
          *
          * @param url The URL to be loaded in the new tab.
          * @param selectTab True (default) if the new tab should be selected immediately.
+         * @param startLoading True (default) if the new tab should start loading immediately.
+         * @param parent the parent session to use for the newly created session.
          */
         fun invoke(
             url: String,

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.toolbar
+
+import mozilla.components.concept.toolbar.AutocompleteDelegate
+import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.feature.session.SessionUseCases
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ToolbarInteractorTest {
+
+    class TestToolbar : Toolbar {
+        override var url: String = ""
+        override var siteSecure: Toolbar.SiteSecurity = Toolbar.SiteSecurity.INSECURE
+
+        override fun setSearchTerms(searchTerms: String) {
+            fail()
+        }
+
+        override fun displayProgress(progress: Int) {
+            fail()
+        }
+
+        override fun onBackPressed(): Boolean {
+            fail()
+            return false
+        }
+
+        override fun setOnUrlCommitListener(listener: (String) -> Unit) {
+            listener("https://mozilla.org")
+        }
+
+        override fun setAutocompleteListener(filter: (String, AutocompleteDelegate) -> Unit) {
+            fail()
+        }
+
+        override fun addBrowserAction(action: Toolbar.Action) {
+            fail()
+        }
+
+        override fun addPageAction(action: Toolbar.Action) {
+            fail()
+        }
+
+        override fun addNavigationAction(action: Toolbar.Action) {
+            fail()
+        }
+
+        override fun setOnEditListener(listener: Toolbar.OnEditListener) {
+            fail()
+        }
+
+        override fun displayMode() {
+            fail()
+        }
+
+        override fun editMode() {
+            fail()
+        }
+    }
+    @Test
+    fun `provide custom use case for loading url`() {
+        var useCaseInvokedWithUrl = ""
+        val loadUrlUseCase = object : SessionUseCases.LoadUrlUseCase {
+            override fun invoke(url: String) {
+                useCaseInvokedWithUrl = url
+            }
+        }
+
+        val toolbarInteractor = spy(ToolbarInteractor(TestToolbar(), loadUrlUseCase))
+        toolbarInteractor.start()
+
+        assertEquals("https://mozilla.org", useCaseInvokedWithUrl)
+    }
+}


### PR DESCRIPTION
@pocmo putting this up to continue our discussion. Introducing an interface for `LoadUrlUseCase` might just be good enough. I've tested the toolbar with the `DefaultLoadUrlUseCase` and the `AddNewTabUseCase` as well as a custom one.

Since most features already depend on feature-session, having feature-tabs depend on it too doesn't seem that bad. This also shouldn't break API. What do you think?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
