### PR TITLE
Add initial "facts" to browser-toolbar component.

### DIFF
--- a/components/browser/toolbar/README.md
+++ b/components/browser/toolbar/README.md
@@ -12,6 +12,15 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:browser-toolbar:{latest-version}"
 ```
 
+## Facts
+
+This component emits the following [Facts](../../support/base/README.md#Facts):
+
+| Action | Item | Description |
+|---|---|---|---|---|
+| CLICK | menu | The user opened the overflow menu. |
+| COMMIT | toolbar | The user has edited the URL. |
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -20,6 +20,7 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
+import mozilla.components.browser.toolbar.facts.emitOpenMenuFact
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
 import mozilla.components.support.ktx.android.content.res.pxToDp
@@ -121,6 +122,8 @@ internal class DisplayToolbar(
             menuBuilder?.build(context)?.show(
                 anchor = this,
                 orientation = BrowserMenu.determineMenuOrientation(toolbar))
+
+            emitOpenMenuFact()
         }
     }
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -14,6 +14,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
+import mozilla.components.browser.toolbar.facts.emitCommitFact
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.ktx.android.content.res.pxToDp
 import mozilla.components.support.ktx.android.view.showKeyboard
@@ -48,7 +49,11 @@ class EditToolbar(
         setPadding(padding, padding, padding, padding)
         setSelectAllOnFocus(true)
 
-        setOnCommitListener { toolbar.onUrlEntered(text.toString()) }
+        setOnCommitListener {
+            toolbar.onUrlEntered(text.toString())
+            emitCommitFact()
+        }
+
         setOnTextChangeListener { text, _ ->
             editListener?.onTextChanged(text)
         }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/facts/ToolbarFacts.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/facts/ToolbarFacts.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+private fun emitToolbarFact(
+    action: Action,
+    item: String,
+    value: String? = null,
+    metadata: Map<String, Any>? = null
+) {
+    Fact(
+        Component.BROWSER_TOOLBAR,
+        action,
+        item,
+        value,
+        metadata
+    ).collect()
+}
+
+private object ToolbarItems {
+    const val TOOLBAR = "toolbar"
+    const val MENU = "menu"
+}
+
+internal fun emitOpenMenuFact() = emitToolbarFact(Action.CLICK, ToolbarItems.MENU)
+
+internal fun emitCommitFact() = emitToolbarFact(Action.COMMIT, ToolbarItems.TOOLBAR)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -16,10 +16,13 @@ import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.processor.CollectionProcessor
 import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.support.test.mock
-import mozilla.components.browser.toolbar.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -636,6 +639,33 @@ class DisplayToolbarTest {
 
         assertEquals(R.color.photonBlue40, displayToolbar.securityIconColor.first)
         assertEquals(R.color.photonBlue40, displayToolbar.securityIconColor.second)
+    }
+
+    @Test
+    fun `clicking menu button emits fact`() {
+        CollectionProcessor.withFactCollection { facts ->
+            val toolbar = mock(BrowserToolbar::class.java)
+            val displayToolbar = DisplayToolbar(context, toolbar)
+            val menuView = extractMenuView(displayToolbar)
+
+            val menuBuilder = mock(BrowserMenuBuilder::class.java)
+            val menu = mock(BrowserMenu::class.java)
+            doReturn(menu).`when`(menuBuilder).build(context)
+            displayToolbar.menuBuilder = menuBuilder
+
+            assertEquals(0, facts.size)
+
+            menuView.performClick()
+
+            assertEquals(1, facts.size)
+
+            val fact = facts[0]
+            assertEquals(Component.BROWSER_TOOLBAR, fact.component)
+            assertEquals(Action.CLICK, fact.action)
+            assertEquals("menu", fact.item)
+            assertNull(fact.value)
+            assertNull(fact.metadata)
+        }
     }
 
     companion object {

--- a/components/support/base/README.md
+++ b/components/support/base/README.md
@@ -14,11 +14,11 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:support-base:{latest-version}"
 ```
 
-### Logging
+## Logging
 
 The base component offers helpers for logging for component (and app) code that allows the app to be in control what gets logged and how.
 
-#### Setup
+### Setup
 
 A log messages are routed through the `Log` object which doesn't process any logs itself. Instead it forwards the calls to `LogSink` implementations. The base component includes the `AndroidLogSink` class which implements `LogSink` and forwards log messages to Android's system log.
 
@@ -39,7 +39,7 @@ Log.logLevel = Log.Priority.WARN
 
 An application can add multiple `LogSink` implementations to save logs to disk, send them to a crash reporting service or display them inside the app.
 
-#### Logger
+### Logger
 
 The `Log` class only offers a low-level logging call. The `logger` sub package contains classes that wrap `Log` and provide a more convenient API for logging.
 
@@ -67,6 +67,25 @@ class MyClass {
      Logger.info("Hello World!")
    }
 }
+```
+
+## Facts
+
+A `Fact` is a generic "event" that a component emitted.
+
+Facts are not meant to implement application logic based on them. Instead they can be observed as a stream of "user/app events" inside components that can be analyzed or forwarded to external telemetry services.
+
+By default nothing happens with `Fact` instances. An app needs to register a `FactProcessor` that will receive all emitted `Fact` objects.
+
+The base component comes with a `LogFactProcessor` that will print all emitted `Fact` instances to a `Logger`.
+
+```kotlin
+// Either install processors on the Facts object:
+Facts.registerProcessor(LogFactProcessor())
+
+// Or use the extension method:
+LogFactProcessor()
+    .register()
 ```
 
 ## License

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/Facts.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/Facts.kt
@@ -27,8 +27,8 @@ object Facts {
         processors.forEach { it.process(fact) }
     }
 
-    @VisibleForTesting
-    internal fun clearProcessors() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun clearProcessors() {
         processors.clear()
     }
 }

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/processor/CollectionProcessor.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/processor/CollectionProcessor.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.facts.processor
+
+import android.support.annotation.VisibleForTesting
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.FactProcessor
+import mozilla.components.support.base.facts.Facts
+
+/**
+ * A [FactProcessor] implementation that keeps all [Fact] objects in a list.
+ *
+ * This [FactProcessor] is only for testing.
+ */
+@VisibleForTesting
+class CollectionProcessor : FactProcessor {
+    private val internalFacts = mutableListOf<Fact>()
+
+    val facts: List<Fact>
+        get() = internalFacts
+
+    override fun process(fact: Fact) {
+        internalFacts.add(fact)
+    }
+
+    companion object {
+        /**
+         * Helper for creating a [CollectionProcessor], registering it and clearing the processors again.
+         *
+         * Use in tests like:
+         *
+         * ```
+         * CollectionProcessor.withFactCollection { facts ->
+         *   // During execution of this block the "facts" list will be updated automatically to contain
+         *   // all facts that were emitted while executing this block.
+         *   // After this block has completed all registered processors will be cleared.
+         * }
+         * ```
+         */
+        fun withFactCollection(block: (List<Fact>) -> Unit) {
+            val processor = CollectionProcessor()
+
+            try {
+                Facts.registerProcessor(processor)
+
+                block.invoke(processor.facts)
+            } finally {
+                Facts.clearProcessors()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds two "facts" to the `browser-toolbar` component.

In the reference browser I want to experiment with forwarding "facts" from our components to glean.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
