### PR TITLE
Closes #1913: Make text in BrowserMenuImageText unclickable

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_text.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_text.xml
@@ -8,16 +8,22 @@
         style="@style/Mozac.Browser.Menu.Item.Container"
         android:layout_width="match_parent"
         android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:clickable="true"
+        android:gravity="center_vertical"
+        android:focusable="true">
 
     <android.support.v7.widget.AppCompatImageView
             android:id="@+id/image"
             style="@style/Mozac.Browser.Menu.Item.ImageText.Icon"
+            android:clickable="false"
+            android:background="@android:color/transparent"
             tools:src="@android:drawable/screen_background_dark"/>
 
     <TextView
             android:id="@+id/text"
             style="@style/Mozac.Browser.Menu.Item.ImageText.Label"
+            android:clickable="false"
+            android:background="@android:color/transparent"
             android:gravity="center_vertical"
             tools:text="Item"/>
 </LinearLayout>

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.BrowserMenuCheckbox
 import mozilla.components.browser.menu.item.BrowserMenuDivider
+import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
@@ -99,7 +100,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     private val menuItems by lazy {
         listOf(
                 menuToolbar,
-                SimpleBrowserMenuItem("Share") {
+                BrowserMenuImageText("Share", R.drawable.mozac_ic_share, "share button", android.R.color.black) {
                     Toast.makeText(applicationContext, "Share", Toast.LENGTH_SHORT).show()
                 },
                 SimpleBrowserMenuItem("Settings") {


### PR DESCRIPTION
No tests to write for layout changes and this is a minor bug that (hopefully) no one notices.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
