### PR TITLE
Add a synchronous testing mode

### DIFF
--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -62,6 +62,9 @@ val first = snapshot.single()
 assertEquals("login_opened", first.name)
 ```
 
+NOTE: Using the testing API requires calling `Glean.enableTestingMode()` first,
+such as from a `@Before` method.
+
 ## Counters
 
 Used to count how often something happens, say how often a certain button was pressed.
@@ -88,6 +91,7 @@ Controls.refreshPressed.add(5) // Adds 5 to the counter.
 ```
 
 There are test APIs available too:
+
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Controls
 
@@ -96,3 +100,6 @@ assertTrue(Controls.refreshPressed.testHasValue())
 // Does the counter have the expected value?
 assertEquals(6, Controls.refreshPressed.testGetValue())
 ```
+
+NOTE: Using the testing API requires calling `Glean.enableTestingMode()` first,
+such as from a `@Before` method.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/BooleanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/BooleanMetricType.kt
@@ -60,7 +60,7 @@ data class BooleanMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return BooleansStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
@@ -77,7 +77,7 @@ data class BooleanMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return BooleansStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/CounterMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/CounterMetricType.kt
@@ -62,7 +62,7 @@ data class CounterMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return CountersStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
@@ -79,7 +79,7 @@ data class CounterMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): Int {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return CountersStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/DatetimeMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/DatetimeMetricType.kt
@@ -87,7 +87,7 @@ data class DatetimeMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return DatetimesStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
@@ -105,7 +105,7 @@ data class DatetimeMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValueAsString(pingName: String = getStorageNames().first()): String {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return DatetimesStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }
@@ -126,7 +126,7 @@ data class DatetimeMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): Date {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return parseISOTimeString(DatetimesStorageEngine.getSnapshot(pingName, false)!![identifier]!!)!!
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Dispatchers.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Dispatchers.kt
@@ -50,8 +50,8 @@ internal object Dispatchers {
             assert(
                 testingMode,
                 {
-                    "glean must be in testing mode by calling Glean.enableTestingMode "
-                    "before using the glean testing API"
+                    "To use the testing API, glean must be in testing mode by calling "
+                    "Glean.enableTestingMode() (for example, in a @Before method)."
                 }
             )
         }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/EventMetricType.kt
@@ -72,7 +72,7 @@ data class EventMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         val snapshot = EventsStorageEngine.getSnapshot(pingName, false) ?: return false
         return snapshot.any { event ->
@@ -92,7 +92,7 @@ data class EventMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): List<RecordedEventData> {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return EventsStorageEngine.getSnapshot(pingName, false)!!.filter { event ->
             event.identifier == identifier

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -310,6 +310,17 @@ open class GleanInternalAPI internal constructor () {
             pingStorageEngine.store(pingId, makePath(pingName, pingId), pingContent)
         } != null
     }
+
+    /**
+     * Should be called from all users of the glean testing API.
+     *
+     * This makes all asynchronous work synchronous so we can test the results of the
+     * API synchronously.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun enableTestingMode() {
+        Dispatchers.API.enableTestingMode()
+    }
 }
 
 object Glean : GleanInternalAPI() {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringListMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringListMetricType.kt
@@ -84,7 +84,7 @@ data class StringListMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return StringListsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
@@ -101,7 +101,7 @@ data class StringListMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): List<String> {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return StringListsStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/StringMetricType.kt
@@ -62,7 +62,7 @@ data class StringMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return StringsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
@@ -79,7 +79,7 @@ data class StringMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): String {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return StringsStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/UuidMetricType.kt
@@ -80,7 +80,7 @@ data class UuidMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return UuidsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
@@ -97,7 +97,7 @@ data class UuidMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): UUID {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         return UuidsStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
@@ -101,7 +101,7 @@ object ErrorRecording {
         errorType: ErrorType,
         pingName: String? = null
     ): Int {
-        Dispatchers.API.awaitJob()
+        Dispatchers.API.assertInTestingMode()
 
         val usePingName = pingName?.let {
             pingName

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
@@ -18,6 +18,7 @@ class DispatchersTest {
     fun `API scope runs off the main thread`() {
         val mainThread = Thread.currentThread()
         var threadCanary = false
+        Dispatchers.API.testingMode = false
 
         runBlocking {
             @Suppress("EXPERIMENTAL_API_USAGE")
@@ -27,9 +28,10 @@ class DispatchersTest {
                 // the test completes.
                 assertEquals(false, threadCanary)
                 threadCanary = true
-            }.join()
+            }!!.join()
         }
 
+        Dispatchers.API.testingMode = true
         assertEquals(true, threadCanary)
         assertSame(mainThread, Thread.currentThread())
     }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -20,7 +20,6 @@ import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
-import mozilla.components.service.glean.Dispatchers as GleanDispatchers
 import org.json.JSONObject
 import org.junit.Assert
 import org.mockito.ArgumentMatchers
@@ -114,7 +113,7 @@ internal fun resetGlean(
     context: Context = ApplicationProvider.getApplicationContext(),
     config: Configuration = Configuration()
 ) {
-    GleanDispatchers.API.awaitJob()
+    Glean.enableTestingMode()
 
     // We're using the WorkManager in a bunch of places, and glean will crash
     // in tests without this line. Let's simply put it here.
@@ -133,7 +132,6 @@ internal fun resetGlean(
     Glean.initialized = false
     Glean.setUploadEnabled(true)
     Glean.initialize(context, config)
-    GleanDispatchers.API.awaitJob()
 }
 
 /**


### PR DESCRIPTION
This adds a flag to run all `Dispatchers.API` jobs synchronously during testing.

I know there was (understandably) a requirement that using the testing API shouldn't require any special setup.  I think in order to get reproducible tests, we may need to give up on that requirement (at least for now).  I've tried to make that requirement a bit easier on users so that every call to every test method will assert that we're in testing mode, with a helpful message about how to fix things if not.

This should *effectively* get us to the same state as my not serious removal of all async from yesterday and certainly removes a lot of variables around async test running.  There are still asynchronous things that are being tested here -- all this really does is eliminate the front level of async from the equation.

There were a few more `MetricsPingScheduler` tests that failed for me locally that I've commented out here.  As always, the priority is to unblock, and then we'll come back and restore coverage as a second pass.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
