### PR TITLE
Issue #1515: Allow custom charset when reading body as string

### DIFF
--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Response.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Response.kt
@@ -81,6 +81,12 @@ data class Response(
          *
          * Executes the given [block] function with the buffered reader as parameter and then closes it down correctly
          * whether an exception is thrown or not.
+         *
+         * @param charset the optional charset to use when decoding the body. If not specified,
+         * the charset provided in the response content-type header will be used. If the header
+         * is missing or the charset is not supported, UTF-8 will be used.
+         * @param block a function to consume the buffered reader.
+         *
          */
         fun <R> useBufferedReader(charset: Charset? = null, block: (BufferedReader) -> R): R = use {
             block(stream.bufferedReader(charset ?: this.charset))
@@ -90,8 +96,12 @@ data class Response(
          * Reads this body completely as a String.
          *
          * Takes care of closing the body down correctly whether an exception is thrown or not.
+         *
+         * @param charset the optional charset to use when decoding the body. If not specified,
+         * the charset provided in the response content-type header will be used. If the header
+         * is missing or the charset not supported, UTF-8 will be used.
          */
-        fun string(): String = useBufferedReader { it.readText() }
+        fun string(charset: Charset? = null): String = useBufferedReader(charset) { it.readText() }
 
         /**
          * Closes this [Body] and releases any system resources associated with it.

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ResponseTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ResponseTest.kt
@@ -47,7 +47,7 @@ class ResponseTest {
     }
 
     @Test
-    fun `Creating BufferedReader with custom Charset from Body`() {
+    fun `Creating BufferedReader from Body with custom Charset `() {
         var stream = "ÄäÖöÜü".byteInputStream(Charsets.ISO_8859_1)
         var body = spy(Response.Body(stream, "text/plain; charset=UTF-8"))
         var readerUsed = false
@@ -65,6 +65,19 @@ class ResponseTest {
             readerUsed = true
         }
         assertTrue(readerUsed)
+
+        verify(body).close()
+    }
+
+    @Test
+    fun `Creating String from Body with custom Charset `() {
+        var stream = "ÄäÖöÜü".byteInputStream(Charsets.ISO_8859_1)
+        var body = spy(Response.Body(stream, "text/plain; charset=UTF-8"))
+        assertNotEquals("ÄäÖöÜü", body.string())
+
+        stream = "ÄäÖöÜü".byteInputStream(Charsets.ISO_8859_1)
+        body = spy(Response.Body(stream, "text/plain; charset=UTF-8"))
+        assertEquals("ÄäÖöÜü", body.string(Charsets.ISO_8859_1))
 
         verify(body).close()
     }


### PR DESCRIPTION

Follow-up from PR comment: https://github.com/mozilla-mobile/android-components/pull/2056#discussion_r256734912

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
