### PR TITLE
[glean] 1523331: Make metrics internal to the library they are defined in.

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -8,7 +8,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 // so that it will be shared between all libraries that use glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "0.12.0"
+String GLEAN_PARSER_VERSION = "0.13.0"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"


### PR DESCRIPTION
This updates glean parser so the generated metrics are in `internal` classes, and therefore can't be used outside of the library they are defined in.

This is a follow-on to #1879 which just put the metrics in the correct namespace.  This additionally makes them internal and not public by bringing over [this simple change](https://github.com/mozilla/glean_parser/pull/28) from `glean_parser`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
