### PR TITLE
Update glean ping documentation[ci skip]

### DIFF
--- a/components/service/glean/docs/baseline.md
+++ b/components/service/glean/docs/baseline.md
@@ -1,16 +1,28 @@
 # The `baseline` ping
+
+## Description
 This ping is intended to provide metrics that are managed by the library itself, and not explicitly
 set by the application or included in the application's `metrics.yaml` file.
 
-The `baseline` ping is automatically sent when the application is moved to the *background* and it includes
+## Scheduling
+The `baseline` ping is automatically sent when the application is moved to the [background](pings.md#defining-background-state) and it includes
 the following fields:
 
+## Contents
 | Field name | Type | Description |
 |---|---|---|
 | `duration` | Timespan | The duration, in seconds, of the last foreground session |
-| `os` | String | The name of the operating system (e.g. "linux", "android", "ios") |
+| `os` | String | The name of the operating system (e.g. "linux", "Android", "ios") |
 | `os_version` | String | The version of the operating system |
 | `device_manufacturer` | String | The manufacturer of the device |
 | `device_model` | String | The model name of the device |
 | `architecture` | String | The architecture of the device (e.g. "arm", "x86") |
 | `locale` | String | The locale of the application |
+
+The `baseline` ping shall also include the common [`ping_info`](pings.md#the-ping_info-section) section found in all pings.
+
+### Querying ping contents
+A quick note about querying ping contents (i.e. for https://sql.telemetry.mozilla.org):  Each metric
+in the baseline ping is organized by its metric type, and uses a namespace of 'glean.baseline'. For 
+instance, in order to select `duration` you would use `metrics.timespan['glean.baseline.duration']`. 
+If you were trying to select a String based metric such as `os`, then you would use `metrics.string['glean.baseline.os']`

--- a/components/service/glean/docs/events.md
+++ b/components/service/glean/docs/events.md
@@ -1,10 +1,15 @@
-# Events ping
+# The `events` ping
 
+## Description
+The events ping's purpose is to transport all of the event metric information.
+
+## Scheduling
 The `events` ping is normally sent when the application goes into the
-background. It is also sent when the queue of events exceeds
+[background](pings.md#defining-background-state). It is also sent when the queue of events exceeds
 `Glean.configuration.maxEvents` (default 500). This happens automatically, with
 no intervention or configuration required by the application.
 
+## Contents
 At the top-level, this ping contains the following keys:
 
 - `ping_info`: The information [common to all pings](pings.md#the-ping_info-section).
@@ -21,13 +26,6 @@ Each entry in the `events` array is an array with the following items:
 
 - [2]: `name`: The name of the event, as definded in the `metrics.yaml` file.
 
-- [3]: `objectId`: An arbitrary string representing the id of the object on
-  which the event occurred. The application is responsible for providing the id
-  to glean when events are recorded.
-
-- [4]: `value` (optional): A application-provided value providing additional
-  context for the event.  Values will never exceed 80 characters.
-
-- [5]: `extra` (optional): A mapping of strings to strings providing additional
-  data about the event. Both the keys and values in this map will never exceed
-  80 characters.
+- [3]: `extra` (optional): A mapping of strings to strings providing additional
+  data about the event. The keys are restricted to 40 characters and values in 
+  this map will never exceed 100 characters.

--- a/components/service/glean/docs/metrics.md
+++ b/components/service/glean/docs/metrics.md
@@ -1,10 +1,24 @@
 # The `metrics` ping
-The `metrics` ping contains all of the metrics defined in `metrics.yaml` that don't specify a ping or 
-where `default` is specified in their [`send in pings`](https://mozilla.github.io/glean_parser/metrics-yaml.html#send-in-pings) property.  
-The ping shall also include the common ping data found in all pings.
 
-The `metrics` ping is automatically sent when the application is moved to the *background* provided
-that the scheduled time interval has elapsed, which is currently 24 hours.  This limits `metrics`
-pings to be sent not more than once per day. The schedule is only checked when the application
-enters the background state so pings may be sent after an interval longer than 24 hours but never
-shorter than 24 hours.
+## Description
+The `metrics` ping is intended for all of the metrics that are explicitly set by the application or
+are included in the application's `metrics.yaml` file.
+
+## Scheduling
+The `metrics` ping is automatically sent when the application enters the [background](pings.md#defining-background-state)
+
+It is also required that the throttling time interval has elapsed, which is currently 24 hours.  
+This limits `metrics` pings to be sent not more than once per day. The schedule is only checked 
+when the application enters the background state so pings may be sent after an interval longer 
+than 24 hours but never shorter than 24 hours.
+
+## Contents
+The `metrics` ping contains all of the metrics defined in `metrics.yaml` that don't specify a ping or 
+where `default` is specified in their [`send in pings`](https://mozilla.github.io/glean_parser/metrics-yaml.html#send-in-pings) property.
+
+The `metrics` ping shall also include the common [`ping_info`](pings.md#the-ping_info-section) section found in all pings.
+
+### Querying ping contents
+A quick note about querying ping contents (i.e. for https://sql.telemetry.mozilla.org):  Each metric
+in the metrics ping is organized by its metric type, and uses a namespace of 'glean.metrics'. For 
+instance, in order to select a String field called `test` you would use `metrics.string['glean.metrics.test']`. 

--- a/components/service/glean/docs/pings.md
+++ b/components/service/glean/docs/pings.md
@@ -92,3 +92,10 @@ on a maximum number of Unicode characters (defined in the API docs), since is
 the most expedient implementation-wise. Other or future implementations may
 perform this truncation based on the number of UTF8 bytes instead, which is
 ultimately what matters for ping size.
+
+## Defining background state
+These docs refer to application 'background' state in several places. This specifically means when 
+the activity is no longer visible to the user, it has entered the Stopped state, and the system 
+invokes the [onStop()](https://developer.android.com/reference/android/app/Activity.html#onStop()) callback. 
+This may occur, for example, when a newly launched activity covers the entire screen. The system may 
+also call onStop() when the activity has finished running, and is about to be terminated.


### PR DESCRIPTION
Add description of background state, as well as add subsections and make all the specific ping docs look similar. This included adding a summary description, scheduling, and content information sections. Added links to new background definition where appropriate.  Finally, updated the events ping documentation to reflect recent changes to the schema with the removal of `objectId` and `value` fields.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
