### PR TITLE
Closes #814: browser-toolbar: Make fading edge length configurable.

### DIFF
--- a/components/browser/toolbar/README.md
+++ b/components/browser/toolbar/README.md
@@ -24,6 +24,7 @@ implementation "org.mozilla.components:browser-toolbar:{latest-version}"
 | browserToolbarMenuColor                 | color     | Color of the overflow menu button.                      |
 | browserToolbarSuggestionBackgroundColor | color     | Background color of the autocomplete suggestion.        |
 | browserToolbarSuggestionForegroundColor | color     | Foreground (text) color of the autocomplete suggestion. |
+| browserToolbarFadingEdgeSize            | dimension | Size of the fading edge shown when the URL is too long. |
 
 ## Facts
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -91,7 +91,6 @@ class BrowserToolbar @JvmOverloads constructor(
      * model based on what the user typed.
      */
     override var private: Boolean
-        //  = 0x1000000
         get() = (editToolbar.urlView.imeOptions and EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING) != 0
         set(value) {
             editToolbar.urlView.imeOptions = if (value) {
@@ -310,6 +309,12 @@ class BrowserToolbar @JvmOverloads constructor(
                     displayToolbar.securityIconColor.second
                 )
                 siteSecurityColor = Pair(inSecure, secure)
+                val fadingEdgeLength = getDimensionPixelSize(
+                    R.styleable.BrowserToolbar_browserToolbarFadingEdgeSize,
+                    resources.pxToDp(DisplayToolbar.URL_FADING_EDGE_SIZE_DP)
+                )
+                displayToolbar.urlView.setFadingEdgeLength(fadingEdgeLength)
+                displayToolbar.urlView.isHorizontalFadingEdgeEnabled = fadingEdgeLength > 0
             }
             recycle()
         }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -89,8 +89,6 @@ internal class DisplayToolbar(
         id = R.id.mozac_browser_toolbar_url_view
         gravity = Gravity.CENTER_VERTICAL
         textSize = URL_TEXT_SIZE
-        setFadingEdgeLength(URL_FADING_EDGE_SIZE_DP)
-        isHorizontalFadingEdgeEnabled = true
 
         setSingleLine(true)
         isClickable = true
@@ -449,10 +447,11 @@ internal class DisplayToolbar(
     }
 
     companion object {
+        internal const val URL_FADING_EDGE_SIZE_DP = 24
+
         private const val ICON_PADDING_DP = 16
         private const val MENU_PADDING_DP = 16
         private const val URL_TEXT_SIZE = 15f
-        private const val URL_FADING_EDGE_SIZE_DP = 24
         private const val PROGRESS_BAR_HEIGHT_DP = 3
     }
 }

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -13,5 +13,6 @@
     <attr name="browserToolbarMenuColor" format="color"/>
     <attr name="browserToolbarSuggestionBackgroundColor" format="color" />
     <attr name="browserToolbarSuggestionForegroundColor" format="color" />
+    <attr name="browserToolbarFadingEdgeSize" format="dimension" />
   </declare-styleable>
 </resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-toolbar**
+  * Added option to configure fading edge length by using `browserToolbarFadingEdgeSize` XML attribute.
+
 # 0.43.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.42.0...v0.43.0)


### PR DESCRIPTION
Also closes #813.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [c] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
