### PR TITLE
Update PR template with changelog link [ci skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@
 <!-- Before submitting the PR, please address each item -->
 - [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
-- [ ] **Changelog**: This PR includes a changelog entry or does not need one
+- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
 - [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features


### PR DESCRIPTION
Since our changelog is not in an obvious (root dir) location, we should point it out..
