### PR TITLE
Do not delay closing of tabs tray.

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractor.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractor.kt
@@ -4,10 +4,6 @@
 
 package mozilla.components.feature.tabs.tabstray
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.TabsUseCases
@@ -33,25 +29,10 @@ class TabsTrayInteractor(
 
     override fun onTabSelected(session: Session) {
         selectTabUseCase.invoke(session)
-
-        CoroutineScope(Dispatchers.Main).launch {
-            delay(CLOSE_TABS_TRAY_DELAY_MS)
-
-            closeTabsTray.invoke()
-        }
+        closeTabsTray.invoke()
     }
 
     override fun onTabClosed(session: Session) {
         removeTabUseCase.invoke(session)
-    }
-
-    companion object {
-        /**
-         * Delay when closing the tabs tray after a user interaction. We delay closing the tabs
-         * tray so that the user has a chance seeing the state change inside the tabs tray before
-         * we close it. Android uses 250ms for most of its animations (e.g.
-         * Switch.THUMB_ANIMATION_DURATION).
-         */
-        private const val CLOSE_TABS_TRAY_DELAY_MS = 250L
     }
 }


### PR DESCRIPTION
Sooo. This should fix https://github.com/mozilla-mobile/reference-browser/issues/393. I'm not sure what I was thinking when I wrote this code. 🤦‍♂️

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
