### PR TITLE
glean: 1527312: Reinstantiate dynamic labels from disk

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngine.kt
@@ -27,6 +27,16 @@ internal interface StorageEngine {
     fun getSnapshotAsJSON(storeName: String, clearStore: Boolean): Any?
 
     /**
+     * Return all of the metric identifiers currently holding data for the given
+     * stores.
+     *
+     * @param stores The stores to look in.
+     * @return a sequence of identifiers (including labels, if any) found in
+     *     those stores.
+     */
+    fun getIdentifiersInStores(stores: List<String>): Sequence<String> = sequence {}
+
+    /**
      * Clear all stored data in the storage engine
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -6,6 +6,13 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.support.annotation.VisibleForTesting
+import mozilla.components.service.glean.BooleanMetricType
+import mozilla.components.service.glean.CounterMetricType
+import mozilla.components.service.glean.DatetimeMetricType
+import mozilla.components.service.glean.StringListMetricType
+import mozilla.components.service.glean.StringMetricType
+import mozilla.components.service.glean.TimespanMetricType
+import mozilla.components.service.glean.UuidMetricType
 import org.json.JSONArray
 import org.json.JSONObject
 import mozilla.components.support.ktx.android.org.json.getOrPutJSONObject
@@ -119,6 +126,27 @@ internal class StorageEngineManager(
     fun clearAllStores() {
         for (storageEngine in storageEngines) {
             storageEngine.value.clearAllStores()
+        }
+    }
+
+    companion object {
+        /**
+        * Get the storage engine associated with a given metric type.
+        *
+        * @return A storage engine, or null if none exists
+        */
+        internal fun <T> getStorageEngineForMetric(subMetric: T): StorageEngine? {
+            // Every metric that supports labels needs an entry here
+            return when (subMetric) {
+                is BooleanMetricType -> BooleansStorageEngine as StorageEngine
+                is CounterMetricType -> CountersStorageEngine as StorageEngine
+                is DatetimeMetricType -> DatetimesStorageEngine as StorageEngine
+                is StringListMetricType -> StringListsStorageEngine as StorageEngine
+                is StringMetricType -> StringsStorageEngine as StorageEngine
+                is TimespanMetricType -> TimespansStorageEngine as StorageEngine
+                is UuidMetricType -> UuidsStorageEngine as StorageEngine
+                else -> null
+            }
         }
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/BooleanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/BooleanMetricTypeTest.kt
@@ -33,7 +33,7 @@ class BooleanMetricTypeTest {
         BooleansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences(BooleansStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .getSharedPreferences(BooleansStorageEngine.javaClass.canonicalName, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .apply()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/CounterMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/CounterMetricTypeTest.kt
@@ -33,7 +33,7 @@ class CounterMetricTypeTest {
         CountersStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences(CountersStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .getSharedPreferences(CountersStorageEngine.javaClass.canonicalName, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .apply()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringListMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringListMetricTypeTest.kt
@@ -36,7 +36,7 @@ class StringListMetricTypeTest {
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()
             .getSharedPreferences(
-                StringListsStorageEngine.javaClass.simpleName,
+                StringListsStorageEngine.javaClass.canonicalName,
                 Context.MODE_PRIVATE)
             .edit()
             .clear()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/StringMetricTypeTest.kt
@@ -33,7 +33,7 @@ class StringMetricTypeTest {
         StringsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences(StringsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .getSharedPreferences(StringsStorageEngine.javaClass.canonicalName, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .apply()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TimespanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TimespanMetricTypeTest.kt
@@ -20,7 +20,7 @@ class TimespanMetricTypeTest {
         TimespansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences(TimespansStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .getSharedPreferences(TimespansStorageEngine.javaClass.canonicalName, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .apply()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/UuidMetricTypeTest.kt
@@ -34,7 +34,7 @@ class UuidMetricTypeTest {
         UuidsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         // Clear the stored "user" preferences between tests.
         ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences(UuidsStorageEngine.javaClass.simpleName, Context.MODE_PRIVATE)
+            .getSharedPreferences(UuidsStorageEngine.javaClass.canonicalName, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .apply()


### PR DESCRIPTION
This is a work-in-progress that I thought made sense to file now to get some brainstorming help and feedback on.

This makes sure that the set of "already seen" dynamic labels includes labels that have been serialized to disk.  Failure to do so would result in meaningless/unusable stats on labels, since the `__other__` label might include values that also have their own label.

I like this approach because it directly uses the existing code to reinstantiate a storage engine, so it should automatically grow to support other things that we'll need to serialize/deserialize (such as ping-lifetime metrics to survive the app being killed by the os).

Known downsides of the current implementation:

- This loading happens lazily on the first use of a dynamically labeled metric during the current execution.  This means that I/O might happen on the main thread.  Unfortunately, this isn't easily resolved, since the `operator get()` function needs to be synchronous, and that's where we do the selection of the specific label we are going to use.  Possible solutions are (1) to handle this during startup (tricky because there's no reference from the storage engine back to the labeled metric object, and it would change the current behavior that storage engines are reinstantiated lazily). Or (2) handle the mapping of the given label to the actual label (where the change to `__other__` might occur) inside the storage engine rather than the metric type object, so it could all be done off the main thread.  This would require a much larger refactor and a deeper understanding of labels in the storage engine than we currently have so this mapping could be done later.

- There's a `O(n)` process for each labeled metric to go through all of the metric values in the storage engine to find its own relevant labels.  Maybe this isn't too bad, but given that the storage engines aren't organized by labeled metric objects, it's suboptimal.  Again, I don't know if we want to refactor the storage engines so that "understand" labeled metrics at a deeper level.

- The set of "seen" labels is tracked per labeled metric object, not per-labeled-metric-object-per-store as they probably should be.  I'm actually not sure what the right behavior is there, tbh.  It's always the same thing if the timings of the stores is same, but if it's in multiple pings with different lifecycles, all bets are off.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
