### PR TITLE
Remove conservativetribune.com

### DIFF
--- a/components/browser/domains/src/main/assets/domains/global
+++ b/components/browser/domains/src/main/assets/domains/global
@@ -406,7 +406,6 @@ liveleak.com
 merriam-webster.com
 wnd.com
 earthlink.net
-conservativetribune.com
 independent.co.uk
 drugs.com
 rotoworld.com


### PR DESCRIPTION
According to [NewsGuard](https://api.newsguardtech.com/6E0FA7E2CF73DA94AB47BB2FCA2F31FEADEFDA6504DAB9BD10FE6EE11958D35751CF3DEEA2E6D8F66DFE9688C3562CB8EF46C880D400F511?cid=6437f3cb-6332-46e6-9000-309663a9e9c8):

>has published misleading headlines, debunked conspiracy theories, and poorly vetted content.


![screenshot_2019-02-21 newsguard nutrition label](https://user-images.githubusercontent.com/611168/53223003-14afbb00-362d-11e9-82d5-50105d53d0e0.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
