### PR TITLE
Closes #651: Add PocketEndpoint!

### DIFF
--- a/components/service/pocket/.gitignore
+++ b/components/service/pocket/.gitignore
@@ -1,0 +1,1 @@
+src/test/resources/pocket/apiKey.txt

--- a/components/service/pocket/build.gradle
+++ b/components/service/pocket/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
+    testImplementation project(':lib-fetch-httpurlconnection')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/pocket/build.gradle
+++ b/components/service/pocket/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':support-base')
     implementation project(':concept-fetch')
 
+    testImplementation Dependencies.kotlin_reflect
     testImplementation Dependencies.androidx_test_core
 
     testImplementation Dependencies.testing_junit

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
@@ -14,7 +14,7 @@ import mozilla.components.service.pocket.net.PocketResponse
 /**
  * Makes requests to the Pocket API and returns the requested data.
  *
- * @see [getInstance] to retrieve an instance.
+ * @see [newInstance] to retrieve an instance.
  */
 class PocketEndpoint internal constructor(
     private val rawEndpoint: PocketEndpointRaw,
@@ -48,7 +48,7 @@ class PocketEndpoint internal constructor(
     companion object {
 
         /**
-         * Returns an instance of [PocketEndpoint].
+         * Returns a new instance of [PocketEndpoint].
          *
          * @param client the HTTP client to use for network requests.
          * @param pocketApiKey the API key for Pocket network requests.
@@ -56,7 +56,7 @@ class PocketEndpoint internal constructor(
          *
          * @throws IllegalArgumentException if the provided API key or user agent is deemed invalid.
          */
-        fun getInstance(client: Client, pocketApiKey: String, userAgent: String): PocketEndpoint {
+        fun newInstance(client: Client, pocketApiKey: String, userAgent: String): PocketEndpoint {
             assertIsValidApiKey(pocketApiKey)
             assertIsValidUserAgent(userAgent)
 

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import android.support.annotation.WorkerThread
+import mozilla.components.concept.fetch.Client
+import mozilla.components.service.pocket.data.PocketGlobalVideoRecommendation
+import mozilla.components.service.pocket.net.PocketResponse
+
+// See @Ignore tests in test class to do end-to-end testing.
+
+/**
+ * Makes requests to the Pocket API and returns the requested data.
+ *
+ * @see [getInstance] to retrieve an instance.
+ */
+class PocketEndpoint internal constructor(
+    private val rawEndpoint: PocketEndpointRaw,
+    private val jsonParser: PocketJSONParser
+) {
+
+    /**
+     * Gets a response, filled with the Pocket global video recommendations from the Pocket API server on success.
+     * This network call is synchronous and the results are not cached. The API version of this call is available in the
+     * source code at [PocketURLs.VALUE_VIDEO_RECS_VERSION].
+     *
+     * If the API returns unexpectedly formatted results, these entries will be omitted and the rest of the items are
+     * returned.
+     *
+     * @return a [PocketResponse.Success] with the Pocket global video recommendations (the list will never be empty)
+     * or, on error, a [PocketResponse.Failure].
+     */
+    @WorkerThread // Synchronous network call.
+    fun getGlobalVideoRecommendations(): PocketResponse<List<PocketGlobalVideoRecommendation>> {
+        val json = rawEndpoint.getGlobalVideoRecommendations()
+        val videoRecs = json?.let { jsonParser.jsonToGlobalVideoRecommendations(it) }
+        return videoRecs.wrapInResponse()
+    }
+
+    private fun <T> List<T>?.wrapInResponse(): PocketResponse<List<T>> = if (isNullOrEmpty()) {
+        PocketResponse.Failure()
+    } else {
+        PocketResponse.Success(this!!)
+    }
+
+    companion object {
+
+        /**
+         * Returns an instance of [PocketEndpoint].
+         *
+         * @param client the HTTP client to use for network requests.
+         * @param pocketApiKey the API key for Pocket network requests.
+         * @param userAgent the user agent for network requests.
+         *
+         * @throws IllegalArgumentException if the provided API key or user agent is deemed invalid.
+         */
+        fun getInstance(client: Client, pocketApiKey: String, userAgent: String): PocketEndpoint {
+            assertIsValidApiKey(pocketApiKey)
+            assertIsValidUserAgent(userAgent)
+
+            val endpoint = PocketEndpointRaw(client, PocketURLs(pocketApiKey), userAgent)
+            return PocketEndpoint(endpoint, PocketJSONParser())
+        }
+    }
+}
+
+private fun assertIsValidApiKey(apiKey: String) {
+    if (apiKey.isBlank()) throw IllegalArgumentException("Expected non-blank API key")
+}
+
+private fun assertIsValidUserAgent(userAgent: String) {
+    if (userAgent.isBlank()) throw java.lang.IllegalArgumentException("Expected non-blank user agent")
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketJSONParser.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketJSONParser.kt
@@ -18,7 +18,7 @@ import org.json.JSONObject
 internal class PocketJSONParser {
 
     /**
-     * @return The videos or null on error; the list will never be empty.
+     * @return The videos, removing entries that are invalid, or null on error; the list will never be empty.
      */
     fun jsonToGlobalVideoRecommendations(jsonStr: String): List<PocketGlobalVideoRecommendation>? = try {
         val rawJSON = JSONObject(jsonStr)

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketJSONParser.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketJSONParser.kt
@@ -20,7 +20,7 @@ internal class PocketJSONParser {
     /**
      * @return The videos or null on error; the list will never be empty.
      */
-    fun jsonToGlobalVideoRecommendations(jsonStr: String?): List<PocketGlobalVideoRecommendation>? = try {
+    fun jsonToGlobalVideoRecommendations(jsonStr: String): List<PocketGlobalVideoRecommendation>? = try {
         val rawJSON = JSONObject(jsonStr)
         val videosJSON = rawJSON.getJSONArray(KEY_VIDEO_RECOMMENDATIONS_INNER)
         val videos = videosJSON.mapNotNull(JSONArray::getJSONObject) { jsonToGlobalVideoRecommendation(it) }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketURLs.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketURLs.kt
@@ -20,20 +20,20 @@ internal class PocketURLs(
     private val apiKey: String
 ) {
 
-    val globalVideoRecs: Uri = "$CDN_BASE/global-video-recs".toUri().appendPocketQueryParams()
-
-    private fun Uri.appendPocketQueryParams(): Uri = buildUpon()
-        .appendQueryParameter(PARAM_API_KEY, apiKey)
-        .appendQueryParameter(PARAM_VERSION, VALUE_VERSION)
-        .appendQueryParameter(PARAM_AUTHORS, VALUE_AUTHORS)
+    val globalVideoRecs: Uri = "$CDN_BASE/global-video-recs".toUri().buildUpon()
+        .appendApiKey()
+        .appendQueryParameter(PARAM_VERSION, VALUE_VIDEO_RECS_VERSION)
+        .appendQueryParameter(PARAM_AUTHORS, VALUE_VIDEO_RECS_AUTHORS)
         .build()
+
+    private fun Uri.Builder.appendApiKey() = appendQueryParameter(PARAM_API_KEY, apiKey)
 
     companion object {
         @VisibleForTesting(otherwise = PRIVATE) internal const val PARAM_API_KEY = "consumer_key"
         @VisibleForTesting(otherwise = PRIVATE) internal const val PARAM_VERSION = "version"
         @VisibleForTesting(otherwise = PRIVATE) internal const val PARAM_AUTHORS = "authors"
 
-        @VisibleForTesting(otherwise = PRIVATE) internal const val VALUE_VERSION = "2"
-        @VisibleForTesting(otherwise = PRIVATE) internal const val VALUE_AUTHORS = "1"
+        @VisibleForTesting(otherwise = PRIVATE) internal const val VALUE_VIDEO_RECS_VERSION = "2"
+        @VisibleForTesting(otherwise = PRIVATE) internal const val VALUE_VIDEO_RECS_AUTHORS = "1"
     }
 }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/data/PocketGlobalVideoRecommendation.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/data/PocketGlobalVideoRecommendation.kt
@@ -19,7 +19,11 @@ package mozilla.components.service.pocket.data
  * @property popularitySortId the index of this recommendation in the list if the list was sorted by popularity.
  * @property authors the authors or publishers of this recommendation; unclear if this can be empty.
  */
-data class PocketGlobalVideoRecommendation(
+// If we change the properties, e.g. adding a field, any consumers that rely on persisting and constructing new
+// instances of this data type, will be required to implement code to migrate the persisted data. To prevent this,
+// we mark the constructors internal. If a consumer is required to persist this data, we should consider providing a
+// persistence solution.
+data class PocketGlobalVideoRecommendation internal constructor(
     val id: Int,
     val url: String,
     val tvURL: String,
@@ -40,7 +44,7 @@ data class PocketGlobalVideoRecommendation(
      * @property name the name of this author.
      * @property url a url to the author's video content channel (e.g. a YouTube channel).
      */
-    data class Author(
+    data class Author internal constructor(
         val id: String,
         val name: String,
         val url: String

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/net/PocketResponse.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/net/PocketResponse.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.net
+
+/**
+ * A response from the Pocket API: the subclasses determine the type of the result and contain usable data.
+ */
+sealed class PocketResponse<T> {
+
+    /**
+     * A successful response from the Pocket API.
+     *
+     * @property data The data returned from the Pocket API.
+     */
+    data class Success<T> internal constructor(val data: T) : PocketResponse<T>()
+
+    /**
+     * A failure response from the Pocket API.
+     */
+    class Failure<T> internal constructor() : PocketResponse<T>()
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.service.pocket.helpers.PocketTestResource
+import mozilla.components.service.pocket.net.PocketResponse
+import mozilla.components.support.test.any
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+private const val VALID_API_KEY = "apiKey"
+private const val VALID_USER_AGENT = "userAgent"
+
+@RunWith(RobolectricTestRunner::class)
+class PocketEndpointTest {
+
+    private lateinit var endpoint: PocketEndpoint
+    private lateinit var raw: PocketEndpointRaw // we shorten the name to avoid confusion with endpoint.
+    private lateinit var jsonParser: PocketJSONParser
+
+    private lateinit var client: Client
+
+    @Before
+    fun setUp() {
+        raw = mock(PocketEndpointRaw::class.java)
+        jsonParser = mock(PocketJSONParser::class.java)
+        endpoint = PocketEndpoint(raw, jsonParser)
+
+        client = mock(Client::class.java)
+    }
+
+    @Test
+    fun `WHEN getting video recommendations and the endpoint returns null THEN a failure is returned`() {
+        `when`(raw.getGlobalVideoRecommendations()).thenReturn(null)
+        `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenThrow(AssertionError("We assume this won't get called so we don't mock it"))
+        assertIsFailure(endpoint.getGlobalVideoRecommendations())
+    }
+
+    @Test
+    fun `WHEN getting video recommendations and the endpoint returns a String THEN the String is put into the jsonParser`() {
+        arrayOf(
+            "",
+            " ",
+            "{}",
+            """{"expectedJSON": 101}"""
+        ).forEach { expected ->
+            `when`(raw.getGlobalVideoRecommendations()).thenReturn(expected)
+            endpoint.getGlobalVideoRecommendations()
+            verify(jsonParser, times(1)).jsonToGlobalVideoRecommendations(expected)
+        }
+    }
+
+    @Test
+    fun `WHEN getting video recommendations, the server returns a String, and the JSON parser returns null THEN a failure is returned`() {
+        `when`(raw.getGlobalVideoRecommendations()).thenReturn("")
+        `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenReturn(null)
+        assertIsFailure(endpoint.getGlobalVideoRecommendations())
+    }
+
+    @Test
+    fun `WHEN getting video recommendations, the server returns a String, and the jsonParser returns an empty list THEN a failure is returned`() {
+        `when`(raw.getGlobalVideoRecommendations()).thenReturn("")
+        `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenReturn(emptyList())
+        assertIsFailure(endpoint.getGlobalVideoRecommendations())
+    }
+
+    @Test
+    fun `WHEN getting video recommendations, the server returns a String, and the jsonParser returns valid data THEN a success with the data is returned`() {
+        val expected = PocketTestResource.videoRecommendationFirstTwo
+        `when`(raw.getGlobalVideoRecommendations()).thenReturn("")
+        `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenReturn(expected)
+
+        val actual = endpoint.getGlobalVideoRecommendations()
+        assertEquals(expected, (actual as? PocketResponse.Success)?.data)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `WHEN getInstance is called with a blank API key THEN an exception is thrown`() {
+        PocketEndpoint.getInstance(client, " ", VALID_USER_AGENT)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `WHEN getInstance is called with a blank user agent THEN an exception is thrown`() {
+        PocketEndpoint.getInstance(client, VALID_API_KEY, " ")
+    }
+
+    @Test
+    fun `WHEN getInstance is called with valid args THEN no exception is thrown`() {
+        PocketEndpoint.getInstance(client, VALID_API_KEY, VALID_USER_AGENT)
+    }
+
+    @Test
+    @Ignore("Requires a network request; run locally to test end-to-end behavior")
+    fun `WHEN making an end-to-end request THEN 20 results are returned`() {
+        // To use this test locally, add the API key file (see API_KEY comments) and comment out ignore annotation.
+        val client = HttpURLConnectionClient()
+        val apiKey = PocketTestResource.API_KEY.get()
+        val endpoint = PocketEndpoint.getInstance(client, apiKey, "android-components:PocketEndpointTest")
+        val response = endpoint.getGlobalVideoRecommendations()
+        val results = (response as? PocketResponse.Success)?.data
+
+        assertEquals(20, results?.size)
+        results?.forEach { println(it.toString()) }
+    }
+}
+
+private fun assertIsFailure(actual: Any) {
+    assertEquals(PocketResponse.Failure::class.java, actual.javaClass)
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
@@ -88,17 +88,17 @@ class PocketEndpointTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun `WHEN getInstance is called with a blank API key THEN an exception is thrown`() {
-        PocketEndpoint.getInstance(client, " ", VALID_USER_AGENT)
+        PocketEndpoint.newInstance(client, " ", VALID_USER_AGENT)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `WHEN getInstance is called with a blank user agent THEN an exception is thrown`() {
-        PocketEndpoint.getInstance(client, VALID_API_KEY, " ")
+        PocketEndpoint.newInstance(client, VALID_API_KEY, " ")
     }
 
     @Test
     fun `WHEN getInstance is called with valid args THEN no exception is thrown`() {
-        PocketEndpoint.getInstance(client, VALID_API_KEY, VALID_USER_AGENT)
+        PocketEndpoint.newInstance(client, VALID_API_KEY, VALID_USER_AGENT)
     }
 
     @Test
@@ -107,7 +107,7 @@ class PocketEndpointTest {
         // To use this test locally, add the API key file (see API_KEY comments) and comment out ignore annotation.
         val client = HttpURLConnectionClient()
         val apiKey = PocketTestResource.API_KEY.get()
-        val endpoint = PocketEndpoint.getInstance(client, apiKey, "android-components:PocketEndpointTest")
+        val endpoint = PocketEndpoint.newInstance(client, apiKey, "android-components:PocketEndpointTest")
         val response = endpoint.getGlobalVideoRecommendations()
         val results = (response as? PocketResponse.Success)?.data
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketJSONParserTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketJSONParserTest.kt
@@ -38,43 +38,7 @@ class PocketJSONParserTest {
 
     @Test
     fun `WHEN parsing valid global video recommendations THEN pocket videos are returned`() {
-        val expectedSubset = listOf(
-            PocketGlobalVideoRecommendation(
-                id = 27587,
-                url = "https://www.youtube.com/watch?v=953Qt4FnAcU",
-                tvURL = "https://www.youtube.com/tv#/watch/video/idle?v=953Qt4FnAcU",
-                title = "How a Master Pastry Chef Uses Architecture to Make Sky High Pastries",
-                excerpt = "At New York City's International Culinary Center, host Rebecca DeAngelis makes a modern day croquembouche with architect-turned pastry chef Jansen Chan",
-                domain = "youtube.com",
-                imageSrc = "https://img-getpocket.cdn.mozilla.net/direct?url=http%3A%2F%2Fimg.youtube.com%2Fvi%2F953Qt4FnAcU%2Fmaxresdefault.jpg&resize=w450",
-                publishedTimestamp = "0",
-                sortId = 0,
-                popularitySortId = 20,
-                authors = listOf(PocketGlobalVideoRecommendation.Author(
-                    id = "96612022",
-                    name = "Eater",
-                    url = "http://www.youtube.com/channel/UCRzPUBhXUZHclB7B5bURFXw"
-                ))
-            ),
-            PocketGlobalVideoRecommendation(
-                id = 27581,
-                url = "https://www.youtube.com/watch?v=GHZ7-kq3GDQ",
-                tvURL = "https://www.youtube.com/tv#/watch/video/idle?v=GHZ7-kq3GDQ",
-                title = "How Does Having Too Much Power Affect Your Brain?",
-                excerpt = "Power is tied to a hierarchical escalator that we rise up through decisions and actions. But once we have power, how does it affect our brain and behavior? How Our Brains Respond to People Who Aren't Like Us - https://youtu.be/KIwe_O0am4URead More:The age of adolescencehttps://www.thelancet.com/jour",
-                domain = "youtube.com",
-                imageSrc = "https://img-getpocket.cdn.mozilla.net/direct?url=http%3A%2F%2Fimg.youtube.com%2Fvi%2FGHZ7-kq3GDQ%2Fmaxresdefault.jpg&resize=w450",
-                publishedTimestamp = "0",
-                sortId = 1,
-                popularitySortId = 17,
-                authors = listOf(PocketGlobalVideoRecommendation.Author(
-                    id = "96612138",
-                    name = "Seeker",
-                    url = "http://www.youtube.com/channel/UCzWQYUVCpZqtN93H8RR44Qw"
-                ))
-            )
-        )
-
+        val expectedSubset = PocketTestResource.videoRecommendationFirstTwo
         val pocketJSON = PocketTestResource.POCKET_VIDEO_RECOMMENDATION.get()
         val actualVideos = parser.jsonToGlobalVideoRecommendations(pocketJSON)
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketURLsTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketURLsTest.kt
@@ -29,13 +29,14 @@ class PocketURLsTest {
     }
 
     @Test
-    fun `WHEN getting the global video recs url THEN it contains the Pocket query parameters`() {
-        assertUriContainsPocketQueryParams(urls.globalVideoRecs)
+    fun `WHEN getting the global video recs url THEN it contains the appropriate query parameters`() {
+        val uri = urls.globalVideoRecs
+        assertUriContainsAPIKeyQueryParams(uri)
+        assertEquals(PocketURLs.VALUE_VIDEO_RECS_VERSION, uri.getQueryParameter(PocketURLs.PARAM_VERSION))
+        assertEquals(PocketURLs.VALUE_VIDEO_RECS_AUTHORS, uri.getQueryParameter(PocketURLs.PARAM_AUTHORS))
     }
 
-    private fun assertUriContainsPocketQueryParams(uri: Uri) {
+    private fun assertUriContainsAPIKeyQueryParams(uri: Uri) {
         assertEquals(TEST_KEY, uri.getQueryParameter(PocketURLs.PARAM_API_KEY))
-        assertEquals(PocketURLs.VALUE_VERSION, uri.getQueryParameter(PocketURLs.PARAM_VERSION))
-        assertEquals(PocketURLs.VALUE_AUTHORS, uri.getQueryParameter(PocketURLs.PARAM_AUTHORS))
     }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/data/PocketGlobalVideoRecommendationTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/data/PocketGlobalVideoRecommendationTest.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.KVisibility
+
+class PocketGlobalVideoRecommendationTest {
+
+    @Test // See constructor comment for details.
+    fun `GIVEN a PocketGlobalVideoRecommendation THEN its constructors are internal`() {
+        assertConstructorsVisibility(PocketGlobalVideoRecommendation::class, KVisibility.INTERNAL)
+    }
+
+    @Test // See PocketGlobalVideoRecommendation constructor for details.
+    fun `GIVEN an Author THEN its constructors are internal`() {
+        assertConstructorsVisibility(PocketGlobalVideoRecommendation.Author::class, KVisibility.INTERNAL)
+    }
+}
+
+private fun <T : Any> assertConstructorsVisibility(assertedClass: KClass<T>, visibility: KVisibility) {
+    assertedClass.constructors.forEach {
+        assertEquals(visibility, it.visibility)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.service.pocket.helpers
 
+import mozilla.components.service.pocket.data.PocketGlobalVideoRecommendation
+
 private const val POCKET_DIR = "pocket"
 
 /**
@@ -13,4 +15,48 @@ enum class PocketTestResource(private val path: String) {
     POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json");
 
     fun get(): String = this::class.java.classLoader!!.getResource(path)!!.readText()
+
+    companion object {
+
+        val videoRecommendationFirstTwo by lazy { listOf(
+            PocketGlobalVideoRecommendation(
+                id = 27587,
+                url = "https://www.youtube.com/watch?v=953Qt4FnAcU",
+                tvURL = "https://www.youtube.com/tv#/watch/video/idle?v=953Qt4FnAcU",
+                title = "How a Master Pastry Chef Uses Architecture to Make Sky High Pastries",
+                excerpt = "At New York City's International Culinary Center, host Rebecca DeAngelis makes a modern day croquembouche with architect-turned pastry chef Jansen Chan",
+                domain = "youtube.com",
+                imageSrc = "https://img-getpocket.cdn.mozilla.net/direct?url=http%3A%2F%2Fimg.youtube.com%2Fvi%2F953Qt4FnAcU%2Fmaxresdefault.jpg&resize=w450",
+                publishedTimestamp = "0",
+                sortId = 0,
+                popularitySortId = 20,
+                authors = listOf(
+                    PocketGlobalVideoRecommendation.Author(
+                        id = "96612022",
+                        name = "Eater",
+                        url = "http://www.youtube.com/channel/UCRzPUBhXUZHclB7B5bURFXw"
+                    )
+                )
+            ),
+            PocketGlobalVideoRecommendation(
+                id = 27581,
+                url = "https://www.youtube.com/watch?v=GHZ7-kq3GDQ",
+                tvURL = "https://www.youtube.com/tv#/watch/video/idle?v=GHZ7-kq3GDQ",
+                title = "How Does Having Too Much Power Affect Your Brain?",
+                excerpt = "Power is tied to a hierarchical escalator that we rise up through decisions and actions. But once we have power, how does it affect our brain and behavior? How Our Brains Respond to People Who Aren't Like Us - https://youtu.be/KIwe_O0am4URead More:The age of adolescencehttps://www.thelancet.com/jour",
+                domain = "youtube.com",
+                imageSrc = "https://img-getpocket.cdn.mozilla.net/direct?url=http%3A%2F%2Fimg.youtube.com%2Fvi%2FGHZ7-kq3GDQ%2Fmaxresdefault.jpg&resize=w450",
+                publishedTimestamp = "0",
+                sortId = 1,
+                popularitySortId = 17,
+                authors = listOf(
+                    PocketGlobalVideoRecommendation.Author(
+                        id = "96612138",
+                        name = "Seeker",
+                        url = "http://www.youtube.com/channel/UCzWQYUVCpZqtN93H8RR44Qw"
+                    )
+                )
+            )
+        ) }
+    }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
@@ -12,7 +12,10 @@ private const val POCKET_DIR = "pocket"
  * Accessors to resources used in testing. These files are available in `app/src/test/resources`.
  */
 enum class PocketTestResource(private val path: String) {
-    POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json");
+    POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json"),
+
+    // NEVER COMMIT THE API KEY FILE. Add this file with a valid API key to use this resource.
+    API_KEY("$POCKET_DIR/apiKey.txt");
 
     fun get(): String = this::class.java.classLoader!!.getResource(path)!!.readText()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,6 +52,9 @@ permalink: /changelog/
 * **browser-storage-sync**
   * Changed how Rust Places database connections are maintained, based on [new reader/writer APIs](https://github.com/mozilla/application-services/pull/718).
 
+* **service-pocket**
+  * Access the list of global video recommendations via `PocketEndpoint.getGlobalVideoRecommendations`.
+
 # 0.46.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.45.0...v0.46.0)


### PR DESCRIPTION
Please ignore the first five commits, which are part of PR #2279.

Future development may add:
- An additional method in `PocketEndpoint` to get articles for Pocket Listen
- An additional endpoint (i.e. whole server to contact) to cross-reference audio data for Pocket Listen (if not available in first results)
- A wrapper around `PocketEndpoint`, e.g. `PocketRepository`, that will add higher level behavior like caching and back-off behavior shared between projects (depending on Echo Show implementation)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
