### PR TITLE
Use the "BaseConfig" namespace when generating the glean API

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -112,7 +112,13 @@ ext.gleanGenerateMetricsAPI = {
     variant ->
 
     def sourceOutputDir =  "$buildDir/telemetry/src/${variant.name}/kotlin"
-    def fullNamespace = "${variant.applicationId}.GleanMetrics"
+    // Get the name of the package as if it were to be used in the R or BuildConfig
+    // files. This is required since applications can define different application ids
+    // depending on the variant type: the generated API definitions don't need to be
+    // different due to that.
+    Task buildConfig = variant.generateBuildConfig
+    def originalPackageName = buildConfig.getBuildConfigPackageName()
+    def fullNamespace = "${originalPackageName}.GleanMetrics"
     def generateKotlinAPI = task("generateMetricsSourceFor${variant.name.capitalize()}", type: Exec) {
         description = "Generate the Kotlin code for the Metrics API"
 

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -28,6 +28,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            applicationIdSuffix ".debug"
+        }
     }
 }
 


### PR DESCRIPTION
This change is required to support applications with different application ids in different variants. In these cases, glean would have generated a metric API in the `$appId1.GleanMetrics` namespace, breaking building other variants that tried to import the API from the variant using, for example, `$appid2`.

For example, for Fenix, Glean is generating code into the package `org.mozilla.fenix.debug.GleanMetrics`, rather than `org.mozilla.fenix.GleanMetrics`, which means code would need to import glean different depending on whether it's in a debug or release build.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
