### PR TITLE
concept-fetch: Add API/flag to force network request..

### DIFF
--- a/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -121,4 +121,10 @@ class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTest
     override fun get200WithContentTypeCharset() {
         super.get200WithContentTypeCharset()
     }
+
+    @Test
+    @UiThreadTest
+    override fun get200WithCacheControl() {
+        super.get200WithCacheControl()
+    }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchClient.kt
@@ -15,6 +15,8 @@ import mozilla.components.concept.fetch.Response
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebRequest
+import org.mozilla.geckoview.WebRequest.CACHE_MODE_DEFAULT
+import org.mozilla.geckoview.WebRequest.CACHE_MODE_RELOAD
 import org.mozilla.geckoview.WebResponse
 import java.io.IOException
 import java.io.InputStream
@@ -42,6 +44,7 @@ class GeckoViewFetchClient(
                 .method(method.name)
                 .addHeadersFrom(request, defaultHeaders)
                 .addBodyFrom(request)
+                .cacheMode(if (request.useCaches) CACHE_MODE_DEFAULT else CACHE_MODE_RELOAD)
                 .build()
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -19,6 +19,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.`when`
@@ -27,6 +28,7 @@ import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoWebExecutor
+import org.mozilla.geckoview.WebRequest
 import org.mozilla.geckoview.WebResponse
 import org.robolectric.RobolectricTestRunner
 import java.io.IOException
@@ -267,6 +269,21 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
         val response = createNewClient().fetch(request)
         assertEquals("ÄäÖöÜü", response.body.string())
+    }
+
+    override fun get200WithCacheControl() {
+        mockResponse(200)
+
+        val request = mock(Request::class.java)
+        `when`(request.url).thenReturn("https://mozilla.org")
+        `when`(request.method).thenReturn(Request.Method.GET)
+        `when`(request.useCaches).thenReturn(false)
+        createNewClient().fetch(request)
+
+        val captor = ArgumentCaptor.forClass(WebRequest::class.java)
+
+        verify(geckoWebExecutor)!!.fetch(captor.capture(), eq(GeckoWebExecutor.FETCH_FLAGS_NONE))
+        assertEquals(WebRequest.CACHE_MODE_RELOAD, captor.value.cacheMode)
     }
 
     private fun mockRequest(headerMap: Map<String, String>? = null, body: String? = null, method: String = "GET") {

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit
  * @property redirect Whether the [Client] should follow redirects (HTTP 3xx) for this request or not.
  * @property cookiePolicy A policy to specify whether or not cookies should be
  * sent with the request, defaults to [CookiePolicy.INCLUDE]
+ * @property useCaches Whether caches should be used or a network request
+ * should be forced, defaults to true (use caches).
  */
 data class Request(
     val url: String,
@@ -38,7 +40,8 @@ data class Request(
     val readTimeout: Pair<Long, TimeUnit>? = null,
     val body: Body? = null,
     val redirect: Redirect = Redirect.FOLLOW,
-    val cookiePolicy: CookiePolicy = CookiePolicy.INCLUDE
+    val cookiePolicy: CookiePolicy = CookiePolicy.INCLUDE,
+    val useCaches: Boolean = true
 ) {
     /**
      * A [Body] to be send with the [Request].

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt
@@ -39,7 +39,9 @@ class RequestTest {
             connectTimeout = Pair(10, TimeUnit.SECONDS),
             readTimeout = Pair(1, TimeUnit.MINUTES),
             body = Request.Body.fromString("Hello World!"),
-            redirect = Request.Redirect.MANUAL
+            redirect = Request.Redirect.MANUAL,
+            cookiePolicy = Request.CookiePolicy.INCLUDE,
+            useCaches = true
         )
 
         assertEquals("https://www.mozilla.org", request.url)
@@ -53,6 +55,8 @@ class RequestTest {
 
         assertEquals("Hello World!", request.body!!.useStream { it.bufferedReader().readText() })
         assertEquals(Request.Redirect.MANUAL, request.redirect)
+        assertEquals(Request.CookiePolicy.INCLUDE, request.cookiePolicy)
+        assertEquals(true, request.useCaches)
 
         val headers = request.headers!!
         assertEquals(3, headers.size)

--- a/components/lib/fetch-httpurlconnection/src/main/java/mozilla/components/lib/fetch/httpurlconnection/HttpURLConnectionClient.kt
+++ b/components/lib/fetch-httpurlconnection/src/main/java/mozilla/components/lib/fetch/httpurlconnection/HttpURLConnectionClient.kt
@@ -63,7 +63,7 @@ private fun HttpURLConnection.addBodyFrom(request: Request) {
     }
 }
 
-private fun HttpURLConnection.setupWith(request: Request) {
+internal fun HttpURLConnection.setupWith(request: Request) {
     requestMethod = request.method.name
     instanceFollowRedirects = request.redirect == Request.Redirect.FOLLOW
 
@@ -74,6 +74,8 @@ private fun HttpURLConnection.setupWith(request: Request) {
     request.readTimeout?.let { (timeout, unit) ->
         readTimeout = unit.toMillis(timeout).toInt()
     }
+
+    useCaches = request.useCaches
 
     // HttpURLConnection can't be configured to omit cookies. As
     // a workaround, we delete all cookies we have stored for

--- a/components/lib/fetch-httpurlconnection/src/test/java/mozilla/components/lib/fetch/httpurlconnection/HttpUrlConnectionFetchTestCases.kt
+++ b/components/lib/fetch-httpurlconnection/src/test/java/mozilla/components/lib/fetch/httpurlconnection/HttpUrlConnectionFetchTestCases.kt
@@ -5,8 +5,12 @@
 package mozilla.components.lib.fetch.httpurlconnection
 
 import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.net.HttpURLConnection
+import java.net.URL
 
 class HttpUrlConnectionFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
     override fun createNewClient(): Client = HttpURLConnectionClient()
@@ -17,5 +21,17 @@ class HttpUrlConnectionFetchTestCases : mozilla.components.tooling.fetch.tests.F
     fun `Client instance`() {
         // We need at least one test case defined here so that this is recognized as test class.
         assertTrue(createNewClient() is HttpURLConnectionClient)
+    }
+
+    @Test
+    override fun get200WithCacheControl() {
+        // We can't run the base fetch test case because HttpResponseCache
+        // doesn't work in a unit test. So we test that we set the
+        // flag correctly instead.
+        val connection = (URL("https://mozilla.org").openConnection() as HttpURLConnection)
+        assertTrue(connection.useCaches)
+
+        connection.setupWith((Request("https://mozilla.org", useCaches = false)))
+        assertFalse(connection.useCaches)
     }
 }

--- a/components/lib/fetch-okhttp/src/test/java/mozilla/components/lib/fetch/okhttp/OkHttpFetchTestCases.kt
+++ b/components/lib/fetch-okhttp/src/test/java/mozilla/components/lib/fetch/okhttp/OkHttpFetchTestCases.kt
@@ -7,9 +7,13 @@ package mozilla.components.lib.fetch.okhttp
 import mozilla.components.concept.fetch.Client
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
+@RunWith(RobolectricTestRunner::class)
 class OkHttpFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
-    override fun createNewClient(): Client = OkHttpClient(okhttp3.OkHttpClient())
+    override fun createNewClient(): Client = OkHttpClient(okhttp3.OkHttpClient(), RuntimeEnvironment.application)
 
     // Inherits test methods from generic test suite base class
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,15 @@ permalink: /changelog/
     val body = response.body.string()
   }
   ```
+  * Added flag to specify whether or not caches should be used. This can be controlled with the `useCaches` parameter when creating a `Request`.
+
+  ```kotlin
+  // Force a network request (do not use cached responses)
+  client.fetch(Request(url, useCaches = false)).use { response ->
+    val body = response.body.string()
+  }
+  ```
+
 * **feature-awesomebar**
   * ⚠️ **This is a breaking API change!**
   * Now makes use of our concept-fetch module when fetching search suggestions. This allows applications to specify which HTTP client library to use e.g. apps already using GeckoView can now specify that the `GeckoViewFetchClient` should be used. As a consequence, the fetch client instance now needs to be provided when adding a search provider. 


### PR DESCRIPTION
Simple solution here (just a flag) to force a network request (ignore caches). We could add more API for various cache modes later, but there are significant differences between the three implementations plus we already have fine-grained control for caching behaviour using request headers.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features 
 