### PR TITLE
Closes #2336: Add PocketListenEndpoint!!

### DIFF
--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
@@ -51,6 +51,7 @@ interface Headers : Iterable<Header> {
      */
     object Common {
         const val CONTENT_TYPE = "Content-Type"
+        const val USER_AGENT = "User-Agent"
     }
 }
 

--- a/components/service/pocket/.gitignore
+++ b/components/service/pocket/.gitignore
@@ -1,1 +1,2 @@
 src/test/resources/pocket/apiKey.txt
+src/test/resources/pocket/listenAccessToken.txt

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/Arguments.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/Arguments.kt
@@ -14,6 +14,6 @@ internal object Arguments {
     }
 
     fun assertIsNotBlank(input: String, exceptionIdentifier: String) {
-        if (input.isBlank()) throw IllegalArgumentException("Expected non-blank $exceptionIdentifier")
+        require(input.isNotBlank()) { "Expected non-blank $exceptionIdentifier" }
     }
 }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/Arguments.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/Arguments.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+/**
+ * A collection of shared argument validation functions.
+ */
+internal object Arguments {
+
+    fun assertIsValidUserAgent(userAgent: String) {
+        assertIsNotBlank(userAgent, "user agent")
+    }
+
+    fun assertIsNotBlank(input: String, exceptionIdentifier: String) {
+        if (input.isBlank()) throw IllegalArgumentException("Expected non-blank $exceptionIdentifier")
+    }
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
@@ -52,7 +52,7 @@ class PocketEndpoint internal constructor(
          */
         fun newInstance(client: Client, pocketApiKey: String, userAgent: String): PocketEndpoint {
             assertIsValidApiKey(pocketApiKey)
-            assertIsValidUserAgent(userAgent)
+            Arguments.assertIsValidUserAgent(userAgent)
 
             val endpoint = PocketEndpointRaw(client, PocketURLs(pocketApiKey), userAgent)
             return PocketEndpoint(endpoint, PocketJSONParser())
@@ -61,9 +61,5 @@ class PocketEndpoint internal constructor(
 }
 
 private fun assertIsValidApiKey(apiKey: String) {
-    if (apiKey.isBlank()) throw IllegalArgumentException("Expected non-blank API key")
-}
-
-private fun assertIsValidUserAgent(userAgent: String) {
-    if (userAgent.isBlank()) throw java.lang.IllegalArgumentException("Expected non-blank user agent")
+    Arguments.assertIsNotBlank(apiKey, "API key")
 }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpoint.kt
@@ -36,13 +36,7 @@ class PocketEndpoint internal constructor(
     fun getGlobalVideoRecommendations(): PocketResponse<List<PocketGlobalVideoRecommendation>> {
         val json = rawEndpoint.getGlobalVideoRecommendations()
         val videoRecs = json?.let { jsonParser.jsonToGlobalVideoRecommendations(it) }
-        return videoRecs.wrapInResponse()
-    }
-
-    private fun <T> List<T>?.wrapInResponse(): PocketResponse<List<T>> = if (isNullOrEmpty()) {
-        PocketResponse.Failure()
-    } else {
-        PocketResponse.Success(this!!)
+        return PocketResponse.wrap(videoRecs)
     }
 
     companion object {

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
@@ -5,10 +5,9 @@
 package mozilla.components.service.pocket
 
 import android.net.Uri
-import android.support.annotation.VisibleForTesting
-import android.support.annotation.VisibleForTesting.PRIVATE
 import android.support.annotation.WorkerThread
 import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
 import mozilla.components.service.pocket.ext.fetchBodyOrNull
@@ -37,12 +36,8 @@ internal class PocketEndpointRaw(
     private fun makeRequest(callingMethod: String, pocketEndpoint: Uri): String? {
         val request = Request(
             url = pocketEndpoint.toString(),
-            headers = MutableHeaders(HEADER_USER_AGENT to userAgent)
+            headers = MutableHeaders(USER_AGENT to userAgent)
         )
         return client.fetchBodyOrNull(callingMethod, request)
-    }
-
-    companion object {
-        @VisibleForTesting(otherwise = PRIVATE) const val HEADER_USER_AGENT = "User-Agent"
     }
 }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
@@ -11,9 +11,7 @@ import android.support.annotation.WorkerThread
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.Response
-import mozilla.components.concept.fetch.isSuccess
-import java.io.IOException
+import mozilla.components.service.pocket.ext.fetchBodyOrNull
 
 /**
  * Make requests to the Pocket endpoint and returns the raw JSON data: this class is intended to be very dumb.
@@ -30,26 +28,18 @@ internal class PocketEndpointRaw(
      * @return The global video recommendations as a raw JSON string or null on error.
      */
     @WorkerThread // synchronous request.
-    fun getGlobalVideoRecommendations(): String? = makeRequest(urls.globalVideoRecs)
+    fun getGlobalVideoRecommendations(): String? = makeRequest("getGlobalVideoRecommendations", urls.globalVideoRecs)
 
     /**
      * @return The requested JSON as a String or null on error.
      */
     @WorkerThread // synchronous request.
-    private fun makeRequest(pocketEndpoint: Uri): String? {
+    private fun makeRequest(callingMethod: String, pocketEndpoint: Uri): String? {
         val request = Request(
             url = pocketEndpoint.toString(),
             headers = MutableHeaders(HEADER_USER_AGENT to userAgent)
         )
-
-        val response: Response? = try {
-            client.fetch(request)
-        } catch (e: IOException) {
-            logger.debug("getGlobalVideoRecommedations: network error", e)
-            null
-        }
-
-        return response?.use { if (response.isSuccess) response.body.string() else null }
+        return client.fetchBodyOrNull(callingMethod, request)
     }
 
     companion object {

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketEndpointRaw.kt
@@ -27,17 +27,17 @@ internal class PocketEndpointRaw(
      * @return The global video recommendations as a raw JSON string or null on error.
      */
     @WorkerThread // synchronous request.
-    fun getGlobalVideoRecommendations(): String? = makeRequest("getGlobalVideoRecommendations", urls.globalVideoRecs)
+    fun getGlobalVideoRecommendations(): String? = makeRequest(urls.globalVideoRecs)
 
     /**
      * @return The requested JSON as a String or null on error.
      */
     @WorkerThread // synchronous request.
-    private fun makeRequest(callingMethod: String, pocketEndpoint: Uri): String? {
+    private fun makeRequest(pocketEndpoint: Uri): String? {
         val request = Request(
             url = pocketEndpoint.toString(),
             headers = MutableHeaders(USER_AGENT to userAgent)
         )
-        return client.fetchBodyOrNull(callingMethod, request)
+        return client.fetchBodyOrNull(request)
     }
 }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketJSONParser.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketJSONParser.kt
@@ -51,7 +51,7 @@ internal class PocketJSONParser {
         }
 
         PocketGlobalVideoRecommendation(
-            id = jsonObj.getInt("id"),
+            id = jsonObj.getLong("id"),
             url = jsonObj.getString("url"),
             tvURL = jsonObj.getString("tv_url"),
             title = jsonObj.getString("title"),

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpoint.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpoint.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import android.support.annotation.WorkerThread
+import mozilla.components.concept.fetch.Client
+import mozilla.components.service.pocket.PocketListenEndpoint.Companion.newInstance
+import mozilla.components.service.pocket.data.PocketListenArticleMetadata
+import mozilla.components.service.pocket.net.PocketResponse
+
+// See @Ignore tests in test class to do end-to-end testing.
+
+/**
+ * Makes requests to the Pocket Listen API and returns the requested data.
+ *
+ * @see [newInstance] to retrieve an instance.
+ */
+class PocketListenEndpoint internal constructor(
+    private val rawEndpoint: PocketListenEndpointRaw,
+    private val jsonParser: PocketListenJSONParser
+) {
+
+    /**
+     * Gets a response, filled with the given article's listen metadata on success. This network call is
+     * synchronous and the results are not cached.
+     *
+     * @return a [PocketResponse.Success] with the given article's listen metada on success or, on error, a
+     * [PocketResponse.Failure].
+     */
+    @WorkerThread // Synchronous network call.
+    fun getListenArticleMetadata(articleID: Int, articleURL: String): PocketResponse<PocketListenArticleMetadata> {
+        val json = rawEndpoint.getArticleListenMetadata(articleID, articleURL)
+        val metadata = json?.let { jsonParser.jsonToListenArticleMetadata(it) }
+        return PocketResponse.wrap(metadata)
+    }
+
+    companion object {
+
+        /**
+         * Returns a new instance of [PocketListenEndpoint].
+         *
+         * @param client the HTTP client to use for network requests.
+         * @param accessToken the access token for Pocket Listen network requests.
+         * @param userAgent the user agent for network requests.
+         *
+         * @throws IllegalArgumentException if the provided access token or user agent is deemed invalid.
+         */
+        fun newInstance(client: Client, accessToken: String, userAgent: String): PocketListenEndpoint {
+            assertIsValidAccessToken(accessToken)
+            Arguments.assertIsValidUserAgent(userAgent)
+
+            val endpoint = PocketListenEndpointRaw(client, PocketListenURLs(), userAgent, accessToken)
+            return PocketListenEndpoint(endpoint, PocketListenJSONParser())
+        }
+    }
+}
+
+private fun assertIsValidAccessToken(accessToken: String) {
+    Arguments.assertIsNotBlank(accessToken, "access token")
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import android.net.Uri
+import android.support.annotation.VisibleForTesting
+import android.support.annotation.VisibleForTesting.PRIVATE
+import android.support.annotation.WorkerThread
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Headers.Common.CONTENT_TYPE
+import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
+import mozilla.components.concept.fetch.MutableHeaders
+import mozilla.components.concept.fetch.Request
+import mozilla.components.service.pocket.ext.fetchBodyOrNull
+
+/**
+ * Makes requests to the Pocket Listen endpoint and returns the raw JSON data: this class is intended to be very dumb.
+ *
+ * @see [PocketListenEndpoint], which wraps this to make it more practical.
+ */
+internal class PocketListenEndpointRaw(
+    private val client: Client,
+    private val urls: PocketListenURLs,
+    private val userAgent: String,
+    private val accessToken: String
+) {
+
+    /**
+     * @return the metadata for the given article as a raw JSON string or null on error.
+     */
+    @WorkerThread // Synchronous network call.
+    fun getArticleListenMetadata(articleID: Int, articleUrl: String): String? {
+        /** @return "key=value&key2=value2..." for the hard-coded key-value pairs. */
+        fun getRequestBodyString(): String = Uri.Builder()
+            .appendQueryParameter("url", articleUrl)
+            .appendQueryParameter("article_id", articleID.toString())
+            .appendQueryParameter("v", "2")
+            .appendQueryParameter("locale", "en-US")
+            .build()
+            .encodedQuery!! // We added query params so this should be non-null: assert it.
+
+        val request = Request(
+            urls.articleService.toString(),
+            Request.Method.POST,
+            MutableHeaders(
+                USER_AGENT to userAgent,
+                CONTENT_TYPE to CONTENT_TYPE_URL_ENCODED,
+                X_ACCESS_TOKEN to accessToken
+            ),
+            body = Request.Body(getRequestBodyString().byteInputStream())
+        )
+
+        // If an invalid body is sent to the server, 404 is returned.
+        return client.fetchBodyOrNull("getArticleListenMetadata", request)
+    }
+
+    companion object {
+        @VisibleForTesting(otherwise = PRIVATE) const val X_ACCESS_TOKEN = "x-access-token"
+        @VisibleForTesting(otherwise = PRIVATE) const val CONTENT_TYPE_URL_ENCODED = "application/x-www-form-urlencoded"
+    }
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
@@ -53,7 +53,7 @@ internal class PocketListenEndpointRaw(
         )
 
         // If an invalid body is sent to the server, 404 is returned.
-        return client.fetchBodyOrNull("getArticleListenMetadata", request)
+        return client.fetchBodyOrNull(request)
     }
 
     companion object {

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenJSONParser.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenJSONParser.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import mozilla.components.service.pocket.data.PocketListenArticleMetadata
+import org.json.JSONArray
+import org.json.JSONException
+
+/**
+ * Holds functions that parse the JSON returned by the Pocket Listen API and converts them to more usable Kotlin types.
+ */
+internal class PocketListenJSONParser {
+
+    /**
+     * @return the article's listen metadata or null on error.
+     */
+    fun jsonToListenArticleMetadata(jsonStr: String): PocketListenArticleMetadata? = try {
+        val rawJSON = JSONArray(jsonStr)
+        val innerObject = rawJSON.getJSONObject(0)
+        PocketListenArticleMetadata(
+            format = innerObject.getString("format"),
+            audioUrl = innerObject.getString("url"),
+            status = innerObject.getString("status"),
+            voice = innerObject.getString("voice"),
+            durationSeconds = innerObject.getLong("duration"),
+            size = innerObject.getString("size")
+        )
+    } catch (e: JSONException) {
+        logger.warn("invalid JSON from Pocket server", e)
+        null
+    }
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenURLs.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenURLs.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import android.net.Uri
+import mozilla.components.support.ktx.kotlin.toUri
+
+// When upgrading to production endpoint, ensure this is HTTPS.
+private const val STAGE_SERVER_BASE = "http://scout-stage.herokuapp.com"
+
+/**
+ * A collection of URLs available through the Pocket Listen API.
+ */
+internal class PocketListenURLs {
+
+    val articleService: Uri = "$STAGE_SERVER_BASE/command/articleservice".toUri()
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/data/PocketGlobalVideoRecommendation.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/data/PocketGlobalVideoRecommendation.kt
@@ -24,7 +24,7 @@ package mozilla.components.service.pocket.data
 // we mark the constructors internal. If a consumer is required to persist this data, we should consider providing a
 // persistence solution.
 data class PocketGlobalVideoRecommendation internal constructor(
-    val id: Int,
+    val id: Long,
     val url: String,
     val tvURL: String,
     val title: String,

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/data/PocketListenArticleMetadata.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/data/PocketListenArticleMetadata.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.data
+
+/**
+ * The metadata for a spoken article's audio file.
+ *
+ * Some documentation on these values, directly from the endpoint, can be found here:
+ *   https://documenter.getpostman.com/view/777613/S17jXChA#426b37e2-0a4f-bd65-35c6-e14f1b19d0f0
+ *
+ * @property format the encoding format of the audio file, e.g. "mp3".
+ * @property audioUrl the url to the spoken article's audio file.
+ * @property status unknown: these docs will be updated when we know.
+ * @property voice the voice name used to speak the article content, e.g. "Salli".
+ * @property durationSeconds length of the audio in seconds.
+ * @property size size of the audio file in bytes.
+ */
+// If we change the properties, e.g. adding a field, any consumers that rely on persisting and constructing new
+// instances of this data type, will be required to implement code to migrate the persisted data. To prevent this,
+// we mark the constructors internal. If a consumer is required to persist this data, we should consider providing a
+// persistence solution.
+data class PocketListenArticleMetadata internal constructor(
+    val format: String,
+    val audioUrl: String,
+    val status: String,
+    val voice: String,
+    val durationSeconds: Long,
+    val size: String
+)

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/ext/ConceptFetch.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/ext/ConceptFetch.kt
@@ -18,11 +18,11 @@ import java.io.IOException
  * @return returns the string contained within the response body for the given [request] or null, on error.
  */
 @WorkerThread // synchronous network call.
-internal fun Client.fetchBodyOrNull(callingMethod: String, request: Request): String? {
+internal fun Client.fetchBodyOrNull(request: Request): String? {
     val response: Response? = try {
         fetch(request)
     } catch (e: IOException) {
-        logger.debug("$callingMethod: network error", e)
+        logger.debug("network error", e)
         null
     }
 

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/ext/ConceptFetch.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/ext/ConceptFetch.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.ext
+
+import android.support.annotation.WorkerThread
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.concept.fetch.isSuccess
+import mozilla.components.service.pocket.logger
+import java.io.IOException
+
+// extension functions for :concept-fetch module.
+
+/**
+ * @return returns the string contained within the response body for the given [request] or null, on error.
+ */
+@WorkerThread // synchronous network call.
+internal fun Client.fetchBodyOrNull(callingMethod: String, request: Request): String? {
+    val response: Response? = try {
+        fetch(request)
+    } catch (e: IOException) {
+        logger.debug("$callingMethod: network error", e)
+        null
+    }
+
+    return response?.use { if (response.isSuccess) response.body.string() else null }
+}

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/net/PocketResponse.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/net/PocketResponse.kt
@@ -20,4 +20,23 @@ sealed class PocketResponse<T> {
      * A failure response from the Pocket API.
      */
     class Failure<T> internal constructor() : PocketResponse<T>()
+
+    companion object {
+
+        /**
+         * Wraps the given [target] in a [PocketResponse]: if [target] is
+         * - null, then Failure
+         * - a Collection and empty, then Failure
+         * - otherwise, Success
+         */
+        internal fun <T : Any> wrap(target: T?): PocketResponse<T> = when (target) {
+            null -> Failure()
+            is Collection<*> -> if (target.isEmpty()) {
+                Failure()
+            } else {
+                Success<T>(target)
+            }
+            else -> Success(target)
+        }
+    }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
 import mozilla.components.concept.fetch.Response
 import mozilla.components.service.pocket.helpers.MockResponses
 import mozilla.components.service.pocket.helpers.assertRequestParams
+import mozilla.components.service.pocket.helpers.assertSuccessfulRequestReturnsResponseBody
 import mozilla.components.service.pocket.helpers.assertResponseIsClosed
 import mozilla.components.support.ktx.kotlin.toUri
 import mozilla.components.support.test.any
@@ -96,16 +97,7 @@ class PocketEndpointRawTest {
 
     @Test
     fun `WHEN requesting global video recs and the response is a success THEN the response body is returned`() {
-        val expectedBody = "{\"jsonStr\": true}"
-        val body = mock(Response.Body::class.java).also {
-            `when`(it.string()).thenReturn(expectedBody)
-        }
-        val response = successResponse.also {
-            `when`(it.body).thenReturn(body)
-        }
-        `when`(client.fetch(any())).thenReturn(response)
-
-        assertEquals(expectedBody, endpoint.getGlobalVideoRecommendations())
+        assertSuccessfulRequestReturnsResponseBody(client, endpoint::getGlobalVideoRecommendations)
     }
 
     @Test

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
@@ -6,8 +6,9 @@ package mozilla.components.service.pocket
 
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
-import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
+import mozilla.components.service.pocket.helpers.assertRequestParams
+import mozilla.components.service.pocket.helpers.assertResponseIsClosed
 import mozilla.components.support.ktx.kotlin.toUri
 import mozilla.components.support.test.any
 import org.junit.Assert.assertEquals
@@ -17,8 +18,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 
@@ -65,7 +64,7 @@ class PocketEndpointRawTest {
         val expectedUrl = "https://mozilla.org/global-video-recs"
         `when`(urls.globalVideoRecs).thenReturn(expectedUrl.toUri())
 
-        assertRequestParams(makeRequest = {
+        assertRequestParams(client, makeRequest = {
             endpoint.getGlobalVideoRecommendations()
         }, assertParams = { request ->
             assertEquals(expectedUrl, request.url)
@@ -74,7 +73,7 @@ class PocketEndpointRawTest {
 
     @Test
     fun `WHEN requesting global video recs THEN the headers include the user agent`() {
-        assertRequestParams(makeRequest = {
+        assertRequestParams(client, makeRequest = {
             endpoint.getGlobalVideoRecommendations()
         }, assertParams = { request ->
             val userAgent = request.headers?.get(USER_AGENT)
@@ -116,34 +115,16 @@ class PocketEndpointRawTest {
 
     @Test
     fun `WHEN requesting global video recs and the response is an error THEN response is closed`() {
-        assertResponseIsClosed(errorResponse) {
+        assertResponseIsClosed(client, errorResponse) {
             endpoint.getGlobalVideoRecommendations()
         }
     }
 
     @Test
     fun `WHEN requesting global video recs and the response is a success THEN response is closed`() {
-        assertResponseIsClosed(successResponse) {
+        assertResponseIsClosed(client, successResponse) {
             endpoint.getGlobalVideoRecommendations()
         }
-    }
-
-    private fun assertRequestParams(makeRequest: () -> Unit, assertParams: (Request) -> Unit) {
-        `when`(client.fetch(any())).thenAnswer {
-            val request = it.arguments[0] as Request
-            assertParams(request)
-            defaultResponse
-        }
-
-        makeRequest()
-
-        verify(client, times(1)).fetch(any())
-    }
-
-    private fun assertResponseIsClosed(response: Response, makeRequest: () -> Unit) {
-        `when`(client.fetch(any())).thenReturn(response)
-        makeRequest()
-        verify(response, times(1)).close()
     }
 
     private fun getMockResponse(status: Int): Response = mock(Response::class.java).also {

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.pocket
 
 import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
 import mozilla.components.support.ktx.kotlin.toUri
@@ -76,7 +77,7 @@ class PocketEndpointRawTest {
         assertRequestParams(makeRequest = {
             endpoint.getGlobalVideoRecommendations()
         }, assertParams = { request ->
-            val userAgent = request.headers?.get(PocketEndpointRaw.HEADER_USER_AGENT)
+            val userAgent = request.headers?.get(USER_AGENT)
             assertEquals(TEST_USER_AGENT, userAgent)
         })
     }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.pocket
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
 import mozilla.components.concept.fetch.Response
+import mozilla.components.service.pocket.helpers.MockResponses
 import mozilla.components.service.pocket.helpers.assertRequestParams
 import mozilla.components.service.pocket.helpers.assertResponseIsClosed
 import mozilla.components.support.ktx.kotlin.toUri
@@ -39,14 +40,8 @@ class PocketEndpointRawTest {
 
     @Before
     fun setUp() {
-        errorResponse = getMockResponse(404)
-        successResponse = getMockResponse(200).also {
-            // A successful response must contain a body.
-            val body = mock(Response.Body::class.java).also { body ->
-                `when`(body.string()).thenReturn("{}")
-            }
-            `when`(it.body).thenReturn(body)
-        }
+        errorResponse = MockResponses.getError()
+        successResponse = MockResponses.getSuccess()
         defaultResponse = errorResponse
 
         client = mock(Client::class.java).also {
@@ -125,9 +120,5 @@ class PocketEndpointRawTest {
         assertResponseIsClosed(client, successResponse) {
             endpoint.getGlobalVideoRecommendations()
         }
-    }
-
-    private fun getMockResponse(status: Int): Response = mock(Response::class.java).also {
-        `when`(it.status).thenReturn(status)
     }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
@@ -78,7 +78,7 @@ class PocketEndpointTest {
 
     @Test
     fun `WHEN getting video recommendations, the server returns a String, and the jsonParser returns valid data THEN a success with the data is returned`() {
-        val expected = PocketTestResource.videoRecommendationFirstTwo
+        val expected = PocketTestResource.getExpectedPocketVideoRecommendationFirstTwo()
         `when`(raw.getGlobalVideoRecommendations()).thenReturn("")
         `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenReturn(expected)
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.pocket
 import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.pocket.helpers.PocketTestResource
+import mozilla.components.service.pocket.helpers.assertResponseIsFailure
 import mozilla.components.service.pocket.net.PocketResponse
 import mozilla.components.support.test.any
 import org.junit.Assert.assertEquals
@@ -45,7 +46,7 @@ class PocketEndpointTest {
     fun `WHEN getting video recommendations and the endpoint returns null THEN a failure is returned`() {
         `when`(raw.getGlobalVideoRecommendations()).thenReturn(null)
         `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenThrow(AssertionError("We assume this won't get called so we don't mock it"))
-        assertIsFailure(endpoint.getGlobalVideoRecommendations())
+        assertResponseIsFailure(endpoint.getGlobalVideoRecommendations())
     }
 
     @Test
@@ -66,14 +67,14 @@ class PocketEndpointTest {
     fun `WHEN getting video recommendations, the server returns a String, and the JSON parser returns null THEN a failure is returned`() {
         `when`(raw.getGlobalVideoRecommendations()).thenReturn("")
         `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenReturn(null)
-        assertIsFailure(endpoint.getGlobalVideoRecommendations())
+        assertResponseIsFailure(endpoint.getGlobalVideoRecommendations())
     }
 
     @Test
     fun `WHEN getting video recommendations, the server returns a String, and the jsonParser returns an empty list THEN a failure is returned`() {
         `when`(raw.getGlobalVideoRecommendations()).thenReturn("")
         `when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenReturn(emptyList())
-        assertIsFailure(endpoint.getGlobalVideoRecommendations())
+        assertResponseIsFailure(endpoint.getGlobalVideoRecommendations())
     }
 
     @Test
@@ -114,8 +115,4 @@ class PocketEndpointTest {
         assertEquals(20, results?.size)
         results?.forEach { println(it.toString()) }
     }
-}
-
-private fun assertIsFailure(actual: Any) {
-    assertEquals(PocketResponse.Failure::class.java, actual.javaClass)
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
@@ -87,23 +87,23 @@ class PocketEndpointTest {
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `WHEN getInstance is called with a blank API key THEN an exception is thrown`() {
+    fun `WHEN newInstance is called with a blank API key THEN an exception is thrown`() {
         PocketEndpoint.newInstance(client, " ", VALID_USER_AGENT)
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `WHEN getInstance is called with a blank user agent THEN an exception is thrown`() {
+    fun `WHEN newInstance is called with a blank user agent THEN an exception is thrown`() {
         PocketEndpoint.newInstance(client, VALID_API_KEY, " ")
     }
 
     @Test
-    fun `WHEN getInstance is called with valid args THEN no exception is thrown`() {
+    fun `WHEN newInstance is called with valid args THEN no exception is thrown`() {
         PocketEndpoint.newInstance(client, VALID_API_KEY, VALID_USER_AGENT)
     }
 
     @Test
     @Ignore("Requires a network request; run locally to test end-to-end behavior")
-    fun `WHEN making an end-to-end request THEN 20 results are returned`() {
+    fun `WHEN making an end-to-end global video recommendations request THEN 20 results are returned`() {
         // To use this test locally, add the API key file (see API_KEY comments) and comment out ignore annotation.
         val client = HttpURLConnectionClient()
         val apiKey = PocketTestResource.API_KEY.get()

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketJSONParserTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketJSONParserTest.kt
@@ -38,7 +38,7 @@ class PocketJSONParserTest {
 
     @Test
     fun `WHEN parsing valid global video recommendations THEN pocket videos are returned`() {
-        val expectedSubset = PocketTestResource.videoRecommendationFirstTwo
+        val expectedSubset = PocketTestResource.getExpectedPocketVideoRecommendationFirstTwo()
         val pocketJSON = PocketTestResource.POCKET_VIDEO_RECOMMENDATION.get()
         val actualVideos = parser.jsonToGlobalVideoRecommendations(pocketJSON)
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointRawTest.kt
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Headers.Common.CONTENT_TYPE
+import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.service.pocket.PocketListenEndpointRaw.Companion.CONTENT_TYPE_URL_ENCODED
+import mozilla.components.service.pocket.PocketListenEndpointRaw.Companion.X_ACCESS_TOKEN
+import mozilla.components.service.pocket.helpers.MockResponses
+import mozilla.components.service.pocket.helpers.assertRequestParams
+import mozilla.components.service.pocket.helpers.assertResponseIsClosed
+import mozilla.components.service.pocket.helpers.assertSuccessfulRequestReturnsResponseBody
+import mozilla.components.support.ktx.kotlin.toUri
+import mozilla.components.support.test.any
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import java.io.IOException
+import java.net.URLEncoder
+
+private const val EXPECTED_USER_AGENT = "Mozilla/5.0 (Expected-User-Agent 4.0) Gecko WebKit-like. Isn't this clear?"
+private const val EXPECTED_ACCESS_TOKEN = "12345" // Amazing, that's the same combination on my luggage!
+
+private val TEST_URL = "https://mozilla.org".toUri()
+
+@RunWith(RobolectricTestRunner::class)
+class PocketListenEndpointRawTest {
+
+    private lateinit var subject: PocketListenEndpointRaw
+    private lateinit var client: Client
+    private lateinit var urls: PocketListenURLs
+
+    private lateinit var errorResponse: Response
+    private lateinit var successResponse: Response
+
+    @Before
+    fun setUp() {
+        errorResponse = MockResponses.getError()
+        successResponse = MockResponses.getSuccess()
+
+        client = mock(Client::class.java)
+        urls = mock(PocketListenURLs::class.java).also {
+            `when`(it.articleService).thenReturn(TEST_URL)
+        }
+
+        subject = PocketListenEndpointRaw(client, urls, EXPECTED_USER_AGENT, EXPECTED_ACCESS_TOKEN)
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata THEN the listen article metadata url is used`() {
+        val expectedUrl = "https://mozilla.org/listen-article-metadata"
+        `when`(urls.articleService).thenReturn(expectedUrl.toUri())
+        assertRequestParams(client, { makeRequestArticleListenMetadata() }, assertParams = { request ->
+            assertEquals(expectedUrl, request.url)
+        })
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata THEN a POST request is used`() {
+        assertRequestParams(client, { makeRequestArticleListenMetadata() }, assertParams = { request ->
+            assertEquals(Request.Method.POST, request.method)
+        })
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata THEN the request headers are correct`() {
+        assertRequestParams(client, { makeRequestArticleListenMetadata() }, assertParams = { request ->
+            assertNotNull(request.headers)
+            val headers = request.headers!!
+            assertEquals(CONTENT_TYPE_URL_ENCODED, headers[CONTENT_TYPE])
+            assertEquals(EXPECTED_USER_AGENT, headers[USER_AGENT])
+            assertEquals(EXPECTED_ACCESS_TOKEN, headers[X_ACCESS_TOKEN])
+        })
+    }
+
+    @Test
+    fun `WHEN request listen article metadata THEN the request body is correct`() {
+        val inputArticleID = 42
+        val inputArticleURL = "https://mozac.org/api/mozilla.components.support.ktx.android.util/"
+
+        val expectedBodyValues = mapOf(
+            "url" to URLEncoder.encode(inputArticleURL, Charsets.UTF_8.name()),
+            "article_id" to inputArticleID.toString(),
+            "v" to "2",
+            "locale" to "en-US"
+        )
+
+        assertRequestParams(client, makeRequest = {
+            subject.getArticleListenMetadata(inputArticleID, inputArticleURL)
+        }, assertParams = { request ->
+            assertNotNull(request.body)
+            val bodyParameters = request.body!!.useStream {
+                it.bufferedReader().readText().split("&")
+            }
+
+            val seenBodyParamKeys = mutableSetOf<String>()
+            bodyParameters.forEach {
+                val (key, value) = it.split("=")
+                assertEquals("for key: $key", expectedBodyValues[key], value)
+
+                seenBodyParamKeys.add(key)
+            }
+
+            assertEquals("Did not check all expected body params", expectedBodyValues.keys, seenBodyParamKeys)
+        })
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata and the client throws an IOException THEN null is returned`() {
+        `when`(client.fetch(any())).thenThrow(IOException::class.java)
+        assertNull(makeRequestArticleListenMetadata())
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata and the response is null THEN null is returned`() {
+        `when`(client.fetch(any())).thenReturn(null)
+        assertNull(makeRequestArticleListenMetadata())
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata and the response is not a success THEN null is returned`() {
+        `when`(client.fetch(any())).thenReturn(errorResponse)
+        assertNull(makeRequestArticleListenMetadata())
+    }
+
+    @Test // if invalid article parameters are passed to the server, 404 is returned.
+    fun `WHEN requesting listen article metadata and the response is a 404 THEN null is returned`() {
+        val response404 = MockResponses.getMockResponse(404)
+        `when`(client.fetch(any())).thenReturn(response404)
+        assertNull(makeRequestArticleListenMetadata())
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata and the response is a success THEN the response body is returned`() {
+        assertSuccessfulRequestReturnsResponseBody(client, ::makeRequestArticleListenMetadata)
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata and the response is an error THEN response is closed`() {
+        assertResponseIsClosed(client, errorResponse) { makeRequestArticleListenMetadata() }
+    }
+
+    @Test
+    fun `WHEN requesting listen article metadata and the response is a success THEN response is closed`() {
+        assertResponseIsClosed(client, successResponse) { makeRequestArticleListenMetadata() }
+    }
+
+    private fun makeRequestArticleListenMetadata(): String? {
+        return subject.getArticleListenMetadata(42, "https://mozilla.org")
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointTest.kt
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.service.pocket.data.PocketListenArticleMetadata
+import mozilla.components.service.pocket.helpers.PocketTestResource
+import mozilla.components.service.pocket.helpers.assertResponseIsFailure
+import mozilla.components.service.pocket.net.PocketResponse
+import mozilla.components.support.test.any
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+private const val VALID_ACCESS_TOKEN = "accessToken"
+private const val VALID_USER_AGENT = "userAgent"
+
+@RunWith(RobolectricTestRunner::class)
+class PocketListenEndpointTest {
+
+    private lateinit var subject: PocketListenEndpoint
+    private lateinit var raw: PocketListenEndpointRaw // we shorten the name to avoid confusion with the endpoint.
+    private lateinit var jsonParser: PocketListenJSONParser
+
+    private lateinit var client: Client
+
+    @Before
+    fun setUp() {
+        raw = mock(PocketListenEndpointRaw::class.java)
+        jsonParser = mock(PocketListenJSONParser::class.java)
+
+        subject = PocketListenEndpoint(raw, jsonParser)
+
+        client = mock(Client::class.java)
+    }
+
+    @Test
+    fun `WHEN getting listen article metadata and the endpoint returns null THEN a failure is returned`() {
+        `when`(raw.getArticleListenMetadata(anyInt(), anyString())).thenReturn(null)
+        `when`(jsonParser.jsonToListenArticleMetadata(any())).thenThrow(AssertionError("We assume this won't get called so we don't mock it"))
+        assertResponseIsFailure(makeRequestGetListenArticleMetadata())
+    }
+
+    @Test
+    fun `WHEN getting listen article metadata and the endpoint returns a String THEN the String is put into the jsonParser`() {
+        arrayOf(
+            "",
+            " ",
+            "{}",
+            """{"expectedJSON": 101}"""
+        ).forEach { expected ->
+            `when`(raw.getArticleListenMetadata(anyInt(), anyString())).thenReturn(expected)
+            makeRequestGetListenArticleMetadata()
+            verify(jsonParser, times(1)).jsonToListenArticleMetadata(expected)
+        }
+    }
+
+    @Test
+    fun `WHEN getting listen article metadata, the server returns a String, and the JSON parser returns null THEN a failure is returned`() {
+        `when`(raw.getArticleListenMetadata(anyInt(), anyString())).thenReturn("")
+        `when`(jsonParser.jsonToListenArticleMetadata(any())).thenReturn(null)
+        assertResponseIsFailure(makeRequestGetListenArticleMetadata())
+    }
+
+    @Test
+    fun `WHEN getting listen article metadata, the server returns a String, and the jsonParser returns valid data THEN a success with the data is returned`() {
+        val expected = PocketTestResource.getExpectedListenArticleMetadata()
+        `when`(raw.getArticleListenMetadata(anyInt(), anyString())).thenReturn("")
+        `when`(jsonParser.jsonToListenArticleMetadata(any())).thenReturn(expected)
+
+        val actual = makeRequestGetListenArticleMetadata()
+        assertEquals(expected, (actual as? PocketResponse.Success)?.data)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `WHEN newInstance is called with a blank access token key THEN an exception is thrown`() {
+        PocketListenEndpoint.newInstance(client, " ", VALID_USER_AGENT)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `WHEN newInstance is called with a blank user agent THEN an exception is thrown`() {
+        PocketListenEndpoint.newInstance(client, VALID_ACCESS_TOKEN, " ")
+    }
+
+    @Test
+    fun `WHEN newInstance is called with valid args THEN no exception is thrown`() {
+        PocketListenEndpoint.newInstance(client, VALID_ACCESS_TOKEN, VALID_USER_AGENT)
+    }
+
+    @Test
+    @Ignore("Requires a network request; run locally to test end-to-end behavior")
+    fun `WHEN making an end-to-end listen article metadata request THEN a non-null result is returned`() {
+        // To use this test locally, add the access token file (see LISTEN_ACCESS_TOKEN comments) and comment out ignore annotation.
+        val client = HttpURLConnectionClient()
+        val accessToken = PocketTestResource.LISTEN_ACCESS_TOKEN.get()
+        val subject = PocketListenEndpoint.newInstance(client, accessToken, "android-components:PocketListenEndpointTest")
+
+        // The input article may seem invalid but it's test data from the server docs:
+        //   https://documenter.getpostman.com/view/777613/S17jXChA#426b37e2-0a4f-bd65-35c6-e14f1b19d0f0
+        val response = subject.getListenArticleMetadata(1234, "https://news.com/my-article.html")
+        val result = (response as? PocketResponse.Success)?.data
+
+        assertNotNull(result)
+        println(result)
+    }
+
+    private fun makeRequestGetListenArticleMetadata(): PocketResponse<PocketListenArticleMetadata> {
+        return subject.getListenArticleMetadata(42, "https://mozilla.org")
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenJSONParserTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenJSONParserTest.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import mozilla.components.service.pocket.helpers.PocketTestResource
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PocketListenJSONParserTest {
+
+    private lateinit var subject: PocketListenJSONParser
+
+    @Before
+    fun setUp() {
+        subject = PocketListenJSONParser()
+    }
+
+    @Test
+    fun `WHEN parsing listen article metadata for a blank string THEN null is returned`() {
+        assertNull(subject.jsonToListenArticleMetadata(" "))
+    }
+
+    @Test
+    fun `WHEN parsing listen article metadata for an invalid JSON String THEN null is returned`() {
+        assertNull(subject.jsonToListenArticleMetadata("{!!}}"))
+    }
+
+    @Test
+    fun `WHEN parsing listen article metadata with missing fields THEN null is returned`() {
+        val modifiedPocketJSON = PocketTestResource.LISTEN_ARTICLE_METADATA.get().let {
+            val rootJSON = JSONArray(it)
+            rootJSON.getJSONObject(0).remove("voice")
+            rootJSON.toString()
+        }
+        assertNull(subject.jsonToListenArticleMetadata(modifiedPocketJSON))
+    }
+
+    @Test
+    fun `WHEN parsing valid listen article metadata THEN the article metadata is returned`() {
+        val pocketJSON = PocketTestResource.LISTEN_ARTICLE_METADATA.get()
+        val actual = subject.jsonToListenArticleMetadata(pocketJSON)
+        assertEquals(PocketTestResource.getExpectedListenArticleMetadata(), actual)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenURLsTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenURLsTest.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PocketListenURLsTest {
+
+    private lateinit var urls: PocketListenURLs
+
+    @Before
+    fun setUp() {
+        urls = PocketListenURLs()
+    }
+
+    @Test
+    fun `WHEN getting the articleservice url THEN the last path segment is for articleservice`() {
+        assertEquals("articleservice", urls.articleService.lastPathSegment)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/data/PocketListenArticleMetadataTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/data/PocketListenArticleMetadataTest.kt
@@ -8,15 +8,10 @@ import mozilla.components.service.pocket.helpers.assertConstructorsVisibility
 import org.junit.Test
 import kotlin.reflect.KVisibility
 
-class PocketGlobalVideoRecommendationTest {
+class PocketListenArticleMetadataTest {
 
     @Test // See constructor comment for details.
     fun `GIVEN a PocketGlobalVideoRecommendation THEN its constructors are internal`() {
-        assertConstructorsVisibility(PocketGlobalVideoRecommendation::class, KVisibility.INTERNAL)
-    }
-
-    @Test // See PocketGlobalVideoRecommendation constructor for details.
-    fun `GIVEN an Author THEN its constructors are internal`() {
-        assertConstructorsVisibility(PocketGlobalVideoRecommendation.Author::class, KVisibility.INTERNAL)
+        assertConstructorsVisibility(PocketListenArticleMetadata::class, KVisibility.INTERNAL)
     }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/ConceptFetchKtTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/ConceptFetchKtTest.kt
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.ext
+
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.MutableHeaders
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
+import mozilla.components.support.test.any
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import java.io.IOException
+
+private const val EXPECTED_DEFAULT_RESPONSE_BODY = "default response body"
+private const val TEST_URL = "https://mozilla.org"
+
+class ConceptFetchKtTest {
+
+    private lateinit var client: Client
+    private lateinit var defaultResponse: Response
+    private lateinit var failureResponse: Response
+    private lateinit var testRequest: Request
+
+    @Before
+    fun setUp() {
+        val responseBody = Response.Body(EXPECTED_DEFAULT_RESPONSE_BODY.byteInputStream())
+        val failureResponseBody = Response.Body("failure response body)".byteInputStream())
+        defaultResponse = spy(Response(TEST_URL, 200, MutableHeaders(), responseBody))
+        failureResponse = spy(Response(TEST_URL, 404, MutableHeaders(), failureResponseBody))
+        testRequest = Request(TEST_URL)
+
+        client = mock(Client::class.java).also {
+            `when`(it.fetch(any())).thenReturn(defaultResponse)
+        }
+    }
+
+    @Test
+    fun `GIVEN fetch throws an exception WHEN fetchBodyOrNull is called THEN null is returned`() {
+        `when`(client.fetch(any())).thenThrow(IOException())
+        assertNull(client.fetchBodyOrNull("", testRequest))
+    }
+
+    @Test
+    fun `GIVEN fetch returns a failure response WHEN fetchBodyOrNull is called THEN null is returned`() {
+        setUpClientFailureResponse()
+        assertNull(client.fetchBodyOrNull("", testRequest))
+    }
+
+    @Test
+    fun `GIVEN fetch returns a success response WHEN fetchBodyOrNull is called THEN the response body is returned`() {
+        val actual = client.fetchBodyOrNull("", testRequest)
+        assertEquals(EXPECTED_DEFAULT_RESPONSE_BODY, actual)
+    }
+
+    @Test
+    fun `GIVEN fetch returns a success response WHEN fetchBodyOrNull is called THEN the response is closed`() {
+        client.fetchBodyOrNull("", testRequest)
+        verify(defaultResponse, times(1)).close()
+    }
+
+    @Test
+    fun `GIVEN fetch returns a failure response WHEN fetchBodyOrNull is called THEN the response is closed`() {
+        setUpClientFailureResponse()
+        client.fetchBodyOrNull("", testRequest)
+        verify(failureResponse, times(1)).close()
+    }
+
+    private fun setUpClientFailureResponse() {
+        `when`(client.fetch(any())).thenReturn(failureResponse)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/ConceptFetchKtTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/ConceptFetchKtTest.kt
@@ -46,31 +46,31 @@ class ConceptFetchKtTest {
     @Test
     fun `GIVEN fetch throws an exception WHEN fetchBodyOrNull is called THEN null is returned`() {
         `when`(client.fetch(any())).thenThrow(IOException())
-        assertNull(client.fetchBodyOrNull("", testRequest))
+        assertNull(client.fetchBodyOrNull(testRequest))
     }
 
     @Test
     fun `GIVEN fetch returns a failure response WHEN fetchBodyOrNull is called THEN null is returned`() {
         setUpClientFailureResponse()
-        assertNull(client.fetchBodyOrNull("", testRequest))
+        assertNull(client.fetchBodyOrNull(testRequest))
     }
 
     @Test
     fun `GIVEN fetch returns a success response WHEN fetchBodyOrNull is called THEN the response body is returned`() {
-        val actual = client.fetchBodyOrNull("", testRequest)
+        val actual = client.fetchBodyOrNull(testRequest)
         assertEquals(EXPECTED_DEFAULT_RESPONSE_BODY, actual)
     }
 
     @Test
     fun `GIVEN fetch returns a success response WHEN fetchBodyOrNull is called THEN the response is closed`() {
-        client.fetchBodyOrNull("", testRequest)
+        client.fetchBodyOrNull(testRequest)
         verify(defaultResponse, times(1)).close()
     }
 
     @Test
     fun `GIVEN fetch returns a failure response WHEN fetchBodyOrNull is called THEN the response is closed`() {
         setUpClientFailureResponse()
-        client.fetchBodyOrNull("", testRequest)
+        client.fetchBodyOrNull(testRequest)
         verify(failureResponse, times(1)).close()
     }
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/Assert.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/Assert.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.fetch.Response
 import mozilla.components.support.test.any
 import org.junit.Assert.assertEquals
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import kotlin.reflect.KClass
@@ -38,6 +39,24 @@ fun assertRequestParams(client: Client, makeRequest: () -> Unit, assertParams: (
 
     // Ensure fetch is called so that the assertions in assertParams are called.
     verify(client, times(1)).fetch(any())
+}
+
+/**
+ * @param client the underlying mock client for the raw endpoint making the request.
+ * @param makeRequest makes the request using the raw endpoint and returns the body text, or null on error
+ */
+fun assertSuccessfulRequestReturnsResponseBody(client: Client, makeRequest: () -> String?) {
+    val expectedBody = "{\"jsonStr\": true}"
+    val body = mock(Response.Body::class.java).also {
+        `when`(it.string()).thenReturn(expectedBody)
+    }
+    val response = MockResponses.getSuccess().also {
+        `when`(it.body).thenReturn(body)
+    }
+    `when`(client.fetch(any())).thenReturn(response)
+
+    assertEquals(expectedBody, makeRequest())
+
 }
 
 /**

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/Assert.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/Assert.kt
@@ -8,6 +8,7 @@ import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
+import mozilla.components.service.pocket.net.PocketResponse
 import mozilla.components.support.test.any
 import org.junit.Assert.assertEquals
 import org.mockito.Mockito.`when`
@@ -56,7 +57,6 @@ fun assertSuccessfulRequestReturnsResponseBody(client: Client, makeRequest: () -
     `when`(client.fetch(any())).thenReturn(response)
 
     assertEquals(expectedBody, makeRequest())
-
 }
 
 /**
@@ -68,4 +68,8 @@ fun assertResponseIsClosed(client: Client, response: Response, makeRequest: () -
     `when`(client.fetch(any())).thenReturn(response)
     makeRequest()
     verify(response, times(1)).close()
+}
+
+fun assertResponseIsFailure(response: Any) {
+    assertEquals(PocketResponse.Failure::class.java, response.javaClass)
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/Assert.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/Assert.kt
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.helpers
+
+import org.junit.Assert.assertEquals
+import kotlin.reflect.KClass
+import kotlin.reflect.KVisibility
+
+fun <T : Any> assertConstructorsVisibility(assertedClass: KClass<T>, visibility: KVisibility) {
+    assertedClass.constructors.forEach {
+        assertEquals(visibility, it.visibility)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/MockResponses.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/MockResponses.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.pocket.helpers
+
+import mozilla.components.concept.fetch.Response
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+/**
+ * A collection of helper functions to generate mock [Response]s.
+ */
+object MockResponses {
+    fun getError(): Response = getMockResponse(404)
+
+    fun getSuccess(): Response = getMockResponse(200).also {
+        // A successful response must contain a body.
+        val body = mock(Response.Body::class.java).also { body ->
+            `when`(body.string()).thenReturn("{}")
+        }
+        `when`(it.body).thenReturn(body)
+    }
+
+    fun getMockResponse(status: Int): Response = mock(Response::class.java).also {
+        `when`(it.status).thenReturn(status)
+    }
+}

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
@@ -12,16 +12,17 @@ private const val POCKET_DIR = "pocket"
  * Accessors to resources used in testing. These files are available in `app/src/test/resources`.
  */
 enum class PocketTestResource(private val path: String) {
+    // For expected Kotlin data type representations of this test data, see the companion object.
     POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json"),
 
     // NEVER COMMIT THE API KEY FILE. Add this file with a valid API key to use this resource.
     API_KEY("$POCKET_DIR/apiKey.txt");
 
+    /** @return the raw resource. */
     fun get(): String = this::class.java.classLoader!!.getResource(path)!!.readText()
 
     companion object {
-
-        val videoRecommendationFirstTwo by lazy { listOf(
+        fun getExpectedPocketVideoRecommendationFirstTwo(): List<PocketGlobalVideoRecommendation> = listOf(
             PocketGlobalVideoRecommendation(
                 id = 27587,
                 url = "https://www.youtube.com/watch?v=953Qt4FnAcU",
@@ -60,6 +61,6 @@ enum class PocketTestResource(private val path: String) {
                     )
                 )
             )
-        ) }
+        )
     }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.pocket.helpers
 
 import mozilla.components.service.pocket.data.PocketGlobalVideoRecommendation
+import mozilla.components.service.pocket.data.PocketListenArticleMetadata
 
 private const val POCKET_DIR = "pocket"
 
@@ -14,6 +15,7 @@ private const val POCKET_DIR = "pocket"
 enum class PocketTestResource(private val path: String) {
     // For expected Kotlin data type representations of this test data, see the companion object.
     POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json"),
+    LISTEN_ARTICLE_METADATA("$POCKET_DIR/listen_article_metadata.json"),
 
     // NEVER COMMIT THE API KEY FILE. Add this file with a valid API key to use this resource.
     API_KEY("$POCKET_DIR/apiKey.txt");
@@ -61,6 +63,15 @@ enum class PocketTestResource(private val path: String) {
                     )
                 )
             )
+        )
+
+        fun getExpectedListenArticleMetadata(): PocketListenArticleMetadata = PocketListenArticleMetadata(
+            format = "mp3",
+            audioUrl = "https://scout-streaming-2018.s3.amazonaws.com/76cd4614-3bba-4272-b07c-0b3161aed7d9.mp3",
+            status = "available",
+            voice = "Salli",
+            durationSeconds = 353,
+            size = "1771738"
         )
     }
 }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResource.kt
@@ -17,8 +17,9 @@ enum class PocketTestResource(private val path: String) {
     POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json"),
     LISTEN_ARTICLE_METADATA("$POCKET_DIR/listen_article_metadata.json"),
 
-    // NEVER COMMIT THE API KEY FILE. Add this file with a valid API key to use this resource.
-    API_KEY("$POCKET_DIR/apiKey.txt");
+    // NEVER COMMIT THESE KEY FILES. Add this file with a valid API key to use this resource.
+    API_KEY("$POCKET_DIR/apiKey.txt"),
+    LISTEN_ACCESS_TOKEN("$POCKET_DIR/listenAccessToken.txt"); // note: file must not end in newline.
 
     /** @return the raw resource. */
     fun get(): String = this::class.java.classLoader!!.getResource(path)!!.readText()

--- a/components/service/pocket/src/test/resources/pocket/listen_article_metadata.json
+++ b/components/service/pocket/src/test/resources/pocket/listen_article_metadata.json
@@ -1,0 +1,10 @@
+[
+  {
+    "format": "mp3",
+    "url": "https://scout-streaming-2018.s3.amazonaws.com/76cd4614-3bba-4272-b07c-0b3161aed7d9.mp3",
+    "status": "available",
+    "voice": "Salli",
+    "duration": 353,
+    "size": "1771738"
+  }
+]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,7 @@ permalink: /changelog/
 
 * **service-pocket**
   * Access the list of global video recommendations via `PocketEndpoint.getGlobalVideoRecommendations`.
+  * ⚠️ **This is a breaking API change!**: `PocketGlobalVideoRecommendation.id` is now a Long instead of an Int
 
 * **concept-fetch**
   * Added common HTTP header constants in `Headers.Common`. This collection is incomplete: add your own!

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,7 @@ permalink: /changelog/
 
 * **service-pocket**
   * Access the list of global video recommendations via `PocketEndpoint.getGlobalVideoRecommendations`.
+  * Access an article's text-to-speech listen metadata via `PocketListenEndpoint.getListenArticleMetadata`.
   * ⚠️ **This is a breaking API change!**: `PocketGlobalVideoRecommendation.id` is now a Long instead of an Int
 
 * **concept-fetch**


### PR DESCRIPTION
This PR adds the public `PocketListenEndpoint` class, which closely follows the `PocketEndpoint` class. Since these access two separate servers, I created two separate classes for them.

The code in between essentially:
- Refactors the existing code so it can be shared between the two classes
- Adds a raw endpoint
- Adds a JSONParser
- Adds the public endpoint to combine the two

I wish I could share more test code (because it's essentially doing the same style of tests) but I found it challenging and time consuming to do so.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
