### PR TITLE
concept-fetch for awesomebar and response decoding fix

### DIFF
--- a/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -115,4 +115,10 @@ class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTest
     override fun get200WithCookiePolicy() {
         super.get200WithCookiePolicy()
     }
+
+    @Test
+    @UiThreadTest
+    override fun get200WithContentTypeCharset() {
+        super.get200WithContentTypeCharset()
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -95,11 +95,14 @@ private fun WebRequest.Builder.addBodyFrom(request: Request): WebRequest.Builder
 }
 
 private fun WebResponse.toResponse(): Response {
+    val headers = translateHeaders(this)
     return Response(
         uri,
         statusCode,
-        translateHeaders(this),
-            body?.let { Response.Body(ByteBufferInputStream(it)) } ?: Response.Body.empty()
+        headers,
+            body?.let {
+                Response.Body(ByteBufferInputStream(it), headers["Content-Type"])
+            } ?: Response.Body.empty()
     )
 }
 

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
@@ -73,7 +73,7 @@ class MutableHeaders(
     /**
      * Returns the last value corresponding to the specified header field name. Or null if the header does not exist.
      */
-    override fun get(name: String) = headers.lastOrNull { header -> header.name == name }?.value
+    override fun get(name: String) = headers.lastOrNull { it.name.toLowerCase() == name.toLowerCase() }?.value
 
     /**
      * Returns the list of values corresponding to the specified header field name.

--- a/components/feature/awesomebar/build.gradle
+++ b/components/feature/awesomebar/build.gradle
@@ -23,6 +23,7 @@ android {
 
 dependencies {
     implementation project(':concept-awesomebar')
+    implementation project(':concept-fetch')
     implementation project(':concept-engine')
     implementation project(':concept-toolbar')
     implementation project(':concept-storage')
@@ -41,6 +42,7 @@ dependencies {
 
     testImplementation project(':support-test')
     testImplementation project(':browser-storage-memory')
+    testImplementation project(':lib-fetch-httpurlconnection')
 
     testImplementation Dependencies.androidx_test_core
 

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
@@ -29,7 +30,6 @@ class AwesomeBarFeature(
     private val engineView: EngineView? = null,
     private val onEditStart: (() -> Unit)? = null,
     private val onEditComplete: (() -> Unit)? = null
-
 ) {
     init {
         toolbar.setOnEditListener(object : mozilla.components.concept.toolbar.Toolbar.OnEditListener {
@@ -67,9 +67,10 @@ class AwesomeBarFeature(
     fun addSearchProvider(
         searchEngine: SearchEngine,
         searchUseCase: SearchUseCases.SearchUseCase,
+        fetchClient: Client,
         mode: SearchSuggestionProvider.Mode = SearchSuggestionProvider.Mode.SINGLE_SUGGESTION
     ): AwesomeBarFeature {
-        awesomeBar.addProviders(SearchSuggestionProvider(searchEngine, searchUseCase, mode))
+        awesomeBar.addProviders(SearchSuggestionProvider(searchEngine, searchUseCase, fetchClient, mode))
         return this
     }
 

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
@@ -145,8 +145,6 @@ class SearchSuggestionProvider(
             return response.use { it.body.string() }
         } catch (e: IOException) {
             return null
-        } catch (e: ClassCastException) {
-            return null
         } catch (e: ArrayIndexOutOfBoundsException) {
             // On some devices we are seeing an ArrayIndexOutOfBoundsException being thrown
             // somewhere inside AOSP/okhttp.

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
@@ -95,7 +95,7 @@ class AwesomeBarFeatureTest {
 
         verify(awesomeBar, never()).addProviders(any())
 
-        feature.addSearchProvider(mock(), mock())
+        feature.addSearchProvider(mock(), mock(), mock())
 
         verify(awesomeBar).addProviders(any())
     }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -56,7 +57,7 @@ class SearchSuggestionProviderTest {
             ).defaultSearch)
             doNothing().`when`(useCase).invoke(anyString(), any<Session>())
 
-            val provider = SearchSuggestionProvider(searchEngine, useCase)
+            val provider = SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
 
             try {
                 val suggestions = provider.onInputChanged("fire")
@@ -114,6 +115,7 @@ class SearchSuggestionProviderTest {
             val provider = SearchSuggestionProvider(
                 searchEngine,
                 useCase,
+                HttpURLConnectionClient(),
                 SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS
             )
 
@@ -149,13 +151,13 @@ class SearchSuggestionProviderTest {
 
     @Test
     fun `Provider should not clear suggestions`() {
-        val provider = SearchSuggestionProvider(mock(), mock())
+        val provider = SearchSuggestionProvider(mock(), mock(), mock())
         assertFalse(provider.shouldClearSuggestions)
     }
 
     @Test
     fun `Provider returns empty list if text is empty`() = runBlocking {
-        val provider = SearchSuggestionProvider(mock(), mock())
+        val provider = SearchSuggestionProvider(mock(), mock(), mock())
 
         val suggestions = provider.onInputChanged("")
         assertTrue(suggestions.isEmpty())
@@ -166,7 +168,7 @@ class SearchSuggestionProviderTest {
         val searchEngine: SearchEngine = mock()
         doReturn(false).`when`(searchEngine).canProvideSearchSuggestions
 
-        val provider = SearchSuggestionProvider(searchEngine, mock())
+        val provider = SearchSuggestionProvider(searchEngine, mock(), mock())
 
         val suggestions = provider.onInputChanged("fire")
         assertEquals(1, suggestions.size)

--- a/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
+++ b/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
@@ -75,12 +75,13 @@ private fun okhttp3.OkHttpClient.rebuildFor(request: Request): okhttp3.OkHttpCli
 
 private fun okhttp3.Response.toResponse(): Response {
     val body = body()
+    val headers = translateHeaders(headers())
 
     return Response(
         url = request().url().toString(),
-        headers = translateHeaders(headers()),
+        headers = headers,
         status = code(),
-        body = if (body != null) Response.Body(body.byteStream()) else Response.Body.empty()
+        body = if (body != null) Response.Body(body.byteStream(), headers["Content-Type"]) else Response.Body.empty()
     )
 }
 

--- a/components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt
+++ b/components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt
@@ -426,6 +426,27 @@ abstract class FetchTestCases {
         assertNull(takeRequest().getHeader("Cookie"))
     }
 
+    @Test
+    open fun get200WithContentTypeCharset() = withServerResponding(
+            MockResponse()
+                .addHeader("Content-Type", "text/html; charset=ISO-8859-1")
+                .setBody(Buffer().writeString("ÄäÖöÜü", Charsets.ISO_8859_1)),
+            MockResponse()
+                .addHeader("Content-Type", "text/html; charset=invalid")
+                .setBody("Hello World")
+    ) { client ->
+
+        val response = client.fetch(Request(rootUrl()))
+
+        assertEquals(200, response.status)
+        assertEquals("ÄäÖöÜü", response.body.string())
+
+        val response2 = client.fetch(Request(rootUrl()))
+
+        assertEquals(200, response2.status)
+        assertEquals("Hello World", response2.body.string())
+    }
+
     private inline fun withServerResponding(
         vararg responses: MockResponse,
         crossinline block: MockWebServer.(Client) -> Unit

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,7 +37,7 @@ permalink: /changelog/
       components.searchEngineManager.getDefaultSearchEngine(requireContext()),
       components.searchUseCases.defaultSearch,
       // Specify that the GV-based fetch client should be used.
-      GeckoViewFetchClient())
+      GeckoViewFetchClient(context))
   ```
 
 * **ui-doorhanger**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,20 @@ permalink: /changelog/
     val body = response.body.string()
   }
   ```
+* **feature-awesomebar**
+  * ⚠️ **This is a breaking API change!**
+  * Now makes use of our concept-fetch module when fetching search suggestions. This allows applications to specify which HTTP client library to use e.g. apps already using GeckoView can now specify that the `GeckoViewFetchClient` should be used. As a consequence, the fetch client instance now needs to be provided when adding a search provider. 
+
+  ```kotlin
+  AwesomeBarFeature(layout.awesomeBar, layout.toolbar, layout.engineView)
+    .addHistoryProvider(components.historyStorage, components.sessionUseCases.loadUrl)
+    .addSessionProvider(components.sessionManager, components.tabsUseCases.selectTab)
+    .addSearchProvider(
+      components.searchEngineManager.getDefaultSearchEngine(requireContext()),
+      components.searchUseCases.defaultSearch,
+      // Specify that the GV-based fetch client should be used.
+      GeckoViewFetchClient())
+  ```
 
 * **ui-doorhanger**
   * Added `DoorhangerPrompt` - a builder for creating a prompt `Doorhanger` providing a way to present decisions to users.

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -110,6 +110,7 @@ configurations {
 
 dependencies {
     implementation project(':concept-awesomebar')
+    implementation project(':concept-fetch')
     implementation project(':concept-engine')
     implementation project(':concept-tabstray')
     implementation project(':concept-toolbar')
@@ -124,6 +125,8 @@ dependencies {
     implementation project(':browser-toolbar')
     implementation project(':browser-menu')
     implementation project(':browser-storage-memory')
+
+    implementation project(':lib-fetch-httpurlconnection')
 
     implementation project(':feature-awesomebar')
     implementation project(':feature-contextmenu')

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -24,6 +24,7 @@ import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
@@ -77,7 +78,8 @@ class BrowserFragment : Fragment(), BackHandler {
             .addSessionProvider(components.sessionManager, components.tabsUseCases.selectTab)
             .addSearchProvider(
                 components.searchEngineManager.getDefaultSearchEngine(requireContext()),
-                components.searchUseCases.defaultSearch)
+                components.searchUseCases.defaultSearch,
+                HttpURLConnectionClient())
             .addClipboardProvider(requireContext(), components.sessionUseCases.loadUrl)
 
         downloadsFeature.set(


### PR DESCRIPTION
This brings in two commits/changes:

- Refactor our Awesomebar to use concept-fetch (tested with all implementations)
- A fix that makes sure all implementations of concept-fetch properly decode the response body based on the provided `content-type` header. This also fixes the encoding issues described in #1515 which happened (and now works) in all implementations (see attached screenshot)

![screenshot_20190213-153003](https://user-images.githubusercontent.com/472523/52748147-bee76d00-2fb3-11e9-8b36-21cf6e9445ab.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
