### PR TITLE
[glean] Create a way for glean test API functions to await async IO operations

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/CommonMetricData.kt
@@ -4,6 +4,11 @@
 
 package mozilla.components.service.glean
 
+import android.support.annotation.VisibleForTesting
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import mozilla.components.support.base.log.logger.Logger
 
 /**
@@ -39,6 +44,7 @@ interface CommonMetricData {
 
     companion object {
         internal const val DEFAULT_STORAGE_NAME = "default"
+        private const val JOB_TIMEOUT_MS = 250L
     }
 
     fun shouldRecord(logger: Logger): Boolean {
@@ -75,5 +81,24 @@ interface CommonMetricData {
 
         val filteredNames = sendInPings.filter { it != DEFAULT_STORAGE_NAME }
         return filteredNames + defaultStorageDestinations
+    }
+
+    /**
+     * Helper function to help await Jobs returned from coroutine launch executions used by metrics
+     * when recording data.  This is to help ensure that data is updated before test functions
+     * check or access them.
+     *
+     * @param job Job that is to be awaited
+     * @param timeout Length of time in milliseconds that .join will be awaited. Defaults to
+     *                [JOB_TIMEOUT_MS].
+     * @throws TimeoutCancellationException if the function times out waiting for the join()
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun awaitJob(job: Job, timeout: Long = JOB_TIMEOUT_MS) {
+        runBlocking {
+            withTimeout(timeout) {
+                job.join()
+            }
+        }
     }
 }


### PR DESCRIPTION
Use the Job returned from calls to Dispatchers.API.launch to wait for the IO operation to complete before test functions return values.
Add a way out to avoid infinite loop situations



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
