### PR TITLE
Reduce glean test impact

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -29,8 +29,15 @@ import java.time.format.DateTimeFormatter
 class PingMakerTest {
     private val mockApplicationContext = mock(Context::class.java)
 
+    // This test requires us to test against the minSdk of 21 in order to make sure that a date
+    // related issue is not regressed. We do this using @Config(sdk = [21, 28]) annotation which
+    // accepts an array of sdk versions to test against. Since loading the sdk versions is time
+    // consuming, we only test the minSdk to reduce test overhead of glean.
+    //
+    // If the minSdk gets changed to >= 24, this can be removed, and DateUtils.getISOTimeString()
+    // can be updated to remove the workaround.
     @Test
-    @Config(minSdk = 21)
+    @Config(sdk = [ 21, 28 ])
     fun `"ping_info" must contain a non-empty start_time and end_time`() {
         val maker = PingMaker(
             StorageEngineManager(


### PR DESCRIPTION
Prior to this change, glean was testing the test `"ping_info" must contain a non-empty start_time and end_time`() using `@Config(minSdk = 21)`.  This resulted in this test being ran for each SDK from 21 up to the target SDK of 28.  Each SDK loading took time and memory.  The function needs to test just the minimum SDK version and the target SDK version in order to prevent a bug in date time formatting so I modified this to just test those two SDK versions, cutting the overall glean test running time by over half.

@pocmo  I'm not sure that this has anything to do with the recent OOM errors but I thought it couldn't hurt.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
