### PR TITLE
[glean] 1525042: Remove a11y_services metric from glean

### DIFF
--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -13,5 +13,4 @@ the following fields:
 | `device_manufacturer` | String | The manufacturer of the device |
 | `device_model` | String | The model name of the device |
 | `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
-| `a11y_services` | StringList | List of the ids of the accessibility services enabled on the device |
 | `locale` | String | The locale of the application |

--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -89,19 +89,6 @@ glean.baseline:
     notification_emails:
       - telemetry-client-dev@mozilla.com
 
-  a11y_services:
-    type: string_list
-    description: |
-      List of accessibility services enabled on the device.
-    send_in_pings:
-      - baseline
-    bugs:
-      - 1497894
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
-    notification_emails:
-      - telemetry-client-dev@mozilla.com
-
   locale:
     type: string
     lifetime: application

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/ping/BaselinePing.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/ping/BaselinePing.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.service.glean.ping
 
-import android.view.accessibility.AccessibilityManager
-import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
 import android.os.Build
 import mozilla.components.service.glean.GleanMetrics.GleanBaseline
@@ -38,39 +36,7 @@ internal class BaselinePing(applicationContext: Context) {
         // Set the CPU architecture
         GleanBaseline.architecture.set(Build.SUPPORTED_ABIS[0])
 
-        // Set the enabled accessibility services
-        getEnabledAccessibilityServices(
-            applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
-        ) ?.let {
-            GleanBaseline.a11yServices.set(it)
-        }
-
         GleanBaseline.locale.set(getLanguageTag())
-    }
-
-    /**
-     * Records a list of the currently enabled accessibility services.
-     *
-     * https://developer.android.com/reference/android/view/accessibility/AccessibilityManager.html
-     * @param accessibilityManager The system's [AccessibilityManager] as
-     * returned from applicationContext.getSystemService
-     * @returns services A list of ids of the enabled accessibility services. If
-     *     the accessibility manager is disabled, returns null.
-     */
-    internal fun getEnabledAccessibilityServices(
-        accessibilityManager: AccessibilityManager
-    ): List<String>? {
-        if (!accessibilityManager.isEnabled) {
-            logger.info("AccessibilityManager is disabled")
-            return null
-        }
-        return accessibilityManager.getEnabledAccessibilityServiceList(
-            AccessibilityServiceInfo.FEEDBACK_ALL_MASK
-        ).mapNotNull {
-            // Note that any reference in java code can be null, so we'd better
-            // check for null values here as well.
-            it.id
-        }
     }
 
     /**

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/BaselinePingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/BaselinePingTest.kt
@@ -4,53 +4,18 @@
 
 package mozilla.components.service.glean.ping
 
-import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
-import android.view.accessibility.AccessibilityManager
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows
 import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 class BaselinePingTest {
-
-    @Test
-    fun `Make sure a11y services are collected`() {
-        val applicationContext = ApplicationProvider.getApplicationContext<Context>()
-        val accessibilityManager = applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
-        val baselinePing = BaselinePing(applicationContext)
-
-        val shadowAccessibilityManager = Shadows.shadowOf(accessibilityManager)
-        shadowAccessibilityManager.setEnabled(true)
-
-        val serviceSpy1 = Mockito.spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
-        Mockito.doReturn("service1").`when`(serviceSpy1).id
-
-        val serviceSpy2 = Mockito.spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
-        Mockito.doReturn("service2").`when`(serviceSpy2).id
-
-        val nullServiceId = Mockito.spy<AccessibilityServiceInfo>(AccessibilityServiceInfo::class.java)
-        Mockito.doReturn(null).`when`(nullServiceId).id
-
-        shadowAccessibilityManager.setEnabledAccessibilityServiceList(
-            listOf(serviceSpy1, serviceSpy2, nullServiceId)
-        )
-
-        assertEquals(
-            listOf("service1", "service2"),
-            baselinePing.getEnabledAccessibilityServices(
-                accessibilityManager
-            )
-        )
-    }
-
     @Test
     fun `getLanguageTag() reports the tag for the default locale`() {
         val baselinePing = BaselinePing(ApplicationProvider.getApplicationContext<Context>())


### PR DESCRIPTION
In 1525042, it was determined that this belongs in app (or at least platform-specific) code and not in glean.  This is just a simple removal.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
