### PR TITLE
[glean] WIP: Don't include `.debug` or `.release` in namespace

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -112,7 +112,13 @@ ext.gleanGenerateMetricsAPI = {
     variant ->
 
     def sourceOutputDir =  "$buildDir/telemetry/src/${variant.name}/kotlin"
-    def fullNamespace = "${variant.applicationId}.GleanMetrics"
+    def applicationId = variant.applicationId
+    if (applicationId.endsWith(".debug")) {
+        applicationId = applicationId.subString[0..-7]
+    } else if (applicationId.endsWith(".release")) {
+        applicationId = applicationId.subString[0..-9]
+    }
+    def fullNamespace = "${applicationId}.GleanMetrics"
     def generateKotlinAPI = task("generateMetricsSourceFor${variant.name.capitalize()}", type: Exec) {
         description = "Generate the Kotlin code for the Metrics API"
 


### PR DESCRIPTION
This is an experiment to fix a bug @boek reported.

For Fenix, Glean is generating code into the package: `org.mozilla.fenix.debug.GleanMetrics`, rather than `org.mozilla.fenix.GleanMetrics`, which means code would need to import glean different depending on whether it's in a debug or release build.

This lobs off `.debug` or `.release` from the `variant.applicationId` if it's there.  An alternative might be to provide a parameter to change this.  I'm happy with either outcome after discussion.

To test this fix, change the `apply from: .../sdk_generator.gradle` line in the application's `build.gradle` to:

`apply from: 'https://raw.githubusercontent.com/mdboom/android-components/glean-namespace-parameter/components/service/glean/scripts/sdk_generator.gradle'`

Cc: @boek

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
