### PR TITLE
[glean] EventsStorageEngine: Wait until writes have been completed before deleting all files

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -329,12 +329,10 @@ internal object EventsStorageEngine : StorageEngine {
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     override fun clearAllStores() {
-        // We need to delete these files on the IO thread to avoid
-        // racing with writing to the file.  However, we want to
-        // block the main thread until this work is done, so the
-        // caller can rely on the files being gone.  This is not a
-        // performance problem since this function is for use in
-        // testing only.
+        // Wait until any writes have cleared until deleting all the files.
+        // This is not a performance problem since this function is for use
+        // in testing only.
+        testWaitForWrites()
         synchronized(eventFileLock) {
             storageDirectory.listFiles()?.forEach {
                 it.delete()


### PR DESCRIPTION
This is an attempt to address an intermittently-failing test.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
