### PR TITLE
Issue #2087: Update to GeckoView Nightly 67.0.20190220040540.

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 internal object GeckoVersions {
-    const val nightly_version = "67.0.20190214044118"
+    const val nightly_version = "67.0.20190220040540"
     const val beta_version = "66.0.20190128143734"
     const val release_version = "65.0.20190125215035"
 }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -9,7 +9,6 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_MEDIA
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_APPLICATION
@@ -53,7 +52,6 @@ sealed class GeckoPermissionRequest constructor(
     ) {
         companion object {
             val permissionsMap = mapOf(
-                PERMISSION_AUTOPLAY_MEDIA to Permission.ContentAutoplayMedia(),
                 PERMISSION_DESKTOP_NOTIFICATION to Permission.ContentNotification(),
                 PERMISSION_GEOLOCATION to Permission.ContentGeoLocation()
             )

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.engine.gecko.permission
 
 import android.Manifest
 import mozilla.components.concept.engine.permission.Permission
-import mozilla.components.concept.engine.permission.Permission.ContentAutoplayMedia
 import mozilla.components.support.test.mock
 import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
@@ -30,11 +29,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_MEDIA, callback)
-        assertEquals(uri, request.uri)
-        assertEquals(listOf(ContentAutoplayMedia()), request.permissions)
-
-        request = GeckoPermissionRequest.Content(uri, PERMISSION_DESKTOP_NOTIFICATION, callback)
+        var request = GeckoPermissionRequest.Content(uri, PERMISSION_DESKTOP_NOTIFICATION, callback)
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.ContentNotification()), request.permissions)
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -9,7 +9,6 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_MEDIA
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_APPLICATION
@@ -53,7 +52,6 @@ sealed class GeckoPermissionRequest constructor(
     ) {
         companion object {
             val permissionsMap = mapOf(
-                PERMISSION_AUTOPLAY_MEDIA to Permission.ContentAutoplayMedia(),
                 PERMISSION_DESKTOP_NOTIFICATION to Permission.ContentNotification(),
                 PERMISSION_GEOLOCATION to Permission.ContentGeoLocation()
             )

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.engine.gecko.permission
 
 import android.Manifest
 import mozilla.components.concept.engine.permission.Permission
-import mozilla.components.concept.engine.permission.Permission.ContentAutoplayMedia
 import mozilla.components.support.test.mock
 import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
@@ -18,7 +17,6 @@ import org.mozilla.geckoview.GeckoSession
 import org.robolectric.RobolectricTestRunner
 
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_MEDIA
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
@@ -30,11 +28,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_MEDIA, callback)
-        assertEquals(uri, request.uri)
-        assertEquals(listOf(ContentAutoplayMedia()), request.permissions)
-
-        request = GeckoPermissionRequest.Content(uri, PERMISSION_DESKTOP_NOTIFICATION, callback)
+        var request = GeckoPermissionRequest.Content(uri, PERMISSION_DESKTOP_NOTIFICATION, callback)
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.ContentNotification()), request.permissions)
 
@@ -52,7 +46,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_MEDIA, callback)
+        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.grant()
         verify(callback).grant()
     }
@@ -62,7 +56,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_MEDIA, callback)
+        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.reject()
         verify(callback).reject()
     }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -9,7 +9,6 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_MEDIA
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_APPLICATION
@@ -53,7 +52,6 @@ sealed class GeckoPermissionRequest constructor(
     ) {
         companion object {
             val permissionsMap = mapOf(
-                PERMISSION_AUTOPLAY_MEDIA to Permission.ContentAutoplayMedia(),
                 PERMISSION_DESKTOP_NOTIFICATION to Permission.ContentNotification(),
                 PERMISSION_GEOLOCATION to Permission.ContentGeoLocation()
             )

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.engine.gecko.permission
 
 import android.Manifest
 import mozilla.components.concept.engine.permission.Permission
-import mozilla.components.concept.engine.permission.Permission.ContentAutoplayMedia
 import mozilla.components.support.test.mock
 import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
@@ -30,11 +29,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_MEDIA, callback)
-        assertEquals(uri, request.uri)
-        assertEquals(listOf(ContentAutoplayMedia()), request.permissions)
-
-        request = GeckoPermissionRequest.Content(uri, PERMISSION_DESKTOP_NOTIFICATION, callback)
+        var request = GeckoPermissionRequest.Content(uri, PERMISSION_DESKTOP_NOTIFICATION, callback)
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.ContentNotification()), request.permissions)
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/PermissionRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/PermissionRequest.kt
@@ -69,8 +69,6 @@ sealed class Permission(open val id: String? = "", open val desc: String? = "") 
     @Parcelize
     data class ContentAudioOther(override val id: String? = "", override val desc: String? = "") : Permission(id)
     @Parcelize
-    data class ContentAutoplayMedia(override val id: String? = "", override val desc: String? = "") : Permission(id)
-    @Parcelize
     data class ContentGeoLocation(override val id: String? = "", override val desc: String? = "") : Permission(id)
     @Parcelize
     data class ContentNotification(override val id: String? = "", override val desc: String? = "") : Permission(id)

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/permission/PermissionRequestTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/permission/PermissionRequestTest.kt
@@ -44,8 +44,6 @@ class PermissionRequestTest {
         assertNotEquals(Permission.ContentAudioOther(), Permission.ContentAudioOther("id"))
         assertNotEquals(Permission.ContentAudioOther("id"), Permission.ContentAudioOther("id", "desc"))
 
-        assertNotEquals(Permission.ContentAutoplayMedia(), Permission.ContentAutoplayMedia("id"))
-        assertNotEquals(Permission.ContentAutoplayMedia("id"), Permission.ContentAutoplayMedia("id", "desc"))
         assertNotEquals(Permission.ContentProtectedMediaId(), Permission.ContentProtectedMediaId("id"))
         assertNotEquals(Permission.ContentProtectedMediaId("id"), Permission.ContentProtectedMediaId("id", "desc"))
         assertNotEquals(Permission.ContentGeoLocation(), Permission.ContentGeoLocation("id"))


### PR DESCRIPTION
AutoPlay is no longer a per-video permission:
https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
