### PR TITLE
Find in page accessibility

### DIFF
--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/FindInPageFeature.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/FindInPageFeature.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.findinpage
 import android.support.annotation.VisibleForTesting
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.internal.FindInPageInteractor
 import mozilla.components.feature.findinpage.internal.FindInPagePresenter
 import mozilla.components.feature.findinpage.view.FindInPageView
@@ -19,10 +20,11 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 class FindInPageFeature(
     sessionManager: SessionManager,
     view: FindInPageView,
+    engineView: EngineView,
     private val onClose: (() -> Unit)? = null
 ) : LifecycleAwareFeature, BackHandler {
     @VisibleForTesting internal var presenter = FindInPagePresenter(view)
-    @VisibleForTesting internal var interactor = FindInPageInteractor(this, sessionManager, view)
+    @VisibleForTesting internal var interactor = FindInPageInteractor(this, sessionManager, view, engineView)
 
     private var session: Session? = null
 

--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/internal/FindInPageInteractor.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/internal/FindInPageInteractor.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.findinpage.internal
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
 import mozilla.components.feature.findinpage.view.FindInPageView
 import mozilla.components.support.ktx.android.view.hideKeyboard
@@ -18,7 +19,8 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 internal class FindInPageInteractor(
     private val feature: FindInPageFeature,
     private val sessionManager: SessionManager,
-    private val view: FindInPageView
+    private val view: FindInPageView,
+    private val engineView: EngineView?
 ) : FindInPageView.Listener {
     private var engineSession: EngineSession? = null
 
@@ -36,13 +38,13 @@ internal class FindInPageInteractor(
 
     override fun onPreviousResult() {
         engineSession?.findNext(forward = false)
-
+        engineView?.asView()?.clearFocus()
         view.asView().hideKeyboard()
     }
 
     override fun onNextResult() {
         engineSession?.findNext(forward = true)
-
+        engineView?.asView()?.clearFocus()
         view.asView().hideKeyboard()
     }
 

--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
@@ -87,7 +87,9 @@ class FindInPageBar @JvmOverloads constructor(
                 // increment it by one.
                 val ordinal = activeMatchOrdinal + 1
                 resultsCountTextView.text = String.format(resultFormat, ordinal, numberOfMatches)
-                resultsCountTextView.contentDescription = String.format(accessibilityFormat, ordinal, numberOfMatches)
+                val accessibilityLabel = String.format(accessibilityFormat, ordinal, numberOfMatches)
+                resultsCountTextView.contentDescription = accessibilityLabel
+                announceForAccessibility(accessibilityLabel)
             } else {
                 resultsCountTextView.text = ""
                 resultsCountTextView.contentDescription = ""

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/FindInPageFeatureTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/FindInPageFeatureTest.kt
@@ -21,7 +21,7 @@ class FindInPageFeatureTest {
         val presenter: FindInPagePresenter = mock()
         val interactor: FindInPageInteractor = mock()
 
-        val feature = FindInPageFeature(mock(), mock())
+        val feature = FindInPageFeature(mock(), mock(), mock())
         feature.presenter = presenter
         feature.interactor = interactor
 
@@ -36,7 +36,7 @@ class FindInPageFeatureTest {
         val presenter: FindInPagePresenter = mock()
         val interactor: FindInPageInteractor = mock()
 
-        val feature = FindInPageFeature(mock(), mock())
+        val feature = FindInPageFeature(mock(), mock(), mock())
         feature.presenter = presenter
         feature.interactor = interactor
 
@@ -51,7 +51,7 @@ class FindInPageFeatureTest {
         val presenter: FindInPagePresenter = mock()
         val interactor: FindInPageInteractor = mock()
 
-        val feature = FindInPageFeature(mock(), mock())
+        val feature = FindInPageFeature(mock(), mock(), mock())
         feature.presenter = presenter
         feature.interactor = interactor
 
@@ -67,7 +67,7 @@ class FindInPageFeatureTest {
         val presenter: FindInPagePresenter = mock()
         val interactor: FindInPageInteractor = mock()
 
-        val feature = spy(FindInPageFeature(mock(), mock()))
+        val feature = spy(FindInPageFeature(mock(), mock(), mock()))
         feature.presenter = presenter
         feature.interactor = interactor
 
@@ -84,7 +84,7 @@ class FindInPageFeatureTest {
         val presenter: FindInPagePresenter = mock()
         val interactor: FindInPageInteractor = mock()
 
-        val feature = spy(FindInPageFeature(mock(), mock()))
+        val feature = spy(FindInPageFeature(mock(), mock(), mock()))
         feature.presenter = presenter
         feature.interactor = interactor
 
@@ -98,7 +98,7 @@ class FindInPageFeatureTest {
         val presenter: FindInPagePresenter = mock()
         val interactor: FindInPageInteractor = mock()
 
-        val feature = FindInPageFeature(mock(), mock())
+        val feature = FindInPageFeature(mock(), mock(), mock())
         feature.presenter = presenter
         feature.interactor = interactor
 
@@ -115,7 +115,7 @@ class FindInPageFeatureTest {
 
         var lambdaInvoked = false
 
-        val feature = FindInPageFeature(mock(), mock()) {
+        val feature = FindInPageFeature(mock(), mock(), mock()) {
             lambdaInvoked = true
         }
 

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPageInteractorTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPageInteractorTest.kt
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
 import mozilla.components.feature.findinpage.view.FindInPageView
 import mozilla.components.support.test.any
@@ -28,7 +29,7 @@ class FindInPageInteractorTest {
     @Test
     fun `Start will register interactor as listener`() {
         val view: FindInPageView = mock()
-        val interactor = FindInPageInteractor(mock(), mock(), view)
+        val interactor = FindInPageInteractor(mock(), mock(), view, mock())
 
         verify(view, never()).listener = interactor
 
@@ -40,7 +41,7 @@ class FindInPageInteractorTest {
     @Test
     fun `Stop will unregister interactor from listening to the view`() {
         val view: FindInPageView = mock()
-        val interactor = FindInPageInteractor(mock(), mock(), view)
+        val interactor = FindInPageInteractor(mock(), mock(), view, mock())
 
         interactor.start()
         interactor.stop()
@@ -53,7 +54,7 @@ class FindInPageInteractorTest {
         val view: FindInPageView = mock()
         `when`(view.asView()).thenReturn(View(context))
 
-        val interactor = FindInPageInteractor(mock(), mock(), view)
+        val interactor = FindInPageInteractor(mock(), mock(), view, mock())
 
         // Nothing should throw here if we haven't bound the interactor to a session
         interactor.onPreviousResult()
@@ -73,7 +74,7 @@ class FindInPageInteractorTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.getEngineSession(any())).thenReturn(engineSession)
 
-        val interactor = FindInPageInteractor(mock(), sessionManager, view)
+        val interactor = FindInPageInteractor(mock(), sessionManager, view, mock())
 
         interactor.bind(mock())
         interactor.onPreviousResult()
@@ -91,7 +92,7 @@ class FindInPageInteractorTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.getEngineSession(any())).thenReturn(engineSession)
 
-        val interactor = FindInPageInteractor(mock(), sessionManager, view)
+        val interactor = FindInPageInteractor(mock(), sessionManager, view, mock())
 
         interactor.bind(mock())
         interactor.onNextResult()
@@ -100,10 +101,26 @@ class FindInPageInteractorTest {
     }
 
     @Test
+    fun `onNextResult blurs focused engine view`() {
+        val view: FindInPageView = mock()
+        `when`(view.asView()).thenReturn(View(context))
+
+        val actualEngineView: View = mock()
+        val engineView: EngineView = mock()
+        `when`(engineView.asView()).thenReturn(actualEngineView)
+
+        val interactor = FindInPageInteractor(mock(), mock(), view, engineView)
+
+        interactor.bind(mock())
+        interactor.onNextResult()
+        verify(actualEngineView).clearFocus()
+    }
+
+    @Test
     fun `onClose notifies feature`() {
         val feature: FindInPageFeature = mock()
 
-        val interactor = FindInPageInteractor(feature, mock(), mock())
+        val interactor = FindInPageInteractor(feature, mock(), mock(), mock())
         interactor.onClose()
 
         verify(feature).unbind()
@@ -116,7 +133,7 @@ class FindInPageInteractorTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.getEngineSession(any())).thenReturn(engineSession)
 
-        val interactor = FindInPageInteractor(mock(), sessionManager, mock())
+        val interactor = FindInPageInteractor(mock(), sessionManager, mock(), mock())
 
         interactor.bind(mock())
         interactor.unbind()
@@ -131,7 +148,7 @@ class FindInPageInteractorTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.getEngineSession(any())).thenReturn(engineSession)
 
-        val interactor = FindInPageInteractor(mock(), sessionManager, mock())
+        val interactor = FindInPageInteractor(mock(), sessionManager, mock(), mock())
 
         interactor.bind(mock())
         interactor.onFindAll("example")
@@ -146,7 +163,7 @@ class FindInPageInteractorTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.getEngineSession(any())).thenReturn(engineSession)
 
-        val interactor = FindInPageInteractor(mock(), sessionManager, mock())
+        val interactor = FindInPageInteractor(mock(), sessionManager, mock(), mock())
 
         interactor.bind(mock())
         interactor.onClearMatches()

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 
@@ -89,7 +90,7 @@ class FindInPageBarTest {
 
     @Test
     fun `displayResult with matches will update views`() {
-        val view = FindInPageBar(context)
+        val view = spy(FindInPageBar(context))
 
         view.displayResult(Session.FindResult(0, 100, false))
 
@@ -98,6 +99,7 @@ class FindInPageBarTest {
 
         assertEquals(textCorrectValue, view.resultsCountTextView.text)
         assertEquals(contentDesCorrectValue, view.resultsCountTextView.contentDescription)
+        verify(view).announceForAccessibility(contentDesCorrectValue)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -101,6 +101,7 @@ permalink: /changelog/
 * **feature-findinpage**
   * ⚠️ **This is a breaking API change!**: `FindInPageFeature` constructor now takes an `EngineView` instance.
   * Blur controlled `EngineView` for better screen reader accessibility.
+  * Announce result count for screen reader users.
 
 # 0.46.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -98,6 +98,10 @@ permalink: /changelog/
 * **concept-fetch**
   * Added common HTTP header constants in `Headers.Common`. This collection is incomplete: add your own!
 
+* **feature-findinpage**
+  * ⚠️ **This is a breaking API change!**: `FindInPageFeature` constructor now takes an `EngineView` instance.
+  * Blur controlled `EngineView` for better screen reader accessibility.
+
 # 0.46.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.45.0...v0.46.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -143,7 +143,7 @@ class BrowserFragment : Fragment(), BackHandler {
             view = layout)
 
         findInPageIntegration.set(
-            feature = FindInPageIntegration(components.sessionManager, layout.findInPage),
+            feature = FindInPageIntegration(components.sessionManager, layout.findInPage, layout.engineView),
             owner = this,
             view = layout)
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/integration/FindInPageIntegration.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/integration/FindInPageIntegration.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.browser.integration
 
 import android.view.View
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
 import mozilla.components.feature.findinpage.view.FindInPageView
 import mozilla.components.support.base.feature.BackHandler
@@ -13,9 +14,10 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 class FindInPageIntegration(
     private val sessionManager: SessionManager,
-    private val view: FindInPageView
+    private val view: FindInPageView,
+    private val engineView: EngineView
 ) : LifecycleAwareFeature, BackHandler {
-    private val feature = FindInPageFeature(sessionManager, view, ::onClose)
+    private val feature = FindInPageFeature(sessionManager, view, engineView, ::onClose)
 
     override fun start() {
         feature.start()


### PR DESCRIPTION
This pull request does two things:

### Focus control
Assure engineview is blurred when conducting search.

This is important for TalkBack. When the caret in Gecko moves from a focusable element (like a link) to a non-focusable element (like a text node in a P), the link is blurred and the document gets focus.

TalkBack then moves the accessibility focus to the input focus, and this throws the user off of the search result.

This change depends on Gecko changes, specifically [bug 1535701](https://bugzilla.mozilla.org/show_bug.cgi?id=1535701) and [bug 1536123](https://bugzilla.mozilla.org/show_bug.cgi?id=1536123).

### Announce Results

This lets TalkBack users know how many results there are for a certain string as they type without having to move a11y focus to the results label.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
