### PR TITLE
Issue #2038: Add browser-icons component for loading and storing website icons.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -116,6 +116,10 @@ projects:
     path: components/browser/errorpages
     description: 'Responsive browser error pages for Android apps.'
     publish: true
+  browser-icons:
+    path: components/browser/icons
+    description: 'A component for loading and storing website icons.'
+    publish: true
   browser-menu:
     path: components/browser/menu
     description: 'A customizable menu for browsers.'

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ High-level components for building browser(-like) apps.
 
 * 🔵 [**Errorpages**](components/browser/errorpages/README.md) - Responsive browser error pages for Android apps.
 
+* 🔴 [**Icons**](components/browser/icons/README.md) - A component for loading and storing website icons (like [Favicons](https://en.wikipedia.org/wiki/Favicon)).
+
 * 🔴 [**Menu**](components/browser/menu/README.md) - A generic menu with customizable items primarily for browser toolbars.
 
 * 🔵 [**Search**](components/browser/search/README.md) - Search plugins and companion code to load, parse and use them.

--- a/components/browser/icons/README.md
+++ b/components/browser/icons/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Browser > Icons
+
+A component for loading and storing website icons (like [Favicons](https://en.wikipedia.org/wiki/Favicon)).
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:browser-icons:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':support-ktx')
+
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    implementation Dependencies.support_annotations
+
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/browser/icons/proguard-rules.pro
+++ b/components/browser/icons/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/browser/icons/src/main/AndroidManifest.xml
+++ b/components/browser/icons/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.browser.icons" />

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import mozilla.components.browser.icons.generator.DefaultIconGenerator
+import mozilla.components.browser.icons.generator.IconGenerator
+import java.util.concurrent.Executors
+
+// Number of worker threads we are using internally.
+private const val THREADS = 3
+
+/**
+ * Entry point for loading icons for websites.
+ */
+class BrowserIcons(
+    private val context: Context,
+    private val generator: IconGenerator = DefaultIconGenerator(context),
+    jobDispatcher: CoroutineDispatcher = Executors.newFixedThreadPool(THREADS).asCoroutineDispatcher()
+) {
+    private val scope = CoroutineScope(jobDispatcher)
+
+    /**
+     * Asynchronously loads an [Icon] for the given [IconRequest].
+     */
+    fun loadIcon(request: IconRequest): Deferred<Icon> = scope.async {
+        // For now we only generate an icon.
+        generator.generate(context, request)
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/Icon.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/Icon.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons
+
+import android.graphics.Bitmap
+
+/**
+ * An [Icon] returned by [BrowserIcons] after processing an [IconRequest]
+ *
+ * @property bitmap The loaded icon as a [Bitmap] or null if no icon could be loaded.
+ * @property color The dominant color of the icon. Will be null if no color could be extracted.
+ * @property source The source of the icon.
+ */
+data class Icon(
+    val bitmap: Bitmap? = null,
+    val color: Int? = null,
+    val source: Source
+) {
+    /**
+     * The source of an [Icon].
+     */
+    enum class Source {
+        /**
+         * This icon was generated.
+         */
+        GENERATOR
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/IconRequest.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/IconRequest.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons
+
+/**
+ * A request to load an [Icon].
+ *
+ * @property url The URL of the website an icon should be loaded for.
+ * @property size The preferred size of the icon that should be loaded.
+ */
+data class IconRequest(
+    val url: String,
+    val size: Size = Size.DEFAULT
+) {
+    /**
+     * Supported sizes.
+     *
+     * We are trying to limit the supported sizes in order to optimize our caching strategy.
+     */
+    @Suppress("MagicNumber")
+    enum class Size(
+        val value: Int
+    ) {
+        DEFAULT(32)
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/DefaultIconGenerator.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/DefaultIconGenerator.kt
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.generator
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.net.Uri
+import android.util.TypedValue
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
+
+/**
+ * [IconGenerator] implementation that will generate an icon with a background color, rounded corners and a letter
+ * representing the URL.
+ */
+class DefaultIconGenerator(
+    context: Context,
+    cornerRadius: Int = DEFAULT_CORNER_RADIUS,
+    private val textColor: Int = Color.WHITE,
+    private val backgroundColors: IntArray = DEFAULT_COLORS
+) : IconGenerator {
+    private val cornerRadius: Float = context.resources.pxToDp(cornerRadius).toFloat()
+
+    @Suppress("MagicNumber")
+    override fun generate(context: Context, request: IconRequest): Icon {
+        val size = context.resources.pxToDp(request.size.value)
+
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val backgroundColor = pickColor(request.url)
+
+        val paint = Paint()
+        paint.color = backgroundColor
+
+        canvas.drawRoundRect(
+            RectF(0f, 0f, size.toFloat(), size.toFloat()), cornerRadius, cornerRadius, paint)
+
+        paint.color = textColor
+
+        val character = getRepresentativeCharacter(request.url)
+
+        // The text size is calculated dynamically based on the target icon size (1/8th). For an icon
+        // size of 112dp we'd use a text size of 14dp (112 / 8).
+        val textSize = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            size.toFloat() / 8.0f,
+            context.resources.displayMetrics
+        )
+
+        paint.textAlign = Paint.Align.CENTER
+        paint.textSize = textSize
+        paint.isAntiAlias = true
+
+        canvas.drawText(
+            character,
+            canvas.width / 2.0f,
+            (canvas.height / 2.0f) - ((paint.descent() + paint.ascent()) / 2.0f),
+            paint
+        )
+
+        return Icon(bitmap = bitmap, color = backgroundColor, source = Icon.Source.GENERATOR)
+    }
+
+    /**
+     * Return a color for this [url]. Colors will be based on the host. URLs with the same host will
+     * return the same color.
+     */
+    internal fun pickColor(url: String): Int {
+        if (url.isEmpty()) {
+            return backgroundColors[0]
+        }
+
+        val snippet = getRepresentativeSnippet(url)
+        val index = Math.abs(snippet.hashCode() % backgroundColors.size)
+
+        return backgroundColors[index]
+    }
+
+    /**
+     * Get the representative part of the URL. Usually this is the eTLD part of the host.
+     *
+     * For example this method will return "facebook.com" for "https://www.facebook.com/foobar".
+     */
+    private fun getRepresentativeSnippet(url: String): String {
+        val uri = Uri.parse(url)
+
+        val host = uri.hostWithoutCommonPrefixes
+        if (!host.isNullOrEmpty()) {
+            return host
+        }
+
+        val path = uri.path
+        if (!path.isNullOrEmpty()) {
+            return path
+        }
+
+        return url
+    }
+
+    /**
+     * Get a representative character for the given URL.
+     *
+     * For example this method will return "f" for "https://m.facebook.com/foobar".
+     */
+    internal fun getRepresentativeCharacter(url: String): String {
+        val snippet = getRepresentativeSnippet(url)
+
+        snippet.forEach { character ->
+            if (character.isLetterOrDigit()) {
+                return character.toUpperCase().toString()
+            }
+        }
+
+        return "?"
+    }
+
+    companion object {
+        // Mozilla's Visual Design Colour Palette
+        // http://firefoxux.github.io/StyleGuide/#/visualDesign/colours
+        private val DEFAULT_COLORS =
+            intArrayOf(-0x65b400, -0x54ff73, -0xb3ff64, -0xffd164, -0xff613e, -0xff62fe, -0xae5500, -0xc9c7a6)
+
+        private const val DEFAULT_CORNER_RADIUS = 2
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/IconGenerator.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/IconGenerator.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.generator
+
+import android.content.Context
+import android.graphics.Bitmap
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * A [IconGenerator] implementation can generate a [Bitmap] for an [IconRequest]. It's a fallback if no icon could be
+ * loaded for a specific URL.
+ */
+interface IconGenerator {
+    fun generate(context: Context, request: IconRequest): Icon
+}

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.icons.generator.IconGenerator
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserIconsTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `Uses generator`() {
+        val mockedIcon: Icon = mock()
+
+        val generator: IconGenerator = mock()
+        `when`(generator.generate(any(), any())).thenReturn(mockedIcon)
+
+        val request = IconRequest(url = "https://www.mozilla.org")
+        val icon = BrowserIcons(context, generator = generator)
+            .loadIcon(request)
+
+        assertEquals(mockedIcon, runBlocking { icon.await() })
+
+        verify(generator).generate(context, request)
+    }
+}

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.generator
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.support.ktx.android.content.res.pxToDp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultIconGeneratorTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun getRepresentativeCharacter() = runBlocking {
+        val generator = DefaultIconGenerator(context)
+
+        assertEquals("M", generator.getRepresentativeCharacter("https://mozilla.org"))
+        assertEquals("W", generator.getRepresentativeCharacter("http://wikipedia.org"))
+        assertEquals("P", generator.getRepresentativeCharacter("http://plus.google.com"))
+        assertEquals("E", generator.getRepresentativeCharacter("https://en.m.wikipedia.org/wiki/Main_Page"))
+
+        // Stripping common prefixes
+        assertEquals("T", generator.getRepresentativeCharacter("http://www.theverge.com"))
+        assertEquals("F", generator.getRepresentativeCharacter("https://m.facebook.com"))
+        assertEquals("T", generator.getRepresentativeCharacter("https://mobile.twitter.com"))
+
+        // Special urls
+        assertEquals("?", generator.getRepresentativeCharacter("file:///"))
+        assertEquals("S", generator.getRepresentativeCharacter("file:///system/"))
+        assertEquals("P", generator.getRepresentativeCharacter("ftp://people.mozilla.org/test"))
+
+        // No values
+        assertEquals("?", generator.getRepresentativeCharacter(""))
+
+        // Rubbish
+        assertEquals("Z", generator.getRepresentativeCharacter("zZz"))
+        assertEquals("Ö", generator.getRepresentativeCharacter("ölkfdpou3rkjaslfdköasdfo8"))
+        assertEquals("?", generator.getRepresentativeCharacter("_*+*'##"))
+        assertEquals("ツ", generator.getRepresentativeCharacter("¯\\_(ツ)_/¯"))
+        assertEquals("ಠ", generator.getRepresentativeCharacter("ಠ_ಠ Look of Disapproval"))
+
+        // Non-ASCII
+        assertEquals("Ä", generator.getRepresentativeCharacter("http://www.ätzend.de"))
+        assertEquals("名", generator.getRepresentativeCharacter("http://名がドメイン.com"))
+        assertEquals("C", generator.getRepresentativeCharacter("http://√.com"))
+        assertEquals("ß", generator.getRepresentativeCharacter("http://ß.de"))
+        assertEquals("Ԛ", generator.getRepresentativeCharacter("http://ԛәлп.com/")) // cyrillic
+
+        // Punycode
+        assertEquals("X", generator.getRepresentativeCharacter("http://xn--tzend-fra.de")) // ätzend.de
+        assertEquals(
+            "X",
+            generator.getRepresentativeCharacter("http://xn--V8jxj3d1dzdz08w.com")
+        ) // 名がドメイン.com
+
+        // Numbers
+        assertEquals("1", generator.getRepresentativeCharacter("https://www.1and1.com/"))
+
+        // IP
+        assertEquals("1", generator.getRepresentativeCharacter("https://192.168.0.1"))
+    }
+
+    @Test
+    fun pickColor() {
+        val generator = DefaultIconGenerator(context)
+
+        val color = generator.pickColor("http://m.facebook.com")
+
+        // Color does not change
+        for (i in 0..99) {
+            assertEquals(color, generator.pickColor("http://m.facebook.com"))
+        }
+
+        // Color is stable for "similar" hosts.
+        assertEquals(color, generator.pickColor("https://m.facebook.com"))
+        assertEquals(color, generator.pickColor("http://facebook.com"))
+        assertEquals(color, generator.pickColor("http://www.facebook.com"))
+        assertEquals(color, generator.pickColor("http://www.facebook.com/foo/bar/foobar?mobile=1"))
+
+        // Returns a color for an empty string
+        assertNotEquals(0, generator.pickColor(""))
+    }
+
+    @Test
+    fun generate() = runBlocking {
+        val generator = DefaultIconGenerator(context)
+
+        val icon = generator.generate(context, IconRequest(
+            url = "https://m.facebook.com"))
+
+        assertNotNull(icon.bitmap)
+        assertNotNull(icon.color)
+
+        val dp32 = context.resources.pxToDp(32)
+        assertEquals(dp32, icon.bitmap!!.width)
+        assertEquals(dp32, icon.bitmap!!.height)
+
+        assertEquals(Bitmap.Config.ARGB_8888, icon.bitmap!!.config)
+
+        assertEquals(Icon.Source.GENERATOR, icon.source)
+    }
+}

--- a/components/browser/icons/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/browser/icons/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-icons**
+  * 🆕 New component for loading and storing website icons (like [Favicons](https://en.wikipedia.org/wiki/Favicon)).
+  * Supports generating a "fallback" icon if no icon could be loaded.
+
 * **concept-fetch**
   * Added API to specify whether or not cookies should be sent with a request. This can be controlled using the `cookiePolicy` parameter when creating a `Request`.
 


### PR DESCRIPTION
This is only the most basic shell for this component and gets us going. For now it will only generate a "fallback" icon (ported from Fennec).

I created the following project to track the other related work:
https://github.com/orgs/mozilla-mobile/projects/22

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
