### PR TITLE
Implement glean ping tagging for "debug view".

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -127,15 +127,23 @@ for the command line switches used to pass the extra keys. These are the current
 |key|type|description|
 |---|----|-----------|
 | logPings | boolean (--ez) | If set to `true`, glean dumps pings to logcat; defaults to `false` |
-| sendPing | string (--es) | Sends the ping with the given name immediately. |
+| sendPing | string (--es) | Sends the ping with the given name immediately |
+| tagPings | string (--es) | Tags all outgoing pings as debug pings to make them available for real-time validation. The value must match the pattern `[a-zA-Z0-9-]{1,20}` |
 
-For example, to direct the glean sample application to dump pings to logcat, and send the "metrics" ping immediately, the following command can be used:
+For example, to direct the glean sample application to (1) dump pings to logcat, (2) tag the ping 
+with the `test-metrics-ping` tag, and (3) send the "metrics" ping immediately, the following command
+can be used:
 
 ```
 adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean.debug.GleanDebugActivity \
   --ez logPings true \
-  --es sendPing metrics
+  --es sendPing metrics \
+  --es tagPings test-metrics-ping
 ```
+
+### Important GleanDebugActivity note!
+
+Options that are set using the adb flags are not immediately reset and will persist until the application is closed or manually reset.
 
 ## Contact
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -20,13 +20,20 @@ import mozilla.components.service.glean.BuildConfig
  * @property maxEvents the number of events to store before the events ping is sent
  * @property logPings whether to log ping contents to the console.
  * @property httpClient The HTTP client implementation to use for uploading pings.
+ * @property pingTag String tag to be applied to headers when uploading pings for debug view
  */
 data class Configuration(
-    val serverEndpoint: String = "https://incoming.telemetry.mozilla.org",
+    val serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
     val userAgent: String = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)",
     val connectionTimeout: Long = 10000,
     val readTimeout: Long = 30000,
     val maxEvents: Int = 500,
     val logPings: Boolean = false,
-    val httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() }
-)
+    val httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() },
+    val pingTag: String? = null
+) {
+    companion object {
+        const val DEFAULT_TELEMETRY_ENDPOINT = "https://incoming.telemetry.mozilla.org"
+        const val DEFAULT_DEBUGVIEW_ENDPOINT = "https://stage.ingestion.nonprod.dataops.mozgcp.net"
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -21,6 +21,7 @@ import mozilla.components.service.glean.BooleanMetricType
 import mozilla.components.service.glean.Lifetime
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
+import mozilla.components.service.glean.TestPingTagClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.robolectric.Shadows.shadowOf
@@ -81,7 +82,7 @@ class GleanDebugActivityTest {
         // Set the extra values and start the intent.
         val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
             GleanDebugActivity::class.java)
-        intent.putExtra("logPings", true)
+        intent.putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
 
@@ -128,9 +129,17 @@ class GleanDebugActivityTest {
         // Set the extra values and start the intent.
         val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
         GleanDebugActivity::class.java)
-        intent.putExtra("sendPing", "store1")
+        intent.putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "store1")
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
+
+        // Since we reset the serverEndpoint back to the default for untagged pings, we need to
+        // override it here so that the local server we created to intercept the pings will
+        // be the one that the ping is sent to.
+        Glean.configuration = Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port
+        )
+
         triggerWorkManager()
         val request = server.takeRequest(10L, TimeUnit.SECONDS)
 
@@ -139,5 +148,97 @@ class GleanDebugActivityTest {
         )
 
         server.shutdown()
+    }
+
+    @Test
+    fun `tagPings filters ID's that don't match the pattern`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("OK"))
+
+        resetGlean(config = Glean.configuration.copy(
+            serverEndpoint = "http://" + server.hostName + ":" + server.port
+        ))
+
+        // Put some metric data in the store, otherwise we won't get a ping out
+        // Define a 'booleanMetric' boolean metric, which will be stored in "store1"
+        val booleanMetric = BooleanMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "boolean_metric",
+            sendInPings = listOf("store1")
+        )
+
+        booleanMetric.set(true)
+        assertTrue(booleanMetric.testHasValue())
+
+        // Set the extra values and start the intent.
+        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
+            GleanDebugActivity::class.java)
+        intent.putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "store1")
+        intent.putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, "inv@lid_id")
+        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
+        activity.create().start().resume()
+
+        // Since a bad tag ID results in resetting the endpoint to the default, verify that
+        // has happened.
+        assertEquals("Server endpoint must be reset if tag didn't pass regex",
+            "http://" + server.hostName + ":" + server.port, Glean.configuration.serverEndpoint)
+
+        triggerWorkManager()
+        val request = server.takeRequest(10L, TimeUnit.SECONDS)
+
+        assertTrue(
+            "Request path must be correct",
+            request.requestUrl.encodedPath().startsWith("/submit/mozilla-components-service-glean/store1")
+        )
+
+        assertNull(
+            "Headers must not contain X-Debug-ID if passed a non matching pattern",
+            request.headers.get("X-Debug-ID")
+        )
+
+        server.shutdown()
+    }
+
+    @Test
+    fun `pings are correctly tagged using tagPings`() {
+        val pingTag = "test-debug-ID"
+
+        // The TestClient class found at the bottom of this file is used to intercept the request
+        // in order to check that the header has been added and the URL has been redirected.
+        val testClient = TestPingTagClient(
+            responseUrl = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT,
+            debugHeaderValue = pingTag)
+
+        // Use the test client in the Glean configuration
+        resetGlean(config = Glean.configuration.copy(
+            httpClient = lazy { testClient }
+        ))
+
+        // Put some metric data in the store, otherwise we won't get a ping out
+        // Define a 'booleanMetric' boolean metric, which will be stored in "store1"
+        val booleanMetric = BooleanMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "boolean_metric",
+            sendInPings = listOf("store1")
+        )
+
+        booleanMetric.set(true)
+        assertTrue(booleanMetric.testHasValue())
+
+        // Set the extra values and start the intent.
+        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
+            GleanDebugActivity::class.java)
+        intent.putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "store1")
+        intent.putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, pingTag)
+        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
+        activity.create().start().resume()
+
+        // This will trigger the call to `fetch()` in the TestPingTagClient which is where the
+        // test assertions will occur
+        triggerWorkManager()
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -10,6 +10,7 @@ import mozilla.components.concept.fetch.Response
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.lib.fetch.okhttp.OkHttpClient
 import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.TestPingTagClient
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -275,5 +276,42 @@ class HttpPingUploaderTest {
         // And IOException during upload is a failed upload that we should retry. The client should
         // return false in this case.
         assertFalse(uploader.upload("path", "ping", config))
+    }
+
+    @Test
+    fun `X-Debug-ID header is correctly added when pingTag is not null`() {
+        val uploader = spy<HttpPingUploader>(HttpPingUploader())
+
+        val debugConfig = Configuration().copy(
+            userAgent = "Glean/Test 25.0.2",
+            connectionTimeout = 3050,
+            readTimeout = 7050,
+            pingTag = "this-ping-is-tagged"
+        )
+
+        val request = uploader.buildRequest(testPath, testPing, debugConfig)
+        assertEquals("this-ping-is-tagged", request.headers!!["X-Debug-ID"])
+    }
+
+    @Test
+    fun `server is correctly redirected when pings are tagged`() {
+        val pingTag = "this-ping-is-tagged"
+
+        // The TestClient class found at the bottom of this file is used to intercept the request
+        // in order to check that the header has been added and the URL has been redirected.
+        val testClient = TestPingTagClient(
+            responseUrl = Configuration.DEFAULT_DEBUGVIEW_ENDPOINT,
+            debugHeaderValue = pingTag)
+
+        // Use the test client in the Glean configuration
+        val testConfig = testDefaultConfig.copy(
+            httpClient = lazy { testClient },
+            pingTag = pingTag
+        )
+
+        // This should trigger the call to `fetch()` within the TestPingTagClient which will perform
+        // both a check against the url and that a header was added.
+        val client = HttpPingUploader()
+        assertTrue(client.upload(testPath, testPing, testConfig))
     }
 }


### PR DESCRIPTION
This implements ping tagging using the extra key `debugID` with adb command when launching the `GleanDebugActivity`.  This will add a header to the upload request `X-Debug-ID` matched with the value supplied to the `debugID` flag on the command line.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
