### PR TITLE
Closes #2394: Add Request.Body.fromParamsForFormUrlEncoded

### DIFF
--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
@@ -41,7 +41,7 @@ interface Headers : Iterable<Header> {
     operator fun contains(name: String): Boolean
 
     /**
-     * A collection of common HTTP header definitions.
+     * A collection of common HTTP header names.
      *
      * A list of common HTTP request headers can be found at
      *   https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Standard_request_fields
@@ -52,6 +52,13 @@ interface Headers : Iterable<Header> {
     object Common {
         const val CONTENT_TYPE = "Content-Type"
         const val USER_AGENT = "User-Agent"
+
+        /*
+         * A collection of common HTTP header values.
+         */
+        object Value {
+            const val CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded"
+        }
     }
 }
 

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.fetch
 
+import android.net.Uri
 import java.io.Closeable
 import java.io.File
 import java.io.IOException
@@ -61,6 +62,23 @@ data class Request(
              * Create a [Body] from the provided [File].
              */
             fun fromFile(file: File): Body = Body(file.inputStream())
+
+            /**
+             * Create a [Body] from the provided [unencodedParams] in the format of Content-Type
+             * "application/x-www-form-urlencoded". Parameters are formatted as "key1=value1&key2=value2..."
+             * and values are percent-encoded. If the given map is empty, the response body will contain the
+             * empty string.
+             *
+             * @see [Headers.Common.Value.CONTENT_TYPE_FORM_URLENCODED]
+             */
+            fun fromParamsForFormUrlEncoded(unencodedParams: Map<String, String>): Body {
+                // It's unintuitive to use the Uri class format and encode
+                // but its GET query syntax is exactly what we need.
+                val uriBuilder = Uri.Builder()
+                unencodedParams.forEach { (key, value) -> uriBuilder.appendQueryParameter(key, value) }
+                val encodedBody = uriBuilder.build().encodedQuery ?: "" // null when the given map is empty.
+                return Body(encodedBody.byteInputStream())
+            }
         }
 
         /**

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
@@ -11,6 +11,7 @@ import android.support.annotation.WorkerThread
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers.Common.CONTENT_TYPE
 import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
+import mozilla.components.concept.fetch.Headers.Common.Value.CONTENT_TYPE_FORM_URLENCODED
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
 import mozilla.components.service.pocket.ext.fetchBodyOrNull
@@ -46,7 +47,7 @@ internal class PocketListenEndpointRaw(
             Request.Method.POST,
             MutableHeaders(
                 USER_AGENT to userAgent,
-                CONTENT_TYPE to CONTENT_TYPE_URL_ENCODED,
+                CONTENT_TYPE to CONTENT_TYPE_FORM_URLENCODED,
                 X_ACCESS_TOKEN to accessToken
             ),
             body = Request.Body(getRequestBodyString().byteInputStream())
@@ -58,6 +59,5 @@ internal class PocketListenEndpointRaw(
 
     companion object {
         @VisibleForTesting(otherwise = PRIVATE) const val X_ACCESS_TOKEN = "x-access-token"
-        @VisibleForTesting(otherwise = PRIVATE) const val CONTENT_TYPE_URL_ENCODED = "application/x-www-form-urlencoded"
     }
 }

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.service.pocket
 
-import android.net.Uri
 import android.support.annotation.VisibleForTesting
 import android.support.annotation.VisibleForTesting.PRIVATE
 import android.support.annotation.WorkerThread
@@ -33,15 +32,6 @@ internal class PocketListenEndpointRaw(
      */
     @WorkerThread // Synchronous network call.
     fun getArticleListenMetadata(articleID: Int, articleUrl: String): String? {
-        /** @return "key=value&key2=value2..." for the hard-coded key-value pairs. */
-        fun getRequestBodyString(): String = Uri.Builder()
-            .appendQueryParameter("url", articleUrl)
-            .appendQueryParameter("article_id", articleID.toString())
-            .appendQueryParameter("v", "2")
-            .appendQueryParameter("locale", "en-US")
-            .build()
-            .encodedQuery!! // We added query params so this should be non-null: assert it.
-
         val request = Request(
             urls.articleService.toString(),
             Request.Method.POST,
@@ -50,7 +40,12 @@ internal class PocketListenEndpointRaw(
                 CONTENT_TYPE to CONTENT_TYPE_FORM_URLENCODED,
                 X_ACCESS_TOKEN to accessToken
             ),
-            body = Request.Body(getRequestBodyString().byteInputStream())
+            body = Request.Body.fromParamsForFormUrlEncoded(mapOf(
+                "url" to articleUrl,
+                "article_id" to articleID.toString(),
+                "v" to "2",
+                "locale" to "en-US"
+            ))
         )
 
         // If an invalid body is sent to the server, 404 is returned.

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointRawTest.kt
@@ -7,9 +7,9 @@ package mozilla.components.service.pocket
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers.Common.CONTENT_TYPE
 import mozilla.components.concept.fetch.Headers.Common.USER_AGENT
+import mozilla.components.concept.fetch.Headers.Common.Value.CONTENT_TYPE_FORM_URLENCODED
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
-import mozilla.components.service.pocket.PocketListenEndpointRaw.Companion.CONTENT_TYPE_URL_ENCODED
 import mozilla.components.service.pocket.PocketListenEndpointRaw.Companion.X_ACCESS_TOKEN
 import mozilla.components.service.pocket.helpers.MockResponses
 import mozilla.components.service.pocket.helpers.assertRequestParams
@@ -78,7 +78,7 @@ class PocketListenEndpointRawTest {
         assertRequestParams(client, { makeRequestArticleListenMetadata() }, assertParams = { request ->
             assertNotNull(request.headers)
             val headers = request.headers!!
-            assertEquals(CONTENT_TYPE_URL_ENCODED, headers[CONTENT_TYPE])
+            assertEquals(CONTENT_TYPE_FORM_URLENCODED, headers[CONTENT_TYPE])
             assertEquals(EXPECTED_USER_AGENT, headers[USER_AGENT])
             assertEquals(EXPECTED_ACCESS_TOKEN, headers[X_ACCESS_TOKEN])
         })


### PR DESCRIPTION
If we don't mind the breaking change, I'd actually prefer `Headers.Names` and `Headers.Values` rather than `Headers.Common.Value`: too much nesting!

Also, are these notable enough to add to the changelog?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
