### PR TITLE
Closes #2471: Lazily initialize HTTP client in Glean 

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -28,5 +28,5 @@ data class Configuration(
     val readTimeout: Long = 30000,
     val maxEvents: Int = 500,
     val logPings: Boolean = false,
-    val httpClient: Client = HttpURLConnectionClient()
+    val httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() }
 )

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/HttpPingUploader.kt
@@ -68,7 +68,7 @@ internal class HttpPingUploader : PingUploader {
         val request = buildRequest(path, data, config)
 
         return try {
-            performUpload(config.httpClient, request)
+            performUpload(config.httpClient.value, request)
         } catch (e: IOException) {
             logger.warn("IOException while uploading ping", e)
             false

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -86,7 +86,7 @@ class HttpPingUploaderTest {
 
         val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-        val config = testDefaultConfig.copy(httpClient = mockClient)
+        val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
 
         assertTrue(uploader.upload(testPath, testPing, config))
     }
@@ -99,7 +99,7 @@ class HttpPingUploaderTest {
 
             val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-            val config = testDefaultConfig.copy(httpClient = mockClient)
+            val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
 
             assertFalse(uploader.upload(testPath, testPing, config))
         }
@@ -114,7 +114,7 @@ class HttpPingUploaderTest {
 
             val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-            val config = testDefaultConfig.copy(httpClient = mockClient)
+            val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
 
             assertTrue(uploader.upload(testPath, testPing, config))
         }
@@ -129,7 +129,7 @@ class HttpPingUploaderTest {
 
             val uploader = spy<HttpPingUploader>(HttpPingUploader())
 
-            val config = testDefaultConfig.copy(httpClient = mockClient)
+            val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
 
             assertTrue(uploader.upload(testPath, testPing, config))
         }
@@ -166,7 +166,7 @@ class HttpPingUploaderTest {
         val testConfig = testDefaultConfig.copy(
             userAgent = "Telemetry/42.23",
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
-            httpClient = HttpURLConnectionClient()
+            httpClient = lazy { HttpURLConnectionClient() }
         )
 
         val client = HttpPingUploader()
@@ -191,7 +191,7 @@ class HttpPingUploaderTest {
         val testConfig = testDefaultConfig.copy(
             userAgent = "Telemetry/42.23",
             serverEndpoint = "http://" + server.hostName + ":" + server.port,
-            httpClient = OkHttpClient()
+            httpClient = lazy { OkHttpClient() }
         )
 
         val client = HttpPingUploader()
@@ -268,7 +268,7 @@ class HttpPingUploaderTest {
         val mockClient: Client = mock()
         `when`(mockClient.fetch(any())).thenThrow(IOException())
 
-        val config = testDefaultConfig.copy(httpClient = mockClient)
+        val config = testDefaultConfig.copy(httpClient = lazy { mockClient })
 
         val uploader = spy<HttpPingUploader>(HttpPingUploader())
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,13 @@ permalink: /changelog/
   * Added `Matchers.maybeInvertMatcher` to optionally apply `not` based on the Boolean argument
   * Added `ViewInteraction.click()` extension function for short-hand.
 
+* **service-glean**
+  * ⚠️ **This is a breaking API change!**: `Configuration` now accepts a Lazy<Client> to make sure the HTTP client (lib) is initialized lazily.
+    ```kotlin
+      val config = Configuration(httpClient = lazy { GeckoViewFetchClient(context, GeckoRuntime()) })
+      Glean.initialize(context, config)
+    ```
+
 # 0.47.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.46.0...v0.47.0)


### PR DESCRIPTION
Minor change: See description in #2471.     