### PR TITLE
Observe session based on the session ID

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SelectionAwareSessionObserver.kt
@@ -45,6 +45,17 @@ abstract class SelectionAwareSessionObserver(
     }
 
     /**
+     * Starts observing changes to the session matching the [sessionId]. If
+     * the session does not exist, then observe the selected session.
+     *
+     * @param sessionId the session ID to observe.
+     */
+    fun observeIdOrSelected(sessionId: String?) {
+        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
+        session?.let { observeFixed(it) } ?: observeSelected()
+    }
+
+    /**
      * Stops the observer.
      */
     @CallSuper

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -17,6 +17,7 @@ class SelectionAwareSessionObserverTest {
     private lateinit var sessionManager: SessionManager
     private lateinit var session1: Session
     private lateinit var session2: Session
+    private lateinit var session3: Session
     private lateinit var observer: MockObserver
 
     @Before
@@ -24,6 +25,7 @@ class SelectionAwareSessionObserverTest {
         sessionManager = SessionManager(engine = mock())
         session1 = Session("https://mozilla.org")
         session2 = Session("https://getpocket.com")
+        session3 = Session("https://wiki.mozilla.org", id = "123")
         observer = MockObserver(sessionManager)
     }
 
@@ -44,6 +46,24 @@ class SelectionAwareSessionObserverTest {
 
         session1.url = "changed"
         assertEquals("changed", observer.observedUrl)
+    }
+
+    @Test
+    fun `observe the session based on the provided ID if exists or the selected session`() {
+        sessionManager.add(session1)
+        observer.observeIdOrSelected("123")
+        assertEquals(session1, observer.activeSession)
+
+        sessionManager.add(session2, selected = true)
+        observer.observeIdOrSelected("123")
+        assertEquals(session2, observer.activeSession)
+
+        sessionManager.add(session3)
+        observer.observeIdOrSelected("123")
+        assertEquals(session3, observer.activeSession)
+
+        observer.observeIdOrSelected(null)
+        assertEquals(session2, observer.activeSession)
     }
 
     @Test

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
@@ -126,7 +126,7 @@ class ContextMenuFeature(
  * needs to be shown.
  */
 internal class ContextMenuObserver(
-    private val sessionManager: SessionManager,
+    sessionManager: SessionManager,
     private val feature: ContextMenuFeature
 ) : SelectionAwareSessionObserver(sessionManager) {
     override fun onLongPress(session: Session, hitResult: HitResult): Boolean {
@@ -135,7 +135,6 @@ internal class ContextMenuObserver(
     }
 
     fun start(sessionId: String?) {
-        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
-        session?.let { observeFixed(it) } ?: observeSelected()
+        observeIdOrSelected(sessionId)
     }
 }

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuObserverTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuObserverTest.kt
@@ -26,6 +26,7 @@ class ContextMenuObserverTest {
 
         observer.start("123")
 
+        verify(observer).observeIdOrSelected("123")
         verify(observer).observeFixed(session)
     }
 
@@ -36,6 +37,7 @@ class ContextMenuObserverTest {
 
         observer.start(null)
 
+        verify(observer).observeIdOrSelected(null)
         verify(observer).observeSelected()
     }
 }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -54,8 +54,7 @@ class DownloadsFeature(
      * to be processed.
      */
     override fun start() {
-        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
-        session?.let { observeFixed(it) } ?: observeSelected()
+        observeIdOrSelected(sessionId)
 
         findPreviousDialogFragment()?.let {
             reAttachOnStartDownloadListener(it)

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -62,6 +62,7 @@ class DownloadsFeatureTest {
 
         feature.start()
 
+        verify(feature).observeIdOrSelected(anyString())
         verify(feature).observeFixed(any())
     }
 
@@ -75,6 +76,7 @@ class DownloadsFeatureTest {
 
         feature.start()
 
+        verify(feature).observeIdOrSelected(null)
         verify(feature).observeSelected()
     }
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/FullScreenFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/FullScreenFeature.kt
@@ -16,7 +16,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  * Feature implementation for handling fullscreen mode (exiting and back button presses).
  */
 open class FullScreenFeature(
-    private val sessionManager: SessionManager,
+    sessionManager: SessionManager,
     private val sessionUseCases: SessionUseCases,
     private val sessionId: String? = null,
     private val fullScreenChanged: (Boolean) -> Unit
@@ -26,8 +26,7 @@ open class FullScreenFeature(
      * Starts the feature and a observer to listen for fullscreen changes.
      */
     override fun start() {
-        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
-        session?.let { observeFixed(it) } ?: observeSelected()
+        observeIdOrSelected(sessionId)
     }
 
     override fun onFullScreenChanged(session: Session, enabled: Boolean) = fullScreenChanged(enabled)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
@@ -30,6 +30,7 @@ class FullScreenFeatureTest {
 
         fullscreenFeature.start()
 
+        verify(fullscreenFeature).observeIdOrSelected(null)
         verify(sessionManager, never()).findSessionById(anyString())
         verify(fullscreenFeature).observeSelected()
     }
@@ -41,6 +42,7 @@ class FullScreenFeatureTest {
 
         fullscreenFeature.start()
 
+        verify(fullscreenFeature).observeIdOrSelected(anyString())
         verify(sessionManager).findSessionById(anyString())
         verify(fullscreenFeature).observeFixed(selectedSession)
     }

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarPresenter.kt
@@ -23,8 +23,7 @@ class ToolbarPresenter(
      * Start presenter: Display data in toolbar.
      */
     fun start() {
-        val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
-        session?.let { observeFixed(it) } ?: observeSelected()
+        observeIdOrSelected(sessionId)
         initializeView()
     }
 

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
@@ -29,6 +29,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
+        verify(toolbarPresenter).observeIdOrSelected(null)
         verify(toolbarPresenter).observeSelected()
         verify(toolbarPresenter).initializeView()
     }
@@ -44,6 +45,7 @@ class ToolbarPresenterTest {
 
         toolbarPresenter.start()
 
+        verify(toolbarPresenter).observeIdOrSelected("123")
         verify(toolbarPresenter).observeFixed(session)
         verify(toolbarPresenter).initializeView()
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,9 @@ permalink: /changelog/
 * **feature-sitepermissions**
   * 🆕 A feature for showing site permission request prompts. For more info take a look at the [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/feature/sitepermissions/README.md).
 
+* **browser-session**
+  * Added `SelectionAwareSessionObserver.observeIdOrSelected(sessionId: String?)` to observe the session based on a session ID. If the session does not exist, then observe the selected session.
+
 # 0.43.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.42.0...v0.43.0)


### PR DESCRIPTION
Create the function `observeFromId` to start observing changes based on
the given `sessionId`.

Closes: #1940

### Changelog
* Create the function `observeFromId` to abstract the following logic:
```
val session = sessionId?.let { sessionManager.findSessionById(sessionId) }
session?.let { observeFixed(it) } ?: observeSelected()
```
with
```
observeFromId(sessionId)
```
* Update impacted feature' and presenter' unit tests. 
### Accessibility
Does not include any user-facing features.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
