### PR TITLE
[glean] Add the `locale` field to the baseline ping

### DIFF
--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -102,6 +102,21 @@ glean.baseline:
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
+  locale:
+    type: string
+    lifetime: application
+    send_in_pings:
+      - baseline
+    description: |
+      The locale of the application (e.g. "es-ES").
+    bugs:
+      - 1512938
+      - 1525540
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+
 glean.internal.metrics:
   client_id:
     type: uuid

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/BaselinePing.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/BaselinePing.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.os.Build
 import mozilla.components.service.glean.GleanMetrics.GleanBaseline
 import mozilla.components.support.base.log.logger.Logger
+import java.util.Locale
 
 /**
  * BaselinePing facilitates setup and initialization of baseline pings.
@@ -43,6 +44,8 @@ internal class BaselinePing(applicationContext: Context) {
         ) ?.let {
             GleanBaseline.a11yServices.set(it)
         }
+
+        GleanBaseline.locale.set(getLanguageTag())
     }
 
     /**
@@ -67,6 +70,48 @@ internal class BaselinePing(applicationContext: Context) {
             // Note that any reference in java code can be null, so we'd better
             // check for null values here as well.
             it.id
+        }
+    }
+
+    /**
+     * Gets a gecko-compatible locale string (e.g. "es-ES" instead of Java [Locale]
+     * "es_ES") for the default locale.
+     *
+     * This method approximates the API21 method [Locale.toLanguageTag].
+     *
+     * @return a locale string that supports custom injected languages.
+     */
+    internal fun getLanguageTag(): String {
+        // Thanks to toLanguageTag() being introduced in API21, we could have
+        // simple returned `locale.toLanguageTag();` from this function. However
+        // what kind of languages the Android build supports is up to the manufacturer
+        // and our apps usually support translations for more rare languages, through
+        // our custom locale injector. For this reason, we can't use `toLanguageTag`
+        // and must try to replicate its logic ourselves.
+        val locale = Locale.getDefault()
+        val language = getLanguage(locale)
+        val country = locale.country // Can be an empty string.
+        return if (country.isEmpty()) language else "$language-$country"
+    }
+
+    /**
+     * Sometimes we want just the language for a locale, not the entire language
+     * tag. But Java's .getLanguage method is wrong. A reference to the deprecated
+     * ISO language codes and their mapping can be found in [Locale.toLanguageTag] docs.
+     *
+     * @param locale a [Locale] object to be stringified.
+     * @return a language string, such as "he" for the Hebrew locales.
+     */
+    internal fun getLanguage(locale: Locale): String {
+        // Can, but should never be, an empty string.
+        val language = locale.language
+
+        // Modernize certain language codes.
+        return when (language) {
+            "iw" -> "he"
+            "in" -> "id"
+            "ji" -> "yi"
+            else -> language
         }
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -222,7 +222,8 @@ class GleanTest {
                 "glean.baseline.os_version",
                 "glean.baseline.device_manufacturer",
                 "glean.baseline.device_model",
-                "glean.baseline.architecture"
+                "glean.baseline.architecture",
+                "glean.baseline.locale"
             )
             val baselineMetricsObject = baselineJson.getJSONObject("metrics")!!
             val baselineStringMetrics = baselineMetricsObject.getJSONObject("string")!!

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/BaselinePingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/BaselinePingTest.kt
@@ -9,11 +9,14 @@ import android.content.Context
 import android.view.accessibility.AccessibilityManager
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 class BaselinePingTest {
@@ -46,5 +49,42 @@ class BaselinePingTest {
                 accessibilityManager
             )
         )
+    }
+
+    @Test
+    fun `getLanguageTag() reports the tag for the default locale`() {
+        val baselinePing = BaselinePing(ApplicationProvider.getApplicationContext<Context>())
+        val defaultLanguageTag = baselinePing.getLanguageTag()
+
+        assertNotNull(defaultLanguageTag)
+        assertFalse(defaultLanguageTag.isEmpty())
+        assertEquals("en-US", defaultLanguageTag)
+    }
+
+    @Test
+    fun `getLanguageTag reports the correct tag for a non-default language`() {
+        val baselinePing = BaselinePing(ApplicationProvider.getApplicationContext<Context>())
+        val defaultLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale("fy", "NL"))
+
+            val languageTag = baselinePing.getLanguageTag()
+
+            assertNotNull(languageTag)
+            assertFalse(languageTag.isEmpty())
+            assertEquals("fy-NL", languageTag)
+        } finally {
+            Locale.setDefault(defaultLocale)
+        }
+    }
+
+    @Test
+    fun `getLanguage reports the modern translation for some languages`() {
+        val baselinePing = BaselinePing(ApplicationProvider.getApplicationContext<Context>())
+
+        assertEquals("he", baselinePing.getLanguage(Locale("iw", "IL")))
+        assertEquals("id", baselinePing.getLanguage(Locale("in", "ID")))
+        assertEquals("yi", baselinePing.getLanguage(Locale("ji", "ID")))
     }
 }


### PR DESCRIPTION
While this field was mentioned in the [ping docs](https://github.com/mozilla-mobile/android-components/blob/master/components/service/glean/docs/baseline.md) and also requested a [data-review](https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3) for, this slipped through the cracks and its implementation never landed.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
