### PR TITLE
Perform browser-toolbar autocompletion off the UI thread

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
@@ -11,13 +11,14 @@ import android.util.AttributeSet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.newFixedThreadPoolContext
 import mozilla.components.browser.awesomebar.layout.SuggestionLayout
 import mozilla.components.browser.awesomebar.transform.SuggestionTransformer
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.support.ktx.android.content.res.pxToDp
+import java.util.concurrent.Executors
 
 private const val PROVIDER_QUERY_THREADS = 3
 
@@ -35,7 +36,7 @@ class BrowserAwesomeBar @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : RecyclerView(context, attrs, defStyleAttr), AwesomeBar {
-    private val jobDispatcher = newFixedThreadPoolContext(PROVIDER_QUERY_THREADS, "AwesomeBarProviders")
+    private val jobDispatcher = Executors.newFixedThreadPool(PROVIDER_QUERY_THREADS).asCoroutineDispatcher()
     private val providers: MutableList<AwesomeBar.SuggestionProvider> = mutableListOf()
     internal var suggestionsAdapter = SuggestionsAdapter(this)
     internal var scope = CoroutineScope(Dispatchers.Main)

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/autocomplete/Providers.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/autocomplete/Providers.kt
@@ -73,6 +73,7 @@ abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
             val wwwDomain = "www.${it.host}"
             if (wwwDomain.startsWith(searchText)) {
                 return DomainAutocompleteResult(
+                    input = searchText,
                     text = getResultText(query, wwwDomain),
                     url = it.url,
                     source = list.listName,
@@ -82,6 +83,7 @@ abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
 
             if (it.host.startsWith(searchText)) {
                 return DomainAutocompleteResult(
+                    input = searchText,
                     text = getResultText(query, it.host),
                     url = it.url,
                     source = list.listName,
@@ -106,12 +108,14 @@ abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
 
 /**
  * Describes an autocompletion result against a list of domains.
+* @property input Input for which this result is being provided.
  * @property text Result of autocompletion, text to be displayed.
  * @property url Result of autocompletion, full matching url.
  * @property source Name of the autocompletion source.
  * @property totalItems A total number of results also available.
  */
 class DomainAutocompleteResult(
+    val input: String,
     val text: String,
     val url: String,
     val source: String,

--- a/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
+++ b/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
@@ -85,7 +85,7 @@ class InMemoryHistoryStorage : HistoryStorage {
     override fun getAutocompleteSuggestion(query: String): HistoryAutocompleteResult? = synchronized(pages) {
         segmentAwareDomainMatch(query, pages.keys)?.let { urlMatch ->
             return HistoryAutocompleteResult(
-                urlMatch.matchedSegment, urlMatch.url, AUTOCOMPLETE_SOURCE_NAME, pages.size)
+                query, urlMatch.matchedSegment, urlMatch.url, AUTOCOMPLETE_SOURCE_NAME, pages.size)
         }
     }
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -93,7 +93,13 @@ open class PlacesHistoryStorage(context: Context) : HistoryStorage, SyncableStor
 
         val resultText = segmentAwareDomainMatch(query, arrayListOf(url))
         return resultText?.let {
-            HistoryAutocompleteResult(it.matchedSegment, it.url, AUTOCOMPLETE_SOURCE_NAME, 1)
+            HistoryAutocompleteResult(
+                input = query,
+                text = it.matchedSegment,
+                url = it.url,
+                source = AUTOCOMPLETE_SOURCE_NAME,
+                totalItems = 1
+            )
         }
     }
 

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation Dependencies.support_appcompat
     implementation Dependencies.support_design
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/AsyncFilterListenerTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/AsyncFilterListenerTest.kt
@@ -1,0 +1,299 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import mozilla.components.concept.toolbar.AutocompleteDelegate
+import mozilla.components.concept.toolbar.AutocompleteResult
+import mozilla.components.support.test.mock
+import mozilla.components.ui.autocomplete.AutocompleteView
+import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.mockito.Mockito.atLeast
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import java.util.concurrent.Executor
+
+class AsyncFilterListenerTest {
+    @Test
+    fun `filter listener cancels prior filter executions`() = runBlocking {
+        val urlView: AutocompleteView = mock()
+        val filter: suspend (String, AutocompleteDelegate) -> Unit = mock()
+
+        val dispatcher = spy(Executor {
+            it.run()
+        }.asCoroutineDispatcher())
+
+        val listener = AsyncFilterListener(urlView, dispatcher, filter)
+
+        verify(dispatcher, never()).cancelChildren()
+
+        listener("test")
+
+        verify(dispatcher, atLeastOnce()).cancelChildren()
+    }
+
+    @Test
+    fun `filter delegate checks for cancellations before it runs, passes results to autocomplete view`() = runBlocking {
+        var filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
+            assertEquals("test", query)
+            delegate.applyAutocompleteResult(AutocompleteResult(
+                input = "test",
+                text = "testing.com",
+                url = "http://www.testing.com",
+                source = "asyncTest",
+                totalItems = 1
+            ))
+        }
+
+        val dispatcher = spy(Executor {
+            it.run()
+        }.asCoroutineDispatcher())
+
+        var didCallApply = 0
+
+        var listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "test"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                assertEquals("asyncTest", result.source)
+                assertEquals("testing.com", result.text)
+                assertEquals(1, result.totalItems)
+                didCallApply += 1
+            }
+
+            override fun noAutocompleteResult() {
+                fail()
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        verify(dispatcher, never()).isActive
+
+        async { listener("test") }.await()
+
+        // Checked if parent scope is still active. Somehow, each access to 'isActive' registers as 4?
+        verify(dispatcher, atLeast(4)).isActive
+        // Passed the result to the view's apply method exactly once.
+        assertEquals(1, didCallApply)
+
+        filter = { query, delegate ->
+            assertEquals("moz", query)
+            delegate.applyAutocompleteResult(AutocompleteResult(
+                input = "moz",
+                text = "mozilla.com",
+                url = "http://www.mozilla.com",
+                source = "asyncTestTwo",
+                totalItems = 2
+            ))
+        }
+        listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "moz"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                assertEquals("asyncTestTwo", result.source)
+                assertEquals("mozilla.com", result.text)
+                assertEquals(2, result.totalItems)
+                didCallApply += 1
+            }
+
+            override fun noAutocompleteResult() {
+                fail()
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        async { listener("moz") }.await()
+
+        verify(dispatcher, atLeast(8)).isActive
+        assertEquals(2, didCallApply)
+    }
+
+    @Test
+    fun `delegate discards stale results`() = runBlocking {
+        val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
+            assertEquals("test", query)
+            delegate.applyAutocompleteResult(AutocompleteResult(
+                input = "test",
+                text = "testing.com",
+                url = "http://www.testing.com",
+                source = "asyncTest",
+                totalItems = 1
+            ))
+        }
+
+        val dispatcher = Executor {
+            it.run()
+        }.asCoroutineDispatcher()
+
+        val listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "nolongertest"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                fail()
+            }
+
+            override fun noAutocompleteResult() {
+                fail()
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        listener("test")
+    }
+
+    @Test
+    fun `delegate discards stale lack of results`() = runBlocking {
+        val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
+            assertEquals("test", query)
+            delegate.noAutocompleteResult("test")
+        }
+
+        val dispatcher = Executor {
+            it.run()
+        }.asCoroutineDispatcher()
+
+        val listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "nolongertest"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                fail()
+            }
+
+            override fun noAutocompleteResult() {
+                fail()
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        listener("test")
+    }
+
+    @Test
+    fun `delegate passes through non-stale lack of results`() = runBlocking {
+        val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
+            assertEquals("test", query)
+            delegate.noAutocompleteResult("test")
+        }
+
+        val dispatcher = Executor {
+            it.run()
+        }.asCoroutineDispatcher()
+
+        var calledNoResults = 0
+        val listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "test"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                fail()
+            }
+
+            override fun noAutocompleteResult() {
+                calledNoResults += 1
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        async { listener("test") }.await()
+
+        assertEquals(1, calledNoResults)
+    }
+
+    @Test
+    fun `delegate discards results if parent scope was cancelled`() = runBlocking {
+        var preservedDelegate: AutocompleteDelegate? = null
+
+        val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
+            preservedDelegate = delegate
+            assertEquals("test", query)
+            delegate.applyAutocompleteResult(AutocompleteResult(
+                input = "test",
+                text = "testing.com",
+                url = "http://www.testing.com",
+                source = "asyncTest",
+                totalItems = 1
+            ))
+        }
+
+        val dispatcher = Executor {
+            it.run()
+        }.asCoroutineDispatcher()
+
+        var calledResults = 0
+        val listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "test"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                assertEquals("asyncTest", result.source)
+                assertEquals("testing.com", result.text)
+                assertEquals(1, result.totalItems)
+                calledResults += 1
+            }
+
+            override fun noAutocompleteResult() {
+                fail()
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        async {
+            listener("test")
+            listener("test")
+        }.await()
+
+        // This result application should be discarded, because scope has been cancelled by the second
+        // 'listener' call above.
+        preservedDelegate!!.applyAutocompleteResult(AutocompleteResult(
+            input = "test",
+            text = "testing.com",
+            url = "http://www.testing.com",
+            source = "asyncCancelled",
+            totalItems = 1
+        ))
+
+        assertEquals(2, calledResults)
+    }
+
+    @Test
+    fun `delegate discards lack of results if parent scope was cancelled`() = runBlocking {
+        var preservedDelegate: AutocompleteDelegate? = null
+
+        val filter: suspend (String, AutocompleteDelegate) -> Unit = { query, delegate ->
+            preservedDelegate = delegate
+            assertEquals("test", query)
+            delegate.noAutocompleteResult("test")
+        }
+
+        val dispatcher = Executor {
+            it.run()
+        }.asCoroutineDispatcher()
+
+        var calledResults = 0
+        val listener = AsyncFilterListener(object : AutocompleteView {
+            override val originalText: String = "test"
+
+            override fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult) {
+                fail()
+            }
+
+            override fun noAutocompleteResult() {
+                calledResults += 1
+            }
+        }, dispatcher, filter, this.coroutineContext)
+
+        async {
+            listener("test")
+            listener("test")
+        }.await()
+
+        // This "no results" call should be discarded, because scope has been cancelled by the second
+        // 'listener' call above.
+        preservedDelegate!!.noAutocompleteResult("test")
+
+        assertEquals(2, calledResults)
+    }
+}

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.toolbar.edit
 
+import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import org.junit.Assert.assertEquals
@@ -13,20 +14,29 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.CountDownLatch
 
 @RunWith(RobolectricTestRunner::class)
 class EditToolbarTest {
     @Test
-    fun `entered text is forwarded to autocomplete filter`() {
+    fun `entered text is forwarded to async autocomplete filter`() {
         val toolbar = BrowserToolbar(RuntimeEnvironment.application)
         toolbar.editToolbar.urlView.onAttachedToWindow()
 
+        val latch = CountDownLatch(1)
         var invokedWithParams: List<Any?>? = null
         toolbar.setAutocompleteListener { p1, p2 ->
             invokedWithParams = listOf(p1, p2)
+            latch.countDown()
         }
 
         toolbar.editToolbar.urlView.setText("Hello")
+
+        // Autocomplete filter will be invoked on a worker thread.
+        // Serialize here for the sake of tests.
+        runBlocking {
+            latch.await()
+        }
 
         assertEquals("Hello", invokedWithParams!![0])
         assertTrue(invokedWithParams!![1] is AutocompleteDelegate)

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -88,12 +88,14 @@ data class SearchResult(
 
 /**
  * Describes an autocompletion result against history storage.
+ * @property input Input for which this result is being provided.
  * @property text Result of autocompletion, text to be displayed.
  * @property url Result of autocompletion, full matching url.
  * @property source Name of the autocompletion source.
  * @property totalItems A total number of results also available.
  */
 data class HistoryAutocompleteResult(
+    val input: String,
     val text: String,
     val url: String,
     val source: String,

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/AutocompleteDelegate.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/AutocompleteDelegate.kt
@@ -17,17 +17,19 @@ interface AutocompleteDelegate {
     /**
      * Autocompletion was invoked and no match was returned.
      */
-    fun noAutocompleteResult()
+    fun noAutocompleteResult(input: String)
 }
 
 /**
  * Describes an autocompletion result.
+ * @property input Input for which this AutocompleteResult is being provided.
  * @property text AutocompleteResult of autocompletion, text to be displayed.
  * @property url AutocompleteResult of autocompletion, full matching url.
  * @property source Name of the autocompletion source.
  * @property totalItems A total number of results also available.
  */
 data class AutocompleteResult(
+    val input: String,
     val text: String,
     val url: String,
     val source: String,

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -63,7 +63,7 @@ interface Toolbar {
      *
      * @param filter A function which will perform autocompletion and send results to [AutocompleteDelegate].
      */
-    fun setAutocompleteListener(filter: (String, AutocompleteDelegate) -> Unit)
+    fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit)
 
     /**
      * Adds an action to be displayed on the right side of the toolbar in display mode.

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeature.kt
@@ -28,7 +28,7 @@ class ToolbarAutocompleteFeature(val toolbar: Toolbar) {
                     return@setAutocompleteListener
                 }
             }
-            delegate.noAutocompleteResult()
+            delegate.noAutocompleteResult(value)
         }
     }
 
@@ -57,13 +57,15 @@ class ToolbarAutocompleteFeature(val toolbar: Toolbar) {
 
     private fun HistoryAutocompleteResult.into(): AutocompleteResult {
         return AutocompleteResult(
-            text = this.text, url = this.url, source = this.source, totalItems = this.totalItems
+            input = this.input, text = this.text, url = this.url, source = this.source,
+            totalItems = this.totalItems
         )
     }
 
     private fun DomainAutocompleteResult.into(): AutocompleteResult {
         return AutocompleteResult(
-                text = this.text, url = this.url, source = this.source, totalItems = this.totalItems
+            input = this.input, text = this.text, url = this.url, source = this.source,
+            totalItems = this.totalItems
         )
     }
 }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -40,7 +40,7 @@ class ToolbarInteractorTest {
             listener("https://mozilla.org")
         }
 
-        override fun setAutocompleteListener(filter: (String, AutocompleteDelegate) -> Unit) {
+        override fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit) {
             fail()
         }
 

--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -42,6 +42,26 @@ typealias OnWindowsFocusChangeListener = (Boolean) -> Unit
 typealias TextFormatter = (String) -> String
 
 /**
+ * Aids in testing functionality which relies on some aspects of InlineAutocompleteEditText.
+ */
+interface AutocompleteView {
+    /**
+     * Current text.
+     */
+    val originalText: String
+
+    /**
+     * Apply provided [result] autocomplete result.
+     */
+    fun applyAutocompleteResult(result: InlineAutocompleteEditText.AutocompleteResult)
+
+    /**
+     * Notify that there is no autocomplete result available.
+     */
+    fun noAutocompleteResult()
+}
+
+/**
  * A UI edit text component which supports inline autocompletion.
  *
  * The background color of autocomplete spans can be configured using
@@ -64,10 +84,10 @@ typealias TextFormatter = (String) -> String
  */
 @Suppress("LargeClass", "TooManyFunctions")
 open class InlineAutocompleteEditText @JvmOverloads constructor(
-    val ctx: Context,
+    ctx: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.editTextStyle
-) : AppCompatEditText(ctx, attrs, defStyleAttr) {
+) : AppCompatEditText(ctx, attrs, defStyleAttr), AutocompleteView {
 
     data class AutocompleteResult(
         val text: String,
@@ -115,7 +135,7 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
     val nonAutocompleteText: String
         get() = getNonAutocompleteText(text)
 
-    val originalText: String
+    override val originalText: String
         get() = text.subSequence(0, autoCompletePrefixLength).toString()
 
     private val autoCompleteBackgroundColor: Int = {
@@ -352,7 +372,7 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
      * @param result the [AutocompleteProvider.AutocompleteResult] to apply
      */
     @Suppress("ComplexMethod", "ReturnCount")
-    fun applyAutocompleteResult(result: AutocompleteResult) {
+    override fun applyAutocompleteResult(result: AutocompleteResult) {
         // If discardAutoCompleteResult is true, we temporarily disabled
         // autocomplete (due to backspacing, etc.) and we should bail early.
         if (discardAutoCompleteResult) {
@@ -458,7 +478,7 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
         announceForAccessibility(text.toString())
     }
 
-    fun noAutocompleteResult() {
+    override fun noAutocompleteResult() {
         removeAutocomplete(text)
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -130,6 +130,17 @@ permalink: /changelog/
     * `browser-engine-gecko-beta`: 66.0
     * `browser-engine-gecko-nightly`: 67.0
 
+* **browser-toolbar**
+  * Toolbar URL autocompletion is now performed off the UI thread.
+
+* **concept-storage**
+  * ⚠️ **This is a breaking API change!**
+  * `HistoryAutocompleteResult` now includes an `input` field.
+
+* **browser-domains**
+  * ⚠️ **This is a breaking API change!**
+  * `DomainAutocompleteResult` now includes an `input` field.
+
 # 0.40.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.39.0...v0.40.0)


### PR DESCRIPTION
At this point in the stack, we're not in control over what our
autocomplete providers are, what actions they'll do in order to
field our queries, etc. For example, some providers may hit the disk
and perform expensive DB queries internally. Some may even hit the
network, in theory!

In order to keep things perceptively speedy, let's run the actual work
off the main thread. This patch sets up a new pool thread to process
autocomplete requests. More than one thread is selected so that we maintain
liveliness during quick user input. Background tasks are cancelled as new
queries come in, and stale results are discarded.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
