### PR TITLE
Rename ToolBar entry button to Clear.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -88,7 +88,7 @@ class EditToolbar(
         val padding = resources.pxToDp(CANCEL_PADDING_DP)
         setPadding(padding, padding, padding, padding)
         setImageResource(mozilla.components.ui.icons.R.drawable.mozac_ic_clear)
-        contentDescription = context.getString(R.string.mozac_close_button_description)
+        contentDescription = context.getString(R.string.mozac_clear_button_description)
         scaleType = ImageView.ScaleType.CENTER
 
         setOnClickListener {

--- a/components/browser/toolbar/src/main/res/values-de/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-de/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">Menü</string>
-    <string name="mozac_close_button_description">Schließen</string>
+    <string name="mozac_clear_button_description">Leeren</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rCN/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">菜单</string>
-    <string name="mozac_close_button_description">关闭</string>
+    <string name="mozac_clear_button_description">清除</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
+++ b/components/browser/toolbar/src/main/res/values-zh-rTW/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">選單</string>
-    <string name="mozac_close_button_description">關閉</string>
+    <string name="mozac_clear_button_description">清除</string>
 </resources>

--- a/components/browser/toolbar/src/main/res/values/strings.xml
+++ b/components/browser/toolbar/src/main/res/values/strings.xml
@@ -5,5 +5,5 @@
 <resources>
     <!-- Content description (not visible, for screen readers etc.): Description for the overflow menu button in the browser toolbar. -->
     <string name="mozac_browser_toolbar_menu_button">Menu</string>
-    <string name="mozac_close_button_description">Close</string>
+    <string name="mozac_clear_button_description">Clear</string>
 </resources>


### PR DESCRIPTION
Simple rename, so no new tests changelog or anything.

I borrowed the "Clear" translations from `mozac_feature_prompts_clear`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
