### PR TITLE
Import localizations from mozilla-l10n/android-l10n

### DIFF
--- a/components/browser/engine-system/src/main/res/values-de/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for a title dialog on web page. -->
+    <string name="mozac_browser_engine_system_alert_title">Die Seite mit der Adresse %1$s meldet:</string>
+</resources>

--- a/components/browser/engine-system/src/main/res/values-zh-rCN/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for a title dialog on web page. -->
+    <string name="mozac_browser_engine_system_alert_title">来自 %1$s 的页面说：</string>
+</resources>

--- a/components/browser/engine-system/src/main/res/values-zh-rTW/strings.xml
+++ b/components/browser/engine-system/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for a title dialog on web page. -->
+    <string name="mozac_browser_engine_system_alert_title">%1$s 這一頁說:</string>
+</resources>

--- a/components/browser/toolbar/src/main/res/values-de/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-de/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_toolbar_menu_button">Menü</string>
+    <string name="mozac_close_button_description">Schließen</string>
+</resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_toolbar_menu_button">菜单</string>
+    <string name="mozac_close_button_description">关闭</string>
+</resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
+    <string name="mozac_browser_toolbar_menu_button">選單</string>
+    <string name="mozac_close_button_description">關閉</string>
+</resources>

--- a/components/feature/contextmenu/src/main/res/values-de/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-de/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for context menu item to open the link in a new tab. -->
+    <string name="mozac_feature_contextmenu_open_link_in_new_tab">Link in neuem Tab öffnen</string>
+
+    <!-- Text for context menu item to open the link in a private tab. -->
+    <string name="mozac_feature_contextmenu_open_link_in_private_tab">Link in privatem Tab öffnen</string>
+
+    <!-- Text for context menu item to open the image in a new tab. -->
+    <string name="mozac_feature_contextmenu_open_image_in_new_tab">Grafik in neuem Tab öffnen</string>
+
+    <!-- Text for context menu item to share the link with an other app. -->
+    <string name="mozac_feature_contextmenu_share_link">Link teilen</string>
+
+    <!-- Text for context menu item to copy the link to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_link">Link kopieren</string>
+
+    <!-- Text for context menu item to copy the URL pointing to the image to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_image_location">Grafikadresse kopieren</string>
+
+    <!-- Text for context menu item to save / download the image. -->
+    <string name="mozac_feature_contextmenu_save_image">Grafik speichern</string>
+
+    <!-- Text for confirmation "snackbar" shown after opening a link in a new tab.  -->
+    <string name="mozac_feature_contextmenu_snackbar_new_tab_opened">Neuer Tab geöffnet</string>
+
+    <!-- Text for confirmation "snackbar" shown after opening a link in a new private tab.  -->
+    <string name="mozac_feature_contextmenu_snackbar_new_private_tab_opened">Neuer privater Tab geöffnet</string>
+
+    <!-- Text for confirmation "snackbar" shown after copying a link or image URL to the clipboard. -->
+    <string name="mozac_feature_contextmenu_snackbar_text_copied">Text in Zwischenablage kopiert</string>
+
+    <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
+    <string name="mozac_feature_contextmenu_snackbar_action_switch">Umschalten</string>
+</resources>

--- a/components/feature/contextmenu/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for context menu item to open the link in a new tab. -->
+    <string name="mozac_feature_contextmenu_open_link_in_new_tab">新建标签页打开链接</string>
+
+    <!-- Text for context menu item to open the link in a private tab. -->
+    <string name="mozac_feature_contextmenu_open_link_in_private_tab">新建隐私标签页打开链接</string>
+
+    <!-- Text for context menu item to open the image in a new tab. -->
+    <string name="mozac_feature_contextmenu_open_image_in_new_tab">在新标签页中打开图像</string>
+
+    <!-- Text for context menu item to share the link with an other app. -->
+    <string name="mozac_feature_contextmenu_share_link">分享链接</string>
+
+    <!-- Text for context menu item to copy the link to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_link">复制链接</string>
+
+    <!-- Text for context menu item to copy the URL pointing to the image to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_image_location">复制图像地址</string>
+
+    <!-- Text for context menu item to save / download the image. -->
+    <string name="mozac_feature_contextmenu_save_image">保存图像</string>
+
+    <!-- Text for confirmation "snackbar" shown after opening a link in a new tab.  -->
+    <string name="mozac_feature_contextmenu_snackbar_new_tab_opened">已打开新标签页</string>
+
+    <!-- Text for confirmation "snackbar" shown after opening a link in a new private tab.  -->
+    <string name="mozac_feature_contextmenu_snackbar_new_private_tab_opened">已新建隐私标签页</string>
+
+    <!-- Text for confirmation "snackbar" shown after copying a link or image URL to the clipboard. -->
+    <string name="mozac_feature_contextmenu_snackbar_text_copied">文本已复制到剪贴板</string>
+
+    <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
+    <string name="mozac_feature_contextmenu_snackbar_action_switch">切换</string>
+</resources>

--- a/components/feature/contextmenu/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for context menu item to open the link in a new tab. -->
+    <string name="mozac_feature_contextmenu_open_link_in_new_tab">用新分頁開啟鏈結</string>
+
+    <!-- Text for context menu item to open the link in a private tab. -->
+    <string name="mozac_feature_contextmenu_open_link_in_private_tab">用隱私分頁開啟鏈結</string>
+
+    <!-- Text for context menu item to open the image in a new tab. -->
+    <string name="mozac_feature_contextmenu_open_image_in_new_tab">用新分頁開啟圖片</string>
+
+    <!-- Text for context menu item to share the link with an other app. -->
+    <string name="mozac_feature_contextmenu_share_link">分享鏈結</string>
+
+    <!-- Text for context menu item to copy the link to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_link">複製鏈結</string>
+
+    <!-- Text for context menu item to copy the URL pointing to the image to the clipboard. -->
+    <string name="mozac_feature_contextmenu_copy_image_location">複製圖片網址</string>
+
+    <!-- Text for context menu item to save / download the image. -->
+    <string name="mozac_feature_contextmenu_save_image">儲存圖片</string>
+
+    <!-- Text for confirmation "snackbar" shown after opening a link in a new tab.  -->
+    <string name="mozac_feature_contextmenu_snackbar_new_tab_opened">已開啟新分頁</string>
+
+    <!-- Text for confirmation "snackbar" shown after opening a link in a new private tab.  -->
+    <string name="mozac_feature_contextmenu_snackbar_new_private_tab_opened">已開啟新隱私分頁</string>
+
+    <!-- Text for confirmation "snackbar" shown after copying a link or image URL to the clipboard. -->
+    <string name="mozac_feature_contextmenu_snackbar_text_copied">已複製文字至剪貼簿</string>
+
+    <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
+    <string name="mozac_feature_contextmenu_snackbar_action_switch">切換</string>
+</resources>

--- a/components/feature/customtabs/src/main/res/values-de/strings.xml
+++ b/components/feature/customtabs/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_feature_customtabs_exit_button">Zurück zur vorherigen App</string>
+    <string name="mozac_feature_customtabs_share_link">Link teilen</string>
+</resources>

--- a/components/feature/customtabs/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/customtabs/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_feature_customtabs_exit_button">返回之前的应用</string>
+    <string name="mozac_feature_customtabs_share_link">分享链接</string>
+</resources>

--- a/components/feature/customtabs/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/customtabs/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_feature_customtabs_exit_button">回到先前的應用程式</string>
+    <string name="mozac_feature_customtabs_share_link">分享鏈結</string>
+</resources>

--- a/components/feature/downloads/src/main/res/values-de/strings.xml
+++ b/components/feature/downloads/src/main/res/values-de/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Alert dialog confirmation before download a file, this is the title. -->
+    <string name="mozac_feature_downloads_dialog_title">Datei herunterladen</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the positive action. -->
+    <string name="mozac_feature_downloads_dialog_download">Herunterladen</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the negative action. -->
+    <string name="mozac_feature_downloads_dialog_cancel">Abbrechen</string>
+
+    <!-- Error shown when the user is trying to download a invalid file. -->
+    <string name="mozac_feature_downloads_file_not_supported">Downloadprotokoll wird nicht unterstützt</string>
+</resources>

--- a/components/feature/downloads/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/downloads/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Alert dialog confirmation before download a file, this is the title. -->
+    <string name="mozac_feature_downloads_dialog_title">下载文件</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the positive action. -->
+    <string name="mozac_feature_downloads_dialog_download">下载</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the negative action. -->
+    <string name="mozac_feature_downloads_dialog_cancel">取消</string>
+
+    <!-- Error shown when the user is trying to download a invalid file. -->
+    <string name="mozac_feature_downloads_file_not_supported">不支持该下载协议</string>
+</resources>

--- a/components/feature/downloads/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/downloads/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Alert dialog confirmation before download a file, this is the title. -->
+    <string name="mozac_feature_downloads_dialog_title">下載檔案</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the positive action. -->
+    <string name="mozac_feature_downloads_dialog_download">下載</string>
+
+    <!-- Alert dialog confirmation before download a file, this is the negative action. -->
+    <string name="mozac_feature_downloads_dialog_cancel">取消</string>
+
+    <!-- Error shown when the user is trying to download a invalid file. -->
+    <string name="mozac_feature_downloads_file_not_supported">不支援的下載通訊協定</string>
+</resources>

--- a/components/feature/findinpage/src/main/res/values-de/strings.xml
+++ b/components/feature/findinpage/src/main/res/values-de/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Watermark/Hint for the find in page input field. -->
+    <string name="mozac_feature_findindpage_input">In Seite suchen</string>
+
+    <!-- String to show the number of results found in the page and the
+    position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_result">%1$d/%2$d</string>
+
+    <!-- String to be read by the accessibility service presenting the number of results found in the page
+    and the position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_accessibility_result" tools:ignore="PluralsCandidate">%1$d von %2$d</string>
+
+    <!-- String to be read by the accessibility service when focusing the next result button. -->
+    <string name="mozac_feature_findindpage_next_result">Nächstes Ergebnis suchen</string>
+
+    <!-- String to be read by the accessibility service when focusing the previous result button. -->
+    <string name="mozac_feature_findindpage_previous_result">Vorheriges Ergebnis suchen</string>
+
+    <!-- String to be read by the accessibility service when focusing the dismiss button in the "find in page" UI. -->
+    <string name="mozac_feature_findindpage_dismiss">„In Seite suchen“ deaktivieren</string>
+
+</resources>

--- a/components/feature/findinpage/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/findinpage/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Watermark/Hint for the find in page input field. -->
+    <string name="mozac_feature_findindpage_input">在页面中查找</string>
+
+    <!-- String to show the number of results found in the page and the
+    position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_result">%1$d/%2$d</string>
+
+    <!-- String to be read by the accessibility service presenting the number of results found in the page
+    and the position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_accessibility_result" tools:ignore="PluralsCandidate">第 %1$d 项，共 %2$d 项</string>
+
+    <!-- String to be read by the accessibility service when focusing the next result button. -->
+    <string name="mozac_feature_findindpage_next_result">查找下一个结果</string>
+
+    <!-- String to be read by the accessibility service when focusing the previous result button. -->
+    <string name="mozac_feature_findindpage_previous_result">查找上一个结果</string>
+
+    <!-- String to be read by the accessibility service when focusing the dismiss button in the "find in page" UI. -->
+    <string name="mozac_feature_findindpage_dismiss">关闭页内查找</string>
+
+</resources>

--- a/components/feature/findinpage/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/findinpage/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Watermark/Hint for the find in page input field. -->
+    <string name="mozac_feature_findindpage_input">在頁面中搜尋</string>
+
+    <!-- String to show the number of results found in the page and the
+    position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_result">%1$d/%2$d</string>
+
+    <!-- String to be read by the accessibility service presenting the number of results found in the page
+    and the position the user is at. The first argument is the position, the second argument is the total. -->
+    <string name="mozac_feature_findindpage_accessibility_result" tools:ignore="PluralsCandidate">第 %1$d 筆，共 %2$d 筆</string>
+
+    <!-- String to be read by the accessibility service when focusing the next result button. -->
+    <string name="mozac_feature_findindpage_next_result">尋找下一筆</string>
+
+    <!-- String to be read by the accessibility service when focusing the previous result button. -->
+    <string name="mozac_feature_findindpage_previous_result">尋找上一筆</string>
+
+    <!-- String to be read by the accessibility service when focusing the dismiss button in the "find in page" UI. -->
+    <string name="mozac_feature_findindpage_dismiss">關閉頁面搜尋</string>
+
+</resources>

--- a/components/feature/prompts/src/main/res/values-de/strings.xml
+++ b/components/feature/prompts/src/main/res/values-de/strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for confirmation for a positive action in dialog  -->
+    <string name="mozac_feature_prompts_ok">OK</string>
+
+    <!-- Text for confirmation for a negative action in dialog.  -->
+    <string name="mozac_feature_prompts_cancel">Abbrechen</string>
+
+    <!-- When a page shows many dialogs, this checkbox will appear for letting the user choose to prevent showing more dialogs. -->
+    <string name="mozac_feature_prompts_no_more_dialogs">Diese Seiten daran hindern, weitere Dialoge zu öffnen</string>
+
+    <!-- Title of a date picker dialog, this text is shown above a date picker. -->
+    <string name="mozac_feature_prompts_pick_a_date">Datum auswählen</string>
+
+    <!-- Title of a time picker dialog, this text is shown above a time picker. -->
+    <string name="mozac_feature_prompts_pick_a_time">Uhrzeit auswählen</string>
+
+    <!-- Title of a date and time picker dialog, this text is shown above the picker. -->
+    <string name="mozac_feature_prompts_pick_a_date_and_time">Datum und Uhrzeit auswählen</string>
+
+    <!-- Text for a positive button, when an user selects a date in date/time picker. -->
+    <string name="mozac_feature_prompts_set_date">Übernehmen</string>
+
+    <!-- Text for a button that clears the selected input in the date/time picker. -->
+    <string name="mozac_feature_prompts_clear">Leeren</string>
+
+    <!-- Text for the title of an authentication dialog. -->
+    <string name="mozac_feature_prompt_sign_in">Anmelden</string>
+
+    <!-- Text for username field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_username_hint">Benutzername</string>
+
+    <!-- Text for password field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_password_hint">Passwort</string>
+
+    <!-- Text for a label for the field when prompt requesting a text is shown. -->
+    <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
+    <string name="mozac_feature_prompts_content_description_input_label">Beschriftung für ein Texteingabefeld</string>
+
+    <!-- Title of a color picker dialog, this text is shown above a color picker. -->
+    <string name="mozac_feature_prompts_choose_a_color">Wählen Sie eine Farbe</string>
+
+    <!-- Text of a confirm button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_allow">Erlauben</string>
+
+    <!-- Text of a negative button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_deny">Ablehnen</string>
+
+    <!-- Text of the title of a dialog when a page is requesting to open a new window. -->
+    <string name="mozac_feature_prompts_popup_dialog_title">Diese Website daran hindern, dass dieses Pop-up-Fenster geöffnet wird?</string>
+</resources>

--- a/components/feature/prompts/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/prompts/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for confirmation for a positive action in dialog  -->
+    <string name="mozac_feature_prompts_ok">确定</string>
+
+    <!-- Text for confirmation for a negative action in dialog.  -->
+    <string name="mozac_feature_prompts_cancel">取消</string>
+
+    <!-- When a page shows many dialogs, this checkbox will appear for letting the user choose to prevent showing more dialogs. -->
+    <string name="mozac_feature_prompts_no_more_dialogs">阻止此页面创建更多对话框</string>
+
+    <!-- Title of a date picker dialog, this text is shown above a date picker. -->
+    <string name="mozac_feature_prompts_pick_a_date">选择日期</string>
+
+    <!-- Title of a time picker dialog, this text is shown above a time picker. -->
+    <string name="mozac_feature_prompts_pick_a_time">选择时间</string>
+
+    <!-- Title of a date and time picker dialog, this text is shown above the picker. -->
+    <string name="mozac_feature_prompts_pick_a_date_and_time">选择日期和时间</string>
+
+    <!-- Text for a positive button, when an user selects a date in date/time picker. -->
+    <string name="mozac_feature_prompts_set_date">设置</string>
+
+    <!-- Text for a button that clears the selected input in the date/time picker. -->
+    <string name="mozac_feature_prompts_clear">清除</string>
+
+    <!-- Text for the title of an authentication dialog. -->
+    <string name="mozac_feature_prompt_sign_in">登录</string>
+
+    <!-- Text for username field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_username_hint">用户名</string>
+
+    <!-- Text for password field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_password_hint">密码</string>
+
+    <!-- Text for a label for the field when prompt requesting a text is shown. -->
+    <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
+    <string name="mozac_feature_prompts_content_description_input_label">文本输入字段的标签</string>
+
+    <!-- Title of a color picker dialog, this text is shown above a color picker. -->
+    <string name="mozac_feature_prompts_choose_a_color">选择颜色</string>
+
+    <!-- Text of a confirm button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_allow">允许</string>
+
+    <!-- Text of a negative button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_deny">拒绝</string>
+
+    <!-- Text of the title of a dialog when a page is requesting to open a new window. -->
+    <string name="mozac_feature_prompts_popup_dialog_title">要阻止此站点打开此弹出式窗口吗？</string>
+</resources>

--- a/components/feature/prompts/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/prompts/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Text for confirmation for a positive action in dialog  -->
+    <string name="mozac_feature_prompts_ok">確定</string>
+
+    <!-- Text for confirmation for a negative action in dialog.  -->
+    <string name="mozac_feature_prompts_cancel">取消</string>
+
+    <!-- When a page shows many dialogs, this checkbox will appear for letting the user choose to prevent showing more dialogs. -->
+    <string name="mozac_feature_prompts_no_more_dialogs">避免此頁面產生更多對話框</string>
+
+    <!-- Title of a date picker dialog, this text is shown above a date picker. -->
+    <string name="mozac_feature_prompts_pick_a_date">挑選一個日期</string>
+
+    <!-- Title of a time picker dialog, this text is shown above a time picker. -->
+    <string name="mozac_feature_prompts_pick_a_time">挑選一個時間</string>
+
+    <!-- Title of a date and time picker dialog, this text is shown above the picker. -->
+    <string name="mozac_feature_prompts_pick_a_date_and_time">挑選一個日期與時間</string>
+
+    <!-- Text for a positive button, when an user selects a date in date/time picker. -->
+    <string name="mozac_feature_prompts_set_date">設定</string>
+
+    <!-- Text for a button that clears the selected input in the date/time picker. -->
+    <string name="mozac_feature_prompts_clear">清除</string>
+
+    <!-- Text for the title of an authentication dialog. -->
+    <string name="mozac_feature_prompt_sign_in">登入</string>
+
+    <!-- Text for username field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_username_hint">使用者名稱</string>
+
+    <!-- Text for password field in an authentication dialog. -->
+    <string name="mozac_feature_prompt_password_hint">密碼</string>
+
+    <!-- Text for a label for the field when prompt requesting a text is shown. -->
+    <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
+    <string name="mozac_feature_prompts_content_description_input_label">文字輸入欄位的標籤</string>
+
+    <!-- Title of a color picker dialog, this text is shown above a color picker. -->
+    <string name="mozac_feature_prompts_choose_a_color">選擇一種色彩</string>
+
+    <!-- Text of a confirm button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_allow">允許</string>
+
+    <!-- Text of a negative button in dialog requesting to open a new window. -->
+    <string name="mozac_feature_prompts_deny">拒絕</string>
+
+    <!-- Text of the title of a dialog when a page is requesting to open a new window. -->
+    <string name="mozac_feature_prompts_popup_dialog_title">要防止此網頁再次開啟此彈出視窗嗎？</string>
+</resources>

--- a/components/feature/sitepermissions/src/main/res/values-de/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-de/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Title of a dialog for a notification permission request. -->
+    <string name="mozac_feature_sitepermissions_notification_title">%1$s erlauben, Benachrichtigungen zu senden?</string>
+
+    <!-- Title of a dialog for a camera permission request. -->
+    <string name="mozac_feature_sitepermissions_camera_title">%1$s erlauben, Ihre Kamera zu verwenden?</string>
+
+    <!-- Title of a dialog for a microphone permission request. -->
+    <string name="mozac_feature_sitepermissions_microfone_title">%1$s erlauben, Ihr Mikrofon zu verwenden?</string>
+
+    <!-- Title of a dialog for a location permission request. -->
+    <string name="mozac_feature_sitepermissions_location_title">%1$s erlauben, Ihren Standort zu verwenden?</string>
+
+    <!-- Title of a dialog for a camera and microphone permission request. -->
+    <string name="mozac_feature_sitepermissions_camera_and_microphone">%1$s erlauben, Ihre Kamera und Ihr Mikrofon zu verwenden?</string>
+
+    <!-- Option in a dialog for requesting a microphone permission, this option will give access to
+         the first microphone-->
+    <string name="mozac_feature_sitepermissions_option_microphone_one">Mikrofon 1</string>
+
+    <!-- Option in a dialog for requesting a camera permission, this option will give access to
+         back facing camera-->
+    <string name="mozac_feature_sitepermissions_back_facing_camera">Kamera Rückseite</string>
+
+    <!-- Option in a dialog for requesting a camera permission, this option will give access to
+     front facing camera-->
+    <string name="mozac_feature_sitepermissions_selfie_camera">Selfie-Kamera Rückseite</string>
+
+    <!-- Text for a positive button in a permission request dialog, this button will give
+        access to this permission-->
+    <string name="mozac_feature_sitepermissions_allow">Erlauben</string>
+
+    <!-- Text for a negative button in a permission request dialog, this button will do not give
+    access to this permission-->
+    <string name="mozac_feature_sitepermissions_not_allow">Nicht erlauben</string>
+
+    <!-- Text for a checkbox in a permission request dialog, this will allow to not show again the prompt-->
+    <string name="mozac_feature_sitepermissions_do_not_ask_again_on_this_site">Auf dieser Website nicht mehr fragen</string>
+</resources>

--- a/components/feature/sitepermissions/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Title of a dialog for a notification permission request. -->
+    <string name="mozac_feature_sitepermissions_notification_title">要允许 %1$s 发送通知吗？</string>
+
+    <!-- Title of a dialog for a camera permission request. -->
+    <string name="mozac_feature_sitepermissions_camera_title">要允许 %1$s 使用您的相机吗？</string>
+
+    <!-- Title of a dialog for a microphone permission request. -->
+    <string name="mozac_feature_sitepermissions_microfone_title">要允许 %1$s 使用您的麦克风吗？</string>
+
+    <!-- Title of a dialog for a location permission request. -->
+    <string name="mozac_feature_sitepermissions_location_title">要允许 %1$s 获取您的位置吗？</string>
+
+    <!-- Title of a dialog for a camera and microphone permission request. -->
+    <string name="mozac_feature_sitepermissions_camera_and_microphone">要允许 %1$s 使用您的相机和麦克风吗？</string>
+
+    <!-- Option in a dialog for requesting a microphone permission, this option will give access to
+         the first microphone-->
+    <string name="mozac_feature_sitepermissions_option_microphone_one">麦克风 1</string>
+
+    <!-- Option in a dialog for requesting a camera permission, this option will give access to
+         back facing camera-->
+    <string name="mozac_feature_sitepermissions_back_facing_camera">后置镜头</string>
+
+    <!-- Option in a dialog for requesting a camera permission, this option will give access to
+     front facing camera-->
+    <string name="mozac_feature_sitepermissions_selfie_camera">自拍镜头</string>
+
+    <!-- Text for a positive button in a permission request dialog, this button will give
+        access to this permission-->
+    <string name="mozac_feature_sitepermissions_allow">允许</string>
+
+    <!-- Text for a negative button in a permission request dialog, this button will do not give
+    access to this permission-->
+    <string name="mozac_feature_sitepermissions_not_allow">不允许</string>
+
+    <!-- Text for a checkbox in a permission request dialog, this will allow to not show again the prompt-->
+    <string name="mozac_feature_sitepermissions_do_not_ask_again_on_this_site">不再询问此网站</string>
+</resources>

--- a/components/feature/sitepermissions/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/sitepermissions/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Title of a dialog for a notification permission request. -->
+    <string name="mozac_feature_sitepermissions_notification_title">要允許 %1$s 傳送通知嗎？</string>
+
+    <!-- Title of a dialog for a camera permission request. -->
+    <string name="mozac_feature_sitepermissions_camera_title">要允許 %1$s 使用您的攝影機嗎？</string>
+
+    <!-- Title of a dialog for a microphone permission request. -->
+    <string name="mozac_feature_sitepermissions_microfone_title">要允許 %1$s 使用您的麥克風嗎？</string>
+
+    <!-- Title of a dialog for a location permission request. -->
+    <string name="mozac_feature_sitepermissions_location_title">要允許 %1$s 知道您的所在位置嗎？</string>
+
+    <!-- Title of a dialog for a camera and microphone permission request. -->
+    <string name="mozac_feature_sitepermissions_camera_and_microphone">要允許 %1$s 使用您的攝影機與麥克風嗎？</string>
+
+    <!-- Option in a dialog for requesting a microphone permission, this option will give access to
+         the first microphone-->
+    <string name="mozac_feature_sitepermissions_option_microphone_one">1 號麥克風</string>
+
+    <!-- Option in a dialog for requesting a camera permission, this option will give access to
+         back facing camera-->
+    <string name="mozac_feature_sitepermissions_back_facing_camera">後鏡頭</string>
+
+    <!-- Option in a dialog for requesting a camera permission, this option will give access to
+     front facing camera-->
+    <string name="mozac_feature_sitepermissions_selfie_camera">自拍鏡頭</string>
+
+    <!-- Text for a positive button in a permission request dialog, this button will give
+        access to this permission-->
+    <string name="mozac_feature_sitepermissions_allow">允許</string>
+
+    <!-- Text for a negative button in a permission request dialog, this button will do not give
+    access to this permission-->
+    <string name="mozac_feature_sitepermissions_not_allow">不允許</string>
+
+    <!-- Text for a checkbox in a permission request dialog, this will allow to not show again the prompt-->
+    <string name="mozac_feature_sitepermissions_do_not_ask_again_on_this_site">針對這個網站不要再問我</string>
+</resources>

--- a/components/feature/tabs/src/main/res/values-de/strings.xml
+++ b/components/feature/tabs/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the "tabs" button in the browser toolbar. -->
+    <string name="mozac_feature_tabs_toolbar_tabs_button">Tabs</string>
+</resources>

--- a/components/feature/tabs/src/main/res/values-zh-rCN/strings.xml
+++ b/components/feature/tabs/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the "tabs" button in the browser toolbar. -->
+    <string name="mozac_feature_tabs_toolbar_tabs_button">标签页</string>
+</resources>

--- a/components/feature/tabs/src/main/res/values-zh-rTW/strings.xml
+++ b/components/feature/tabs/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Content description (not visible, for screen readers etc.): Description for the "tabs" button in the browser toolbar. -->
+    <string name="mozac_feature_tabs_toolbar_tabs_button">分頁</string>
+</resources>

--- a/components/lib/crash/src/main/res/values-de/strings.xml
+++ b/components/lib/crash/src/main/res/values-de/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the crash reporter dialog. %1$s will be replaced with the name of the app (e.g. Firefox Focus). -->
+    <string name="mozac_lib_crash_dialog_title">Es tut uns leid. %1$s hatte ein Problem und ist abgestürzt.</string>
+
+    <!-- Label of the checkbox for sending crash reports in the crash reporter dialog. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
+    <string name="mozac_lib_crash_dialog_checkbox">Absturzbericht an %1$s senden</string>
+
+    <!-- Label of the button closing the crash reporter dialog. -->
+    <string name="mozac_lib_crash_dialog_button_close">Schließen</string>
+
+    <!-- Label of the button closing the crash reporter dialog and restarting the app. -->
+    <string name="mozac_lib_crash_dialog_button_restart">%1$s neu starten</string>
+</resources>

--- a/components/lib/crash/src/main/res/values-zh-rCN/strings.xml
+++ b/components/lib/crash/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the crash reporter dialog. %1$s will be replaced with the name of the app (e.g. Firefox Focus). -->
+    <string name="mozac_lib_crash_dialog_title">抱歉， %1$s 遇到问题并已崩溃。</string>
+
+    <!-- Label of the checkbox for sending crash reports in the crash reporter dialog. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
+    <string name="mozac_lib_crash_dialog_checkbox">向 %1$s 发送崩溃报告</string>
+
+    <!-- Label of the button closing the crash reporter dialog. -->
+    <string name="mozac_lib_crash_dialog_button_close">关闭</string>
+
+    <!-- Label of the button closing the crash reporter dialog and restarting the app. -->
+    <string name="mozac_lib_crash_dialog_button_restart">重启 %1$s</string>
+</resources>

--- a/components/lib/crash/src/main/res/values-zh-rTW/strings.xml
+++ b/components/lib/crash/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the crash reporter dialog. %1$s will be replaced with the name of the app (e.g. Firefox Focus). -->
+    <string name="mozac_lib_crash_dialog_title">很抱歉，%1$s 遇到問題，發生錯誤。</string>
+
+    <!-- Label of the checkbox for sending crash reports in the crash reporter dialog. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
+    <string name="mozac_lib_crash_dialog_checkbox">傳送錯誤報告給 %1$s</string>
+
+    <!-- Label of the button closing the crash reporter dialog. -->
+    <string name="mozac_lib_crash_dialog_button_close">關閉</string>
+
+    <!-- Label of the button closing the crash reporter dialog and restarting the app. -->
+    <string name="mozac_lib_crash_dialog_button_restart">重新啟動 %1$s</string>
+</resources>

--- a/components/support/ktx/src/main/res/values-de/strings.xml
+++ b/components/support/ktx/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_support_ktx_menu_share_with">Teilen mit…</string>
+    <string name="mozac_support_ktx_share_dialog_title">Teilen über</string>
+</resources>

--- a/components/support/ktx/src/main/res/values-zh-rCN/strings.xml
+++ b/components/support/ktx/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_support_ktx_menu_share_with">使用下列方式分享…</string>
+    <string name="mozac_support_ktx_share_dialog_title">分享到</string>
+</resources>

--- a/components/support/ktx/src/main/res/values-zh-rTW/strings.xml
+++ b/components/support/ktx/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_support_ktx_menu_share_with">使用下列方式分享…</string>
+    <string name="mozac_support_ktx_share_dialog_title">分享到</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-de/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_ui_tabcounter_description">Tab-Zähler</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-zh-rCN/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_ui_tabcounter_description">标签页计数器</string>
+</resources>

--- a/components/ui/tabcounter/src/main/res/values-zh-rTW/strings.xml
+++ b/components/ui/tabcounter/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mozac_ui_tabcounter_description">標籤計數器</string>
+</resources>


### PR DESCRIPTION
This is the first import for strings from Pontoon via android-l10n. I'd love an extra-careful technical review of these.

I admit, I haven't built locally. But c-l looks OK.

### Pull Request checklist
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
