### PR TITLE
Closes #1373: HistoryStorage delete APIs

### DIFF
--- a/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
+++ b/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.lang.Thread.sleep
 
 @RunWith(RobolectricTestRunner::class)
 class InMemoryHistoryStorageTest {
@@ -235,5 +236,97 @@ class InMemoryHistoryStorageTest {
         assertEquals(3, res.totalItems)
 
         assertNull(history.getAutocompleteSuggestion("hello"))
+    }
+
+    @Test
+    fun `store can delete everything`() = runBlocking {
+        val history = InMemoryHistoryStorage()
+
+        history.recordVisit("http://www.mozilla.org", VisitType.TYPED)
+        history.recordVisit("http://www.mozilla.org", VisitType.DOWNLOAD)
+        history.recordVisit("http://www.mozilla.org", VisitType.BOOKMARK)
+        history.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
+        history.recordVisit("http://www.firefox.com", VisitType.EMBED)
+        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_PERMANENT)
+        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_TEMPORARY)
+        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+
+        history.recordObservation("http://www.firefox.com", PageObservation("Firefox"))
+
+        assertEquals(2, history.getVisited().size)
+
+        history.deleteEverything()
+
+        assertEquals(0, history.getVisited().size)
+    }
+
+    @Test
+    fun `store can delete by url`() = runBlocking {
+        val history = InMemoryHistoryStorage()
+
+        history.recordVisit("http://www.mozilla.org", VisitType.TYPED)
+        history.recordVisit("http://www.mozilla.org", VisitType.DOWNLOAD)
+        history.recordVisit("http://www.mozilla.org", VisitType.BOOKMARK)
+        history.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
+        history.recordVisit("http://www.firefox.com", VisitType.EMBED)
+        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_PERMANENT)
+        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_TEMPORARY)
+        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+
+        history.recordObservation("http://www.firefox.com", PageObservation("Firefox"))
+
+        assertEquals(2, history.getVisited().size)
+
+        history.deleteVisitsFor("http://www.mozilla.org")
+
+        assertEquals(1, history.getVisited().size)
+        assertEquals("http://www.firefox.com", history.getVisited()[0])
+
+        history.deleteVisitsFor("http://www.firefox.com")
+        assertEquals(0, history.getVisited().size)
+    }
+
+    @Test
+    fun `store can delete by 'since'`() = runBlocking {
+        val history = InMemoryHistoryStorage()
+
+        history.recordVisit("http://www.mozilla.org", VisitType.TYPED)
+        history.recordVisit("http://www.mozilla.org", VisitType.DOWNLOAD)
+        history.recordVisit("http://www.mozilla.org", VisitType.BOOKMARK)
+
+        history.deleteVisitsSince(0)
+        val visits = history.getVisited()
+        assertEquals(0, visits.size)
+    }
+
+    @Test
+    fun `store can delete by 'range'`() {
+        val history = InMemoryHistoryStorage()
+
+        runBlocking {
+            history.recordVisit("http://www.mozilla.org/1", VisitType.TYPED)
+            sleep(10)
+            history.recordVisit("http://www.mozilla.org/2", VisitType.DOWNLOAD)
+            sleep(10)
+            history.recordVisit("http://www.mozilla.org/3", VisitType.BOOKMARK)
+        }
+
+        val ts = runBlocking {
+            val visits = history.getDetailedVisits(0, Long.MAX_VALUE)
+
+            assertEquals(3, visits.size)
+            visits[1].visitTime
+        }
+
+        runBlocking {
+            history.deleteVisitsBetween(ts - 1, ts + 1)
+        }
+        val visits = runBlocking {
+            history.getDetailedVisits(0, Long.MAX_VALUE)
+        }
+        assertEquals(2, visits.size)
+
+        assertEquals("http://www.mozilla.org/1", visits[0].url)
+        assertEquals("http://www.mozilla.org/3", visits[1].url)
     }
 }

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -384,6 +384,54 @@ class PlacesHistoryStorageTest {
     }
 
     @Test
+    fun `storage passes through calls to deleteEverything`() = runBlocking {
+        val storage = storage!!
+        val writer = writer!!
+        storage.deleteEverything()
+        verify(writer).deleteEverything()
+        verify(writer, never()).deleteVisitsBetween(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong())
+        verify(writer, never()).deleteVisitsSince(ArgumentMatchers.anyLong())
+        verify(writer, never()).deletePlace(ArgumentMatchers.anyString())
+        Unit
+    }
+
+    @Test
+    fun `storage passes through calls to deleteVisitsBetween`() = runBlocking {
+        val storage = storage!!
+        val writer = writer!!
+        storage.deleteVisitsBetween(15, 20)
+        verify(writer, never()).deleteEverything()
+        verify(writer).deleteVisitsBetween(15, 20)
+        verify(writer, never()).deleteVisitsSince(ArgumentMatchers.anyLong())
+        verify(writer, never()).deletePlace(ArgumentMatchers.anyString())
+        Unit
+    }
+
+    @Test
+    fun `storage passes through calls to deleteVisitsSince`() = runBlocking {
+        val storage = storage!!
+        val writer = writer!!
+        storage.deleteVisitsSince(15)
+        verify(writer, never()).deleteEverything()
+        verify(writer, never()).deleteVisitsBetween(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong())
+        verify(writer).deleteVisitsSince(15)
+        verify(writer, never()).deletePlace(ArgumentMatchers.anyString())
+        Unit
+    }
+
+    @Test
+    fun `storage passes through calls to deleteVisitsFor`() = runBlocking {
+        val storage = storage!!
+        val writer = writer!!
+        storage.deleteVisitsFor("http://www.firefox.com")
+        verify(writer, never()).deleteEverything()
+        verify(writer, never()).deleteVisitsBetween(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong())
+        verify(writer, never()).deleteVisitsSince(ArgumentMatchers.anyLong())
+        verify(writer).deletePlace("http://www.firefox.com")
+        Unit
+    }
+
+    @Test
     fun `storage passes through calls to cleanup`() {
         val storage = storage!!
         val conn = conn!!
@@ -392,5 +440,27 @@ class PlacesHistoryStorageTest {
 
         storage.cleanup()
         verify(conn, times(1)).close()
+    }
+
+    @Test
+    fun `storage passes through calls to runMaintanence`() = runBlocking {
+        val storage = storage!!
+        val writer = writer!!
+
+        verify(writer, never()).runMaintenance()
+
+        storage.runMaintenance()
+        verify(writer, times(1)).runMaintenance()
+    }
+
+    @Test
+    fun `storage passes through calls to prune`() = runBlocking {
+        val storage = storage!!
+        val writer = writer!!
+
+        verify(writer, never()).pruneDestructively()
+
+        storage.prune()
+        verify(writer, times(1)).pruneDestructively()
     }
 }

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -7,6 +7,7 @@ package mozilla.components.concept.storage
 /**
  * An interface which defines read/write methods for history data.
  */
+@SuppressWarnings("TooManyFunctions")
 interface HistoryStorage {
     /**
      * Records a visit to a page.
@@ -57,6 +58,40 @@ interface HistoryStorage {
      * @return An optional domain URL which best matches the query.
      */
     fun getAutocompleteSuggestion(query: String): HistoryAutocompleteResult?
+
+    /**
+     * Remove all locally stored data.
+     */
+    suspend fun deleteEverything()
+
+    /**
+     * Remove history visits in an inclusive range from [since] to now.
+     * @param since A unix timestamp, milliseconds.
+     */
+    suspend fun deleteVisitsSince(since: Long)
+
+    /**
+     * Remove history visits in an inclusive range from [startTime] to [endTime].
+     * @param startTime A unix timestamp, milliseconds.
+     * @param endTime A unix timestamp, milliseconds.
+     */
+    suspend fun deleteVisitsBetween(startTime: Long, endTime: Long)
+
+    /**
+     * Remove all history visits for a given [url].
+     * @param url A page URL for which to remove visits.
+     */
+    suspend fun deleteVisitsFor(url: String)
+
+    /**
+     * Prune history storage, removing stale history.
+     */
+    suspend fun prune()
+
+    /**
+     * Perform internal storage maintenance.
+     */
+    suspend fun runMaintenance()
 
     /**
      * Cleanup any allocated resources.

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -81,6 +81,30 @@ class HistoryDelegateTest {
                 return null
             }
 
+            override suspend fun deleteEverything() {
+                fail()
+            }
+
+            override suspend fun deleteVisitsSince(since: Long) {
+                fail()
+            }
+
+            override suspend fun deleteVisitsBetween(startTime: Long, endTime: Long) {
+                fail()
+            }
+
+            override suspend fun deleteVisitsFor(url: String) {
+                fail()
+            }
+
+            override suspend fun prune() {
+                fail()
+            }
+
+            override suspend fun runMaintenance() {
+                fail()
+            }
+
             override fun cleanup() {
                 fail()
             }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,13 @@ permalink: /changelog/
 * **feature-accounts**, **service-firefox-account**
   * Added API to start an FxA pairing flow. See `FirefoxAccountsAuthFeature.beginPairingAuthentication` and `FxaAccountsManager.beingAuthentication` respectively.
 
+* **concept-storage**
+  * ⚠️ **This is a breaking API change!** for non-component implementations of `HistoryStorage`.
+  * `HistoryStorage` got new APIs: `deleteEverything`, `deleteVisitsSince`, `deleteVisitsBetween`, `deleteVisitsFor`, `prune` and `runMaintenance`.
+
+* **browser-storage-sync**, **browser-storage-memory**
+  * Implementations of `concept-storage`/`HistoryStorage` expose the newly added APIs.
+
 # 0.47.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.46.0...v0.47.0)


### PR DESCRIPTION
This PR mainly just exposes APIs that the places lib provides, and adds them to our toy in-memory impl.

I've documented sync implications for each delete call.

r? @pocmo or @csadilek for general review
cc @boek as an API consumer
cc @thomcc because you asked :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
