### PR TITLE
Closes #2150: Add engine API to install WebExtensions

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import mozilla.components.concept.engine.webextension.WebExtension
 import org.json.JSONObject
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoWebExecutor
@@ -58,6 +59,19 @@ class GeckoEngine(
     override fun speculativeConnect(url: String) {
         executor.speculativeConnect(url)
     }
+
+    /**
+     * See [Engine.installWebExtension].
+     */
+    override fun installWebExtension(ext: WebExtension) {
+        fakeRuntime.registerWebExtension(org.mozilla.geckoview.WebExtension(ext.id, ext.url))
+    }
+
+    // TODO remove once GV API lands
+    class FakeRuntime {
+        fun registerWebExtension(ext: org.mozilla.geckoview.WebExtension) { }
+    }
+    internal var fakeRuntime = FakeRuntime()
 
     override fun name(): String = "Gecko"
 

--- a/components/browser/engine-gecko-nightly/src/main/java/org/mozilla/geckoview/WebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/org/mozilla/geckoview/WebExtension.kt
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.geckoview
+
+// TODO Remove this mock
+data class WebExtension(val id: String, val location: String)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -8,6 +8,8 @@ import android.content.Context
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.UnsupportedSettingException
+import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -139,9 +141,24 @@ class GeckoEngineTest {
         val executor: GeckoWebExecutor = mock()
 
         val engine = GeckoEngine(context, runtime = runtime, executorProvider = { executor })
-
         engine.speculativeConnect("https://www.mozilla.org")
-
         verify(executor).speculativeConnect("https://www.mozilla.org")
+    }
+
+    @Test
+    fun `install web extension`() {
+        val runtime = mock(GeckoRuntime::class.java)
+        val engine = GeckoEngine(context, runtime = runtime)
+
+        // TODO remove once GV API lands
+        engine.fakeRuntime = mock(GeckoEngine.FakeRuntime::class.java)
+
+        engine.installWebExtension(WebExtension("test-webext", "resource://android/assets/extensions/test"))
+
+        val extCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension>()
+        verify(engine.fakeRuntime).registerWebExtension(extCaptor.capture())
+
+        assertEquals("test-webext", extCaptor.value.id)
+        assertEquals("resource://android/assets/extensions/test", extCaptor.value.location)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -6,7 +6,9 @@ package mozilla.components.concept.engine
 
 import android.content.Context
 import android.util.AttributeSet
+import mozilla.components.concept.engine.webextension.WebExtension
 import org.json.JSONObject
+import java.lang.UnsupportedOperationException
 
 /**
  * Entry point for interacting with the engine implementation.
@@ -55,6 +57,15 @@ interface Engine {
      * Not all [Engine] implementations may actually implement this.
      */
     fun speculativeConnect(url: String)
+
+    /**
+     * Installs the provided extension in this engine.
+     *
+     * @param ext the [WebExtension] to install.
+     * @throws UnsupportedOperationException if this engine doesn't support web extensions.
+     */
+    fun installWebExtension(ext: WebExtension): Unit =
+            throw UnsupportedOperationException("Web extension support is not available in this engine")
 
     /**
      * Provides access to the settings of this engine.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.webextension
+
+/**
+ * Represents a browser extension based on the WebExtension API:
+ * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions
+ *
+ * @property id the unique ID of this extension.
+ * @property url the url pointing to a resources path for locating the extension
+ * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ */
+data class WebExtension(
+    val id: String,
+    val url: String
+)

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine
+
+import android.content.Context
+import android.util.AttributeSet
+import mozilla.components.concept.engine.webextension.WebExtension
+import org.json.JSONObject
+import org.junit.Test
+import java.lang.UnsupportedOperationException
+
+class EngineTest {
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun `throws exception if webextensions not supported`() {
+        val engine = object : Engine {
+            override fun createView(context: Context, attrs: AttributeSet?): EngineView {
+                throw NotImplementedError("Not needed for test")
+            }
+
+            override fun createSession(private: Boolean): EngineSession {
+                throw NotImplementedError("Not needed for test")
+            }
+
+            override fun createSessionState(json: JSONObject): EngineSessionState {
+                throw NotImplementedError("Not needed for test")
+            }
+
+            override fun name(): String {
+                throw NotImplementedError("Not needed for test")
+            }
+
+            override fun speculativeConnect(url: String) {
+                throw NotImplementedError("Not needed for test")
+            }
+
+            override val settings: Settings
+                get() = throw NotImplementedError("Not needed for test")
+        }
+        engine.installWebExtension(WebExtension("my-ext", "resource://path"))
+    }
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.webextension
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class WebExtensionTest {
+
+    @Test
+    fun createWebExtension() {
+        val ext1 = WebExtension("1", "url1")
+        val ext2 = WebExtension("2", "url2")
+
+        assertNotEquals(ext1, ext2)
+        assertEquals(ext1, WebExtension("1", "url1"))
+        assertEquals("1", ext1.id)
+        assertEquals("url1", ext1.url)
+    }
+}

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -6,12 +6,18 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webextension.WebExtension
 
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings)
+        GeckoEngine(applicationContext, engineSettings).apply {
+
+            // TODO verify how to specify the extension path. This is based on:
+            // https://phabricator.services.mozilla.com/D16268#change-Fdft9eM6r9i1
+            installWebExtension(WebExtension("mozac-helloworld", "resource://android/assets/extensions/helloworld"))
+        }
     }
 }

--- a/samples/browser/src/main/assets/extensions/helloworld/helloworld.js
+++ b/samples/browser/src/main/assets/extensions/helloworld/helloworld.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/samples/browser/src/main/assets/extensions/helloworld/manifest.json
+++ b/samples/browser/src/main/assets/extensions/helloworld/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 2,
+  "name": "Mozilla Android Components - Hello World",
+  "version": "1.0",
+  "content_scripts": [
+    {
+      "matches": ["*://*/*"],
+      "js": ["helloworld.js"],
+      "run_at": "document_end"
+    }
+  ]
+}


### PR DESCRIPTION
This is draft showing how to install web extensions using our engine. It's based and dependent on https://bugzilla.mozilla.org/show_bug.cgi?id=1518841 / https://phabricator.services.mozilla.com/D16268 landing.

Apps should be able to install extensions directly and we will also have android components wrapping extensions (for ReaderView, AdBlocking), as well as a feature-webextensions module to manage extensions. So, this is just a first step.
