### PR TITLE
1535339: Upgrade glean_parser for extra_keys metadata changes

### DIFF
--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -37,7 +37,8 @@ views:
       Recorded when the login view is opened.
     ...
     extra_keys:
-      source: The source from which the login view was opened, e.g. "toolbar".
+      source: 
+        description: The source from which the login view was opened, e.g. "toolbar".
 ```
 
 Now you can use the event from the applications code:

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -9,7 +9,7 @@ import groovy.json.JsonOutput
 // so that it will be shared between all libraries that use glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "0.17.1"
+String GLEAN_PARSER_VERSION = "0.18.0"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/samples/glean/metrics.yaml
+++ b/samples/glean/metrics.yaml
@@ -16,8 +16,10 @@ browser.engagement:
     notification_emails:
       - telemetry-client-dev@mozilla.com
     extra_keys:
-      key1: "This is key one"
-      key2: "This is key two"
+      key1:
+        description: "This is key one"
+      key2:
+        description: "This is key two"
     expires: never
 
 basic:


### PR DESCRIPTION
This upgrades `glean_parser` to get the event `extra_keys` metadata changes from https://github.com/mozilla/glean_parser/pull/42

The changes to this code are pretty minor, as you can see.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
