### PR TITLE
Closes #2246: document how to add a new gradle module (with template)

### DIFF
--- a/docs/contribute/add_a_gradle_module.md
+++ b/docs/contribute/add_a_gradle_module.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Add a new Gradle module
+permalink: /contributing/add-a-gradle-module
+---
+
+This document describes how to add a new Gradle module, also known as a Gradle project or subproject. For example, by following this guide, you can add a new module like `:concept-engine`.
+
+Android Studio's built-in module creation tools do not understand android-components's module structure so its built-in tools like `File -> New -> New Module` do not work correctly: instead, we'll create the Gradle module manually.
+
+## Pre-work
+1. Check if your code can fit into an existing module
+1. Figure out what to name the new module. It will be made up of two parts: e.g. `concept-engine` or `service-pocket`. For a full-list of existing prefixes, see [`./components`](https://github.com/mozilla-mobile/android-components/tree/master/components). If you're unsure, consult the team.
+1. Write a one-line description for your module: this text will be repeated in several files.
+1. Make your new module's directory, e.g. `mkdir -p components/service/pocket`
+
+## Copy & update the new module template
+Copy the new gradle module template to your new module's directory, e.g. `cp -R ./tools/new-gradle-module-template/* components/service/pocket`.
+
+Modify the copied files to reference your module instead of the template:
+- In `README.md`:
+  - Change page title
+  - Replace one-line description with your own
+  - Modify dependency example
+- In `src/` directory:
+  - In `src/main`, update directory hierarchy to match your module, e.g. `src/main/java/mozilla/components/service/pocket`
+  - In `src/test`, do the same
+  - Update the `package` statement in `Placeholder.kt` and `PlaceholderTest.kt`
+  - Update AndroidManifest to point at your package
+- **Look out for changes we may have missed**
+
+**N.B.:** our conventions for configuring modules may change so this template may get outdated: consult the team if you run into trouble. Please file a bug if the template is outdated.
+
+## Update references to new module
+1. Add your module to `.buildconfig.yml`: follow the existing conventions. **Without this line, gradle won't know to look at your new module and your module will not show up in Android Studio.**
+1. Add your new module to the root `README.md`
+1. Add your new module to `./docs/components.md`.
+
+## Test your changes
+To test your changes in Android Studio, click `File -> Sync Project with Gradle Files` and after it completes ensure your new module appears in the `Project` view.
+
+## Examples
+**N.B.:** our conventions for configuring modules may change so this example may get outdated.
+
+This is the PR where we added `:services-pocket`: https://github.com/mozilla-mobile/android-components/pull/2247

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,6 +24,7 @@ Before contributing, please review our [Community Participation Guidelines](http
 * [Architecture and Overview]({{ site.baseurl }}/contributing/architecture)
 * [Code coverage]({{ site.baseurl }}/contributing/code-coverage)
 * [Working on unreleased component code in an app]({{ site.baseurl }}{% link contribute/components_inside_app.md %})
+* [Add a new Gradle module]({{ site.baseurl }})/contributing/add-a-gradle-module)
 
 ### Process
 

--- a/tools/new-gradle-module-template/README.md
+++ b/tools/new-gradle-module-template/README.md
@@ -1,0 +1,22 @@
+# [Android Components](../../../README.md) > PARENT_DIR > NEW_MODULE
+
+To create a new module, follow the instructions at https://mozac.org/contributing/add-a-gradle-module
+
+TODO: follow instructions above and additionally update this file. Add your one-line description here.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/)
+([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:parentdir-newmodule:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/tools/new-gradle-module-template/build.gradle
+++ b/tools/new-gradle-module-template/build.gradle
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+
+    implementation project(':support-ktx')
+    implementation project(':support-base')
+
+    testImplementation Dependencies.androidx_test_core
+
+    testImplementation Dependencies.testing_junit
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/tools/new-gradle-module-template/proguard-rules.pro
+++ b/tools/new-gradle-module-template/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/tools/new-gradle-module-template/src/main/AndroidManifest.xml
+++ b/tools/new-gradle-module-template/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.parentdir.newmodule" >
+</manifest>

--- a/tools/new-gradle-module-template/src/main/java/mozilla/components/parentdir/newmodule/Placeholder.kt
+++ b/tools/new-gradle-module-template/src/main/java/mozilla/components/parentdir/newmodule/Placeholder.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.parentdir.newmodule
+
+class Placeholder

--- a/tools/new-gradle-module-template/src/test/java/mozilla/components/parentdir/newmodule/PlaceholderTest.kt
+++ b/tools/new-gradle-module-template/src/test/java/mozilla/components/parentdir/newmodule/PlaceholderTest.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.parentdir.newmodule
+
+class PlaceholderTest

--- a/tools/new-gradle-module-template/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tools/new-gradle-module-template/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
~~**BEFORE LANDING**: I need to provide an example for what adding a module might look like and I want to reference the commits from PR https://github.com/mozilla-mobile/android-components/pull/2247, which hasn't landed yet.~~

_edit:_ done.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
