### PR TITLE
Have top of geckoview "stick" to toolbar in nested scroll

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -48,13 +48,11 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
     override fun onTouchEvent(ev: MotionEvent): Boolean {
         val event = MotionEvent.obtain(ev)
         val action = ev.actionMasked
+        val eventY = event.y.toInt()
 
         if (action == MotionEvent.ACTION_DOWN) {
             nestedOffsetY = 0
         }
-
-        val eventY = event.y.toInt()
-        event.offsetLocation(0f, nestedOffsetY.toFloat())
 
         when (action) {
             MotionEvent.ACTION_MOVE -> {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-engine-gecko-nightly**
+  * Tweaked `NestedGeckoView` to "stick" to `AppBar` in nested scroll, like other Android apps. This is possible after a [fix](https://bugzilla.mozilla.org/show_bug.cgi?id=1515774) in APZ gesture detection.
+
 * **feature-customtabs**
   * Added a temporary workaround for Custom Tab intents not being recognized when using the Jetifier tool.
 


### PR DESCRIPTION
This mimics the behavior in Chrome and other native Android apps like Twitter. The current tests are sufficient for this tweak.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features