### PR TITLE
Closes #1890: PromptFeature - Allow app to specify permission request code

### DIFF
--- a/components/feature/prompts/README.md
+++ b/components/feature/prompts/README.md
@@ -14,15 +14,13 @@ implementation "org.mozilla.components:feature-prompts:{latest-version}"
 ### PromptFeature
 
   ```kotlin
-
-  val onNeedToRequestPermissions : ( Session, Array<String>, Int) -> Unit = {
-    session, permissions, requestCode ->
+  val onNeedToRequestPermissions : (Array<String>) -> Unit = { permissions ->
     /* You are in charge of triggering the request for the permissions needed,
      * this way you can control, when you request the permissions,
      * in case that you want to show an informative dialog,
      * to clarify the use of these permissions.
      */
-    this.requestPermissions(permissions, requestCode)
+    this.requestPermissions(permissions, MY_PROMPT_PERMISSION_REQUEST_CODE)
   }
 
   val promptFeature = PromptFeature(fragment = this,
@@ -31,14 +29,14 @@ implementation "org.mozilla.components:feature-prompts:{latest-version}"
     onNeedToRequestPermissions = onNeedToRequestPermissions
   )
 
-  //It will start listing for new prompt requests for web content.
+  // It will start listing for new prompt requests from web content.
   promptFeature.start()
 
-  //It will stop listing for future prompt requests for web content.
+  // It will stop listing for prompt requests from web content.
   promptFeature.stop()
 
-  /* There some requests that are not handled with dialogs, instead they are delegated to other apps
-   * to perform the request, an example is a file picker request, that delegates to the OS file picker.
+  /* There are some requests that are not handled with dialogs, instead they are delegated to other apps
+   * to perform the request e.g a file picker request, which delegates to the OS file picker.
    * For this reason, you have to forward the results of these requests to the prompt feature by overriding,
    * onActivityResult in your Activity or Fragment and forward its calls to promptFeature.onActivityResult.
    */
@@ -47,12 +45,14 @@ implementation "org.mozilla.components:feature-prompts:{latest-version}"
   }
 
   /* Additionally, there are requests that need to have some runtime permission before they can be performed,
-   * like file pickers request that need access to read the selected files. As onActivityResult you need to override
-   * onRequestPermissionsResult in your Activity or Fragment and forward its
-   * calls to promptFeature.onRequestPermissionsResult.
+   * like file pickers request that need access to read the selected files. You need to override
+   * onRequestPermissionsResult in your Activity or Fragment and forward the results to
+   * promptFeature.PermissionsResult.
    */
   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
-    promptFeature.onActivityResult(requestCode, resultCode, data)
+    when (requestCode) {        
+        MY_PROMPT_PERMISSION_REQUEST_CODE -> promptFeature.onPermissionsResult(permissions, grantResults)
+    }
   }
   ```
 

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -40,31 +40,38 @@ import java.util.Date
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal const val FRAGMENT_TAG = "mozac_feature_prompt_dialog"
 
-typealias OnNeedToRequestPermissions = (session: Session, permissions: Array<String>, requestCode: Int) -> Unit
+typealias OnNeedToRequestPermissions = (permissions: Array<String>) -> Unit
 
 /**
- * Feature for displaying native dialogs for html elements like:
- * input type date,file,time,color, option, menu, authentication, confirmation and other alerts.
+ * Feature for displaying native dialogs for html elements like: input type
+ * date, file, time, color, option, menu, authentication, confirmation and alerts.
  *
- * There are some requests that are not handled with dialogs instead with intents like file choosers and others.
- * For this reason, you have to keep the feature aware of flow of requesting data from other apps, overriding
- * onActivityResult on your [Activity] or [Fragment] and forward its calls to [onActivityResult].
+ * There are some requests that are handled with intents instead of dialogs,
+ * like file choosers and others. For this reason, you have to keep the feature
+ * aware of the flow of requesting data from other apps, overriding
+ * onActivityResult in your [Activity] or [Fragment] and forward its calls
+ * to [onActivityResult].
  *
- * This feature will subscribe to the currently selected [Session] and display a suitable native dialog based on
- * [Session.Observer.onPromptRequested] events. Once the dialog is closed or the user selects an item from the dialog
- * the related [PromptFeature] will be consumed.
+ * This feature will subscribe to the currently selected [Session] and display
+ * a suitable native dialog based on [Session.Observer.onPromptRequested] events.
+ * Once the dialog is closed or the user selects an item from the dialog
+ * the related [PromptRequest] will be consumed.
  *
- * @property activity The [Activity] host of this feature, if the host is a [Fragment], just ignore this parameter
- * and pass a [fragment] parameter. Never [fragment] and [activity] should be both null or you will get
- * an [IllegalStateException].
- * @property fragment The [Fragment] host of this feature, if the host is an [Activity], just ignore this parameter
- * and pass [activity] parameter. Never [fragment] and [activity] should be both null or you will get
- * an [IllegalStateException].
- * @property sessionManager The [Fragment] instance in order to subscribe to the selected [Session].
- * @property fragmentManager The [FragmentManager] to be used when displaying a dialog (fragment).
- * @property onNeedToRequestPermissions A callback to let you know that there are some permissions that need to be
- * granted before performing a [PromptRequest]. You are in change of requesting these permissions and notify the feature
- * calling [onRequestPermissionsResult] method.
+ * @property activity The [Activity] which hosts this feature. If hosted by a
+ * [Fragment], this parameter can be ignored. Note that an
+ * [IllegalStateException] will be thrown if neither an active nor a fragment
+ * is specified.
+ * @property fragment The [Fragment] which hosts this feature. If hosted by an
+ * [Activity], this parameter can be ignored. Note that an
+ * [IllegalStateException] will be thrown if neither an active nor a fragment
+ * is specified.
+ * @property sessionManager The [SessionManager] instance in order to subscribe
+ * to the selected [Session].
+ * @property fragmentManager The [FragmentManager] to be used when displaying
+ * a dialog (fragment).
+ * @property onNeedToRequestPermissions a callback invoked when permissions
+ * need to be requested before a prompt (e.g. a file picker) can be displayed.
+ * Once the request is completed, [onPermissionsResult] needs to be invoked.
  */
 
 @Suppress("TooManyFunctions")
@@ -91,7 +98,8 @@ class PromptFeature(
     private val context get() = activity ?: requireNotNull(fragment).requireContext()
 
     /**
-     * Start observing the selected session and when needed show native dialogs.
+     * Starts observing the selected session to listen for prompt requests
+     * and displays a dialog when needed.
      */
     override fun start() {
         observer.observeSelected()
@@ -105,21 +113,21 @@ class PromptFeature(
     }
 
     /**
-     * Stop observing the selected session incoming onPromptRequested events.
+     * Stops observing the selected session for incoming prompt requests.
      */
     override fun stop() {
         observer.stop()
     }
 
     /**
-     * Forward the calls to onActivityResult on your [Activity] or [Fragment], to let the feature know, the results
-     * of intents for handling prompt requests, that need to be performed by other apps like file chooser requests.
+     * Notifies the feature of intent results for prompt requests handled by
+     * other apps like file chooser requests.
      *
      * @param requestCode The code of the app that requested the intent.
      * @param intent The result of the request.
      */
     fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        if (requestCode == FILE_PICKER_REQUEST) {
+        if (requestCode == FILE_PICKER_ACTIVITY_REQUEST_CODE) {
             sessionManager.selectedSession?.promptRequest?.consume {
 
                 val request = it as File
@@ -135,30 +143,28 @@ class PromptFeature(
     }
 
     /**
-     * Forward the calls to onRequestPermissionsResult on your [Activity] or [Fragment], to let the feature know,
-     * the results for the requested permissions that are needed for performing a [PromptRequest].
+     * Notifies the feature that the permissions request was completed. It will then
+     * either process or dismiss the prompt request.
      *
-     * @param requestCode The code of the app that requested the intent.
      * @param permissions List of permission requested.
+     * @param grantResults The grant results for the corresponding permissions
      * @see [onNeedToRequestPermissions].
      */
-    fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
-        when (requestCode) {
-            FILE_PICKER_REQUEST -> {
-                if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
-                    onPermissionsGranted()
-                } else {
-                    onPermissionsDeny()
-                }
-            }
+    fun onPermissionsResult(permissions: Array<String>, grantResults: IntArray) {
+        if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+            onPermissionsGranted()
+        } else {
+            onPermissionsDenied()
         }
     }
 
     /**
-     * Use in conjunction with [onNeedToRequestPermissions], to notify the feature that all the required permissions
-     * have been granted, and it can perform the pending [PromptRequest] in the selected session.
+     * Used in conjunction with [onNeedToRequestPermissions], to notify the feature
+     * that all the required permissions have been granted, and the pending [PromptRequest]
+     * can be performed.
      *
-     * If the required permission has not been completely granted [onNeedToRequestPermissions] will be called.
+     * If the required permission has not been granted
+     * [onNeedToRequestPermissions] will be called.
      */
     @VisibleForTesting(otherwise = PRIVATE)
     internal fun onPermissionsGranted() {
@@ -171,11 +177,11 @@ class PromptFeature(
     }
 
     /**
-     * Use in conjunction with [onNeedToRequestPermissions] to notify the feature that one or more required permissions
-     * have been denied.
+     * Used in conjunction with [onNeedToRequestPermissions] to notify the feature that one
+     * or more required permissions have been denied.
      */
     @VisibleForTesting(otherwise = PRIVATE)
-    internal fun onPermissionsDeny() {
+    internal fun onPermissionsDenied() {
         sessionManager.selectedSession?.apply {
             promptRequest.consume { request ->
                 if (request is File) {
@@ -223,8 +229,8 @@ class PromptFeature(
     }
 
     /**
-     * Event that is triggered when a native dialog needs to be shown.
-     * Displays suitable dialog for the type of the [promptRequest].
+     * Invoked when a native dialog needs to be shown.
+     * Displays a suitable dialog for the pending [promptRequest].
      *
      * @param session The session which requested the dialog.
      * @param promptRequest The session the request the dialog.
@@ -235,7 +241,7 @@ class PromptFeature(
         // Requests that are handle with intents
         when (promptRequest) {
             is File -> {
-                handleFilePickerRequest(promptRequest, session)
+                handleFilePickerRequest(promptRequest)
                 return
             }
         }
@@ -243,8 +249,9 @@ class PromptFeature(
     }
 
     /**
-     * Event that is called when a dialog is dismissed.
-     * This consumes the [PromptFeature] value from the [Session] indicated by [sessionId].
+     * Invoked when a dialog is dismissed. This consumes the [PromptFeature]
+     * value from the [Session] indicated by [sessionId].
+     *
      * @param sessionId this is the id of the session which requested the prompt.
      */
     internal fun onCancel(sessionId: String) {
@@ -262,8 +269,9 @@ class PromptFeature(
     }
 
     /**
-     * Event that is called when the user confirm the action on the dialog.
-     * This consumes the [PromptFeature] value from the [Session] indicated by [sessionId].
+     * Invoked when the user confirms the action on the dialog. This consumes
+     * the [PromptFeature] value from the [Session] indicated by [sessionId].
+     *
      * @param sessionId that requested to show the dialog.
      * @param value an optional value provided by the dialog as a result of confirming the action.
      */
@@ -298,8 +306,9 @@ class PromptFeature(
     }
 
     /**
-     * Event that is called when the user is requesting to clear the selected value from the dialog.
+     * Invoked when the user is requesting to clear the selected value from the dialog.
      * This consumes the [PromptFeature] value from the [Session] indicated by [sessionId].
+     *
      * @param sessionId that requested to show the dialog.
      */
     internal fun onClear(sessionId: String) {
@@ -313,7 +322,7 @@ class PromptFeature(
     }
 
     /**
-     * Re-attach a fragment that is still visible but not linked to this feature anymore.
+     * Re-attaches a fragment that is still visible but not linked to this feature anymore.
      */
     private fun reattachFragment(fragment: PromptDialogFragment) {
         val session = sessionManager.findSessionById(fragment.sessionId)
@@ -328,18 +337,15 @@ class PromptFeature(
         fragment.feature = this
     }
 
-    internal fun handleFilePickerRequest(
-        promptRequest: File,
-        session: Session
-    ) {
+    internal fun handleFilePickerRequest(promptRequest: File) {
         if (context.isPermissionGranted(READ_EXTERNAL_STORAGE)) {
             val intent = buildFileChooserIntent(
                 promptRequest.isMultipleFilesSelection,
                 promptRequest.mimeTypes
             )
-            startActivityForResult(intent, FILE_PICKER_REQUEST)
+            startActivityForResult(intent, FILE_PICKER_ACTIVITY_REQUEST_CODE)
         } else {
-            onNeedToRequestPermissions(session, arrayOf(READ_EXTERNAL_STORAGE), FILE_PICKER_REQUEST)
+            onNeedToRequestPermissions(arrayOf(READ_EXTERNAL_STORAGE))
         }
     }
 
@@ -464,8 +470,8 @@ class PromptFeature(
     }
 
     /**
-     * Observes [Session.Observer.onPromptRequested] of the selected session and notifies the feature whenever a prompt
-     * needs to be shown.
+     * Observes [Session.Observer.onPromptRequested] of the selected session
+     * and notifies the feature whenever a prompt needs to be shown.
      */
     internal class PromptRequestObserver(
         sessionManager: SessionManager,
@@ -479,6 +485,6 @@ class PromptFeature(
     }
 
     companion object {
-        const val FILE_PICKER_REQUEST = 1234
+        const val FILE_PICKER_ACTIVITY_REQUEST_CODE = 1234
     }
 }

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -35,7 +35,6 @@ import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Met
 import mozilla.components.concept.engine.prompt.PromptRequest.MenuChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
-import mozilla.components.feature.prompts.PromptFeature.Companion.FILE_PICKER_REQUEST
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -71,7 +70,7 @@ class PromptFeatureTest {
         mockFragmentManager = mockFragmentManager()
 
         mockSessionManager = Mockito.spy(SessionManager(engine))
-        promptFeature = PromptFeature(null, mock(), mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(null, mock(), mockSessionManager, mockFragmentManager) { }
     }
 
     @Test
@@ -114,7 +113,7 @@ class PromptFeatureTest {
         mockFragmentManager = mock()
         doReturn(fragment).`when`(mockFragmentManager).findFragmentByTag(any())
 
-        promptFeature = PromptFeature(mock(), null, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(mock(), null, mockSessionManager, mockFragmentManager) { }
 
         promptFeature.start()
         verify(fragment).feature = promptFeature
@@ -135,7 +134,7 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(fragmentManager).beginTransaction()
         doReturn(transaction).`when`(transaction).remove(fragment)
 
-        val feature = PromptFeature(null, mock(), mockSessionManager, fragmentManager) { _, _, _ -> }
+        val feature = PromptFeature(null, mock(), mockSessionManager, fragmentManager) { }
 
         feature.start()
         verify(fragmentManager).beginTransaction()
@@ -154,7 +153,7 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(fragmentManager).beginTransaction()
         doReturn(transaction).`when`(transaction).remove(fragment)
 
-        val feature = PromptFeature(mock(), mock(), mockSessionManager, fragmentManager) { _, _, _ -> }
+        val feature = PromptFeature(mock(), mock(), mockSessionManager, fragmentManager) { }
 
         feature.start()
         verify(fragmentManager).beginTransaction()
@@ -473,7 +472,7 @@ class PromptFeatureTest {
 
     @Test(expected = IllegalStateException::class)
     fun `Initializing a PromptFeature without giving an activity or fragment reference will throw an exception`() {
-        promptFeature = PromptFeature(null, null, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(null, null, mockSessionManager, mockFragmentManager) { }
     }
 
     @Test
@@ -483,12 +482,12 @@ class PromptFeatureTest {
         val intent = Intent()
         val code = 1
 
-        promptFeature = PromptFeature(mockActivity, null, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(mockActivity, null, mockSessionManager, mockFragmentManager) { }
 
         promptFeature.startActivityForResult(intent, code)
         verify(mockActivity).startActivityForResult(intent, code)
 
-        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { }
 
         promptFeature.startActivityForResult(intent, code)
         verify(mockFragment).startActivityForResult(intent, code)
@@ -503,13 +502,13 @@ class PromptFeatureTest {
         val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ ->
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) {
             onRequestPermissionWasCalled = true
         }
 
         doReturn(context).`when`(mockFragment).requireContext()
 
-        promptFeature.handleFilePickerRequest(filePickerRequest, mock())
+        promptFeature.handleFilePickerRequest(filePickerRequest)
 
         assertTrue(onRequestPermissionWasCalled)
         verify(mockFragment, never()).startActivityForResult(intent, code)
@@ -522,7 +521,7 @@ class PromptFeatureTest {
         val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ ->
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) {
             onRequestPermissionWasCalled = true
         }
 
@@ -530,7 +529,7 @@ class PromptFeatureTest {
 
         grantPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
 
-        promptFeature.handleFilePickerRequest(filePickerRequest, mock())
+        promptFeature.handleFilePickerRequest(filePickerRequest)
 
         assertFalse(onRequestPermissionWasCalled)
         verify(mockFragment).startActivityForResult(any<Intent>(), anyInt())
@@ -556,7 +555,7 @@ class PromptFeatureTest {
     @Test
     fun `buildFileChooserIntent with allowMultipleFiles true and not empty mimeTypes will create an intent with EXTRA_ALLOW_MULTIPLE and EXTRA_MIME_TYPES`() {
 
-        promptFeature = PromptFeature(null, mock(), mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(null, mock(), mockSessionManager, mockFragmentManager) { }
 
         val intent = promptFeature.buildFileChooserIntent(true, arrayOf("image/jpeg"))
 
@@ -605,7 +604,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(filePickerRequest)
 
-        promptFeature.onPermissionsDeny()
+        promptFeature.onPermissionsDenied()
 
         verify(mockSessionManager).selectedSession
         assertTrue(onDismissWasCalled)
@@ -633,7 +632,7 @@ class PromptFeatureTest {
 
         stubContext()
 
-        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_REQUEST, RESULT_OK, intent)
+        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
 
         verify(mockSessionManager).selectedSession
         assertTrue(onSingleFileSelectionWasCalled)
@@ -669,7 +668,7 @@ class PromptFeatureTest {
 
         stubContext()
 
-        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_REQUEST, RESULT_OK, intent)
+        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
 
         verify(mockSessionManager).selectedSession
         assertTrue(onMultipleFileSelectionWasCalled)
@@ -691,7 +690,7 @@ class PromptFeatureTest {
 
         session.promptRequest = Consumable.from(filePickerRequest)
 
-        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_REQUEST, RESULT_CANCELED, intent)
+        promptFeature.onActivityResult(PromptFeature.FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_CANCELED, intent)
 
         verify(mockSessionManager).selectedSession
         assertTrue(onDismissWasCalled)
@@ -703,7 +702,7 @@ class PromptFeatureTest {
 
         promptFeature = spy(promptFeature)
 
-        promptFeature.onRequestPermissionsResult(FILE_PICKER_REQUEST, emptyArray(), IntArray(1) { PERMISSION_GRANTED })
+        promptFeature.onPermissionsResult(emptyArray(), IntArray(1) { PERMISSION_GRANTED })
 
         verify(promptFeature).onPermissionsGranted()
     }
@@ -713,20 +712,9 @@ class PromptFeatureTest {
 
         promptFeature = spy(promptFeature)
 
-        promptFeature.onRequestPermissionsResult(FILE_PICKER_REQUEST, emptyArray(), IntArray(1) { PERMISSION_DENIED })
+        promptFeature.onPermissionsResult(emptyArray(), IntArray(1) { PERMISSION_DENIED })
 
-        verify(promptFeature).onPermissionsDeny()
-    }
-
-    @Test
-    fun `onRequestPermissionsResult with invalid request code will not call neither onPermissionsGranted nor onPermissionsDeny`() {
-
-        promptFeature = spy(promptFeature)
-
-        promptFeature.onRequestPermissionsResult(-1344, emptyArray(), IntArray(1) { PERMISSION_DENIED })
-
-        verify(promptFeature, never()).onPermissionsGranted()
-        verify(promptFeature, never()).onPermissionsDeny()
+        verify(promptFeature).onPermissionsDenied()
     }
 
     @Test
@@ -925,6 +913,6 @@ class PromptFeatureTest {
 
         doReturn(context).`when`(mockFragment).requireContext()
 
-        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) { _, _, _ -> }
+        promptFeature = PromptFeature(null, mockFragment, mockSessionManager, mockFragmentManager) {}
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,29 @@ permalink: /changelog/
     }
   ```
 
+ * **feature-prompts**
+   * ⚠️ **This is a breaking API change!**
+   * These change are similar to the ones for feature-downloads above and aim to provide a consistent way of handling permission requests.
+   * The required permissions are now passed to the `onNeedToRequestPermissions` callback.
+   ```kotlin
+   promptFeature = PromptFeature(
+      fragment = this,
+      sessionManager = components.sessionManager,
+      fragmentManager = requireFragmentManager(),
+      onNeedToRequestPermissions = { permissions ->
+          requestPermissions(permissions, REQUEST_CODE_PROMPT_PERMISSIONS)
+      }
+   )
+   ```
+   * Renamed `onRequestsPermissionsResult` to `onPermissionResult` and allow applications to specify the permission request code. This method should be invoked from `onRequestPermissionsResult`:
+  ```kotlin
+   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+      when (requestCode) {
+          REQUEST_CODE_DOWNLOAD_PERMISSIONS -> downloadsFeature.onPermissionsResult(permissions, grantResults)
+      }        
+    }
+  ```
+
 * **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
   * After "Merge Day" and the release of Firefox 65 we updated our gecko-based components to follow the new upstream versions:
     * `browser-engine-gecko`: 65.0

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -106,10 +106,11 @@ class BrowserFragment : Fragment(), BackHandler {
         promptFeature = PromptFeature(
             fragment = this,
             sessionManager = components.sessionManager,
-            fragmentManager = requireFragmentManager()
-        ) { _, permissions, requestCode ->
-            requestPermissions(permissions, requestCode)
-        }
+            fragmentManager = requireFragmentManager(),
+            onNeedToRequestPermissions = { permissions ->
+                requestPermissions(permissions, REQUEST_CODE_PROMPT_PERMISSIONS)
+            }
+        )
 
         windowFeature = WindowFeature(components.engine, components.sessionManager)
 
@@ -189,6 +190,7 @@ class BrowserFragment : Fragment(), BackHandler {
     companion object {
         private const val SESSION_ID = "session_id"
         private const val REQUEST_CODE_DOWNLOAD_PERMISSIONS = 1
+        private const val REQUEST_CODE_PROMPT_PERMISSIONS = 2
 
         fun create(sessionId: String? = null): BrowserFragment = BrowserFragment().apply {
             arguments = Bundle().apply {
@@ -200,8 +202,8 @@ class BrowserFragment : Fragment(), BackHandler {
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         when (requestCode) {
             REQUEST_CODE_DOWNLOAD_PERMISSIONS -> downloadsFeature.onPermissionsResult(permissions, grantResults)
+            REQUEST_CODE_PROMPT_PERMISSIONS -> promptFeature.onPermissionsResult(permissions, grantResults)
         }
-        promptFeature.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
This is so we have a consistent way for how our features request permissions (see updated sample code in this commit) and to put the app in control of permission request codes. Otherwise, we'd risk code collisions and bugs.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
