### PR TITLE
Closes #2231 Check if CustomTabToolbarFeature initialized in onBackPressed

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -36,7 +36,7 @@ class CustomTabsToolbarFeature(
     private val closeListener: () -> Unit
 ) : LifecycleAwareFeature, BackHandler {
     private val context = toolbar.context
-    private var initialized = false
+    internal var initialized = false
     internal var readableColor = Color.WHITE
 
     override fun start() {
@@ -137,13 +137,20 @@ class CustomTabsToolbarFeature(
     override fun stop() {}
 
     /**
-     * Removes the current Custom Tabs session when the back button is pressed and returns true.
+     * When the back button is pressed if not initialized returns false,
+     * when initialized removes the current Custom Tabs session and returns true.
      * Should be called when the back button is pressed.
      */
-    override fun onBackPressed() = sessionManager.runWithSession(sessionId) {
-        closeListener.invoke()
-        remove(it)
-        true
+    override fun onBackPressed(): Boolean {
+        return if (!initialized) {
+            false
+        } else {
+            sessionManager.runWithSession(sessionId) {
+                closeListener.invoke()
+                remove(it)
+                true
+            }
+        }
     }
 
     companion object {

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -307,7 +307,7 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
-    fun `onBackPressed removes session`() {
+    fun `onBackPressed removes initialized session`() {
         val sessionId = "123"
         val session: Session = mock()
         val toolbar = BrowserToolbar(RuntimeEnvironment.application)
@@ -317,6 +317,8 @@ class CustomTabsToolbarFeatureTest {
         `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
 
         val feature = spy(CustomTabsToolbarFeature(sessionManager, toolbar, sessionId) { closeExecuted = true })
+        feature.initialized = true
+
         val result = feature.onBackPressed()
 
         assertTrue(result)
@@ -334,6 +336,26 @@ class CustomTabsToolbarFeatureTest {
         `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
 
         val feature = spy(CustomTabsToolbarFeature(sessionManager, toolbar, sessionId) { closeExecuted = true })
+
+        val result = feature.onBackPressed()
+
+        assertFalse(result)
+        assertFalse(closeExecuted)
+    }
+
+    @Test
+    fun `onBackPressed with uninitialized feature returns false`() {
+        val sessionId = "123"
+        val session: Session = mock()
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        val sessionManager: SessionManager = mock()
+        var closeExecuted = false
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
+
+        val feature = spy(CustomTabsToolbarFeature(sessionManager, toolbar, sessionId) {
+            closeExecuted = true
+        })
+        feature.initialized = false
 
         val result = feature.onBackPressed()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,9 @@ permalink: /changelog/
 
 * **browser-awesomebar**
   * [BrowserAwesomeBar](https://mozac.org/api/mozilla.components.browser.awesomebar/-browser-awesome-bar/) is now replacing suggestions "in-place" if their ids match. Additionally `BrowserAwesomeBar` now automatically scrolls to the top whenever the entered text changes.
+  
+* **feature-customtabs**
+ * Now returns false in `onBackPressed()` if feature is not initialized
 
 # 0.44.0
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
