### PR TITLE
Closes #2186: Adds private mode to IntentProcessor

### DIFF
--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -28,6 +28,7 @@ typealias IntentHandler = (Intent) -> Boolean
  * @property useDefaultHandlers Whether or not the built-in handlers should be used.
  * @property openNewTab Whether a processed intent should open a new tab or
  * open URLs in the currently selected tab.
+ * @property isPrivate Whether a processed intent should open a new tab as private
  */
 class IntentProcessor(
     private val sessionUseCases: SessionUseCases,
@@ -35,7 +36,8 @@ class IntentProcessor(
     private val searchUseCases: SearchUseCases,
     private val context: Context,
     private val useDefaultHandlers: Boolean = true,
-    private val openNewTab: Boolean = true
+    private val openNewTab: Boolean = true,
+    private val isPrivate: Boolean = false
 ) {
     private val defaultActionViewHandler = { intent: Intent ->
         val safeIntent = SafeIntent(intent)
@@ -56,7 +58,7 @@ class IntentProcessor(
             }
 
             else -> {
-                val session = createSession(url, source = Source.ACTION_VIEW)
+                val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
                 sessionUseCases.loadUrl.invoke(url, session)
                 true
             }
@@ -73,7 +75,7 @@ class IntentProcessor(
             else -> {
                 val url = extraText.split(" ").find { it.isUrl() }
                 if (url != null) {
-                    val session = createSession(url, source = Source.ACTION_SEND)
+                    val session = createSession(url, private = isPrivate, source = Source.ACTION_SEND)
                     sessionUseCases.loadUrl.invoke(url, session)
                     true
                 } else {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,9 @@ permalink: /changelog/
 * **feature-toolbar**
   * `ToolbarPresenter` now handles situations where no `Session` is selected.
 
+* **intent-processor**
+  * Intent processor now lets you set `isPrivate` which will open process intents as private tabs
+
 * **service-fretboard (Kinto)**
   * ⚠️ **This is a breaking API change!**
   * Now makes use of our concept-fetch module when communicating with the server. This allows applications to specify which HTTP client library to use e.g. apps already using GeckoView can now specify that the `GeckoViewFetchClient` should be used. As a consequence, the fetch client instance now needs to be provided when creating a `KintoExperimentSource`. 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features


I'm assuming I don't need a test for creating a flag, but please let me know if I do.

I chose to make this a public variable as, in Fenix, we want to set the isPrivate flag before processing without creating a whole new IntentProcessor. Perhaps there's a cleaner solution that allows this variable to set private, though? I also wanted to avoid using a custom processor since we wanted all other functionality to be the same.