### PR TITLE
service-glean: Use HTTP client implementing concept-fetch for upload.

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
     implementation project(':support-ktx')
     implementation project(':support-base')
+    implementation project(':concept-fetch')
+    implementation project(':lib-fetch-httpurlconnection')
 
     testImplementation Dependencies.androidx_test_core
 
@@ -52,6 +54,9 @@ dependencies {
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
     testImplementation Dependencies.androidx_work_testing
+
+    testImplementation project(':support-test')
+    testImplementation project(':lib-fetch-okhttp')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.glean.config
 
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.glean.BuildConfig
 
 /**
@@ -17,12 +19,14 @@ import mozilla.components.service.glean.BuildConfig
  *           the [serverEndpoint]
  * @property maxEvents the number of events to store before the events ping is sent
  * @property logPings whether to log ping contents to the console.
+ * @property httpClient The HTTP client implementation to use for uploading pings.
  */
 data class Configuration(
     val serverEndpoint: String = "https://incoming.telemetry.mozilla.org",
     val userAgent: String = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)",
-    val connectionTimeout: Int = 10000,
-    val readTimeout: Int = 30000,
+    val connectionTimeout: Long = 10000,
+    val readTimeout: Long = 30000,
     val maxEvents: Int = 500,
-    val logPings: Boolean = false
+    val logPings: Boolean = false,
+    val httpClient: Client = HttpURLConnectionClient()
 )

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -4,33 +4,31 @@
 
 package mozilla.components.service.glean.net
 
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.lib.fetch.okhttp.OkHttpClient
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-
+import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.doThrow
-import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import java.io.IOException
-import java.io.OutputStream
 import java.net.CookieHandler
 import java.net.CookieManager
 import java.net.HttpCookie
-import java.net.HttpURLConnection
-import java.net.MalformedURLException
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class HttpPingUploaderTest {
@@ -44,115 +42,101 @@ class HttpPingUploaderTest {
 
     @Test
     fun `connection timeouts must be properly set`() {
-        val connection = mock<HttpURLConnection>(HttpURLConnection::class.java)
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-        val client = spy<HttpPingUploader>(HttpPingUploader())
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
 
-        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
-        doReturn(200).`when`(client).doUpload(connection, testPing)
-
-        client.upload(testPath, testPing, testDefaultConfig)
-
-        verify<HttpURLConnection>(connection).readTimeout = 7050
-        verify<HttpURLConnection>(connection).connectTimeout = 3050
-        verify<HttpURLConnection>(connection, times(1)).disconnect()
+        assertEquals(Pair(7050L, TimeUnit.MILLISECONDS), request.readTimeout)
+        assertEquals(Pair(3050L, TimeUnit.MILLISECONDS), request.connectTimeout)
     }
 
     @Test
     fun `user-agent must be properly set`() {
-        val connection = mock(HttpURLConnection::class.java)
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-        val client = spy<HttpPingUploader>(HttpPingUploader())
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
 
-        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
-        doReturn(200).`when`(client).doUpload(connection, testPing)
-
-        client.upload(testPath, testPing, testDefaultConfig)
-
-        verify(connection).setRequestProperty("User-Agent", testDefaultConfig.userAgent)
-        verify<HttpURLConnection>(connection, times(1)).disconnect()
+        assertEquals(testDefaultConfig.userAgent, request.headers!!["User-Agent"])
     }
 
     @Test
     fun `X-Client-* headers must be properly set`() {
-        val connection = mock(HttpURLConnection::class.java)
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-        val client = spy<HttpPingUploader>(HttpPingUploader())
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
 
-        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
-        doReturn(200).`when`(client).doUpload(connection, testPing)
+        assertEquals("Glean", request.headers!!["X-Client-Type"])
+        assertEquals(BuildConfig.LIBRARY_VERSION, request.headers!!["X-Client-Version"])
+    }
 
-        client.upload(testPath, testPing, testDefaultConfig)
+    @Test
+    fun `Cookie policy must be properly set`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-        verify(connection).setRequestProperty("X-Client-Type", "Glean")
-        verify(connection).setRequestProperty("X-Client-Version", BuildConfig.LIBRARY_VERSION)
-        verify<HttpURLConnection>(connection, times(1)).disconnect()
+        val request = uploader.buildRequest(testPath, testPing, testDefaultConfig)
+
+        assertEquals(request.cookiePolicy, Request.CookiePolicy.OMIT)
     }
 
     @Test
     fun `upload() returns true for successful submissions (200)`() {
-        val connection = mock(HttpURLConnection::class.java)
+        val mockClient: Client = mock()
+        `when`(mockClient.fetch(any())).thenReturn(Response(
+            "URL", 200, mock(), mock()))
 
-        doReturn(200).`when`(connection).responseCode
-        doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-        val client = spy<HttpPingUploader>(HttpPingUploader())
-        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+        val config = testDefaultConfig.copy(httpClient = mockClient)
 
-        assertTrue(client.upload(testPath, testPing, testDefaultConfig))
-        verify<HttpURLConnection>(connection, times(1)).disconnect()
+        assertTrue(uploader.upload(testPath, testPing, config))
     }
-
     @Test
     fun `upload() returns false for server errors (5xx)`() {
         for (responseCode in 500..527) {
-            val connection = mock(HttpURLConnection::class.java)
+            val mockClient: Client = mock()
+            `when`(mockClient.fetch(any())).thenReturn(Response(
+                "URL", responseCode, mock(), mock()))
 
-            doReturn(responseCode).`when`(connection).responseCode
-            doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+            val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-            val client = spy<HttpPingUploader>(HttpPingUploader())
-            doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+            val config = testDefaultConfig.copy(httpClient = mockClient)
 
-            assertFalse(client.upload(testPath, testPing, testDefaultConfig))
-            verify<HttpURLConnection>(connection, times(1)).disconnect()
+            assertFalse(uploader.upload(testPath, testPing, config))
         }
     }
 
     @Test
     fun `upload() returns true for successful submissions (2xx)`() {
         for (responseCode in 200..226) {
-            val connection = mock(HttpURLConnection::class.java)
+            val mockClient: Client = mock()
+            `when`(mockClient.fetch(any())).thenReturn(Response(
+                "URL", responseCode, mock(), mock()))
 
-            doReturn(responseCode).`when`(connection).responseCode
-            doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+            val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-            val client = spy<HttpPingUploader>(HttpPingUploader())
-            doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+            val config = testDefaultConfig.copy(httpClient = mockClient)
 
-            assertTrue(client.upload(testPath, testPing, testDefaultConfig))
-            verify<HttpURLConnection>(connection, times(1)).disconnect()
+            assertTrue(uploader.upload(testPath, testPing, config))
         }
     }
 
     @Test
     fun `upload() returns true for failing submissions with broken requests (4xx)`() {
         for (responseCode in 400..451) {
-            val connection = mock(HttpURLConnection::class.java)
+            val mockClient: Client = mock()
+            `when`(mockClient.fetch(any())).thenReturn(Response(
+                "URL", responseCode, mock(), mock()))
 
-            doReturn(responseCode).`when`(connection).responseCode
-            doReturn(mock(OutputStream::class.java)).`when`(connection).outputStream
+            val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-            val client = spy<HttpPingUploader>(HttpPingUploader())
-            doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+            val config = testDefaultConfig.copy(httpClient = mockClient)
 
-            assertTrue(client.upload(testPath, testPing, testDefaultConfig))
-            verify<HttpURLConnection>(connection, times(1)).disconnect()
+            assertTrue(uploader.upload(testPath, testPing, config))
         }
     }
 
     @Test
-    fun `upload() correctly uploads the ping data`() {
+    fun `upload() correctly uploads the ping data with default configuration`() {
         val server = MockWebServer()
         server.enqueue(MockResponse().setBody("OK"))
 
@@ -175,10 +159,53 @@ class HttpPingUploaderTest {
     }
 
     @Test
-    fun `removeCookies() must not throw for malformed URLs`() {
+    fun `upload() correctly uploads the ping data with httpurlconnection client`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("OK"))
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            httpClient = HttpURLConnectionClient()
+        )
+
         val client = HttpPingUploader()
-        CookieHandler.setDefault(CookieManager())
-        client.removeCookies("lolprotocol://definitely-not-valid,")
+        assertTrue(client.upload(testPath, testPing, testConfig))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+        assertTrue(request.headers.values("Cookie").isEmpty())
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `upload() correctly uploads the ping data with OkHttp client`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("OK"))
+
+        val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            httpClient = OkHttpClient()
+        )
+
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
+
+        val request = server.takeRequest()
+        assertEquals(testPath, request.path)
+        assertEquals("POST", request.method)
+        assertEquals(testPing, request.body.readUtf8())
+        assertEquals("Telemetry/42.23", request.getHeader("User-Agent"))
+        assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"))
+        assertTrue(request.headers.values("Cookie").isEmpty())
+
+        server.shutdown()
     }
 
     @Test
@@ -237,29 +264,16 @@ class HttpPingUploaderTest {
     }
 
     @Test
-    fun `upload() returns true on malformed URLs`() {
-        val client = spy<HttpPingUploader>(HttpPingUploader())
-        doThrow(MalformedURLException()).`when`(client).openConnection(anyString(), anyString())
-
-        // If the URL is malformed then there's nothing we can do to recover. Therefore this is treated
-        // like a successful upload.
-        assertTrue(client.upload("path", "ping", testDefaultConfig))
-    }
-
-    @Test
     fun `upload() should return false when upload fails`() {
-        val stream = mock(OutputStream::class.java)
-        doThrow(IOException()).`when`(stream).write(any(ByteArray::class.java))
+        val mockClient: Client = mock()
+        `when`(mockClient.fetch(any())).thenThrow(IOException())
 
-        val connection = mock(HttpURLConnection::class.java)
-        doReturn(stream).`when`(connection).outputStream
+        val config = testDefaultConfig.copy(httpClient = mockClient)
 
-        val client = spy<HttpPingUploader>(HttpPingUploader())
-        doReturn(connection).`when`(client).openConnection(anyString(), anyString())
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
         // And IOException during upload is a failed upload that we should retry. The client should
         // return false in this case.
-        assertFalse(client.upload("path", "ping", testDefaultConfig))
-        verify<HttpURLConnection>(connection, times(1)).disconnect()
+        assertFalse(uploader.upload("path", "ping", config))
     }
 }


### PR DESCRIPTION
@Dexterp37 This is a PR that modifies `glean` to make use of a HTTP client that implements the interface of `concept-fetch`.

This allows us to unify the HTTP client that an app uses:
* In apps with GeckoView we would want all requests to go through Gecko/Necko (and show up in dev tools, yay) (`browser-engine-gecko-*`)
* In apps that are concerned about the app size we want to go with `HttpUrlConnection` (`lib-fetch-httpurlconnection`)
* And finally in apps that already use `OkHttp` we want to do that for telemetry too (`lib-fetch-okttp`).

Since glean tries to be a "no configuration needed" kind of library I've set the default client to `HttpURLConnectionClient` which means no app will **need** to configure this. I picked `HttpURLConnectionClient` since that doesn't require any third-party dependencies and because it's "only" a wrapper around `HttpURLConnection` it is super small.

What do you think?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
