### PR TITLE
Issue #1845: Expose list of media in Session.

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
 import mozilla.components.browser.errorpages.ErrorType
@@ -582,6 +583,7 @@ class GeckoEngineSession(
         geckoSession.permissionDelegate = createPermissionDelegate()
         geckoSession.promptDelegate = GeckoPromptDelegate(this)
         geckoSession.historyDelegate = createHistoryDelegate()
+        geckoSession.mediaDelegate = GeckoMediaDelegate(this)
     }
 
     companion object {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.concept.engine.media.Media
+import org.mozilla.geckoview.MediaElement
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_ABORT
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_EMPTIED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_ENDED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_PAUSE
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_PLAY
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_PLAYING
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_SEEKED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_SEEKING
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_STALLED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_SUSPEND
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_WAITING
+
+/**
+ * [Media] (`concept-engine`) implementation for GeckoView.
+ */
+internal class GeckoMedia(
+    internal val mediaElement: MediaElement
+) : Media() {
+    override val controller: Controller = GeckoMediaController(mediaElement)
+
+    init {
+        mediaElement.delegate = MediaDelegate(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is GeckoMedia) {
+            return false
+        }
+
+        return mediaElement == other.mediaElement
+    }
+
+    override fun hashCode(): Int {
+        return mediaElement.hashCode()
+    }
+}
+
+private class MediaDelegate(
+    private val media: Media
+) : MediaElement.Delegate {
+    @Suppress("ComplexMethod")
+    override fun onPlaybackStateChange(mediaElement: MediaElement, mediaState: Int) {
+        when (mediaState) {
+            MEDIA_STATE_PLAY -> media.playbackState = Media.PlaybackState.PLAY
+            MEDIA_STATE_PLAYING -> media.playbackState = Media.PlaybackState.PLAYING
+            MEDIA_STATE_PAUSE -> media.playbackState = Media.PlaybackState.PAUSE
+            MEDIA_STATE_ENDED -> media.playbackState = Media.PlaybackState.ENDED
+            MEDIA_STATE_SEEKING -> media.playbackState = Media.PlaybackState.SEEKING
+            MEDIA_STATE_SEEKED -> media.playbackState = Media.PlaybackState.SEEKED
+            MEDIA_STATE_STALLED -> media.playbackState = Media.PlaybackState.STALLED
+            MEDIA_STATE_SUSPEND -> media.playbackState = Media.PlaybackState.SUSPENDED
+            MEDIA_STATE_WAITING -> media.playbackState = Media.PlaybackState.WAITING
+            MEDIA_STATE_ABORT -> media.playbackState = Media.PlaybackState.ABORT
+            MEDIA_STATE_EMPTIED -> media.playbackState = Media.PlaybackState.EMPTIED
+        }
+    }
+
+    override fun onReadyStateChange(mediaElement: MediaElement, readyState: Int) = Unit
+    override fun onMetadataChange(mediaElement: MediaElement, metaData: MediaElement.Metadata) = Unit
+    override fun onLoadProgress(mediaElement: MediaElement, progressInfo: MediaElement.LoadProgressInfo) = Unit
+    override fun onVolumeChange(mediaElement: MediaElement, volume: Double, muted: Boolean) = Unit
+    override fun onTimeChange(mediaElement: MediaElement, time: Double) = Unit
+    override fun onPlaybackRateChange(mediaElement: MediaElement, rate: Double) = Unit
+    override fun onFullscreenChange(mediaElement: MediaElement, fullscreen: Boolean) = Unit
+    override fun onError(mediaElement: MediaElement, errorCode: Int) = Unit
+}

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaController.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaController.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.concept.engine.media.Media
+import org.mozilla.geckoview.MediaElement
+
+/**
+ * [Media.Controller] (`concept-engine`) implementation for GeckoView.
+ */
+internal class GeckoMediaController(
+    private val mediaElement: MediaElement
+) : Media.Controller {
+    override fun pause() {
+        mediaElement.pause()
+    }
+
+    override fun play() {
+        mediaElement.play()
+    }
+
+    override fun seek(time: Double) {
+        mediaElement.seek(time)
+    }
+
+    override fun setMuted(muted: Boolean) {
+        mediaElement.setMuted(muted)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.media.Media
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.MediaElement
+
+/**
+ * [GeckoSession.MediaDelegate] implementation for wrapping [MediaElement] instances in [GeckoMedia] ([Media]) and
+ * forwarding them to the [EngineSession.Observer].
+ */
+internal class GeckoMediaDelegate(
+    private val engineSession: GeckoEngineSession
+) : GeckoSession.MediaDelegate {
+    private val mediaMap: MutableMap<MediaElement, Media> = mutableMapOf()
+
+    override fun onMediaAdd(session: GeckoSession, element: MediaElement) {
+        engineSession.notifyObservers {
+            val media = GeckoMedia(element)
+
+            mediaMap[element] = media
+
+            onMediaAdded(media)
+        }
+    }
+
+    override fun onMediaRemove(session: GeckoSession, element: MediaElement) {
+        mediaMap[element]?.let { media ->
+            engineSession.notifyObservers { onMediaRemoved(media) }
+        }
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaControllerTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaControllerTest.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.support.test.mock
+import org.junit.Test
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mozilla.geckoview.MediaElement
+
+class GeckoMediaControllerTest {
+    @Test
+    fun `Pause is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.pause()
+
+        verify(mediaElement).pause()
+    }
+
+    @Test
+    fun `Play is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.play()
+
+        verify(mediaElement).play()
+    }
+
+    @Test
+    fun `Seek is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.seek(1337.42)
+
+        verify(mediaElement).seek(1337.42)
+    }
+
+    @Test
+    fun `SetMuted is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.setMuted(true)
+
+        verify(mediaElement).setMuted(true)
+        verifyNoMoreInteractions(mediaElement)
+
+        controller.setMuted(false)
+        verify(mediaElement).setMuted(false)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
@@ -1,0 +1,84 @@
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.MediaElement
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoMediaDelegateTest {
+    @Test
+    fun `Added MediaElement is wrapped in GeckoMedia and forwarded to observer`() {
+        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+
+        var observedMedia: Media? = null
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onMediaAdded(media: Media) {
+                observedMedia = media
+            }
+        })
+
+        val mediaElement: MediaElement = mock()
+        engineSession.geckoSession.mediaDelegate!!.onMediaAdd(mock(), mediaElement)
+
+        assertNotNull(observedMedia!!)
+
+        observedMedia!!.controller.play()
+        verify(mediaElement).play()
+    }
+
+    @Test
+    fun `WHEN MediaElement is removed THEN previously added GeckoMedia is used to notify observer`() {
+        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+
+        var addedMedia: Media? = null
+        var removedMedia: Media? = null
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onMediaAdded(media: Media) {
+                addedMedia = media
+            }
+
+            override fun onMediaRemoved(media: Media) {
+                removedMedia = media
+            }
+        })
+
+        val mediaElement: MediaElement = mock()
+        engineSession.geckoSession.mediaDelegate!!.onMediaAdd(mock(), mediaElement)
+        engineSession.geckoSession.mediaDelegate!!.onMediaRemove(mock(), mediaElement)
+
+        assertNotNull(addedMedia!!)
+        assertNotNull(removedMedia!!)
+        assertEquals(addedMedia, removedMedia)
+    }
+
+    @Test
+    fun `WHEN unknown media is removed THEN observer is not notified`() {
+        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+
+        var onMediaRemovedExecuted = false
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onMediaRemoved(media: Media) {
+                onMediaRemovedExecuted = true
+            }
+        })
+
+        val mediaElement: MediaElement = mock()
+        engineSession.geckoSession.mediaDelegate!!.onMediaRemove(mock(), mediaElement)
+
+        assertFalse(onMediaRemovedExecuted)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.MediaElement
+
+class GeckoMediaTest {
+    @Test
+    fun `Playback state is updated from MediaDelegate`() {
+        val mediaElement: MediaElement = mock()
+
+        val media = GeckoMedia(mediaElement)
+
+        val captor = argumentCaptor<MediaElement.Delegate>()
+        verify(mediaElement).delegate = captor.capture()
+
+        val delegate = captor.value
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PLAYING)
+        assertEquals(Media.PlaybackState.PLAYING, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_SEEKING)
+        assertEquals(Media.PlaybackState.SEEKING, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_WAITING)
+        assertEquals(Media.PlaybackState.WAITING, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PAUSE)
+        assertEquals(Media.PlaybackState.PAUSE, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PLAY)
+        assertEquals(Media.PlaybackState.PLAY, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_SEEKED)
+        assertEquals(Media.PlaybackState.SEEKED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_STALLED)
+        assertEquals(Media.PlaybackState.STALLED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_SUSPEND)
+        assertEquals(Media.PlaybackState.SUSPENDED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_ABORT)
+        assertEquals(Media.PlaybackState.ABORT, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_EMPTIED)
+        assertEquals(Media.PlaybackState.EMPTIED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_ENDED)
+        assertEquals(Media.PlaybackState.ENDED, media.playbackState)
+    }
+
+    @Test
+    fun `GeckoMedia exposes GeckoMediaController`() {
+        val mediaElement: MediaElement = mock()
+
+        val media = GeckoMedia(mediaElement)
+
+        assertTrue(media.controller is GeckoMediaController)
+    }
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
@@ -121,5 +122,18 @@ internal class EngineObserver(val session: Session) : EngineSession.Observer {
 
     override fun onCloseWindowRequest(windowRequest: WindowRequest) {
         session.closeWindowRequest = Consumable.from(windowRequest)
+    }
+
+    override fun onMediaAdded(media: Media) {
+        session.media = session.media.toMutableList().also {
+            it.add(media)
+        }
+    }
+
+    override fun onMediaRemoved(media: Media) {
+        session.media = session.media.toMutableList().also {
+            it.remove(media)
+        }
+        media.unregisterObservers()
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.manifest.WebAppManifest
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
@@ -36,6 +37,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
+import java.lang.IllegalArgumentException
 
 class SessionTest {
     @Test
@@ -605,6 +607,8 @@ class SessionTest {
         defaultObserver.onOpenWindowRequested(session, windowRequest)
         defaultObserver.onCloseWindowRequested(session, windowRequest)
         defaultObserver.onWebAppManifestChanged(session, mock())
+        defaultObserver.onMediaAdded(session, emptyList(), mock())
+        defaultObserver.onMediaRemoved(session, emptyList(), mock())
     }
 
     @Test
@@ -785,5 +789,98 @@ class SessionTest {
     fun `toString returns string containing id and url`() {
         val session = Session(id = "my-session-id", initialUrl = "https://www.mozilla.org")
         assertEquals("Session(my-session-id, https://www.mozilla.org)", session.toString())
+    }
+
+    @Test
+    fun `observer is notified when media is added`() {
+        var observedList: List<Media>? = null
+        var observedMedia: Media? = null
+
+        val observer = object : Session.Observer {
+            override fun onMediaAdded(session: Session, media: List<Media>, added: Media) {
+                observedList = media
+                observedMedia = added
+            }
+        }
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        val addedMedia1: Media = mock()
+        session.media = listOf(addedMedia1)
+
+        assertEquals(addedMedia1, observedMedia)
+        assertEquals(listOf(addedMedia1), observedList)
+
+        val addedMedia2: Media = mock()
+        session.media = listOf(addedMedia1, addedMedia2)
+
+        assertEquals(addedMedia2, observedMedia)
+        assertEquals(listOf(addedMedia1, addedMedia2), observedList)
+
+        val addedMedia3: Media = mock()
+        session.media = listOf(addedMedia1, addedMedia3, addedMedia2)
+
+        assertEquals(addedMedia3, observedMedia)
+        assertEquals(listOf(addedMedia1, addedMedia3, addedMedia2), observedList)
+    }
+
+    @Test
+    fun `observer is notified when media is removed`() {
+        var observedList: List<Media>? = null
+        var observedMedia: Media? = null
+
+        val observer = object : Session.Observer {
+            override fun onMediaRemoved(session: Session, media: List<Media>, removed: Media) {
+                observedList = media
+                observedMedia = removed
+            }
+        }
+
+        val media1: Media = mock()
+        val media2: Media = mock()
+        val media3: Media = mock()
+
+        val session = Session("https://www.mozilla.org")
+        session.media = listOf(media1)
+        session.media = listOf(media1, media2)
+        session.media = listOf(media1, media2, media3)
+        session.register(observer)
+
+        session.media = listOf(media1, media2)
+
+        assertEquals(media3, observedMedia)
+        assertEquals(listOf(media1, media2), observedList)
+
+        session.media = listOf(media2)
+
+        assertEquals(media1, observedMedia)
+        assertEquals(listOf(media2), observedList)
+
+        session.media = listOf()
+
+        assertEquals(media2, observedMedia)
+        assertEquals(emptyList<Media>(), observedList)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `Session throws if more than one Media object is added at a time`() {
+        val session = Session("https://www.mozilla.org")
+        session.media = listOf(mock(), mock())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `Session throws if more than one Media object is removed at a time`() {
+        val session = Session("https://www.mozilla.org")
+
+        val media1: Media = mock()
+        val media2: Media = mock()
+        val media3: Media = mock()
+
+        session.media = listOf(media1)
+        session.media = listOf(media1, media2)
+        session.media = listOf(media1, media2, media3)
+
+        session.media = listOf(media1)
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -10,6 +10,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 
 import mozilla.components.concept.engine.prompt.PromptRequest
@@ -319,5 +320,52 @@ class EngineObserverTest {
         assertTrue(session.closeWindowRequest.isConsumed())
         observer.onCloseWindowRequest(windowRequest)
         assertFalse(session.closeWindowRequest.isConsumed())
+    }
+
+    @Test
+    fun `onMediaAdded will add media to session`() {
+        val session = Session("https://www.mozilla.org")
+        val observer = EngineObserver(session)
+
+        val media1: Media = mock()
+        observer.onMediaAdded(media1)
+
+        assertEquals(listOf(media1), session.media)
+
+        val media2: Media = mock()
+        observer.onMediaAdded(media2)
+
+        assertEquals(listOf(media1, media2), session.media)
+
+        val media3: Media = mock()
+        observer.onMediaAdded(media3)
+
+        assertEquals(listOf(media1, media2, media3), session.media)
+    }
+
+    @Test
+    fun `onMediaRemoved will remove media from session`() {
+        val session = Session("https://www.mozilla.org")
+        val observer = EngineObserver(session)
+
+        val media1: Media = mock()
+        val media2: Media = mock()
+        val media3: Media = mock()
+
+        session.media = listOf(media1)
+        session.media = listOf(media1, media2)
+        session.media = listOf(media1, media2, media3)
+
+        observer.onMediaRemoved(media2)
+
+        assertEquals(listOf(media1, media3), session.media)
+
+        observer.onMediaRemoved(media1)
+
+        assertEquals(listOf(media3), session.media)
+
+        observer.onMediaRemoved(media3)
+
+        assertEquals(emptyList<Media>(), session.media)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import android.graphics.Bitmap
 import android.support.annotation.CallSuper
+import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 
 import mozilla.components.concept.engine.prompt.PromptRequest
@@ -46,6 +47,8 @@ abstract class EngineSession(
         fun onPromptRequest(promptRequest: PromptRequest) = Unit
         fun onOpenWindowRequest(windowRequest: WindowRequest) = Unit
         fun onCloseWindowRequest(windowRequest: WindowRequest) = Unit
+        fun onMediaAdded(media: Media) = Unit
+        fun onMediaRemoved(media: Media) = Unit
 
         @Suppress("LongParameterList")
         fun onExternalResource(

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/media/Media.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/media/Media.kt
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.media
+
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+import kotlin.properties.Delegates
+
+/**
+ * Value type that represents a media element that is present on the currently displayed page in a session.
+ */
+abstract class Media(
+    delegate: Observable<Media.Observer> = ObserverRegistry()
+) : Observable<Media.Observer> by delegate {
+    /**
+     * The current [PlaybackState] of this media element.
+     */
+    var playbackState: PlaybackState by Delegates.observable(PlaybackState.UNKNOWN) {
+        _, old, new -> notifyObservers(old, new) { onPlaybackStateChanged(this@Media, new) }
+    }
+
+    /**
+     * The [Controller] for controlling playback of this media element.
+     */
+    abstract val controller: Controller
+
+    /**
+     * Interface to be implemented by classes that want to observe a media element.
+     */
+    interface Observer {
+        fun onPlaybackStateChanged(media: Media, playbackState: PlaybackState) = Unit
+    }
+
+    /**
+     * Controller for controlling playback of a media element.
+     */
+    interface Controller {
+        /**
+         * Pauses the media.
+         */
+        fun pause()
+
+        /**
+         * Plays the media.
+         */
+        fun play()
+
+        /**
+         * Seek the media to a given time.
+         */
+        fun seek(time: Double)
+
+        /**
+         * Mutes/Unmutes the media.
+         */
+        fun setMuted(muted: Boolean)
+    }
+
+    // Implementation note: This is a 1:1 mapping of the playback states that GeckoView notifies us about. Maybe we
+    // want to map this to a simpler model that doesn't contain all the in-between states?
+    // For example we could try to map this to a PlaybackState of Android's media session right here.
+    // https://developer.android.com/reference/android/media/session/PlaybackState
+    enum class PlaybackState {
+        /**
+         * Unknown. No state has been received from the engine yet.
+         */
+        UNKNOWN,
+
+        /**
+         * The media is no longer paused, as a result of the play method, or the autoplay attribute.
+         */
+        PLAY,
+
+        /**
+         * Sent when the media has enough data to start playing, after the play event, but also when recovering from
+         * being stalled, when looping media restarts, and after seeked, if it was playing before seeking.
+         */
+        PLAYING,
+
+        /**
+         * Sent when the playback state is changed to paused.
+         */
+        PAUSE,
+
+        /**
+         * Sent when playback completes.
+         */
+        ENDED,
+
+        /**
+         * Sent when a seek operation begins.
+         */
+        SEEKING,
+
+        /**
+         * Sent when a seek operation completes.
+         */
+        SEEKED,
+
+        /**
+         * Sent when the user agent is trying to fetch media data, but data is unexpectedly not forthcoming.
+         */
+        STALLED,
+
+        /**
+         * Sent when loading of the media is suspended. This may happen either because the download has completed or
+         * because it has been paused for any other reason.
+         */
+        SUSPENDED,
+
+        /**
+         * Sent when the requested operation (such as playback) is delayed pending the completion of another operation
+         * (such as a seek).
+         */
+        WAITING,
+
+        /**
+         * Sent when playback is aborted; for example, if the media is playing and is restarted from the beginning,
+         * this event is sent.
+         */
+        ABORT,
+
+        /**
+         * The media has become empty. For example, this event is sent if the media has already been loaded, and the
+         * load() method is called to reload it.
+         */
+        EMPTIED,
+    }
+
+    /**
+     * Helper method to notify observers.
+     */
+    private fun notifyObservers(old: Any, new: Any, block: Observer.() -> Unit) {
+        if (old != new) {
+            notifyObservers(block)
+        }
+    }
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import android.graphics.Bitmap
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.test.mock
@@ -34,6 +35,9 @@ class EngineSessionTest {
         val windowRequest = mock(WindowRequest::class.java)
         session.register(observer)
 
+        val mediaAdded: Media = mock()
+        val mediaRemoved: Media = mock()
+
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
         session.notifyInternalObservers { onProgress(25) }
@@ -53,6 +57,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
         session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onMediaAdded(mediaAdded) }
+        session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
@@ -73,6 +79,8 @@ class EngineSessionTest {
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
         verify(observer).onOpenWindowRequest(windowRequest)
         verify(observer).onCloseWindowRequest(windowRequest)
+        verify(observer).onMediaAdded(mediaAdded)
+        verify(observer).onMediaRemoved(mediaRemoved)
         verifyNoMoreInteractions(observer)
     }
 
@@ -107,6 +115,9 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
         session.unregister(observer)
 
+        val mediaAdded: Media = mock()
+        val mediaRemoved: Media = mock()
+
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
         session.notifyInternalObservers { onProgress(100) }
         session.notifyInternalObservers { onLoadingStateChange(false) }
@@ -124,6 +135,8 @@ class EngineSessionTest {
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onOpenWindowRequest(otherWindowRequest) }
         session.notifyInternalObservers { onCloseWindowRequest(otherWindowRequest) }
+        session.notifyInternalObservers { onMediaAdded(mediaAdded) }
+        session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -159,6 +172,8 @@ class EngineSessionTest {
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onOpenWindowRequest(otherWindowRequest)
         verify(observer, never()).onCloseWindowRequest(otherWindowRequest)
+        verify(observer, never()).onMediaAdded(mediaAdded)
+        verify(observer, never()).onMediaRemoved(mediaRemoved)
         verifyNoMoreInteractions(observer)
     }
 
@@ -571,6 +586,8 @@ class EngineSessionTest {
         defaultObserver.onCancelContentPermissionRequest(mock(PermissionRequest::class.java))
         defaultObserver.onOpenWindowRequest(mock(WindowRequest::class.java))
         defaultObserver.onCloseWindowRequest(mock(WindowRequest::class.java))
+        defaultObserver.onMediaAdded(mock())
+        defaultObserver.onMediaRemoved(mock())
     }
 
     @Test

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/media/MediaTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/media/MediaTest.kt
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.media
+
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class MediaTest {
+    @Test
+    fun `Observer is notified when playback state is changed`() {
+        val media = FakeMedia()
+
+        var observedMedia: Media? = null
+        var observedState: Media.PlaybackState? = null
+
+        val observer = object : Media.Observer {
+            override fun onPlaybackStateChanged(media: Media, playbackState: Media.PlaybackState) {
+                observedMedia = media
+                observedState = playbackState
+            }
+        }
+
+        media.register(observer)
+
+        media.playbackState = Media.PlaybackState.PLAYING
+
+        assertEquals(Media.PlaybackState.PLAYING, observedState)
+        assertEquals(media, observedMedia)
+
+        media.playbackState = Media.PlaybackState.SEEKING
+
+        assertEquals(Media.PlaybackState.SEEKING, observedState)
+        assertEquals(media, observedMedia)
+
+        media.playbackState = Media.PlaybackState.PAUSE
+
+        assertEquals(Media.PlaybackState.PAUSE, observedState)
+        assertEquals(media, observedMedia)
+    }
+
+    @Test
+    fun `Default playback state is unknown`() {
+        val media = FakeMedia()
+        assertEquals(Media.PlaybackState.UNKNOWN, media.playbackState)
+    }
+
+    @Test
+    fun `Media-Observer has default implementation`() {
+        val defaultObserver = object : Media.Observer {}
+
+        val media: Media = mock()
+
+        defaultObserver.onPlaybackStateChanged(media, Media.PlaybackState.SEEKED)
+    }
+
+    @Test
+    fun `Observer is not notified about same playback state twice in a row`() {
+        val observer: Media.Observer = mock()
+
+        val media = FakeMedia()
+        media.register(observer)
+
+        media.playbackState = Media.PlaybackState.SEEKING
+        media.playbackState = Media.PlaybackState.SEEKING
+
+        verify(observer, times(1)).onPlaybackStateChanged(any(), any())
+    }
+}
+
+private class FakeMedia : Media() {
+    override val controller: Controller = mock()
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,13 @@ permalink: /changelog/
     * `browser-engine-gecko-beta`: GeckoView 67.0
     * `browser-engine-gecko-nightly`: GeckoView 68.0
 
+* **browser-session**
+  * Session now exposes a list of `Media` instances representing playable media on the currently displayed page (see `concept-engine`).
+
+* **concept-engine**, **browser-engine-gecko-nightly**
+  * Added `Media` class representing a playable media element on the the currently displayed page. Consumers can subscribe to `Media` instances in order to receive updates whenever the state of a `Media` object changes. Currently only the "playback state" is exposed. Consumers can control playback through the
+  attached `Media.Controller` instance.
+
 * **concept-fetch**
   * ⚠️ **This is a breaking API change!**: `Headers.Common` was renamed to `Headers.Names`.
   * Added `Headers.Values`.


### PR DESCRIPTION
Closes #1845. This is the beginning of the media API. There's more to do but this lays the foundation by exposing `Media` objects on the `Session` and allowing to subscribe to `Media` changes.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
