### PR TITLE
Use new application-services package names

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -82,10 +82,11 @@ object Dependencies {
     const val tools_lintapi = "com.android.tools.lint:lint-api:${Versions.lint}"
     const val tools_linttests = "com.android.tools.lint:lint-tests:${Versions.lint}"
 
-    const val mozilla_fxa = "org.mozilla.fxaclient:fxaclient:${Versions.mozilla_appservices}"
-    const val mozilla_sync_logins = "org.mozilla.sync15:logins:${Versions.mozilla_appservices}"
-    const val mozilla_places = "org.mozilla.places:places:${Versions.mozilla_appservices}"
+    const val mozilla_fxa = "org.mozilla.appservices:fxaclient:${Versions.mozilla_appservices}"
+    const val mozilla_sync_logins = "org.mozilla.appservices:logins:${Versions.mozilla_appservices}"
+    const val mozilla_places = "org.mozilla.appservices:places:${Versions.mozilla_appservices}"
     const val mozilla_rustlog = "org.mozilla.appservices:rustlog:${Versions.mozilla_appservices}"
+
     const val mozilla_servo_arm = "org.mozilla.servoview:servoview-armv7:${Versions.servo}"
     const val mozilla_servo_x86 = "org.mozilla.servoview:servoview-x86:${Versions.servo}"
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
@@ -5,11 +5,11 @@
 package mozilla.components.browser.storage.sync
 
 import android.support.annotation.GuardedBy
-import org.mozilla.places.PlacesApi
-import org.mozilla.places.ReadablePlacesConnection
-import org.mozilla.places.ReadablePlacesConnectionInterface
-import org.mozilla.places.SyncAuthInfo
-import org.mozilla.places.WritablePlacesConnectionInterface
+import mozilla.appservices.places.PlacesApi
+import mozilla.appservices.places.ReadablePlacesConnection
+import mozilla.appservices.places.ReadablePlacesConnectionInterface
+import mozilla.appservices.places.SyncAuthInfo
+import mozilla.appservices.places.WritablePlacesConnectionInterface
 import java.io.Closeable
 import java.io.File
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -20,13 +20,13 @@ import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.concept.sync.AuthInfo
 import mozilla.components.support.utils.segmentAwareDomainMatch
-import org.mozilla.places.PlacesConnection
-import org.mozilla.places.PlacesException
-import org.mozilla.places.VisitObservation
+import mozilla.appservices.places.PlacesConnection
+import mozilla.appservices.places.PlacesException
+import mozilla.appservices.places.VisitObservation
 
 const val AUTOCOMPLETE_SOURCE_NAME = "placesHistory"
 
-typealias SyncAuthInfo = org.mozilla.places.SyncAuthInfo
+typealias SyncAuthInfo = mozilla.appservices.places.SyncAuthInfo
 
 /**
  * Implementation of the [HistoryStorage] which is backed by a Rust Places lib via [PlacesConnection].
@@ -53,7 +53,7 @@ open class PlacesHistoryStorage(context: Context) : HistoryStorage, SyncableStor
             places.writer().noteObservation(
                 VisitObservation(
                     url = uri,
-                    visitType = org.mozilla.places.VisitType.UPDATE_PLACE,
+                    visitType = mozilla.appservices.places.VisitType.UPDATE_PLACE,
                     title = observation.title
                 )
             )

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
@@ -25,10 +25,10 @@ internal fun AuthInfo.into(): SyncAuthInfo {
 /**
  * Conversion from a generic [VisitType] into its richer comrade within the 'places' lib.
  */
-internal fun VisitType.into(): org.mozilla.places.VisitType {
+internal fun VisitType.into(): mozilla.appservices.places.VisitType {
     return when (this) {
-        VisitType.LINK -> org.mozilla.places.VisitType.LINK
-        VisitType.RELOAD -> org.mozilla.places.VisitType.RELOAD
-        VisitType.TYPED -> org.mozilla.places.VisitType.TYPED
+        VisitType.LINK -> mozilla.appservices.places.VisitType.LINK
+        VisitType.RELOAD -> mozilla.appservices.places.VisitType.RELOAD
+        VisitType.TYPED -> mozilla.appservices.places.VisitType.TYPED
     }
 }

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -19,10 +19,10 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.times
 import org.mockito.Mockito.never
-import org.mozilla.places.ReadablePlacesConnectionInterface
-import org.mozilla.places.SearchResult
-import org.mozilla.places.VisitObservation
-import org.mozilla.places.WritablePlacesConnectionInterface
+import mozilla.appservices.places.ReadablePlacesConnectionInterface
+import mozilla.appservices.places.SearchResult
+import mozilla.appservices.places.VisitObservation
+import mozilla.appservices.places.WritablePlacesConnectionInterface
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import java.lang.IllegalArgumentException
@@ -54,17 +54,17 @@ class PlacesHistoryStorageTest {
 
         storage.recordVisit("http://www.mozilla.org", VisitType.LINK)
         verify(writer, times(1)).noteObservation(
-                VisitObservation("http://www.mozilla.org", visitType = org.mozilla.places.VisitType.LINK)
+                VisitObservation("http://www.mozilla.org", visitType = mozilla.appservices.places.VisitType.LINK)
         )
 
         storage.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
         verify(writer, times(1)).noteObservation(
-                VisitObservation("http://www.mozilla.org", visitType = org.mozilla.places.VisitType.RELOAD)
+                VisitObservation("http://www.mozilla.org", visitType = mozilla.appservices.places.VisitType.RELOAD)
         )
 
         storage.recordVisit("http://www.firefox.com", VisitType.TYPED)
         verify(writer, times(1)).noteObservation(
-                VisitObservation("http://www.firefox.com", visitType = org.mozilla.places.VisitType.TYPED)
+                VisitObservation("http://www.firefox.com", visitType = mozilla.appservices.places.VisitType.TYPED)
         )
     }
 
@@ -75,12 +75,12 @@ class PlacesHistoryStorageTest {
 
         storage.recordObservation("http://www.mozilla.org", PageObservation(title = "Mozilla"))
         verify(writer, times(1)).noteObservation(
-                VisitObservation("http://www.mozilla.org", visitType = org.mozilla.places.VisitType.UPDATE_PLACE, title = "Mozilla")
+                VisitObservation("http://www.mozilla.org", visitType = mozilla.appservices.places.VisitType.UPDATE_PLACE, title = "Mozilla")
         )
 
         storage.recordObservation("http://www.firefox.com", PageObservation(title = null))
         verify(writer, times(1)).noteObservation(
-                VisitObservation("http://www.firefox.com", visitType = org.mozilla.places.VisitType.UPDATE_PLACE, title = null)
+                VisitObservation("http://www.firefox.com", visitType = mozilla.appservices.places.VisitType.UPDATE_PLACE, title = null)
         )
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,9 +65,9 @@ if (localProperties != null) {
 
         includeBuild(appServicesLocalPath) {
             dependencySubstitution {
-                substitute module('org.mozilla.fxaclient:fxaclient') with project(':fxa-client-library')
-                substitute module('org.mozilla.sync15:logins') with project(':logins-library')
-                substitute module('org.mozilla.places:places') with project(':places-library')
+                substitute module('org.mozilla.appservices:fxaclient') with project(':fxa-client-library')
+                substitute module('org.mozilla.appservices:logins') with project(':logins-library')
+                substitute module('org.mozilla.appservices:places') with project(':places-library')
                 substitute module('org.mozilla.appservices:rustlog') with project(':rustlog-library')
             }
         }


### PR DESCRIPTION
Reflects mozilla/application-services#776 changes.
Blocked on a new a-s release.