### PR TITLE
Downgrade to Robolectric 4.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val androidx_runner = "1.1.0"
 
     const val junit = "4.12"
-    const val robolectric = "4.2"
+    const val robolectric = "4.1"
     const val mockito = "2.24.5"
 
     const val mockwebserver = "3.10.0"


### PR DESCRIPTION
Robolectric 4.2 doesn't work properly on Windows: glean tests now fail with weird ResourceNotFound errors. This is due to some issues in how paths are handled on Windows in the latest Robolectric.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
