### PR TITLE
dokka: Link to GeckoView javadoc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,10 @@ task docs(type: org.jetbrains.dokka.gradle.DokkaAndroidTask, overwrite: true) {
         }
     }
 
+    externalDocumentationLink {
+        url = new URL("https://mozilla.github.io/geckoview/javadoc/mozilla-central/package-list")
+    }
+
     sourceDirs = files(subprojects.findAll {
         !it.name.startsWith("samples")
     }.collect { p ->


### PR DESCRIPTION
This will make classes from GeckoView link to the GeckoView javadocs.