### PR TITLE
Update changelog with missing entry for TabsUseCases [ci skip]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -782,6 +782,18 @@ permalink: /changelog/
   * Added support for alerts dialogs.
   * Added support for date picker dialogs.
 
+* **feature-tabs**
+  * Added support to remove all or specific types of tabs to the `TabsUseCases`.
+  
+  ```kotlin
+  // Remove all tabs
+  tabsUseCases.removeAllTabs()
+  // Remove all regular tabs
+  tabsUseCases.removeAllTabsOfType(private = false)
+  // Remove all private tabs
+  tabsUseCases.removeAllTabsOfType(private = true)
+  ```
+
 * **support-ktx**
   New extension function `toDate` that converts a string to a Date object from a formatter input.
   ```kotlin


### PR DESCRIPTION
When https://github.com/mozilla-mobile/android-components/pull/1490 landed, we didn't add a changelog entry for it which may have made the feature less visible.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
