### PR TITLE
Closes #2262: Rename Response.X to isX..

### DIFF
--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Response.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Response.kt
@@ -127,12 +127,12 @@ data class Response(
  * Returns true if the response was successful (status in the range 200-299) or false otherwise.
  */
 @Suppress("MagicNumber")
-val Response.success: Boolean
+val Response.isSuccess: Boolean
     get() = status in 200..299
 
 /**
  * Returns true if the response was a client error (status in the range 400-499) or false otherwise.
  */
 @Suppress("MagicNumber")
-val Response.clientError: Boolean
+val Response.isClientError: Boolean
     get() = status in 400..499

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ResponseTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/ResponseTest.kt
@@ -123,23 +123,23 @@ class ResponseTest {
 
     @Test
     fun `success() extension function returns true for 2xx response codes`() {
-        assertTrue(Response("https://www.mozilla.org", 200, headers = mock(), body = mock()).success)
-        assertTrue(Response("https://www.mozilla.org", 203, headers = mock(), body = mock()).success)
+        assertTrue(Response("https://www.mozilla.org", 200, headers = mock(), body = mock()).isSuccess)
+        assertTrue(Response("https://www.mozilla.org", 203, headers = mock(), body = mock()).isSuccess)
 
-        assertFalse(Response("https://www.mozilla.org", 404, headers = mock(), body = mock()).success)
-        assertFalse(Response("https://www.mozilla.org", 500, headers = mock(), body = mock()).success)
-        assertFalse(Response("https://www.mozilla.org", 302, headers = mock(), body = mock()).success)
+        assertFalse(Response("https://www.mozilla.org", 404, headers = mock(), body = mock()).isSuccess)
+        assertFalse(Response("https://www.mozilla.org", 500, headers = mock(), body = mock()).isSuccess)
+        assertFalse(Response("https://www.mozilla.org", 302, headers = mock(), body = mock()).isSuccess)
     }
 
     @Test
     fun `clientError() extension function returns true for 4xx response codes`() {
-        assertTrue(Response("https://www.mozilla.org", 404, headers = mock(), body = mock()).clientError)
-        assertTrue(Response("https://www.mozilla.org", 403, headers = mock(), body = mock()).clientError)
+        assertTrue(Response("https://www.mozilla.org", 404, headers = mock(), body = mock()).isClientError)
+        assertTrue(Response("https://www.mozilla.org", 403, headers = mock(), body = mock()).isClientError)
 
-        assertFalse(Response("https://www.mozilla.org", 200, headers = mock(), body = mock()).clientError)
-        assertFalse(Response("https://www.mozilla.org", 203, headers = mock(), body = mock()).clientError)
-        assertFalse(Response("https://www.mozilla.org", 500, headers = mock(), body = mock()).clientError)
-        assertFalse(Response("https://www.mozilla.org", 302, headers = mock(), body = mock()).clientError)
+        assertFalse(Response("https://www.mozilla.org", 200, headers = mock(), body = mock()).isClientError)
+        assertFalse(Response("https://www.mozilla.org", 203, headers = mock(), body = mock()).isClientError)
+        assertFalse(Response("https://www.mozilla.org", 500, headers = mock(), body = mock()).isClientError)
+        assertFalse(Response("https://www.mozilla.org", 302, headers = mock(), body = mock()).isClientError)
     }
 
     @Test

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
@@ -9,7 +9,7 @@ import mozilla.components.browser.search.suggestions.SearchSuggestionClient
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.success
+import mozilla.components.concept.fetch.isSuccess
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.support.base.log.logger.Logger
 import java.io.IOException
@@ -144,7 +144,7 @@ class SearchSuggestionProvider(
             )
 
             val response = fetchClient.fetch(request)
-            if (!response.success) {
+            if (!response.isSuccess) {
                 return null
             }
 

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/source/kinto/KintoClient.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/source/kinto/KintoClient.kt
@@ -7,7 +7,7 @@ package mozilla.components.service.experiments.source.kinto
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.success
+import mozilla.components.concept.fetch.isSuccess
 import mozilla.components.service.experiments.ExperimentDownloadException
 import java.io.IOException
 
@@ -65,7 +65,7 @@ internal class KintoClient(
 
             val request = Request(url, headers = headers, useCaches = false)
             val response = httpClient.fetch(request)
-            if (!response.success) {
+            if (!response.isSuccess) {
                 throw ExperimentDownloadException("Status code: ${response.status}")
             }
             return response.body.string()

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/source/kinto/KintoClient.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/source/kinto/KintoClient.kt
@@ -7,7 +7,7 @@ package mozilla.components.service.fretboard.source.kinto
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.success
+import mozilla.components.concept.fetch.isSuccess
 import mozilla.components.service.fretboard.ExperimentDownloadException
 import java.io.IOException
 
@@ -65,7 +65,7 @@ internal class KintoClient(
 
             val request = Request(url, headers = headers, useCaches = false)
             val response = httpClient.fetch(request)
-            if (!response.success) {
+            if (!response.isSuccess) {
                 throw ExperimentDownloadException("Status code: ${response.status}")
             }
             return response.body.string()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
@@ -9,8 +9,8 @@ import android.support.annotation.VisibleForTesting.PRIVATE
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.clientError
-import mozilla.components.concept.fetch.success
+import mozilla.components.concept.fetch.isClientError
+import mozilla.components.concept.fetch.isSuccess
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.base.log.logger.Logger
@@ -102,7 +102,7 @@ internal class HttpPingUploader : PingUploader {
             logger.debug("Ping upload: ${response.status}")
 
             when {
-                response.success -> {
+                response.isSuccess -> {
                     // Known success errors (2xx):
                     // 200 - OK. Request accepted into the pipeline.
 
@@ -111,7 +111,7 @@ internal class HttpPingUploader : PingUploader {
                     return true
                 }
 
-                response.clientError -> {
+                response.isClientError -> {
                     // Known client (4xx) errors:
                     // 404 - not found - POST/PUT to an unknown namespace
                     // 405 - wrong request type (anything other than POST/PUT)

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
@@ -12,7 +12,7 @@ import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
-import mozilla.components.concept.fetch.success
+import mozilla.components.concept.fetch.isSuccess
 import java.io.IOException
 
 /**
@@ -49,7 +49,7 @@ internal class PocketEndpointRaw(
             null
         }
 
-        return response?.use { if (response.success) response.body.string() else null }
+        return response?.use { if (response.isSuccess) response.body.string() else null }
     }
 
     companion object {

--- a/components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt
+++ b/components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.success
+import mozilla.components.concept.fetch.isSuccess
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
@@ -283,7 +283,7 @@ abstract class FetchTestCases {
 
             // Verify response
 
-            assertTrue(response.success)
+            assertTrue(response.isSuccess)
             assertEquals(201, response.status)
 
             assertEquals("Thank you!", response.body.string())

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@ permalink: /changelog/
 
 * **browser-menu**
   * ⚠️ **This is a breaking API change!**: Removed redundant `BrowserMenuImageText` `contentDescription`
+  
+* **concept-fetch**
+  * ⚠️ **This is a breaking API change**: the [`Response`](https://mozac.org/api/mozilla.components.concept.fetch/-response/) properties `.success` and `.clientError` were renamed to `.isSuccess` and `isClientError` respectively to match Java conventions.
 
 * **feature-downloads**
   * Fixing bug #2265. In some occasions, when trying to download a file, the download failed and the download notification shows "Unsuccessful download".


### PR DESCRIPTION
This follows Java naming conventions.

**N.B.:** this is a breaking change so we may not want to make it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - No additional tests: no behavior changes
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
