### PR TITLE
Make loading page progress bar accessible to TalkBack.

### DIFF
--- a/components/browser/toolbar/src/main/res/values-de/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-de/strings.xml
@@ -3,4 +3,5 @@
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">Menü</string>
     <string name="mozac_clear_button_description">Leeren</string>
+    <string name="mozac_browser_toolbar_progress_loading">Wird geladen</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
@@ -3,4 +3,5 @@
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">菜单</string>
     <string name="mozac_clear_button_description">清除</string>
+    <string name="mozac_browser_toolbar_progress_loading">正在加载</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
@@ -3,4 +3,5 @@
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">選單</string>
     <string name="mozac_clear_button_description">清除</string>
+    <string name="mozac_browser_toolbar_progress_loading">載入中</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values/strings.xml
+++ b/components/browser/toolbar/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">Menu</string>
     <string name="mozac_clear_button_description">Clear</string>
+    <!-- Announcement made by the screen reader when the progress bar is shown and a page is loading -->
+    <string name="mozac_browser_toolbar_progress_loading">Loading</string>
 </resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,9 @@ permalink: /changelog/
 * **browser-storage-sync**, **browser-storage-memory**
   * Implementations of `concept-storage`/`HistoryStorage` expose newly added `deleteVisit`.
 
+* **browser-toolbar**
+  * Add TalkBack support for page load status.
+
 # 0.48.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.47.0...v0.48.0)


### PR DESCRIPTION
ProgressBars can be made accessible to TalkBack by setting `android:accessibilityLiveRegion`.
They will emit `TYPE_VIEW_SELECTED` events. TalkBack will format those events into percentage
announcements along with a pitch-change earcon. We are not using that feature here for
several reasons:
1. They are dispatched via a 200ms timeout. Since loading a page can be a short process,
   and since we only update the bar a handful of times, these events often never fire and
   they don't give the user a true sense of the progress.
2. The last 100% event is dispatched after the view is hidden. This prevents the event
   from being fired, so the user never gets a "complete" event.
3. Live regions in TalkBack have their role announced, so the user will hear
   "Progress bar, 25%". For a common feature like page load this is very chatty and unintuitive.
4. We can provide custom strings instead of the less useful percentage utterance, but
   TalkBack will not play an earcon if an event has its own text.

For all those reasons, we are going another route here with a "loading" announcement
when the progress bar first appears along with scroll events that have the same
pitch-change earcon in TalkBack (although they are a bit louder). This gives a concise and
consistent feedback to the user that they can depend on.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
