### PR TITLE
Update A-S dependency, profile avatar, use PlacesAPI#matchUrl for autocompletion

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val sentry = "1.7.14"
     const val okhttp = "3.12.1"
 
-    const val mozilla_appservices = "0.14.0"
+    const val mozilla_appservices = "0.15.0"
     const val servo = "0.0.1.20181017.aa95911"
 }
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -89,10 +89,11 @@ open class PlacesHistoryStorage(context: Context) : HistoryStorage, SyncableStor
     }
 
     override fun getAutocompleteSuggestion(query: String): HistoryAutocompleteResult? {
-        val urls = places.api().queryAutocomplete(query, limit = 100)
-        val resultText = segmentAwareDomainMatch(query, urls.map { it.url })
+        val url = places.api().matchUrl(query) ?: return null
+
+        val resultText = segmentAwareDomainMatch(query, arrayListOf(url))
         return resultText?.let {
-            HistoryAutocompleteResult(it.matchedSegment, it.url, AUTOCOMPLETE_SOURCE_NAME, urls.size)
+            HistoryAutocompleteResult(it.matchedSegment, it.url, AUTOCOMPLETE_SOURCE_NAME, 1)
         }
     }
 

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -156,13 +156,9 @@ class PlacesHistoryStorageTest {
     fun `storage passes through getAutocompleteSuggestion calls`() {
         val storage = storage!!
         val places = places!!
-        `when`(places.queryAutocomplete("mozilla", 100)).thenReturn(listOf(
-            SearchResult("mozilla", "http://www.mozilla.org", "Mozilla", 10),
-            SearchResult("mozilla", "http://www.firefox.com", "Mozilla Firefox", 5),
-            SearchResult("mozilla", "https://en.wikipedia.org/wiki/Mozilla", "", 8))
-        )
+        `when`(places.matchUrl("mozilla")).thenReturn("http://www.mozilla.org")
         val res = storage.getAutocompleteSuggestion("mozilla")!!
-        assertEquals(3, res.totalItems)
+        assertEquals(1, res.totalItems)
         assertEquals("http://www.mozilla.org", res.url)
         assertEquals("mozilla.org", res.text)
         assertEquals("placesHistory", res.source)

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -75,13 +75,7 @@ class FirefoxAccount internal constructor(private val inner: InternalFxAcct) : F
      */
     override fun getProfile(ignoreCache: Boolean): Deferred<Profile> {
         return scope.async {
-            val internalProfile = inner.getProfile(ignoreCache)
-            Profile(
-                    uid = internalProfile.uid,
-                    email = internalProfile.email,
-                    avatar = internalProfile.avatar,
-                    displayName = internalProfile.displayName
-            )
+            Profile.fromInternal(inner.getProfile(ignoreCache))
         }
     }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Profile.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Profile.kt
@@ -4,9 +4,32 @@
 
 package mozilla.components.service.fxa
 
+import org.mozilla.fxaclient.internal.Profile as InternalProfile
+
+data class Avatar(
+    val url: String,
+    val isDefault: Boolean
+)
+
 data class Profile(
     val uid: String?,
     val email: String?,
-    val avatar: String?,
+    val avatar: Avatar?,
     val displayName: String?
-)
+) {
+    companion object {
+        internal fun fromInternal(p: InternalProfile): Profile {
+            return Profile(
+                uid = p.uid,
+                email = p.email,
+                avatar = p.avatar?.let {
+                    Avatar(
+                        url = it,
+                        isDefault = p.avatarDefault
+                    )
+                },
+                displayName = p.displayName
+            )
+        }
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* Mozilla App Services dependency upgraded: **0.15.0** 🔺
+
 * **browser-engine-gecko-nightly**
   * Tweaked `NestedGeckoView` to "stick" to `AppBar` in nested scroll, like other Android apps. This is possible after a [fix](https://bugzilla.mozilla.org/show_bug.cgi?id=1515774) in APZ gesture detection.
 


### PR DESCRIPTION
This updates A-S dependency to 0.15.0, and subsumes a commit from #1812 which addresses API breakage.

Also included is the use of the new matchUrl API which, tailored for use in the URL autocompletion cases.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
