### PR TITLE
Closes #2099: ToolbarPresenter: Display empty state.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -189,7 +189,7 @@ internal class DisplayToolbar(
     fun updateProgress(progress: Int) {
         progressView.progress = progress
 
-        progressView.visibility = if (progress < progressView.max) View.VISIBLE else View.GONE
+        progressView.visibility = if (progress < progressView.max && progress > 0) View.VISIBLE else View.GONE
     }
 
     /**

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -36,12 +36,23 @@ class ToolbarPresenter(
         initializeView()
     }
 
-    internal fun initializeView() {
-        activeSession?.let { session ->
-            toolbar.url = session.url
+    override fun onAllSessionsRemoved() {
+        initializeView()
+    }
 
-            updateToolbarSecurity(session.securityInfo)
+    override fun onSessionRemoved(session: Session) {
+        if (sessionManager.selectedSession == null) {
+            initializeView()
         }
+    }
+
+    internal fun initializeView() {
+        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
+            ?: sessionManager.selectedSession
+
+        toolbar.url = session?.url ?: ""
+        toolbar.displayProgress(session?.progress ?: 0)
+        updateToolbarSecurity(session?.securityInfo ?: Session.SecurityInfo())
     }
 
     override fun onUrlChanged(session: Session, url: String) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-toolbar**
   * Added option to configure fading edge length by using `browserToolbarFadingEdgeSize` XML attribute.
 
+* **feature-toolbar**
+  * `ToolbarPresenter` now handles situations where no `Session` is selected.
+
 # 0.43.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.42.0...v0.43.0)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
