### PR TITLE
Issue #1328: Support redirect flags in Gecko fetch client

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 internal object GeckoVersions {
-    const val nightly_version = "67.0.20190222081112"
+    const val nightly_version = "67.0.20190225102402"
     const val beta_version = "66.0.20190128143734"
     const val release_version = "65.0.20190125215035"
 }

--- a/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/androidTest/java/mozilla/components/browser/engine/gecko/fetch/geckoview/GeckoViewFetchTestCases.kt
@@ -10,7 +10,6 @@ import androidx.test.filters.MediumTest
 import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.concept.fetch.Client
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 
 @MediumTest
@@ -86,7 +85,6 @@ class GeckoViewFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTest
 
     @Test
     @UiThreadTest
-    @Ignore("Blocked on: https://bugzilla.mozilla.org/show_bug.cgi?id=1526327")
     override fun get302FollowRedirectsDisabled() {
         super.get302FollowRedirectsDisabled()
     }


### PR DESCRIPTION
Another draft PR to enable redirect flags as GV API becomes available: https://bugzilla.mozilla.org/show_bug.cgi?id=1526327 and https://phabricator.services.mozilla.com/D19523 (landed and got backed out since). 