### PR TITLE
Closes #2479: Convert fromParamsForUrlEncoded to take vararg.

### DIFF
--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Request.kt
@@ -74,7 +74,7 @@ data class Request(
              *
              * @see [Headers.Values.CONTENT_TYPE_FORM_URLENCODED]
              */
-            fun fromParamsForFormUrlEncoded(unencodedParams: Map<String, String>): Body {
+            fun fromParamsForFormUrlEncoded(vararg unencodedParams: Pair<String, String>): Body {
                 // It's unintuitive to use the Uri class format and encode
                 // but its GET query syntax is exactly what we need.
                 val uriBuilder = Uri.Builder()

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt
@@ -90,19 +90,19 @@ class RequestTest {
     }
 
     @Test
-    fun `WHEN creating a request body from an empty params map THEN the empty string is returned`() {
-        assertEquals("", Request.Body.fromParamsForFormUrlEncoded(emptyMap()).readText())
+    fun `WHEN creating a request body from empty params THEN the empty string is returned`() {
+        assertEquals("", Request.Body.fromParamsForFormUrlEncoded().readText())
     }
 
     @Test
     fun `WHEN creating a request body from params with empty keys or values THEN they are represented as the empty string in the result`() {
         // In practice, we don't expect anyone to do this but this test is here as to documentation of what happens.
         val expected = "=value&hello=world&key="
-        val body = Request.Body.fromParamsForFormUrlEncoded(mapOf(
+        val body = Request.Body.fromParamsForFormUrlEncoded(
             "" to "value",
             "hello" to "world",
             "key" to ""
-        ))
+        )
         assertEquals(expected, body.readText())
     }
 
@@ -112,10 +112,10 @@ class RequestTest {
         val encodedURL = URLEncoder.encode(inputUrl, Charsets.UTF_8.name())
         val expected = "v=2&url=$encodedURL"
 
-        val body = Request.Body.fromParamsForFormUrlEncoded(mapOf(
+        val body = Request.Body.fromParamsForFormUrlEncoded(
             "v" to "2",
             "url" to inputUrl
-        ))
+        )
         assertEquals(expected, body.readText())
     }
 

--- a/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
+++ b/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketListenEndpointRaw.kt
@@ -40,12 +40,12 @@ internal class PocketListenEndpointRaw(
                 CONTENT_TYPE to CONTENT_TYPE_FORM_URLENCODED,
                 X_ACCESS_TOKEN to accessToken
             ),
-            body = Request.Body.fromParamsForFormUrlEncoded(mapOf(
+            body = Request.Body.fromParamsForFormUrlEncoded(
                 "url" to articleUrl,
                 "article_id" to articleID.toString(),
                 "v" to "2",
                 "locale" to "en-US"
-            ))
+            )
         )
 
         // If an invalid body is sent to the server, 404 is returned.


### PR DESCRIPTION
This is not a breaking change: this function originally landed in the
development of 0.48.0 and this new commit should be released in the same
version.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
