### PR TITLE
Use stable IDs for awesomebar suggestions; retain suggestions on the screen 

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
@@ -80,6 +80,11 @@ class BrowserAwesomeBar @JvmOverloads constructor(
 
     @Synchronized
     override fun onInputStarted() {
+        // Make sure we're always displaying first suggestions at the top of the screen after input
+        // changes. Without this manual scroll, we might end with UI "scrolled" to a middle of the
+        // suggestions list.
+        scrollToPosition(0)
+
         providers.forEach { provider -> provider.onInputStarted() }
     }
 
@@ -87,7 +92,12 @@ class BrowserAwesomeBar @JvmOverloads constructor(
     override fun onInputChanged(text: String) {
         job?.cancel()
 
-        suggestionsAdapter.clearSuggestions()
+        // Make sure we're always displaying first suggestions at the top of the screen after input
+        // changes. Without this manual scroll, we might end with UI "scrolled" to a middle of the
+        // suggestions list.
+        scrollToPosition(0)
+
+        suggestionsAdapter.optionallyClearSuggestions()
 
         job = scope.launch {
             providers.forEach { provider ->

--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
@@ -24,6 +24,10 @@ internal class SuggestionsAdapter(
 ) : RecyclerView.Adapter<ViewHolderWrapper>() {
     internal var layout: SuggestionLayout = DefaultSuggestionLayout()
 
+    init {
+        setHasStableIds(true)
+    }
+
     /**
      * List of suggestions to be displayed by this adapter.
      */
@@ -64,7 +68,7 @@ internal class SuggestionsAdapter(
     /**
      * Removes all suggestions except the ones from providers that have set shouldClearSuggestions to false.
      */
-    fun clearSuggestions() = synchronized(suggestions) {
+    fun optionallyClearSuggestions() = synchronized(suggestions) {
         val updatedSuggestions = suggestions.toMutableList()
 
         suggestionMap.keys.forEach { provider ->
@@ -95,8 +99,13 @@ internal class SuggestionsAdapter(
         return ViewHolderWrapper(layout.createViewHolder(awesomeBar, view, viewType), view)
     }
 
+    override fun getItemId(position: Int): Long {
+        val suggestion = suggestions[position]
+        return suggestion.generatedUniqueId
+    }
+
     override fun getItemViewType(position: Int): Int = synchronized(suggestions) {
-        val suggestion = suggestions.get(position)
+        val suggestion = suggestions[position]
         return layout.getLayoutResource(suggestion)
     }
 

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
@@ -22,6 +22,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserAwesomeBarTest {
@@ -97,6 +98,8 @@ class BrowserAwesomeBarTest {
             var providerCancelled = false
 
             val blockingProvider = object : AwesomeBar.SuggestionProvider {
+                override val id: String = UUID.randomUUID().toString()
+
                 override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
                     providerTriggered = true
 
@@ -137,6 +140,8 @@ class BrowserAwesomeBarTest {
             var providerCancelled = false
 
             val blockingProvider = object : AwesomeBar.SuggestionProvider {
+                override val id: String = UUID.randomUUID().toString()
+
                 override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
                     providerTriggered = true
 
@@ -177,6 +182,8 @@ class BrowserAwesomeBarTest {
             var timesProviderCalled = 0
 
             val provider = object : AwesomeBar.SuggestionProvider {
+                override val id: String = UUID.randomUUID().toString()
+
                 var isFirstCall = true
 
                 override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
@@ -228,20 +235,23 @@ class BrowserAwesomeBarTest {
             val awesomeBar = BrowserAwesomeBar(context)
             awesomeBar.scope = testMainScope
 
-            val inputSuggestions = listOf(AwesomeBar.Suggestion(title = "Tetst"))
+            val inputSuggestions = listOf(AwesomeBar.Suggestion(mock(), title = "Tetst"))
             val provider = object : AwesomeBar.SuggestionProvider {
+                override val id: String = UUID.randomUUID().toString()
+
                 override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
                     return inputSuggestions
                 }
             }
+
             awesomeBar.addProviders(provider)
 
             val adapter: SuggestionsAdapter = mock()
             awesomeBar.suggestionsAdapter = adapter
 
             val transformedSuggestions = listOf(
-                AwesomeBar.Suggestion(title = "Hello"),
-                AwesomeBar.Suggestion(title = "World")
+                AwesomeBar.Suggestion(provider, title = "Hello"),
+                AwesomeBar.Suggestion(provider, title = "World")
             )
 
             val transformer = spy(object : SuggestionTransformer {
@@ -282,6 +292,8 @@ class BrowserAwesomeBarTest {
     }
 
     private fun mockProvider(): AwesomeBar.SuggestionProvider = spy(object : AwesomeBar.SuggestionProvider {
+        override val id: String = UUID.randomUUID().toString()
+
         override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
             return emptyList()
         }

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
@@ -55,7 +55,7 @@ class SuggestionsAdapterTest {
 
         assertEquals(3, adapter.itemCount)
 
-        adapter.clearSuggestions()
+        adapter.optionallyClearSuggestions()
 
         assertEquals(0, adapter.itemCount)
     }
@@ -69,7 +69,7 @@ class SuggestionsAdapterTest {
 
         assertEquals(3, adapter.itemCount)
 
-        adapter.clearSuggestions()
+        adapter.optionallyClearSuggestions()
 
         assertEquals(3, adapter.itemCount)
 
@@ -79,7 +79,7 @@ class SuggestionsAdapterTest {
 
         assertEquals(7, adapter.itemCount)
 
-        adapter.clearSuggestions()
+        adapter.optionallyClearSuggestions()
 
         assertEquals(3, adapter.itemCount)
     }
@@ -89,13 +89,13 @@ class SuggestionsAdapterTest {
         val adapter = SuggestionsAdapter(mock())
 
         adapter.addSuggestions(mockProvider(), listOf(
-            AwesomeBar.Suggestion(title = "Hello", score = 10),
-            AwesomeBar.Suggestion(title = "World", score = 2),
-            AwesomeBar.Suggestion(title = "How", score = 7),
-            AwesomeBar.Suggestion(title = "is", score = 12),
-            AwesomeBar.Suggestion(title = "the", score = 0),
-            AwesomeBar.Suggestion(title = "weather", score = -2),
-            AwesomeBar.Suggestion(title = "tomorrow", score = 1000)))
+            AwesomeBar.Suggestion(mock(), title = "Hello", score = 10),
+            AwesomeBar.Suggestion(mock(), title = "World", score = 2),
+            AwesomeBar.Suggestion(mock(), title = "How", score = 7),
+            AwesomeBar.Suggestion(mock(), title = "is", score = 12),
+            AwesomeBar.Suggestion(mock(), title = "the", score = 0),
+            AwesomeBar.Suggestion(mock(), title = "weather", score = -2),
+            AwesomeBar.Suggestion(mock(), title = "tomorrow", score = 1000)))
 
         assertEquals(7, adapter.itemCount)
 
@@ -116,8 +116,8 @@ class SuggestionsAdapterTest {
         val adapter = SuggestionsAdapter(mock())
 
         adapter.addSuggestions(mockProvider(), listOf(
-            AwesomeBar.Suggestion(title = "Test"),
-            AwesomeBar.Suggestion(title = "World", chips = listOf(
+            AwesomeBar.Suggestion(mock(), title = "Test"),
+            AwesomeBar.Suggestion(mock(), title = "World", chips = listOf(
                 AwesomeBar.Suggestion.Chip("Chip1"),
                 AwesomeBar.Suggestion.Chip("Chip2")))))
 

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.browser.awesomebar.R
 import mozilla.components.browser.awesomebar.widget.FlowLayout
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -35,6 +36,7 @@ class DefaultSuggestionViewHolderTest {
         val viewHolder = DefaultSuggestionViewHolder.Default(awesomeBar, view)
 
         val suggestion = AwesomeBar.Suggestion(
+            mock(),
             title = "Hello World",
             description = "https://www.mozilla.org")
 
@@ -59,6 +61,7 @@ class DefaultSuggestionViewHolderTest {
 
         var callbackExecuted = false
         val suggestion = AwesomeBar.Suggestion(
+            mock(),
             onSuggestionClicked = { callbackExecuted = true }
         )
 
@@ -82,6 +85,7 @@ class DefaultSuggestionViewHolderTest {
             BrowserAwesomeBar(context), view)
 
         val suggestion = AwesomeBar.Suggestion(
+            mock(),
             chips = listOf(
                 AwesomeBar.Suggestion.Chip("Hello"),
                 AwesomeBar.Suggestion.Chip("World"),
@@ -113,6 +117,7 @@ class DefaultSuggestionViewHolderTest {
         var chipClicked: String? = null
 
         val suggestion = AwesomeBar.Suggestion(
+            mock(),
             chips = listOf(
                 AwesomeBar.Suggestion.Chip("Hello"),
                 AwesomeBar.Suggestion.Chip("World"),

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -11,6 +11,7 @@ import android.graphics.Bitmap
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.utils.WebURLFinder
+import java.util.UUID
 
 private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
 
@@ -24,6 +25,8 @@ class ClipboardSuggestionProvider(
     private val icon: Bitmap? = null,
     private val title: String? = null
 ) : AwesomeBar.SuggestionProvider {
+    override val id: String = UUID.randomUUID().toString()
+
     private val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
@@ -32,7 +35,8 @@ class ClipboardSuggestionProvider(
         } ?: return emptyList()
 
         return listOf(AwesomeBar.Suggestion(
-            id = "mozac-feature-awesomebar-clipboard",
+            provider = this,
+            id = url,
             description = url,
             flags = setOf(AwesomeBar.Suggestion.Flag.CLIPBOARD),
             icon = { _, _ -> icon },
@@ -42,6 +46,10 @@ class ClipboardSuggestionProvider(
             }
         ))
     }
+
+    override val shouldClearSuggestions: Boolean
+        // We do not want the suggestion of this provider to disappear and re-appear when text changes.
+        get() = false
 }
 
 private fun findUrl(text: String): String? {

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
@@ -8,6 +8,7 @@ import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.SearchResult
 import mozilla.components.feature.session.SessionUseCases
+import java.util.UUID
 
 private const val HISTORY_SUGGESTION_LIMIT = 20
 
@@ -20,6 +21,8 @@ class HistoryStorageSuggestionProvider(
     private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase
 ) : AwesomeBar.SuggestionProvider {
 
+    override val id: String = UUID.randomUUID().toString()
+
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
         if (text.isEmpty()) {
             return emptyList()
@@ -27,9 +30,14 @@ class HistoryStorageSuggestionProvider(
         return historyStorage.getSuggestions(text, HISTORY_SUGGESTION_LIMIT).into()
     }
 
+    override val shouldClearSuggestions: Boolean
+        // We do not want the suggestion of this provider to disappear and re-appear when text changes.
+        get() = false
+
     private fun Iterable<SearchResult>.into(): List<AwesomeBar.Suggestion> {
         return this.map {
             AwesomeBar.Suggestion(
+                provider = this@HistoryStorageSuggestionProvider,
                 id = it.id,
                 title = it.title,
                 description = it.url,

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.awesomebar.provider
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.tabs.TabsUseCases
+import java.util.UUID
 
 /**
  * A [AwesomeBar.SuggestionProvider] implementation that provides suggestions based on the sessions in the
@@ -16,6 +17,8 @@ class SessionSuggestionProvider(
     private val sessionManager: SessionManager,
     private val selectTabUseCase: TabsUseCases.SelectTabUseCase
 ) : AwesomeBar.SuggestionProvider {
+    override val id: String = UUID.randomUUID().toString()
+
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
         if (text.isEmpty()) {
             return emptyList()
@@ -29,7 +32,8 @@ class SessionSuggestionProvider(
             ) {
                 suggestions.add(
                     AwesomeBar.Suggestion(
-                        id = "mozac-browser-session:${session.id}",
+                        provider = this,
+                        id = session.id,
                         title = session.title,
                         description = session.url,
                         onSuggestionClicked = { selectTabUseCase.invoke(session) }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
@@ -19,6 +19,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -155,6 +156,12 @@ class ClipboardSuggestionProviderTest {
         suggestion.onSuggestionClicked!!.invoke()
 
         verify(useCase).invoke(eq("https://www.mozilla.org"), any())
+    }
+
+    @Test
+    fun `Provider suggestion should not get cleared when text changes`() {
+        val provider = ClipboardSuggestionProvider(context, mock())
+        assertFalse(provider.shouldClearSuggestions)
     }
 
     private fun assertClipboardYieldsUrl(text: String, url: String) {

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -44,5 +45,11 @@ class HistoryStorageSuggestionProviderTest {
 
         val suggestions = provider.onInputChanged("moz")
         assertEquals(20, suggestions.size)
+    }
+
+    @Test
+    fun `Provider suggestion should not get cleared when text changes`() {
+        val provider = HistoryStorageSuggestionProvider(mock(), mock())
+        assertFalse(provider.shouldClearSuggestions)
     }
 }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
@@ -229,9 +230,9 @@ class SearchSuggestionProviderTest {
             doReturn(searchEngine).`when`(searchEngineManager).getDefaultSearchEngine(any(), any())
 
             val useCase = spy(SearchUseCases(
-                    RuntimeEnvironment.application,
-                    searchEngineManager,
-                    SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
+                RuntimeEnvironment.application,
+                searchEngineManager,
+                SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
             ).defaultSearch)
             doNothing().`when`(useCase).invoke(anyString(), any<Session>())
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,12 @@ permalink: /changelog/
 * **browser-toolbar**
   * `BrowserToolbar` `cancelView` is now `clearView` with new text clearing behavior and color attribute updated from `browserToolbarCancelColor` to `browserToolbarClearColor`
 
+* **concept-awesomebar**
+  * ⚠️ **This is a breaking API change**: [AwesomeBar.Suggestion](https://mozac.org/api/mozilla.components.concept.awesomebar/-awesome-bar/-suggestion/) instances must now declare the provider that created them.
+
+* **browser-awesomebar**
+  * [BrowserAwesomeBar](https://mozac.org/api/mozilla.components.browser.awesomebar/-browser-awesome-bar/) is now replacing suggestions "in-place" if their ids match. Additionally `BrowserAwesomeBar` now automatically scrolls to the top whenever the entered text changes.
+
 # 0.44.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.43.0...v0.44.0)


### PR DESCRIPTION
These patches make sure we have stable IDs coming out of the suggestion providers, configure the underlying recycler view to rely on stable IDs, and re-configures suggestion providers to not erase their suggestions from the screen as user is typing.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
