### PR TITLE
Closes #1210: Fixes intermittent failing test in SearchEngineManager.

### DIFF
--- a/components/browser/search/build.gradle
+++ b/components/browser/search/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 
+    testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -18,16 +18,18 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.provider.AssetsSearchEngineProvider
 import mozilla.components.browser.search.provider.SearchEngineProvider
 import mozilla.components.browser.search.provider.localization.LocaleSearchLocalizationProvider
+import kotlin.coroutines.CoroutineContext
 
 /**
  * This class provides access to a centralized registry of search engines.
  */
 class SearchEngineManager(
     private val providers: List<SearchEngineProvider> = listOf(
-            AssetsSearchEngineProvider(LocaleSearchLocalizationProvider()))
+            AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())),
+    coroutineContext: CoroutineContext = Dispatchers.Default
 ) {
     private var deferredSearchEngines: Deferred<List<SearchEngine>>? = null
-    private val scope = CoroutineScope(Dispatchers.Default)
+    private val scope = CoroutineScope(coroutineContext)
     var defaultSearchEngine: SearchEngine? = null
 
     /**
@@ -97,7 +99,7 @@ class SearchEngineManager(
         return searchEngines
     }
 
-    private val localeChangedReceiver by lazy {
+    internal val localeChangedReceiver by lazy {
         object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent?) {
                 scope.launch {


### PR DESCRIPTION
From my investigation, there's a lot going on in this test that can be split up into smaller bits in order to make it easier to unit test without the need for external Android APIs.

1. Registering the broadcast with the intent filter.
2. Broadcast receiver's `onReceive` calling the `load` method.
3. `load` calling the providers `loadSearchEngines`.

Even though the broadcast receiver is in a `runBlocking` block, we see the test fail because the suspend function is hidden instead the receiver so isn't being blocked, thus making it run async regardless. 

My fix is to expose the coroutine context that we use in the SearchEngineManager, so that we can provide it with the `TestCoroutineContext`. The benefit of this, is that it allows us to force the coroutine jobs to be run first with `coroutineContext.triggerActions()` in the `runBlocking` block before verification.

I've written two tests to cover the three parts as individual tests but I've also patched the original one to work. We can keep all three, the new tests, or remove them and rely on the original one.

The `@ObsoleteCoroutinesApi` is required until the `TestCoroutineContext` is moved to a new place in a minor refactor of the coroutine library (see https://github.com/Kotlin/kotlinx.coroutines/issues/541).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
