### PR TITLE
Issue #651: Add :service-pocket module skeleton.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -192,6 +192,10 @@ projects:
     path: components/service/glean
     description: 'A client-side telemetry SDK for collecting metrics and sending them to the Mozilla telemetry service'
     publish: true
+  service-pocket:
+    path: components/service/pocket
+    description: 'A library to communicate with the Pocket API'
+    publish: true
   service-telemetry:
     path: components/service/telemetry
     description: 'A generic library for generating and sending telemetry pings from Android applications to the Mozilla telemetry service.'

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ _Components and libraries to interact with backend services._
 
 * 🔴 [**Glean**](components/service/glean/README.md) - A client-side telemetry SDK for collecting metrics and sending them to Mozilla's telemetry service (eventually replacing [service-telemetry](components/service/telemetry/README.md)).
 
+* 🔴 [**Pocket**](components/service/pocket/README.md) - A library for communicating with the Pocket API.
+
 * 🔵 [**Telemetry**](components/service/telemetry/README.md) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 
 ## Support

--- a/components/service/pocket/README.md
+++ b/components/service/pocket/README.md
@@ -1,0 +1,20 @@
+# [Android Components](../../../README.md) > Service > Pocket
+
+A library for communicating with the Pocket API.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) 
+([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:service-pocket:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/service/pocket/build.gradle
+++ b/components/service/pocket/build.gradle
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+
+    implementation project(':support-ktx')
+    implementation project(':support-base')
+
+    testImplementation Dependencies.androidx_test_core
+
+    testImplementation Dependencies.testing_junit
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/service/pocket/proguard-rules.pro
+++ b/components/service/pocket/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/service/pocket/src/main/AndroidManifest.xml
+++ b/components/service/pocket/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.service.pocket" >
+</manifest>

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/Placeholder.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/Placeholder.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+class Placeholder

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PlaceholderTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PlaceholderTest.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+class PlaceholderTest

--- a/components/service/pocket/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/service/pocket/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/docs/components.md
+++ b/docs/components.md
@@ -51,6 +51,7 @@ Independent, small visual UI elements to use in applications.
 
 * [service-firefox-accounts](https://github.com/mozilla-mobile/android-components/tree/master/components/service/firefox-accounts) - A library for integrating with [Firefox Accounts](https://mozilla.github.io/application-services/docs/accounts/welcome.html).
 * [service-fretboard](https://github.com/mozilla-mobile/android-components/tree/master/components/service/fretboard) - An Android framework for segmenting users in order to run A/B tests and rollout features gradually.
+* [service-pocket](https://github.com/mozilla-mobile/android-components/tree/master/components/service/pocket) - A library for communicating with the Pocket API.
 * [service-telemetry](https://github.com/mozilla-mobile/android-components/tree/master/components/service/telemetry) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 * [service-glean](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service (eventually replacing `service-telemetry`).
 


### PR DESCRIPTION
This was modeled after the commit that added :service-glean:
92a936c7915df27121d5cac6f3c2e644411522fb

I decided to submit this PR now, before I added any useful code here, so I can make sure I added the module correctly and give space for others to work on it (if relevant).

Less importantly, I'm blocked on creating docs to show how to create a new module #2246 until I have an up-to-date commit to reference, like this one. :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
