### PR TITLE
Closes #2265: Validating null or empty headers in the download manager

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadManager.kt
@@ -73,15 +73,15 @@ class DownloadManager(
 
         val request = Request(Uri.parse(download.url))
             .setNotificationVisibility(VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            .setMimeType(download.contentType)
-            .addRequestHeader("User-Agent", download.userAgent)
 
-        if (cookie.isNotEmpty()) {
-            request.addRequestHeader("Cookie", cookie)
+        if (!download.contentType.isNullOrEmpty()) {
+            request.setMimeType(download.contentType)
         }
 
-        if (refererURL.isNotEmpty()) {
-            request.addRequestHeader("Referer", refererURL)
+        with(request) {
+            addRequestHeaderSafely("User-Agent", download.userAgent)
+            addRequestHeaderSafely("Cookie", cookie)
+            addRequestHeaderSafely("Referer", refererURL)
         }
 
         request.setDestinationInExternalPublicDir(download.destinationDirectory, fileName)
@@ -158,4 +158,11 @@ class DownloadManager(
         Toast.makeText(applicationContext, R.string.mozac_feature_downloads_file_not_supported, Toast.LENGTH_LONG)
             .show()
     }
+}
+
+internal fun Request.addRequestHeaderSafely(name: String, value: String?) {
+    if (value.isNullOrEmpty()) {
+        return
+    }
+    addRequestHeader(name, value)
 }

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadManagerTest.kt
@@ -7,16 +7,21 @@ package mozilla.components.feature.downloads
 import android.Manifest.permission.INTERNET
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
+import android.app.DownloadManager.Request
 import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
-import org.junit.Assert.assertFalse
 import mozilla.components.browser.session.Download
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -97,6 +102,25 @@ class DownloadManagerTest {
         notifyDownloadCompleted(id)
 
         assertFalse(downloadCompleted)
+    }
+
+    @Test
+    fun `no null or empty headers can be added to the DownloadManager`() {
+        val mockRequest: Request = mock()
+
+        mockRequest.addRequestHeaderSafely("User-Agent", "")
+
+        verifyZeroInteractions(mockRequest)
+
+        mockRequest.addRequestHeaderSafely("User-Agent", null)
+
+        verifyZeroInteractions(mockRequest)
+
+        val fireFox = "Mozilla/5.0 (Windows NT 5.1; rv:7.0.1) Gecko/20100101 Firefox/7.0.1"
+
+        mockRequest.addRequestHeaderSafely("User-Agent", fireFox)
+
+        verify(mockRequest).addRequestHeader(anyString(), anyString())
     }
 
     private fun notifyDownloadCompleted(id: Long) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-menu**
   * ⚠️ **This is a breaking API change!**: Removed redundant `BrowserMenuImageText` `contentDescription`
 
+* **feature-downloads**
+  * Fixing bug #2265. In some occasions, when trying to download a file, the download failed and the download notification shows "Unsuccessful download".
+
 # 0.45.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.44.0...v0.45.0)


### PR DESCRIPTION
For some reasons `download.userAgent` was null and we were passing this value as a header to the download manager. The Android download manager doesn't like null or empty headers!

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
