### PR TITLE
[glean] 1533746: Make events survive application restarts

### DIFF
--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -71,6 +71,12 @@ assertEquals("login_opened", first.name)
 NOTE: Using the testing API requires calling `Glean.enableTestingMode()` first,
 such as from a `@Before` method.
 
+Event timestamps use a system timer that is guaranteed to be monotonic only
+within a particular boot of the device. Therefore, if there are any unsent
+recorded events on disk when the application starts, any pings containing those
+events are sent immediately, so that glean can start over using a new timer and
+events based on different timers are never sent within the same ping.
+
 ## Counters
 
 Used to count how often something happens, say how often a certain button was pressed.

--- a/components/service/glean/docs/pings/events.md
+++ b/components/service/glean/docs/pings/events.md
@@ -4,10 +4,23 @@
 The events ping's purpose is to transport all of the event metric information.
 
 ## Scheduling
-The `events` ping is normally sent when the application goes into the
-[background](pings.md#defining-background-state). It is also sent when the queue of events exceeds
-`Glean.configuration.maxEvents` (default 500). This happens automatically, with
-no intervention or configuration required by the application.
+
+The `events` ping is sent under the following circumstances:
+
+- Normally, it is sent when the application goes into the
+  [background](pings.md#defining-background-state), if there
+  are any recorded events to send.
+
+- When the queue of events exceeds `Glean.configuration.maxEvents` (default
+  500).
+
+- If there are any unsent events found on disk when starting the application. It
+  would be impossible to coordinate the timestamps across a reboot, so it's best
+  to just collect all events from the previous run into their own ping, and
+  start over.
+
+All of these cases are handled automatically, with no intervention or
+configuration required by the application.
 
 ## Contents
 At the top-level, this ping contains the following keys:
@@ -19,7 +32,7 @@ At the top-level, this ping contains the following keys:
 
 Each entry in the `events` array is an array with the following items:
 
-- [0]: `msSinceStart`: The milliseconds since the start of the process.
+- [0]: `timestamp`: The milliseconds relative to the first event in the ping.
 
 - [1]: `category`: The category of the event, as defined by its location in the
   `metrics.yaml` file.
@@ -27,5 +40,5 @@ Each entry in the `events` array is an array with the following items:
 - [2]: `name`: The name of the event, as definded in the `metrics.yaml` file.
 
 - [3]: `extra` (optional): A mapping of strings to strings providing additional
-  data about the event. The keys are restricted to 40 characters and values in 
+  data about the event. The keys are restricted to 40 characters and values in
   this map will never exceed 100 characters.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -92,6 +92,8 @@ open class GleanInternalAPI internal constructor () {
         // API. For this reason we're safe to set `initialized = true` right after it.
         initializeCoreMetrics(applicationContext)
 
+        initialized = true
+
         // Deal with any pending events so we can start recording new ones
         EventsStorageEngine.onReadyToSendPings(applicationContext)
 
@@ -100,7 +102,6 @@ open class GleanInternalAPI internal constructor () {
         // on being dispatched to the API context before any other metric.
         metricsPingScheduler = MetricsPingScheduler(applicationContext)
         metricsPingScheduler.startupCheck()
-        initialized = true
 
         // Other pings might set some other metrics (i.e. the baseline metrics),
         // so we need to be initialized by now.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -25,8 +25,10 @@ import mozilla.components.service.glean.storages.PingStorageEngine
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.UuidsStorageEngine
 import mozilla.components.service.glean.storages.DatetimesStorageEngine
+import mozilla.components.service.glean.storages.EventsStorageEngine
 import mozilla.components.service.glean.storages.RecordedExperimentData
 import mozilla.components.service.glean.storages.StringsStorageEngine
+import mozilla.components.service.glean.utils.ensureDirectoryExists
 import mozilla.components.support.base.log.logger.Logger
 
 @Suppress("TooManyFunctions")
@@ -90,6 +92,9 @@ open class GleanInternalAPI internal constructor () {
         // API. For this reason we're safe to set `initialized = true` right after it.
         initializeCoreMetrics(applicationContext)
 
+        // Deal with any pending events so we can start recording new ones
+        EventsStorageEngine.onReadyToSendPings(applicationContext)
+
         // Set up information and scheduling for glean owned pings. Ideally, the "metrics"
         // ping startup check should be performed before any other ping, since it relies
         // on being dispatched to the API context before any other metric.
@@ -101,6 +106,7 @@ open class GleanInternalAPI internal constructor () {
         // so we need to be initialized by now.
         baselinePing = BaselinePing()
 
+        // At this point, all metrics and events can be recorded.
         ProcessLifecycleOwner.get().lifecycle.addObserver(gleanLifecycleObserver)
     }
 
@@ -201,16 +207,7 @@ open class GleanInternalAPI internal constructor () {
 
         val gleanDataDir = File(applicationContext.applicationInfo.dataDir, Glean.GLEAN_DATA_DIR)
 
-        // Make sure the data directory exists and is writable.
-        if (!gleanDataDir.exists() && !gleanDataDir.mkdirs()) {
-            logger.error("Failed to create Glean's data dir ${gleanDataDir.absolutePath}")
-            return
-        }
-
-        if (!gleanDataDir.isDirectory || !gleanDataDir.canWrite()) {
-            logger.error("Glean's data directory is not a writable directory ${gleanDataDir.absolutePath}")
-            return
-        }
+        ensureDirectoryExists(gleanDataDir)
 
         // The first time Glean runs, we set the client id and other internal
         // one-time only metrics.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -9,31 +9,57 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.SystemClock
 import android.support.annotation.VisibleForTesting
+import kotlinx.coroutines.Dispatchers as KotlinDispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import mozilla.components.service.glean.Dispatchers
 import mozilla.components.service.glean.error.ErrorRecording.recordError
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.EventMetricType
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.service.glean.scheduler.PingUploadWorker
+import mozilla.components.service.glean.utils.ensureDirectoryExists
 import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
+import java.io.File
+import java.io.IOException
 
 /**
  * This singleton handles the in-memory storage logic for events. It is meant to be used by
  * the Specific Events API and the ping assembling objects.
  *
+ * So that the data survives shutting down of the application, events are stored
+ * in an append-only file on disk, in addition to the store in memory. Each line
+ * of this file records a single event in JSON, exactly as it will be sent in the
+ * ping.  There is one file per store.
+ *
  * This class contains a reference to the Android application Context. While the IDE warns
  * us that this could leak, the application context lives as long as the application and this
  * object. For this reason, we should be safe to suppress the IDE warning.
  */
-@SuppressLint("StaticFieldLeak")
+@SuppressLint("StaticFieldLeak, TooManyFunctions")
 internal object EventsStorageEngine : StorageEngine {
     override lateinit var applicationContext: Context
 
     // Events recorded within the list should be reasonably sorted by timestamp, assuming
     // the sequence of calls to [record] has not been messed with. However, please only
     // trust the recorded timestamp values.
-    private val eventStores: MutableMap<String, MutableList<RecordedEventData>> = mutableMapOf()
+    internal val eventStores: MutableMap<String, MutableList<RecordedEventData>> = mutableMapOf()
+
+    // The storage directory where the append-only events files reside.
+    internal val storageDirectory: File by lazy {
+        val dir = File(
+            applicationContext.applicationInfo.dataDir,
+            "${Glean.GLEAN_DATA_DIR}/events/"
+        )
+        ensureDirectoryExists(dir)
+        dir
+    }
 
     // The timestamp of recorded events is computed relative to this point in time
     // which should roughly match with the process start time. Note that, according
@@ -43,7 +69,73 @@ internal object EventsStorageEngine : StorageEngine {
     // Maximum length of any string value in the extra dictionary, in characters
     internal const val MAX_LENGTH_EXTRA_KEY_VALUE = 100
 
+    // The position of the fields within the JSON payload for each event
+    internal const val TIMESTAMP_FIELD = 0
+    internal const val CATEGORY_FIELD = 1
+    internal const val NAME_FIELD = 2
+    internal const val EXTRA_FIELD = 3
+    internal const val N_FIELDS = 4
+
     private val logger = Logger("glean/EventsStorageEngine")
+
+    // Timeout for waiting on async IO (during testing only)
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal const val JOB_TIMEOUT_MS = 250L
+
+    // A lock to prevent simultaneous writing of the event files
+    private val eventFileLock = Any()
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    var ioTask: Job? = null
+
+    /**
+     * Initialize events storage. This must be called once on application startup,
+     * e.g. from [Glean.initialize], but after we are ready to send pings, since
+     * this could potentially collect and send pings.
+     *
+     * If there are any events queued on disk, it loads them into memory so
+     * that the memory and disk representations are in sync.
+     *
+     * Secondly, if this is the first time the application has been run since
+     * rebooting, any pings containing events are assembled into pings and cleared
+     * immediately, since their timestamps won't be compatible with the timestamps
+     * we would create during this boot of the device.
+     *
+     * @param context The application context
+     */
+    internal fun onReadyToSendPings(context: Context) {
+        // We want this to run off of the main thread, because it might perform I/O.
+        // However, we don't use the built-in KotlinDispatchers.IO since we need
+        // to make sure this work is done before any other glean API calls, and this
+        // will force them to be queued after this work.
+        Dispatchers.API.launch {
+            // Load events from disk
+            storageDirectory.listFiles()?.forEach { file ->
+                val storeData = eventStores.getOrPut(file.name) { mutableListOf() }
+                file.forEachLine { line ->
+                    try {
+                        val jsonContent = JSONArray(line)
+                        val event = deserializeEvent(jsonContent)
+                        storeData.add(event)
+                    } catch (e: JSONException) {
+                        // pass
+                    }
+                }
+            }
+
+            // TODO Technically, we only need to send out all pending events
+            // if they came from a previous boot (since their timestamps won't match).
+            // However, there are various challenges in detecting when the device has
+            // been booted, so for now we just pay the penalty of a few more
+            // unnecessary pings.
+            if (eventStores.size != 0) {
+                eventStores.keys.forEach { storeName ->
+                    Glean.assembleAndSerializePing(storeName)
+                }
+                PingUploadWorker.enqueueWorker()
+            }
+        }
+    }
 
     /**
      * Record an event in the desired stores.
@@ -84,14 +176,20 @@ internal object EventsStorageEngine : StorageEngine {
             eventKeys
         }
 
-        val msSinceStart = monotonicElapsedMs - startTime
-        val event = RecordedEventData(metricData.category, metricData.name, msSinceStart, truncatedExtraKeys)
+        val event = RecordedEventData(
+            metricData.category,
+            metricData.name,
+            monotonicElapsedMs,
+            truncatedExtraKeys
+        )
+        val jsonEvent = serializeEvent(event).toString()
 
         // Record a copy of the event in all the needed stores.
         synchronized(this) {
             for (storeName in metricData.getStorageNames()) {
                 val storeData = eventStores.getOrPut(storeName) { mutableListOf() }
                 storeData.add(event.copy())
+                writeEventToDisk(storeName, jsonEvent)
                 if (storeData.size == Glean.configuration.maxEvents &&
                     Glean.assembleAndSerializePing(storeName)) {
                     // Queue background worker to upload the newly created ping
@@ -110,13 +208,26 @@ internal object EventsStorageEngine : StorageEngine {
      *
      * @return the list of events recorded in the requested store
      */
-    @Synchronized
     fun getSnapshot(storeName: String, clearStore: Boolean): List<RecordedEventData>? {
-        if (clearStore) {
-            return eventStores.remove(storeName)
+        // Rewrite all of the timestamps to they are relative to the first
+        // timestamp
+        val events = eventStores[storeName]?.let { store ->
+            var firstTimestamp = store[0].timestamp
+            store.map { event ->
+                event.copy(timestamp = event.timestamp - firstTimestamp)
+            }
         }
 
-        return eventStores[storeName]
+        if (clearStore) {
+            ioTask = GlobalScope.launch(KotlinDispatchers.IO) {
+                synchronized(eventFileLock) {
+                    getFile(storeName).delete()
+                }
+            }
+            eventStores.remove(storeName)
+        }
+
+        return events
     }
 
     /**
@@ -131,16 +242,85 @@ internal object EventsStorageEngine : StorageEngine {
         return getSnapshot(storeName, clearStore)?.let { pingEvents ->
             val eventsArray = JSONArray()
             pingEvents.forEach {
-                val eventData = JSONArray()
-                eventData.put(it.msSinceStart)
-                eventData.put(it.category)
-                eventData.put(it.name)
-                if (it.extra != null) {
-                    eventData.put(JSONObject(it.extra))
-                }
-                eventsArray.put(eventData)
+                eventsArray.put(serializeEvent(it))
             }
-            return eventsArray
+            eventsArray
+        }
+    }
+
+    /**
+     * Get the File object in which to store events for the given store.
+     *
+     * @param storeName The name of the store
+     * @return File object to store events
+     */
+    private fun getFile(storeName: String): File {
+        return File(storageDirectory, storeName)
+    }
+
+    /**
+     * Serializes an event to its JSON representation.
+     *
+     * @param category Event category
+     * @param name Event name
+     * @param msSinceStart The ms since the process started
+     * @param extra A `Map<String, String>` of extra values
+     * @return JSONArray representing the event
+     */
+    private fun serializeEvent(event: RecordedEventData): JSONArray {
+        val eventData = JSONArray()
+        eventData.put(event.timestamp)
+        eventData.put(event.category)
+        eventData.put(event.name)
+        if (event.extra != null) {
+            eventData.put(JSONObject(event.extra))
+        }
+        return eventData
+    }
+
+    /**
+     * Deserializes an event in JSON into a RecordedEventData object.
+     *
+     * @param jsonContent The JSONArray containing the data for the event.
+     * @return event data object
+     */
+    private fun deserializeEvent(jsonContent: JSONArray): RecordedEventData {
+        if (jsonContent.length() != N_FIELDS) {
+            throw JSONException("Invalid event")
+        }
+
+        val extra: Map<String, String>? = jsonContent.optJSONObject(EXTRA_FIELD)?.let {
+            val extraValues: MutableMap<String, String> = mutableMapOf()
+            val names = it.names()
+            for (i in 0..(names.length() - 1)) {
+                extraValues[names.getString(i)] = it.getString(names.getString(i))
+            }
+            extraValues
+        }
+
+        return RecordedEventData(
+            jsonContent.getString(CATEGORY_FIELD),
+            jsonContent.getString(NAME_FIELD),
+            jsonContent.getLong(TIMESTAMP_FIELD),
+            extra
+        )
+    }
+
+    /**
+     * Writes an event to a single store on disk.
+     *
+     * @param storeName The name of the store to add the event to.
+     * @param eventContent A string of JSON as returned by [serializeEvent]
+     */
+    internal fun writeEventToDisk(storeName: String, eventContent: String) {
+        ioTask = GlobalScope.launch(KotlinDispatchers.IO) {
+            synchronized(eventFileLock) {
+                try {
+                    getFile(storeName).appendText("${eventContent}\n")
+                } catch (e: IOException) {
+                    logger.warn("IOException while writing event to disk: $e")
+                }
+            }
         }
     }
 
@@ -149,7 +329,29 @@ internal object EventsStorageEngine : StorageEngine {
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     override fun clearAllStores() {
+        // We need to delete these files on the IO thread to avoid
+        // racing with writing to the file.  However, we want to
+        // block the main thread until this work is done, so the
+        // caller can rely on the files being gone.  This is not a
+        // performance problem since this function is for use in
+        // testing only.
+        synchronized(eventFileLock) {
+            storageDirectory.listFiles()?.forEach {
+                it.delete()
+            }
+        }
         eventStores.clear()
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal fun testWaitForWrites(timeout: Long = JOB_TIMEOUT_MS) {
+        ioTask?.let {
+            runBlocking {
+                withTimeout(timeout) {
+                    it.join()
+                }
+            }
+        }
     }
 }
 
@@ -157,7 +359,7 @@ internal object EventsStorageEngine : StorageEngine {
 data class RecordedEventData(
     val category: String,
     val name: String,
-    val msSinceStart: Long,
+    var timestamp: Long,
     val extra: Map<String, String>? = null,
 
     internal val identifier: String = if (category.isEmpty()) { name } else { "$category.$name" }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/PingStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/PingStorageEngine.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.utils.ensureDirectoryExists
 import mozilla.components.support.base.log.logger.Logger
 import java.io.BufferedReader
 import java.io.File
@@ -139,23 +140,6 @@ internal class PingStorageEngine(context: Context) {
                 logger.error("IO Exception when reading file ${file.name}")
                 return false
             }
-        }
-    }
-
-    /**
-     * Helper function to determine if the ping directory exists and attempts to create them if
-     * they don't
-     *
-     * @param directory File representing the directory path in which to store pings.
-     */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun ensureDirectoryExists(directory: File) {
-        if (!directory.exists() && !directory.mkdirs()) {
-            logger.error("Directory doesn't exist and can't be created: " + directory.absolutePath)
-        }
-
-        if (!directory.isDirectory || !directory.canWrite()) {
-            logger.error("Directory is not writable directory: " + directory.absolutePath)
         }
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/utils/FileUtils.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/utils/FileUtils.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.utils
+
+import mozilla.components.support.base.log.logger.Logger
+import java.io.File
+
+private val logger: Logger = Logger("glean/FileUtils")
+
+/**
+ * Helper function to determine if the directory exists and attempts to create it if
+ * it doesn't
+ *
+ * @param directory File representing the directory path
+ */
+internal fun ensureDirectoryExists(directory: File) {
+    if (!directory.exists() && !directory.mkdirs()) {
+        logger.error("Directory doesn't exist and can't be created: " + directory.absolutePath)
+    }
+
+    if (!directory.isDirectory || !directory.canWrite()) {
+        logger.error("Directory is not writable directory: " + directory.absolutePath)
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/EventMetricTypeTest.kt
@@ -87,7 +87,7 @@ class EventMetricTypeTest {
         assertEquals("click", secondEvent.name)
 
         assertTrue("The sequence of the events must be preserved",
-            firstEvent.msSinceStart < secondEvent.msSinceStart)
+            firstEvent.timestamp < secondEvent.timestamp)
     }
 
     @Test
@@ -121,7 +121,7 @@ class EventMetricTypeTest {
         assertEquals("click", secondEvent.name)
 
         assertTrue("The sequence of the events must be preserved",
-            firstEvent.msSinceStart < secondEvent.msSinceStart)
+            firstEvent.timestamp < secondEvent.timestamp)
     }
 
     @Test
@@ -189,7 +189,7 @@ class EventMetricTypeTest {
         assertEquals("click", secondEvent.name)
 
         assertTrue("The sequence of the events must be preserved",
-            firstEvent.msSinceStart < secondEvent.msSinceStart)
+            firstEvent.timestamp < secondEvent.timestamp)
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -108,10 +108,12 @@ internal fun collectAndCheckPingSchema(storeName: String): JSONObject {
  *
  * @param context the application context to init glean with
  * @param config the [Configuration] to init glean with
+ * @param clearStores if true, clear the contents of all stores
  */
 internal fun resetGlean(
     context: Context = ApplicationProvider.getApplicationContext(),
-    config: Configuration = Configuration()
+    config: Configuration = Configuration(),
+    clearStores: Boolean = true
 ) {
     Glean.enableTestingMode()
 
@@ -119,12 +121,15 @@ internal fun resetGlean(
     // in tests without this line. Let's simply put it here.
     WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
-    // Clear all the stored data.
-    val storageManager = StorageEngineManager(applicationContext = context)
-    storageManager.clearAllStores()
-    // The experiments storage engine needs to be cleared manually as it's not listed
-    // in the `StorageEngineManager`.
-    ExperimentsStorageEngine.clearAllStores()
+    if (clearStores) {
+        // Clear all the stored data.
+        val storageManager = StorageEngineManager(applicationContext = context)
+        storageManager.clearAllStores()
+        // The experiments storage engine needs to be cleared manually as it's not listed
+        // in the `StorageEngineManager`.
+        ExperimentsStorageEngine.clearAllStores()
+    }
+
     // Clear the "first run" flag.
     val firstRun = FileFirstRunDetector(File(context.applicationInfo.dataDir, Glean.GLEAN_DATA_DIR))
     firstRun.reset()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -18,12 +18,14 @@ import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.TimeUnit
@@ -118,8 +120,8 @@ class EventsStorageEngineTest {
     }
 
     @Test
-    fun `record() computes the correct time since process start`() {
-        val expectedTimeSinceStart: Long = 37
+    fun `record() computes the correct time between events`() {
+        val delayTime: Long = 37
 
         val event = EventMetricType<NoExtraKeys>(
             disabled = false,
@@ -130,19 +132,24 @@ class EventsStorageEngineTest {
         )
 
         // Sleep a bit Record the event in the store.
-        SystemClock.sleep(expectedTimeSinceStart)
+        EventsStorageEngine.record(
+            metricData = event,
+            monotonicElapsedMs = SystemClock.elapsedRealtime()
+        )
+        SystemClock.sleep(delayTime)
         EventsStorageEngine.record(
             metricData = event,
             monotonicElapsedMs = SystemClock.elapsedRealtime()
         )
 
         val snapshot = EventsStorageEngine.getSnapshot(storeName = "store1", clearStore = false)
-        assertEquals(1, snapshot!!.size)
+        assertEquals(2, snapshot!!.size)
         assertEquals("telemetry", snapshot.first().category)
         assertEquals("test_event_time", snapshot.first().name)
         assertNull("The 'extra' must be null if not provided",
                 snapshot.first().extra)
-        assertEquals(expectedTimeSinceStart, snapshot.first().msSinceStart)
+        assertEquals(0, snapshot.first().timestamp)
+        assertEquals(delayTime, snapshot[1].timestamp)
     }
 
     @Test
@@ -171,9 +178,17 @@ class EventsStorageEngineTest {
 
         // Get the snapshot from "store1" and clear it.
         val snapshot = EventsStorageEngine.getSnapshot(storeName = "store1", clearStore = true)
+        EventsStorageEngine.testWaitForWrites()
         // Check that getting a new snapshot for "store1" returns an empty store.
         assertNull("The engine must report 'null' on empty stores",
                 EventsStorageEngine.getSnapshot(storeName = "store1", clearStore = false))
+        val files = EventsStorageEngine.storageDirectory.listFiles()
+        assertEquals(1, files.size)
+        assertEquals(
+            "There should be no events on disk for store1, but there are for store2",
+            "store2",
+            EventsStorageEngine.storageDirectory.listFiles().first().name
+        )
 
         // Check that we get the right data from both the stores. Clearing "store1" must
         // not clear "store2" as well.
@@ -323,5 +338,119 @@ class EventsStorageEngineTest {
                 "truncatedExtra" to (testValue.repeat(10)).substring(0, EventsStorageEngine.MAX_LENGTH_EXTRA_KEY_VALUE)
             ) == snapshot.first().extra)
         assertEquals(1, testGetNumRecordedErrors(testEvent, ErrorType.InvalidValue))
+    }
+
+    @Test
+    fun `flush queued events on startup`() {
+        assertEquals(
+            "There should be no events on disk to start",
+            0,
+            EventsStorageEngine.storageDirectory.listFiles().size
+        )
+
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("OK"))
+
+        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ))
+
+        val event = EventMetricType<SomeExtraKeys>(
+            disabled = false,
+            category = "telemetry",
+            name = "test_event",
+            lifetime = Lifetime.Ping,
+            sendInPings = listOf("store1")
+        )
+
+        event.record(extra = mapOf(SomeExtraKeys.SomeExtra to "bar"))
+        assertEquals(1, event.testGetValue().size)
+
+        // Clear the in-memory storage only to mock being loaded in a fresh process
+        EventsStorageEngine.eventStores.clear()
+        resetGlean(
+            getContextWithMockedInfo(),
+            Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            clearStores = false
+        )
+
+        // Trigger worker task to upload the pings in the background
+        triggerWorkManager()
+
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        assertEquals("POST", request.method)
+        val applicationId = "mozilla-components-service-glean"
+        assert(
+            request.path.startsWith("/submit/$applicationId/store1/${Glean.SCHEMA_VERSION}/")
+        )
+        val pingJsonData = request.body.readUtf8()
+        val pingJson = JSONObject(pingJsonData)
+        checkPingSchema(pingJson)
+        assertNotNull(pingJson.opt("events"))
+        assertEquals(
+            1,
+            pingJson.getJSONArray("events").length()
+        )
+    }
+
+    @Test
+    fun `handle truncated events on disk`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("OK"))
+
+        resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port,
+            logPings = true
+        ))
+
+        val event = EventMetricType<ExtraKeys>(
+            disabled = false,
+            category = "telemetry",
+            name = "test_event",
+            lifetime = Lifetime.Ping,
+            sendInPings = listOf("store1")
+        )
+
+        // Record the event in the store, without providing optional arguments.
+        event.record(mapOf(ExtraKeys.Key1 to "bar"))
+        // Add a couple of truncated events to disk. One is still valid JSON, the other isn't.
+        // These event should be skipped, all others intact.
+        EventsStorageEngine.writeEventToDisk("store1", "[500]")
+        EventsStorageEngine.writeEventToDisk("store1", "[500, \"foo")
+        event.record(mapOf(ExtraKeys.Key1 to "baz"))
+        assertEquals(2, event.testGetValue().size)
+
+        // Clear the in-memory storage only to mock being loaded in a fresh process
+        EventsStorageEngine.eventStores.clear()
+        resetGlean(
+            getContextWithMockedInfo(),
+                Glean.configuration.copy(
+                serverEndpoint = "http://" + server.hostName + ":" + server.port,
+                logPings = true
+            ),
+            clearStores = false
+        )
+        triggerWorkManager()
+
+        event.record(mapOf(ExtraKeys.Key1 to "bip"))
+
+        val request = server.takeRequest(20L, TimeUnit.SECONDS)
+        assertEquals("POST", request.method)
+        val applicationId = "mozilla-components-service-glean"
+        assert(
+            request.path.startsWith("/submit/$applicationId/store1/${Glean.SCHEMA_VERSION}/")
+        )
+        val pingJsonData = request.body.readUtf8()
+        val pingJson = JSONObject(pingJsonData)
+        checkPingSchema(pingJson)
+        assertNotNull(pingJson.opt("events"))
+        val events = pingJson.getJSONArray("events")
+        assertEquals(2, events.length())
+        assertEquals("bar", events.getJSONArray(0)!!.getJSONObject(3)!!.getString("key1"))
+        assertEquals("baz", events.getJSONArray(1)!!.getJSONObject(3)!!.getString("key1"))
     }
 }


### PR DESCRIPTION
This modifies the events storage engine to use an append-only file on disk to store events so that they survive application shutdowns.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
