### PR TITLE
Closes #1908: AutoSave doesn't work if no sessions left

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -37,11 +37,11 @@ class SessionManager(
      * Produces a snapshot of this manager's state, suitable for restoring via [SessionManager.restore].
      * Only regular sessions are included in the snapshot. Private and Custom Tab sessions are omitted.
      *
-     * @return [Snapshot] or null if no sessions are present.
+     * @return [Snapshot] of the current session state.
      */
-    fun createSnapshot(): Snapshot? = synchronized(values) {
+    fun createSnapshot(): Snapshot = synchronized(values) {
         if (values.isEmpty()) {
-            return null
+            return Snapshot.empty()
         }
 
         // Filter out CustomTab and private sessions.
@@ -60,7 +60,7 @@ class SessionManager(
 
         // We might have some sessions (private, custom tab) but none we'd include in the snapshot.
         if (sessionStateTuples.isEmpty()) {
-            return null
+            return Snapshot.empty()
         }
 
         // We need to find out the index of our selected session in the filtered list. If we have a
@@ -530,6 +530,10 @@ class SessionManager(
             val engineSession: EngineSession? = null,
             val engineSessionState: EngineSessionState? = null
         )
+
+        companion object {
+            fun empty() = Snapshot(emptyList(), NO_SELECTION)
+        }
     }
 }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/AutoSave.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/AutoSave.kt
@@ -108,9 +108,7 @@ class AutoSave(
 
             try {
                 val snapshot = sessionManager.createSnapshot()
-                if (snapshot != null) {
-                    sessionStorage.save(snapshot)
-                }
+                sessionStorage.save(snapshot)
             } finally {
                 val took = now() - start
                 logger.debug("Saved state to disk [${took}ms]")

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -300,7 +300,7 @@ class SessionManagerTest {
     @Test
     fun `createSnapshot works when manager has no sessions`() {
         val manager = SessionManager(mock())
-        assertNull(manager.createSnapshot())
+        assertTrue(manager.createSnapshot().isEmpty())
     }
 
     @Test
@@ -309,7 +309,7 @@ class SessionManagerTest {
         val session = Session("http://mozilla.org", true)
         manager.add(session)
 
-        assertNull(manager.createSnapshot())
+        assertTrue(manager.createSnapshot().isEmpty())
     }
 
     @Test
@@ -319,7 +319,7 @@ class SessionManagerTest {
         session.customTabConfig = Mockito.mock(CustomTabConfig::class.java)
         manager.add(session)
 
-        assertNull(manager.createSnapshot())
+        assertTrue(manager.createSnapshot().isEmpty())
     }
 
     @Test
@@ -329,7 +329,7 @@ class SessionManagerTest {
         session.customTabConfig = Mockito.mock(CustomTabConfig::class.java)
         manager.add(session)
 
-        assertNull(manager.createSnapshot())
+        assertTrue(manager.createSnapshot().isEmpty())
     }
 
     @Test(expected = IllegalArgumentException::class)


### PR DESCRIPTION
@pocmo just added the test which failed in #1896 and a quick fix. I think it's better for `createSnapshot` not to return a nullable type.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
