### PR TITLE
[glean] Remove references to the missing timezone field

### DIFF
--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -13,6 +13,5 @@ the following fields:
 | `device_manufacturer` | String | The manufacturer of the device |
 | `device_model` | String | The model name of the device |
 | `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
-| `timezone` | Number | The timezone of the device, as an offset from UTC |
 | `a11y_services` | StringList | List of the ids of the accessibility services enabled on the device |
 | `locale` | String | The locale of the application |

--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -5,9 +5,6 @@
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 glean.baseline:
-  ## TODO: Some metrics are commented out below until we implement them as part
-  ## of 1497894 and its dependent bugs
-
   duration:
     type: timespan
     description: |
@@ -91,17 +88,6 @@ glean.baseline:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
-
-  # timezone:
-  #   type: number
-  #   description: |
-  #     The timezone of the device, in offset from UTC.
-  #   send_in_pings:
-  #     - baseline
-  #   bugs:
-  #     - 1497894
-  #   notification_emails:
-  #     - telemetry-client-dev@mozilla.com
 
   a11y_services:
     type: string_list


### PR DESCRIPTION
In bug 1518165 it was decided that the timezone information in `start_time`, `end_time` and the date header is sufficient for analyses and that we won't need an additional timezone field. This gets rid of the vestigial comments.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
