### PR TITLE
[glean] 1525333: Provide way to send pings immediately

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -117,12 +117,16 @@ for the command line switches used to pass the extra keys. These are the current
 
 |key|type|description|
 |---|----|-----------|
-| logPings | boolean | if set to `true`, glean dumps pings to logcat; defaults to `false`|
+| logPings | boolean (--ez) | If set to `true`, glean dumps pings to logcat; defaults to `false` |
+| sendPing | string (--es) | Sends the ping with the given name immediately. |
 
-For example, to start the glean sample application with the option to dump pings to logcat turned on,
-the following command can be used:
+For example, to direct the glean sample application to dump pings to logcat, and send the "metrics" ping immediately, the following command can be used:
 
-`adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean.debug.GleanDebugActivity --ez logPings true`
+```
+adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean.debug.GleanDebugActivity \
+  --ez logPings true \
+  --es sendPing metrics
+```
 
 ## Contact
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -257,8 +257,10 @@ open class GleanInternalAPI internal constructor () {
      * Send a list of pings by name.
      *
      * Both the ping collection and ping uploading happens asyncronously.
+     * If the ping currently contains no content, it will not be sent.
      *
      * @param pingNames List of pings to send.
+     * @return true if any pings were actually sent.
      */
     internal fun sendPings(pingNames: List<String>): Boolean {
         if (!isInitialized()) {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
@@ -22,6 +22,12 @@ import mozilla.components.support.base.log.logger.Logger
 class GleanDebugActivity : Activity() {
     private val logger = Logger("glean/GleanDebugActivity")
 
+    // IMPORTANT: These activities are unsecured, and may be triggered by
+    // any other application on the device, including in release builds.
+    // Therefore, care should be taken in selecting what features are
+    // exposed this way.  For example, it would be dangerous to change the
+    // submission URL.
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -35,6 +41,10 @@ class GleanDebugActivity : Activity() {
             // the real product's activity.
             logger.info("Setting debug config $debugConfig")
             Glean.configuration = debugConfig
+
+            intent.getStringExtra("sendPing")?.let {
+                Glean.sendPings(listOf(it))
+            }
         }
 
         val intent = packageManager.getLaunchIntentForPackage(packageName)


### PR DESCRIPTION
This adds a "BroadcastReceiver" so that we can send glean messages at runtime using adb.

A couple of things to note:

- This is only enabled in a DEBUG build.  I don't know if that's required, but it seems like good practice to avoid the ability to expose information in a release build.

- I added an intent to turn logging of pings to logCat on.  I know we already have a way to do that, but I think this might be better since it doesn't require restarting the app.  Happy to remove if others disagree, but we probably should have only-one-way-to-do-it on that.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
