### PR TITLE
[glean] 1512933: Internalize some classes

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -28,7 +28,7 @@ import mozilla.components.support.base.log.logger.Logger
 import java.io.File
 
 @Suppress("TooManyFunctions")
-open class GleanInternalAPI {
+open class GleanInternalAPI internal constructor () {
     private val logger = Logger("glean/Glean")
 
     // Include our singletons of StorageEngineManager and PingMaker

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
@@ -21,7 +21,7 @@ import org.json.JSONObject
  * A simple ping Uploader, which implements a "send once" policy, never
  * storing or attempting to send the ping again.
  */
-class HttpPingUploader(configuration: Configuration) : PingUploader {
+internal class HttpPingUploader(configuration: Configuration) : PingUploader {
     private val config = configuration
     private val logger = Logger("glean/HttpPingUploader")
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/PingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/PingUploader.kt
@@ -12,7 +12,7 @@ import java.util.TimeZone
 /**
  * The interface defining how to send pings.
  */
-interface PingUploader {
+internal interface PingUploader {
     fun upload(path: String, data: String): Boolean
 
     fun createDateHeaderValue(): String {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericScalarStorageEngine.kt
@@ -36,7 +36,7 @@ internal typealias ScalarRecordingCombiner<T> = (currentValue: T?, newValue: T) 
  * A base class for 'scalar' like metrics. This allows sharing the common
  * store managing and lifetime behaviours.
  */
-abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
+internal abstract class GenericScalarStorageEngine<ScalarType> : StorageEngine {
     override lateinit var applicationContext: Context
 
     // Let derived class define a logger so that they can provide a proper name,


### PR DESCRIPTION
This adds `internal` to some classes that were not intended to be public API.

For `GleanInternalAPI`, it still looks tricky to make that private and not show up in the docs without adding a lot of maintenance headaches (e.g. wrapper classes etc.).  This does make the constructor `internal` though, so other users at least can't make their own and have to go through the "one true" `Glean` singleton.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
