### PR TITLE
Closes #1028: Add x86 servo build variant

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -87,7 +87,7 @@ def create_module_tasks(module):
     module_overrides = {
         ":samples-browser": {
             "assembleOnly/Test": (
-                ["ServoArm", "SystemUniversal"],
+                ["ServoArm", "ServoX86", "SystemUniversal"],
                 [
                     "GeckoBetaAarch64", "GeckoBetaArm", "GeckoBetaX86",
                     "GeckoNightlyAarch64", "GeckoNightlyArm", "GeckoNightlyX86",

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -73,7 +73,8 @@ object Dependencies {
     const val mozilla_sync_logins = "org.mozilla.sync15:logins:${Versions.mozilla_appservices}"
     const val mozilla_places = "org.mozilla.places:places:${Versions.mozilla_appservices}"
     const val mozilla_rustlog = "org.mozilla.appservices:rustlog:${Versions.mozilla_appservices}"
-    const val mozilla_servo = "org.mozilla.servoview:servoview-armv7:${Versions.servo}"
+    const val mozilla_servo_arm = "org.mozilla.servoview:servoview-armv7:${Versions.servo}"
+    const val mozilla_servo_x86 = "org.mozilla.servoview:servoview-x86:${Versions.servo}"
 
     const val thirdparty_okhttp = "com.squareup.okhttp3:okhttp:${Versions.okhttp}"
     const val thirdparty_sentry = "io.sentry:sentry-android:${Versions.sentry}"

--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -26,9 +26,8 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    // We only compile against the ARM artifact. We let the app decide which artifact to actually
-    // use at runtime. As the Kotlin/Java API is the same for all ABIs it is not important which one
-    // we import here.
+    // We only compile against the ARM artifact. External module will decide which module to provide by build configuration.
+    // As the Kotlin/Java API is the same for all ABIs it is not important which one we import here.
     compileOnly Gecko.geckoview_beta_arm
     testImplementation Gecko.geckoview_beta_arm
 

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -33,9 +33,8 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(path: ':support-utils')
 
-    // We only compile against the ARM artifact. We let the app decide which artifact to actually
-    // use at runtime. As the Kotlin/Java API is the same for all ABIs it is not important which one
-    // we import here.
+    // We only compile against the ARM artifact. External module will decide which module to provide by build configuration.
+    // As the Kotlin/Java API is the same for all ABIs it is not important which one we import here.
     compileOnly Gecko.geckoview_nightly_arm
     testImplementation Gecko.geckoview_nightly_arm
 

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -26,9 +26,8 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    // We only compile against the ARM artifact. We let the app decide which artifact to actually
-    // use at runtime. As the Kotlin/Java API is the same for all ABIs it is not important which one
-    // we import here.
+    // We only compile against the ARM artifact. External module will decide which module to provide by build configuration.
+    // As the Kotlin/Java API is the same for all ABIs it is not important which one we import here.
     compileOnly Gecko.geckoview_release_arm
     testImplementation Gecko.geckoview_release_arm
 

--- a/components/browser/engine-servo/build.gradle
+++ b/components/browser/engine-servo/build.gradle
@@ -36,7 +36,10 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
-    implementation Dependencies.mozilla_servo
+    // We only compile against the ARM artifact. External module will decide which module to provide by build configuration.
+    // As the Kotlin/Java API is the same for all ABIs it is not important which one we import here.
+    compileOnly Dependencies.mozilla_servo_arm
+    testImplementation Dependencies.mozilla_servo_arm
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/samples/browser/README.md
+++ b/samples/browser/README.md
@@ -12,7 +12,7 @@ The browser app has two product flavor dimensions:
 
 * **channel**: Using different release channels of GeckoView: _nightly_, _beta_, _production_. In most cases you want to use the _nightly_ flavor as this will support all of the latest functionality.
 
-* **abi**: Using different GeckoView builds based on the processor architecture: _arm_, _x86_, _aarch64_. Lookup the processor architecture that matches your device. For most Android devices that's _arm_ or _aarch64_. For running on an emulator pick _x86_ and a matching hardware-accelerated emulator image.
+* **abi**: Using different GeckoView or ServoView builds based on the processor architecture: _arm_, _x86_, _aarch64_. Lookup the processor architecture that matches your device. For most Android devices that's _arm_ or _aarch64_. For running on an emulator pick _x86_ and a matching hardware-accelerated emulator image.
 
 ## License
 

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -80,7 +80,7 @@ android {
             setIgnore(true)
         }
 
-        if (flavors.contains("servo") && !flavors.contains("arm")) {
+        if (flavors.contains("servo") && !flavors.contains("arm") && !flavors.contains("x86")) {
             setIgnore(true)
         }
     }
@@ -103,6 +103,9 @@ configurations {
     geckoReleaseArmImplementation {}
     geckoReleaseX86Implementation {}
     geckoReleaseAarch64Implementation {}
+
+    servoX86Implementation {}
+    servoArmImplementation {}
 }
 
 dependencies {
@@ -140,6 +143,8 @@ dependencies {
     implementation project(':support-ktx')
 
     servoImplementation project(':browser-engine-servo')
+    servoX86Implementation Dependencies.mozilla_servo_x86
+    servoArmImplementation Dependencies.mozilla_servo_arm
 
     geckoNightlyImplementation project(':browser-engine-gecko-nightly')
     geckoNightlyArmImplementation Gecko.geckoview_nightly_arm


### PR DESCRIPTION
Rebased version of #1296. Added the new flavor to the build configuration.