### PR TITLE
Closes #2255: Adds onBackPressListener to editToolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -468,6 +468,12 @@ class BrowserToolbar @JvmOverloads constructor(
         }
     }
 
+    internal fun onEditCancelled() {
+        if (editToolbar.editListener?.onCancelEditing() != false) {
+            displayMode()
+        }
+    }
+
     private fun updateState(state: State) {
         this.state = state
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.support.v4.content.ContextCompat
 import android.text.InputType
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
@@ -60,6 +61,13 @@ class EditToolbar(
         setOnTextChangeListener { text, _ ->
             updateClearViewVisibility(text)
             editListener?.onTextChanged(text)
+        }
+
+        setOnDispatchKeyEventPreImeListener { event ->
+            if (event?.keyCode == KeyEvent.KEYCODE_BACK) {
+                toolbar.onEditCancelled()
+            }
+            false
         }
     }
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -37,6 +37,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
@@ -174,6 +175,17 @@ class BrowserToolbarTest {
 
         assertTrue(mockedListener.called)
         assertEquals("https://www.mozilla.org", mockedListener.url)
+    }
+
+    @Test
+    fun `internal onEditCancelled callback will be forwarded to editListener`() {
+        val toolbar = BrowserToolbar(context)
+        val listener: Toolbar.OnEditListener = mock()
+        toolbar.setOnEditListener(listener)
+        assertEquals(toolbar.editToolbar.editListener, listener)
+
+        toolbar.onEditCancelled()
+        verify(listener, times(1)).onCancelEditing()
     }
 
     @Test

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -127,6 +127,11 @@ interface Toolbar {
         fun onStartEditing() = Unit
 
         /**
+         * Fired when the user presses the back button while in edit mode.
+         */
+        fun onCancelEditing(): Boolean
+
+        /**
          * Fired when the toolbar switches back to display mode.
          */
         fun onStopEditing() = Unit

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -46,6 +46,10 @@ class AwesomeBarFeature(
                 onEditComplete?.invoke() ?: hideAwesomeBar()
                 awesomeBar.onInputCancelled()
             }
+
+            override fun onCancelEditing(): Boolean {
+                return true
+            }
         })
 
         awesomeBar.setOnStopListener { toolbar.displayMode() }

--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -35,6 +35,7 @@ typealias OnCommitListener = () -> Unit
 typealias OnFilterListener = (String) -> Unit
 typealias OnSearchStateChangeListener = (Boolean) -> Unit
 typealias OnTextChangeListener = (String, String) -> Unit
+typealias OnDispatchKeyEventPreImeListener = (KeyEvent?) -> Boolean
 typealias OnKeyPreImeListener = (View, Int, KeyEvent) -> Boolean
 typealias OnSelectionChangedListener = (Int, Int) -> Unit
 typealias OnWindowsFocusChangeListener = (Boolean) -> Unit
@@ -109,6 +110,9 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
 
     private var textChangeListener: OnTextChangeListener? = null
     fun setOnTextChangeListener(l: OnTextChangeListener) { textChangeListener = l }
+
+    private var dispatchKeyEventPreImeListener: OnDispatchKeyEventPreImeListener? = null
+    fun setOnDispatchKeyEventPreImeListener(l: OnDispatchKeyEventPreImeListener?) { dispatchKeyEventPreImeListener = l }
 
     private var keyPreImeListener: OnKeyPreImeListener? = null
     fun setOnKeyPreImeListener(l: OnKeyPreImeListener) { keyPreImeListener = l }
@@ -226,8 +230,8 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
     public override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        this.keyPreImeListener = onKeyPreIme
-        this.selectionChangedListener = onSelectionChanged
+        if (this.keyPreImeListener == null) { this.keyPreImeListener = onKeyPreIme }
+        if (this.selectionChangedListener == null) { this.selectionChangedListener = onSelectionChanged }
 
         setOnKeyListener(onKey)
         addTextChangedListener(TextChangeListener())
@@ -626,6 +630,12 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
         override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
             // do nothing
         }
+    }
+
+    override fun dispatchKeyEventPreIme(event: KeyEvent?): Boolean {
+        return event?.let {
+            dispatchKeyEventPreImeListener?.invoke(it) ?: onKeyPreIme(it.keyCode, it)
+        } ?: super.dispatchKeyEventPreIme(event)
     }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,11 @@ permalink: /changelog/
 * **browser-menu**
    * Added `TwoStateButton` in `BrowserMenuItemToolbar` that will change resources based on the `isInPrimaryState` lambda and added ability to disable the button with optional `disableInSecondaryState` argument.
 
+* **browser-toolbar**
+  * Adds `onCancelEditing` to `onEditListener` in `BrowserToolbar` which is fired when a back button press occurs while the keyboard is displayed.
+    This is especially useful if you want to call `activity.onBackPressed()` to navigate away rather than just dismiss the keyboard.
+    Its return value is used to determine if `displayMode` will switch from edit to view.
+
 # 0.46.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.45.0...v0.46.0)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
