### PR TITLE
[glean]Refactor Glean.kt to extract baseline ping functionality

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/BaselinePing.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/BaselinePing.kt
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.ping
+
+import android.view.accessibility.AccessibilityManager
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.os.Build
+import mozilla.components.service.glean.metrics.GleanBaseline
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * BaselinePing facilitates setup and initialization of baseline pings.
+ */
+internal class BaselinePing(applicationContext: Context) {
+    private val logger = Logger("glean/BaselinePing")
+
+    companion object {
+        const val STORE_NAME = "baseline"
+    }
+
+    init {
+        // Set the OS type
+        GleanBaseline.os.set("Android")
+
+        // Set the OS version
+        // https://developer.android.com/reference/android/os/Build.VERSION
+        GleanBaseline.osVersion.set(Build.VERSION.SDK_INT.toString())
+
+        // Set the device strings
+        // https://developer.android.com/reference/android/os/Build
+        GleanBaseline.deviceManufacturer.set(Build.MANUFACTURER)
+        GleanBaseline.deviceModel.set(Build.MODEL)
+
+        // Set the CPU architecture
+        GleanBaseline.architecture.set(Build.SUPPORTED_ABIS[0])
+
+        // Set the enabled accessibility services
+        getEnabledAccessibilityServices(
+            applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        ) ?.let {
+            GleanBaseline.a11yServices.set(it)
+        }
+    }
+
+    /**
+     * Records a list of the currently enabled accessibility services.
+     *
+     * https://developer.android.com/reference/android/view/accessibility/AccessibilityManager.html
+     * @param accessibilityManager The system's [AccessibilityManager] as
+     * returned from applicationContext.getSystemService
+     * @returns services A list of ids of the enabled accessibility services. If
+     *     the accessibility manager is disabled, returns null.
+     */
+    internal fun getEnabledAccessibilityServices(
+        accessibilityManager: AccessibilityManager
+    ): List<String>? {
+        if (!accessibilityManager.isEnabled) {
+            logger.info("AccessibilityManager is disabled")
+            return null
+        }
+        return accessibilityManager.getEnabledAccessibilityServiceList(
+            AccessibilityServiceInfo.FEEDBACK_ALL_MASK
+        ).mapNotNull {
+            // Note that any reference in java code can be null, so we'd better
+            // check for null values here as well.
+            it.id
+        }
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -7,9 +7,7 @@ package mozilla.components.service.glean
 import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.LifecycleRegistry
-import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
-import android.view.accessibility.AccessibilityManager
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -26,17 +24,16 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -439,31 +436,11 @@ class GleanTest {
     }
 
     @Test
-    fun `Make sure a11y services are collected`() {
-        val applicationContext = ApplicationProvider.getApplicationContext<Context>()
-        val accessibilityManager = applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+    fun `metricsPingScheduler is properly initialized`() {
+        Glean.metricsPingScheduler.clearSchedulerData()
+        Glean.metricsPingScheduler.updateSentTimestamp()
 
-        val shadowAccessibilityManager = shadowOf(accessibilityManager)
-        shadowAccessibilityManager.setEnabled(true)
-
-        val serviceSpy1 = spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
-        doReturn("service1").`when`(serviceSpy1).id
-
-        val serviceSpy2 = spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
-        doReturn("service2").`when`(serviceSpy2).id
-
-        val nullServiceId = spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
-        doReturn(null).`when`(nullServiceId).id
-
-        shadowAccessibilityManager.setEnabledAccessibilityServiceList(
-            listOf(serviceSpy1, serviceSpy2, nullServiceId)
-        )
-
-        assertEquals(
-            listOf("service1", "service2"),
-            Glean.getEnabledAccessibilityServices(
-                accessibilityManager
-            )
-        )
+        // Should return false since we just updated the last time the ping was sent above
+        assertFalse(Glean.metricsPingScheduler.canSendPing())
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/BaselinePingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/BaselinePingTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.ping
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+@RunWith(RobolectricTestRunner::class)
+class BaselinePingTest {
+
+    @Test
+    fun `Make sure a11y services are collected`() {
+        val applicationContext = ApplicationProvider.getApplicationContext<Context>()
+        val accessibilityManager = applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        val baselinePing = BaselinePing(applicationContext)
+
+        val shadowAccessibilityManager = Shadows.shadowOf(accessibilityManager)
+        shadowAccessibilityManager.setEnabled(true)
+
+        val serviceSpy1 = Mockito.spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
+        Mockito.doReturn("service1").`when`(serviceSpy1).id
+
+        val serviceSpy2 = Mockito.spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
+        Mockito.doReturn("service2").`when`(serviceSpy2).id
+
+        val nullServiceId = Mockito.spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
+        Mockito.doReturn(null).`when`(nullServiceId).id
+
+        shadowAccessibilityManager.setEnabledAccessibilityServiceList(
+            listOf(serviceSpy1, serviceSpy2, nullServiceId)
+        )
+
+        assertEquals(
+            listOf("service1", "service2"),
+            baselinePing.getEnabledAccessibilityServices(
+                accessibilityManager
+            )
+        )
+    }
+}


### PR DESCRIPTION
Solution for Bug 1518859.  

This moves baseline ping initialization and functionality such as constants to BaselinePingScheduler to be more in line with the MetricsPingScheduler.  The baseline scheduler doesn't restrict the number of pings per time interval currently, but would allow for that functionality if needed in the future.  

This will also facilitate work on Bug 1508965 in sending pings in background using WorkManager.  

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
