### PR TITLE
[glean] 1536792: Reinstate metrics ping scheduler tests.

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -30,6 +30,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
@@ -191,28 +192,28 @@ class MetricsPingSchedulerTest {
         assertEquals(expectedDate, mps.getLastCollectedDate(expectedDate))
     }
 
-    // @Test
-    // fun `collectMetricsPing must update the last sent date and reschedule the collection`() {
-    //     val mpsSpy = spy<MetricsPingScheduler>(
-    //         MetricsPingScheduler(ApplicationProvider.getApplicationContext<Context>()))
+    @Test
+    fun `collectMetricsPing must update the last sent date and reschedule the collection`() {
+        val mpsSpy = spy<MetricsPingScheduler>(
+            MetricsPingScheduler(ApplicationProvider.getApplicationContext<Context>()))
 
-    //     // Ensure we have the right assumptions in place: the methods were not called
-    //     // prior to |collectPingAndReschedule|.
-    //     verify(mpsSpy, times(0)).updateSentDate(anyString())
-    //     verify(mpsSpy, times(0)).schedulePingCollection(
-    //         kotlinFriendlyAny<Calendar>(),
-    //         anyBoolean()
-    //     )
+        // Ensure we have the right assumptions in place: the methods were not called
+        // prior to |collectPingAndReschedule|.
+        verify(mpsSpy, times(0)).updateSentDate(anyString())
+        verify(mpsSpy, times(0)).schedulePingCollection(
+            kotlinFriendlyAny<Calendar>(),
+            anyBoolean()
+        )
 
-    //     mpsSpy.collectPingAndReschedule(Calendar.getInstance())
+        mpsSpy.collectPingAndReschedule(Calendar.getInstance())
 
-    //     // Verify that we correctly called in the methods.
-    //     verify(mpsSpy, times(1)).updateSentDate(anyString())
-    //     verify(mpsSpy, times(1)).schedulePingCollection(
-    //         kotlinFriendlyAny<Calendar>(),
-    //         anyBoolean()
-    //     )
-    // }
+        // Verify that we correctly called in the methods.
+        verify(mpsSpy, times(1)).updateSentDate(anyString())
+        verify(mpsSpy, times(1)).schedulePingCollection(
+            kotlinFriendlyAny<Calendar>(),
+            anyBoolean()
+        )
+    }
 
     @Test
     fun `collectMetricsPing must correctly trigger the collection of the metrics ping`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -267,36 +267,36 @@ class MetricsPingSchedulerTest {
         }
     }
 
-    // @Test
-    // fun `startupCheck must immediately collect if the ping is overdue for today`() {
-    //     // Set the current system time to a known datetime.
-    //     val fakeNow = Calendar.getInstance()
-    //     fakeNow.clear()
-    //     fakeNow.set(2015, 6, 11, 7, 0, 0)
+    @Test
+    fun `startupCheck must immediately collect if the ping is overdue for today`() {
+        // Set the current system time to a known datetime.
+        val fakeNow = Calendar.getInstance()
+        fakeNow.clear()
+        fakeNow.set(2015, 6, 11, 7, 0, 0)
 
-    //     // Set the last sent date to a previous day, so that today's ping is overdue.
-    //     val mpsSpy =
-    //         spy<MetricsPingScheduler>(MetricsPingScheduler(ApplicationProvider.getApplicationContext<Context>()))
-    //     val overdueTestDate = "2015-07-05T12:36:00-06:00"
-    //     mpsSpy.updateSentDate(overdueTestDate)
+        // Set the last sent date to a previous day, so that today's ping is overdue.
+        val mpsSpy =
+            spy<MetricsPingScheduler>(MetricsPingScheduler(ApplicationProvider.getApplicationContext<Context>()))
+        val overdueTestDate = "2015-07-05T12:36:00-06:00"
+        mpsSpy.updateSentDate(overdueTestDate)
 
-    //     verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny<Calendar>())
+        verify(mpsSpy, never()).collectPingAndReschedule(kotlinFriendlyAny<Calendar>())
 
-    //     // Make sure to return the fake date when requested.
-    //     doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
+        // Make sure to return the fake date when requested.
+        doReturn(fakeNow).`when`(mpsSpy).getCalendarInstance()
 
-    //     // Trigger the startup check. We need to wrap this in `blockDispatchersAPI` since
-    //     // the immediate startup collection happens in the Dispatchers.API context. If we
-    //     // don't, test will fail due to async weirdness.
-    //     mpsSpy.startupCheck()
+        // Trigger the startup check. We need to wrap this in `blockDispatchersAPI` since
+        // the immediate startup collection happens in the Dispatchers.API context. If we
+        // don't, test will fail due to async weirdness.
+        mpsSpy.startupCheck()
 
-    //     // And that we're storing the current date (this only reports the date, not the time).
-    //     fakeNow.set(Calendar.HOUR_OF_DAY, 0)
-    //     assertEquals(fakeNow.time, mpsSpy.getLastCollectedDate())
+        // And that we're storing the current date (this only reports the date, not the time).
+        fakeNow.set(Calendar.HOUR_OF_DAY, 0)
+        assertEquals(fakeNow.time, mpsSpy.getLastCollectedDate())
 
-    //     // Verify that we're immediately collecting.
-    //     verify(mpsSpy, times(1)).collectPingAndReschedule(fakeNow)
-    // }
+        // Verify that we're immediately collecting.
+        verify(mpsSpy, times(1)).collectPingAndReschedule(fakeNow)
+    }
 
     @Test
     fun `startupCheck must schedule collection for the next calendar day if collection already happened`() {


### PR DESCRIPTION
This is a draft PR while I debug and re-examine the `MetricsPingScheduler` tests that were turned off last week.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
