### PR TITLE
Issue #2062: SessionManager: Allow calling restore() with empty snapshot.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -190,11 +190,10 @@ class SessionManager(
      *   notification will fire.
      *
      * @param snapshot A [Snapshot] which may be produced by [createSnapshot].
-     * @throws IllegalArgumentException if an empty snapshot is passed in.
      */
     fun restore(snapshot: Snapshot) = synchronized(values) {
-        require(snapshot.sessions.isNotEmpty()) {
-            "Snapshot must contain session state tuples"
+        if (snapshot.sessions.isEmpty()) {
+            return
         }
 
         // Let's be forgiving about incoming illegal selection indices, but strict about what we

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -332,10 +332,16 @@ class SessionManagerTest {
         assertTrue(manager.createSnapshot().isEmpty())
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `restore checks validity of a snapshot - empty`() {
         val manager = SessionManager(mock())
+
+        val observer: SessionManager.Observer = mock()
+        manager.register(observer)
+
         manager.restore(SessionManager.Snapshot(listOf(), selectedSessionIndex = 0))
+
+        verify(observer, never()).onSessionsRestored()
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,7 @@ permalink: /changelog/
 
 * **browser-session**, **feature-session-bundling**
   * `SessionStorage` and `SessionBundleStorage` now save and restore the title of `Session` objects.
+  * `SessionManager.restore()` now allows passing in empty snapshots.
 
 # 0.42.0
 


### PR DESCRIPTION
Closes #2062.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
