### PR TITLE
Implement persistent storage for Ping lifetime metrics

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/LabeledMetricTypeTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.storages.BooleansStorageEngine
 import mozilla.components.service.glean.storages.CountersStorageEngine
 import mozilla.components.service.glean.storages.MockScalarStorageEngine
@@ -434,6 +435,12 @@ class LabeledMetricTypeTest {
             eq(MockScalarStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         val storageEngine = MockScalarStorageEngine()
         storageEngine.applicationContext = context

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/BooleansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/BooleansStorageEngineTest.kt
@@ -46,6 +46,12 @@ class BooleansStorageEngineTest {
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
@@ -48,6 +48,12 @@ class CountersStorageEngineTest {
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
@@ -52,6 +52,12 @@ class DatetimesStorageEngineTest {
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
@@ -213,6 +213,12 @@ class StringListsStorageEngineTest {
             ArgumentMatchers.eq(storageEngine::class.java.canonicalName),
             ArgumentMatchers.eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        Mockito.`when`(context.getSharedPreferences(
+            ArgumentMatchers.eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            ArgumentMatchers.eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -46,6 +46,12 @@ class StringsStorageEngineTest {
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -72,6 +72,12 @@ class TimespansStorageEngineTest {
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -48,6 +48,12 @@ class UuidsStorageEngineTest {
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
+        `when`(context.getSharedPreferences(
+            eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
+            eq(Context.MODE_PRIVATE)
+        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
+                Context.MODE_PRIVATE))
 
         storageEngine.applicationContext = context
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)


### PR DESCRIPTION
Add ping lifetime storage using SharedPreferences similar to how User lifetime storage is used, except that when Ping lifetime data is snapshot, it will be cleared from the cache and the SharedPreferences.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
