### PR TITLE
 Closes #1987: Make back button presses sessionId aware 

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -16,7 +16,7 @@ class SessionFeature(
     private val sessionManager: SessionManager,
     private val sessionUseCases: SessionUseCases,
     engineView: EngineView,
-    sessionId: String? = null
+    private val sessionId: String? = null
 ) : LifecycleAwareFeature, BackHandler {
     internal val presenter = EngineViewPresenter(sessionManager, engineView, sessionId)
 
@@ -33,9 +33,13 @@ class SessionFeature(
      * @return true if the event was handled, otherwise false.
      */
     override fun onBackPressed(): Boolean {
-        sessionManager.selectedSession?.let { session ->
-            if (session.canGoBack) {
-                sessionUseCases.goBack.invoke()
+        val session = sessionId?.let {
+            sessionManager.findSessionById(it)
+        } ?: sessionManager.selectedSession
+
+        session?.let { it ->
+            if (it.canGoBack) {
+                sessionUseCases.goBack.invoke(it)
                 return true
             }
         }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -37,11 +37,9 @@ class SessionFeature(
             sessionManager.findSessionById(it)
         } ?: sessionManager.selectedSession
 
-        session?.let { it ->
-            if (it.canGoBack) {
-                sessionUseCases.goBack.invoke(it)
-                return true
-            }
+        if (session?.canGoBack == true) {
+            sessionUseCases.goBack.invoke(session)
+            return true
         }
 
         return false

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -115,9 +115,9 @@ class SessionUseCases(
         /**
          * Navigates back in the history of the currently selected session
          */
-        fun invoke() {
-            sessionManager.selectedSession?.let {
-                sessionManager.getOrCreateEngineSession(it).goBack()
+        fun invoke(session: Session? = sessionManager.selectedSession) {
+            if (session != null) {
+                sessionManager.getOrCreateEngineSession(session).goBack()
             }
         }
     }
@@ -128,9 +128,9 @@ class SessionUseCases(
         /**
          * Navigates forward in the history of the currently selected session
          */
-        fun invoke() {
-            sessionManager.selectedSession?.let {
-                sessionManager.getOrCreateEngineSession(it).goForward()
+        fun invoke(session: Session? = sessionManager.selectedSession) {
+            if (session != null) {
+                sessionManager.getOrCreateEngineSession(session).goForward()
             }
         }
     }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -8,6 +8,8 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
@@ -27,7 +29,7 @@ class SessionFeatureTest {
     }
 
     @Test
-    fun handleBackPressed() {
+    fun `handleBackPressed uses selectedSession`() {
         val session = Session("https://www.mozilla.org")
         `when`(sessionManager.selectedSession).thenReturn(session)
         `when`(sessionManager.selectedSessionOrThrow).thenReturn(session)
@@ -43,6 +45,51 @@ class SessionFeatureTest {
         session.canGoBack = true
         feature.onBackPressed()
         verify(engineSession).goBack()
+    }
+
+    @Test
+    fun `handleBackPressed uses sessionId`() {
+        val session = Session("https://www.mozilla.org")
+        val sessionAlt = Session("https://firefox.com")
+        val engineSession = mock(EngineSession::class.java)
+        val sessionId = "123"
+
+        `when`(sessionManager.selectedSession).thenReturn(sessionAlt)
+        `when`(sessionManager.selectedSessionOrThrow).thenReturn(sessionAlt)
+        `when`(sessionManager.findSessionById(sessionId)).thenReturn(session)
+        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        session.canGoBack = true
+
+        val feature = SessionFeature(sessionManager, sessionUseCases, engineView, sessionId)
+
+        val result = feature.onBackPressed()
+
+        verify(engineSession).goBack()
+        assertTrue(result)
+    }
+
+    @Test
+    fun `handleBackPressed does nothing when sessionId provided but no session found`() {
+        val engineSession = mock(EngineSession::class.java)
+        val sessionId = "123"
+
+        val feature = SessionFeature(sessionManager, sessionUseCases, engineView, sessionId)
+
+        val result = feature.onBackPressed()
+
+        verify(engineSession, never()).goBack()
+        assertFalse(result)
+    }
+
+    @Test
+    fun `handleBackPressed does nothing when no session found`() {
+        val engineSession = mock(EngineSession::class.java)
+
+        val feature = SessionFeature(sessionManager, sessionUseCases, engineView)
+        val result = feature.onBackPressed()
+
+        verify(engineSession, never()).goBack()
+        assertFalse(result)
     }
 
     @Test

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -13,13 +13,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class SessionUseCasesTest {
     private val sessionManager = mock(SessionManager::class.java)
     private val selectedEngineSession = mock(EngineSession::class.java)
@@ -84,12 +82,38 @@ class SessionUseCasesTest {
 
     @Test
     fun goBack() {
+        val engineSession = mock(EngineSession::class.java)
+        val session = mock(Session::class.java)
+
+        useCases.goBack.invoke(null)
+        verify(engineSession, never()).goBack()
+        verify(selectedEngineSession, never()).goBack()
+
+        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        useCases.goBack.invoke(session)
+        verify(engineSession).goBack()
+
+        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.goBack.invoke()
         verify(selectedEngineSession).goBack()
     }
 
     @Test
     fun goForward() {
+        val engineSession = mock(EngineSession::class.java)
+        val session = mock(Session::class.java)
+
+        useCases.goForward.invoke(null)
+        verify(engineSession, never()).goForward()
+        verify(selectedEngineSession, never()).goForward()
+
+        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        useCases.goForward.invoke(session)
+        verify(engineSession).goForward()
+
+        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.goForward.invoke()
         verify(selectedEngineSession).goForward()
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ permalink: /changelog/
 
 * **feature-session**
   * Fixed an issue causing `EngineViewPresenter` to render a selected `Session` even though it was configured to show a fixed `Session`. This issue caused a crash (`IllegalStateException: Display already acquired`) in the [Reference Browser](https://github.com/mozilla-mobile/reference-browser) when a "Custom Tab" and the "Browser" tried to render the same `Session`.
+  * Fixed an issue where back and forward button handling would not take place on the session whose ID was provided.
 
 * **browser-engine-system**
   * Added support for [JavaScript prompt alerts](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt) on WebView.


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
