### PR TITLE
Use the passed-in config object to HttpPingUploader.logPings

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
@@ -6,7 +6,6 @@ package mozilla.components.service.glean.net
 
 import android.support.annotation.VisibleForTesting
 import mozilla.components.service.glean.BuildConfig
-import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.base.log.logger.Logger
 import java.io.IOException
@@ -27,13 +26,14 @@ internal class HttpPingUploader : PingUploader {
 
     /**
      * Log the contents of a ping to the console, if configured to do so in
-     * config.logPings.
+     * [Configuration.logPings].
      *
      * @param path the URL path to append to the server address
      * @param data the serialized text data to send
+     * @param config the glean configuration object
      */
-    private fun logPing(path: String, data: String) {
-        if (Glean.configuration.logPings == true) {
+    private fun logPing(path: String, data: String, config: Configuration) {
+        if (config.logPings) {
             // Parse and reserialize the JSON so it has indentation and is human-readable.
             val indented = try {
                 val json = JSONObject(data)
@@ -56,6 +56,7 @@ internal class HttpPingUploader : PingUploader {
      *
      * @param path the URL path to append to the server address
      * @param data the serialized text data to send
+     * @param config the glean configuration object
      *
      * @return true if the ping was correctly dealt with (sent successfully
      *         or faced an unrecoverable error), false if there was a recoverable
@@ -63,7 +64,7 @@ internal class HttpPingUploader : PingUploader {
      */
     @Suppress("ReturnCount", "MagicNumber")
     override fun upload(path: String, data: String, config: Configuration): Boolean {
-        logPing(path, data)
+        logPing(path, data, config)
 
         var connection: HttpURLConnection? = null
         try {


### PR DESCRIPTION
Do not directly query `Glean.configuration` as it might be not initialized during tests.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
