### PR TITLE
Closes #2277 - Add ability to set default search engine

### DIFF
--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -8,10 +8,10 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -28,6 +28,7 @@ class SearchEngineManager(
 ) {
     private var deferredSearchEngines: Deferred<List<SearchEngine>>? = null
     private val scope = CoroutineScope(Dispatchers.Default)
+    var defaultSearchEngine: SearchEngine? = null
 
     /**
      * Asynchronously load search engines from providers. Inherits caller's [CoroutineScope.coroutineContext].
@@ -55,8 +56,8 @@ class SearchEngineManager(
     /**
      * Returns the default search engine.
      *
-     * The default engine is the first engine loaded by the first provider passed to the
-     * constructor of SearchEngineManager.
+     * If defaultSearchEngine has not been set, the default engine is the first engine loaded by the
+     * first provider passed to the constructor of SearchEngineManager.
      *
      * Optionally a name can be passed to this method (e.g. from the user's preferences). If
      * a matching search engine was loaded then this search engine will be returned instead.
@@ -66,7 +67,7 @@ class SearchEngineManager(
         val searchEngines = getSearchEngines(context)
 
         return when (name) {
-            EMPTY -> searchEngines[0]
+            EMPTY -> defaultSearchEngine ?: searchEngines[0]
             else -> searchEngines.find { it.name == name } ?: searchEngines[0]
         }
     }

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -73,6 +73,16 @@ class SearchEngineManager(
     }
 
     /**
+     * Returns search engine corresponding to name passed to this method, or null if not found.
+     */
+    @Synchronized
+    fun getSearchEngineByName(context: Context, name: String): SearchEngine? {
+        val searchEngines = getSearchEngines(context)
+
+        return searchEngines.find { it.name == name }
+    }
+
+    /**
      * Registers for ACTION_LOCALE_CHANGED broadcasts and automatically reloads the search engines
      * whenever the locale changes.
      */

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -73,16 +73,6 @@ class SearchEngineManager(
     }
 
     /**
-     * Returns search engine corresponding to name passed to this method, or null if not found.
-     */
-    @Synchronized
-    fun getSearchEngineByName(context: Context, name: String): SearchEngine? {
-        val searchEngines = getSearchEngines(context)
-
-        return searchEngines.find { it.name == name }
-    }
-
-    /**
      * Registers for ACTION_LOCALE_CHANGED broadcasts and automatically reloads the search engines
      * whenever the locale changes.
      */

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -114,6 +114,45 @@ class SearchEngineManagerTest {
         }
     }
 
+    @Test
+    fun `manager returns set default engine as default when no identifier is specified`() {
+        runBlocking {
+            val provider = mockProvider(
+                listOf(
+                    mockSearchEngine("mozsearch"),
+                    mockSearchEngine("google"),
+                    mockSearchEngine("bing")
+                )
+            )
+
+            val manager = SearchEngineManager(listOf(provider))
+            manager.defaultSearchEngine = mockSearchEngine("bing")
+
+            val default = manager.getDefaultSearchEngine(RuntimeEnvironment.application)
+            assertEquals("bing", default.identifier)
+        }
+    }
+
+    @Test
+    fun `manager returns engine from identifier as default when identifier is specified`() {
+        runBlocking {
+            val provider = mockProvider(
+                listOf(
+                    mockSearchEngine("mozsearch", "Mozilla Search"),
+                    mockSearchEngine("google", "Google Search"),
+                    mockSearchEngine("bing", "Bing Search")
+                )
+            )
+
+            val manager = SearchEngineManager(listOf(provider))
+            manager.defaultSearchEngine = mockSearchEngine("bing")
+
+            val default =
+                manager.getDefaultSearchEngine(RuntimeEnvironment.application, "Google Search")
+            assertEquals("google", default.identifier)
+        }
+    }
+
     @Ignore
     @Test
     fun `locale update broadcast will trigger reload`() {

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -115,6 +115,29 @@ class SearchEngineManagerTest {
     }
 
     @Test
+    fun `manager returns engine by name if it exists`() {
+        runBlocking {
+            val mozSearch = mockSearchEngine("mozsearch", "Mozilla Search")
+            val googleSearch = mockSearchEngine("google", "Google Search")
+            val provider = mockProvider(
+                listOf(
+                    googleSearch, mozSearch
+                )
+            )
+
+            val manager = SearchEngineManager(listOf(provider))
+
+            val searchEngine =
+                manager.getSearchEngineByName(RuntimeEnvironment.application, mozSearch.name)
+            assertEquals(mozSearch, searchEngine)
+
+            val noSuchSearchEngine =
+                manager.getSearchEngineByName(RuntimeEnvironment.application, "Fake Search")
+            assertEquals(null, noSuchSearchEngine)
+        }
+    }
+
+    @Test
     fun `manager returns set default engine as default when no identifier is specified`() {
         runBlocking {
             val provider = mockProvider(

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -115,29 +115,6 @@ class SearchEngineManagerTest {
     }
 
     @Test
-    fun `manager returns engine by name if it exists`() {
-        runBlocking {
-            val mozSearch = mockSearchEngine("mozsearch", "Mozilla Search")
-            val googleSearch = mockSearchEngine("google", "Google Search")
-            val provider = mockProvider(
-                listOf(
-                    googleSearch, mozSearch
-                )
-            )
-
-            val manager = SearchEngineManager(listOf(provider))
-
-            val searchEngine =
-                manager.getSearchEngineByName(RuntimeEnvironment.application, mozSearch.name)
-            assertEquals(mozSearch, searchEngine)
-
-            val noSuchSearchEngine =
-                manager.getSearchEngineByName(RuntimeEnvironment.application, "Fake Search")
-            assertEquals(null, noSuchSearchEngine)
-        }
-    }
-
-    @Test
     fun `manager returns set default engine as default when no identifier is specified`() {
         runBlocking {
             val provider = mockProvider(

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -22,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
@@ -56,9 +55,10 @@ class SearchSuggestionProviderTest {
                 searchEngineManager,
                 SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
             ).defaultSearch)
-            doNothing().`when`(useCase).invoke(anyString(), any<Session>())
+            doNothing().`when`(useCase).invoke(anyString(), any<Session>(), any<SearchEngine>())
 
-            val provider = SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
+            val provider =
+                SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
 
             try {
                 val suggestions = provider.onInputChanged("fire")
@@ -79,11 +79,11 @@ class SearchSuggestionProviderTest {
                 assertEquals("firefox nightly", suggestion.chips[9].title)
                 assertEquals("firefox clear cache", suggestion.chips[10].title)
 
-                verify(useCase, never()).invoke(anyString(), any<Session>())
+                verify(useCase, never()).invoke(anyString(), any<Session>(), any<SearchEngine>())
 
                 suggestion.onChipClicked!!.invoke(suggestion.chips[6])
 
-                verify(useCase).invoke(eq("firefox focus"), any<Session>())
+                verify(useCase).invoke(eq("firefox focus"), any<Session>(), any<SearchEngine>())
             } finally {
                 server.shutdown()
             }
@@ -111,7 +111,7 @@ class SearchSuggestionProviderTest {
                 searchEngineManager,
                 SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
             ).defaultSearch)
-            doNothing().`when`(useCase).invoke(anyString(), any<Session>())
+            doNothing().`when`(useCase).invoke(anyString(), any<Session>(), any<SearchEngine>())
 
             val provider = SearchSuggestionProvider(
                 searchEngine,
@@ -139,11 +139,11 @@ class SearchSuggestionProviderTest {
                 assertEquals("firefox nightly", suggestions[9].title)
                 assertEquals("firefox clear cache", suggestions[10].title)
 
-                verify(useCase, never()).invoke(anyString(), any<Session>())
+                verify(useCase, never()).invoke(anyString(), any<Session>(), any<SearchEngine>())
 
                 suggestions[6].onSuggestionClicked!!.invoke()
 
-                verify(useCase).invoke(eq("firefox focus"), any<Session>())
+                verify(useCase).invoke(eq("firefox focus"), any<Session>(), any<SearchEngine>())
             } finally {
                 server.shutdown()
             }
@@ -165,20 +165,21 @@ class SearchSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider should return default suggestion for search engine that cannot provide suggestion`() = runBlocking {
-        val searchEngine: SearchEngine = mock()
-        doReturn(false).`when`(searchEngine).canProvideSearchSuggestions
+    fun `Provider should return default suggestion for search engine that cannot provide suggestion`() =
+        runBlocking {
+            val searchEngine: SearchEngine = mock()
+            doReturn(false).`when`(searchEngine).canProvideSearchSuggestions
 
-        val provider = SearchSuggestionProvider(searchEngine, mock(), mock())
+            val provider = SearchSuggestionProvider(searchEngine, mock(), mock())
 
-        val suggestions = provider.onInputChanged("fire")
-        assertEquals(1, suggestions.size)
+            val suggestions = provider.onInputChanged("fire")
+            assertEquals(1, suggestions.size)
 
-        val suggestion = suggestions[0]
-        assertEquals(1, suggestion.chips.size)
+            val suggestion = suggestions[0]
+            assertEquals(1, suggestion.chips.size)
 
-        assertEquals("fire", suggestion.chips[0].title)
-    }
+            assertEquals("fire", suggestion.chips[0].title)
+        }
 
     @Test
     fun `Provider doesn't fail if fetch returns HTTP error`() {
@@ -189,7 +190,7 @@ class SearchSuggestionProviderTest {
 
             val searchEngine: SearchEngine = mock()
             doReturn(server.url("/").toString())
-                    .`when`(searchEngine).buildSuggestionsURL("fire")
+                .`when`(searchEngine).buildSuggestionsURL("fire")
             doReturn(true).`when`(searchEngine).canProvideSearchSuggestions
             doReturn("google").`when`(searchEngine).name
 
@@ -197,13 +198,14 @@ class SearchSuggestionProviderTest {
             doReturn(searchEngine).`when`(searchEngineManager).getDefaultSearchEngine(any(), any())
 
             val useCase = spy(SearchUseCases(
-                    RuntimeEnvironment.application,
-                    searchEngineManager,
-                    SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
+                RuntimeEnvironment.application,
+                searchEngineManager,
+                SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
             ).defaultSearch)
-            doNothing().`when`(useCase).invoke(anyString(), any<Session>())
+            doNothing().`when`(useCase).invoke(anyString(), any<Session>(), any<SearchEngine>())
 
-            val provider = SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
+            val provider =
+                SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
 
             try {
                 val suggestions = provider.onInputChanged("fire")
@@ -234,9 +236,10 @@ class SearchSuggestionProviderTest {
                 searchEngineManager,
                 SessionManager(mock()).apply { add(Session("https://www.mozilla.org")) }
             ).defaultSearch)
-            doNothing().`when`(useCase).invoke(anyString(), any<Session>())
+            doNothing().`when`(useCase).invoke(anyString(), any<Session>(), any<SearchEngine>())
 
-            val provider = SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
+            val provider =
+                SearchSuggestionProvider(searchEngine, useCase, HttpURLConnectionClient())
             val suggestions = provider.onInputChanged("fire")
             assertEquals(1, suggestions.size)
 

--- a/components/feature/search/build.gradle
+++ b/components/feature/search/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation project(':browser-search')
+    api project(':browser-search')
     implementation project(':browser-session')
     implementation project(':concept-engine')
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ permalink: /changelog/
   
 * **feature-search**
   * Adds default search engine var to `SearchEngineManager`
+  * Adds optional `SearchEngine` to `invoke()` in `SearchUseCases`
 
 * **service-experiments**
   * A new client-side experiments SDK for running segmenting user populations to run multi-branch experiments on them. This component is going to replace `service-fretboard`. The SDK is currently in development and the component is not ready to be used yet.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,9 @@ permalink: /changelog/
 
 * **feature-downloads**
   * Fixing bug #2265. In some occasions, when trying to download a file, the download failed and the download notification shows "Unsuccessful download".
+  
+* **feature-search**
+  * Adds default search engine var to `SearchEngineManager`
 
 * **service-experiments**
   * A new client-side experiments SDK for running segmenting user populations to run multi-branch experiments on them. This component is going to replace `service-fretboard`. The SDK is currently in development and the component is not ready to be used yet.


### PR DESCRIPTION
I think since the calls to SearchEngineManager `getDefaultSearchEngine` are tested in `SearchEngineManagerTest`, this PR does need its own tests? 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
