### PR TITLE
[glean] WIP: 1525904: Add a no-op version of glean

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -188,6 +188,10 @@ projects:
     path: components/service/glean
     description: 'A client-side telemetry SDK for collecting metrics and sending them to the Mozilla telemetry service'
     publish: true
+  service-glean-no-op:
+    path: components/service/glean-no-op
+    description: 'A no-op version of the glean telemetry library'
+    publish: true
   service-telemetry:
     path: components/service/telemetry
     description: 'A generic library for generating and sending telemetry pings from Android applications to the Mozilla telemetry service.'

--- a/components/service/glean-no-op/README.md
+++ b/components/service/glean-no-op/README.md
@@ -1,0 +1,21 @@
+# [Android Components](../../../README.md) > Service > Glean-No-Op
+
+A no-op version of the glean telemetry API.  For use when you want to build
+a tool with glean support without actually collecting or sending telemetry.
+
+See [glean](../glean/README.org) for more information.
+
+TODO: Document how to use this no-op version.
+
+## Contact
+
+To contact us you can:
+- Find us on the Mozilla Slack in *#glean*, on [Mozilla IRC](https://wiki.mozilla.org/IRC) in *#telemetry*.
+- To report issues or request changes, file a bug in [Bugzilla in Toolkit::Telemetry](https://bugzilla.mozilla.org/enter_bug.cgi?product=Toolkit&component=Telemetry&status_whiteboard=%5Btelemetry%3Amobilesdk%3Am%3F%5D) and mention Glean in the title.
+- Send an email to *glean-team@mozilla.com*.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/service/glean-no-op/build.gradle
+++ b/components/service/glean-no-op/build.gradle
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/service/glean-no-op/proguard-rules.pro
+++ b/components/service/glean-no-op/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/service/glean-no-op/src/main/AndroidManifest.xml
+++ b/components/service/glean-no-op/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.service.glean.noop" />

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/BooleanMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/BooleanMetricType.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class BooleanMetricType(
+    val disabled: Boolean,
+    val category: String,
+    val lifetime: Lifetime,
+    val name: String,
+    val sendInPings: List<String>
+) {
+    @Suppress("UNUSED_PARAMETER")
+    fun set(value: Boolean) {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/CounterMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/CounterMetricType.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class CounterMetricType(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>
+) {
+    @Suppress("UNUSED_PARAMETER")
+    fun add(amount: Int = 1) {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/EventMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/EventMetricType.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class EventMetricType(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>,
+    objects: List<String>,
+    allowedExtraKeys: List<String>? = null
+) {
+    @Suppress("UNUSED_PARAMETER")
+    fun record(objectId: String, value: String? = null, extra: Map<String, String>? = null) {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+import android.content.Context
+import mozilla.components.service.glean.config.Configuration
+
+/**
+ * Enumeration of different metric lifetimes.
+ */
+enum class Lifetime {
+    /**
+    * The metric is reset with each sent ping
+    */
+    Ping,
+    /**
+    * The metric is reset on application restart
+    */
+    Application,
+    /**
+    * The metric is reset with each user profile
+    */
+    User
+}
+
+@Suppress("UNUSED_PARAMETER")
+open class GleanInternalAPI internal constructor () {
+    @Suppress("UNUSED_PARAMETER")
+    fun initialize(
+        applicationContext: Context,
+        configuration: Configuration = Configuration()
+    ) {
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun setUploadEnabled(enabled: Boolean) {
+    }
+
+    fun getUploadEnabled(): Boolean {
+        return false
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun setExperimentActive(
+        experimentId: String,
+        branch: String,
+        extra: Map<String, String>? = null
+    ) {
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun setExperimentInactive(experimentId: String) {
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun handleEvent(pingEvent: Glean.PingEvent) {
+    }
+}
+
+object Glean : GleanInternalAPI() {
+    /**
+    * Enumeration of different metric lifetimes.
+    */
+    enum class PingEvent {
+        /**
+        * When the application goes into the background
+        */
+        Background,
+        /**
+        * A periodic event to send the default ping
+        */
+        Default
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/LabeledMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/LabeledMetricType.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class LabeledMetricType<T>(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>,
+    subMetric: T,
+    labels: Set<String>? = null
+) {
+    val subMetric = subMetric
+
+    @Suppress("UNUSED_PARAMETER")
+    operator fun get(label: String): T {
+        return subMetric
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/StringListMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/StringListMetricType.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class StringListMetricType(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>
+) {
+    @Suppress("UNUSED_PARAMETER")
+    fun add(value: String) {
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun set(value: List<String>) {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class StringMetricType(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>
+) {
+    @Suppress("UNUSED_PARAMETER")
+    fun set(value: String) {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/TimeUnit.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/TimeUnit.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+/**
+ * Enumeration of different resolutions supported by
+ * the Timespan metric type.
+ */
+enum class TimeUnit {
+    Nanosecond,
+    Microsecond,
+    Millisecond,
+    Second,
+    Minute,
+    Hour,
+    Day
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/TimespanMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/TimespanMetricType.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+@Suppress("UNUSED_PARAMETER")
+class TimespanMetricType(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>,
+    timeUnit: TimeUnit
+) {
+    fun start() {
+    }
+
+    fun stopAndSum() {
+    }
+
+    fun cancel() {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+import java.util.UUID
+
+@Suppress("UNUSED_PARAMETER")
+class UuidMetricType(
+    disabled: Boolean,
+    category: String,
+    lifetime: Lifetime,
+    name: String,
+    sendInPings: List<String>
+) {
+    fun generateAndSet(): UUID? {
+        return UUID.randomUUID()
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun set(value: UUID) {
+    }
+}

--- a/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean-no-op/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.config
+
+@Suppress("UNUSED_PARAMETER")
+class Configuration(
+    serverEndpoint: String = "",
+    userAgent: String = "",
+    connectionTimeout: Int = 0,
+    readTimeout: Int = 0,
+    maxEvents: Int = 0,
+    logPings: Boolean = false
+)

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation project(':service-glean')
+    implementation project(':service-glean-no-op')
     implementation project(':support-base')
 
     implementation Dependencies.kotlin_stdlib


### PR DESCRIPTION
This is an experiment to demonstrate how having a no-op version of glean might work.

The use case is so that libraries within android-components (and elsewhere) might use glean to collect telemetry, but to ensure that those libraries can still be used in contexts that won't collect telemetry.

This follows a pattern used by [leakcanary](https://github.com/square/leakcanary).

Open questions:

We'd need a way to ensure that the noop and regular glean implementations don't drift.  I see a few ways forward:

- Have a third interface-only library that both libraries inherit from, and let the compiler ensure that both are implementing the same interface.
- Use a tool such as [Java API Compliance Checker](https://lvc.github.io/japi-compliance-checker/) to ensure that the two libraries have the same public API.

The success of this approach probably comes down to how well we can document and communicate this requirement to users of glean-using libraries.  I don't have any good ideas there beyond **putting things in bold**. :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
