### PR TITLE
Closes #1018: Allow reading GV default user agent via engine settings

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -15,6 +15,7 @@ import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import org.json.JSONObject
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 
 /**
@@ -95,10 +96,7 @@ class GeckoEngine(
             set(value) { defaultSettings?.testingModeEnabled = value }
 
         override var userAgentString: String?
-            // TODO if no default user agent string is provided we should
-            // return the engine default here, but we can't get to it in
-            // a practical way right now: https://bugzilla.mozilla.org/show_bug.cgi?id=1512997
-            get() = defaultSettings?.userAgentString
+            get() = defaultSettings?.userAgentString ?: GeckoSession.getDefaultUserAgent()
             set(value) { defaultSettings?.userAgentString = value }
     }.apply {
         defaultSettings?.let {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -11,7 +11,6 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -22,6 +21,7 @@ import org.mockito.Mockito.verify
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
+import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -76,9 +76,11 @@ class GeckoEngineTest {
         engine.settings.testingModeEnabled = true
         assertTrue(engine.settings.testingModeEnabled)
 
-        assertNull(engine.settings.userAgentString)
-        engine.settings.userAgentString = "test-ua"
-        assertEquals("test-ua", engine.settings.userAgentString)
+        // Specifying no ua-string default should result in GeckoView's default.
+        assertEquals(GeckoSession.getDefaultUserAgent(), engine.settings.userAgentString)
+        // It also should be possible to read and set a new default.
+        engine.settings.userAgentString = engine.settings.userAgentString + "-test"
+        assertEquals(GeckoSession.getDefaultUserAgent() + "-test", engine.settings.userAgentString)
 
         assertEquals(TrackingProtectionPolicy.none(), engine.settings.trackingProtectionPolicy)
         engine.settings.trackingProtectionPolicy = TrackingProtectionPolicy.all()


### PR DESCRIPTION
We already had support to get/set the user agent string override but so far we couldn't return a default user agent string when none was provided (for system engine we already can). We now have GV's default ua-string accessible via GeckoSession, so bringing this last piece in with this PR.