### PR TITLE
1536141: Send events as objects rather than arrays

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'kotlin-android'
  * created during unit testing.
  * This uses a specific version of the schema identified by a git commit hash.
  */
-String GLEAN_PING_SCHEMA_GIT_HASH = "3bf541d"
+String GLEAN_PING_SCHEMA_GIT_HASH = "0248519"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/baseline/baseline.1.schema.json"
 
 android {

--- a/components/service/glean/docs/pings/events.md
+++ b/components/service/glean/docs/pings/events.md
@@ -30,15 +30,40 @@ At the top-level, this ping contains the following keys:
 - `events`: An array of all of the events that have occurred since the last time
   the `events` ping was sent.
 
-Each entry in the `events` array is an array with the following items:
+Each entry in the `events` array is an object with the following properties:
 
-- [0]: `timestamp`: The milliseconds relative to the first event in the ping.
+- `"timestamp"`: The milliseconds relative to the first event in the ping.
 
-- [1]: `category`: The category of the event, as defined by its location in the
+- `"category"`: The category of the event, as defined by its location in the
   `metrics.yaml` file.
 
-- [2]: `name`: The name of the event, as definded in the `metrics.yaml` file.
+- `"name"`: The name of the event, as definded in the `metrics.yaml` file.
 
-- [3]: `extra` (optional): A mapping of strings to strings providing additional
+- `"extra"` (optional): A mapping of strings to strings providing additional
   data about the event. The keys are restricted to 40 characters and values in
   this map will never exceed 100 characters.
+  
+### Example event JSON
+  
+```json
+{
+  ...,
+  
+  "events": [
+    {
+      "timestamp": 123456789,
+      "category": "examples",
+      "name": "event_example",
+      "extra": {
+        "metadata1": "extra", 
+        "metadata2": "more_extra"
+      }
+    },
+    {
+      "timestamp": 123456791,
+      "category": "examples",
+      "name": "event_example"
+    }
+  ]
+}
+```

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -225,7 +225,7 @@ class EventsStorageEngineTest {
         assertNull("The engine must report 'null' on empty stores",
             EventsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = false))
         // Check that this serializes to the expected JSON format.
-        assertEquals("[[0,\"telemetry\",\"test_event_clear\"]]",
+        assertEquals("[{\"timestamp\":0,\"category\":\"telemetry\",\"name\":\"test_event_clear\"}]",
             snapshot.toString())
     }
 
@@ -252,7 +252,7 @@ class EventsStorageEngineTest {
         assertNull("The engine must report 'null' on empty stores",
             EventsStorageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = false))
         // Check that this serializes to the expected JSON format.
-        assertEquals("[[0,\"telemetry\",\"test_event_clear\",{\"someExtra\":\"field\"}]]",
+        assertEquals("[{\"timestamp\":0,\"category\":\"telemetry\",\"name\":\"test_event_clear\",\"extra\":{\"someExtra\":\"field\"}}]",
             snapshot.toString())
     }
 
@@ -297,7 +297,7 @@ class EventsStorageEngineTest {
             assertEquals(500, eventsArray.length())
 
             for (i in 0..499) {
-                assertEquals("$i", eventsArray.getJSONArray(i).getJSONObject(3)["test_event_number"])
+                assertEquals("$i", eventsArray.getJSONObject(i).getJSONObject("extra")["test_event_number"])
             }
         } finally {
             server.shutdown()
@@ -457,7 +457,7 @@ class EventsStorageEngineTest {
         assertNotNull(pingJson.opt("events"))
         val events = pingJson.getJSONArray("events")
         assertEquals(2, events.length())
-        assertEquals("bar", events.getJSONArray(0)!!.getJSONObject(3)!!.getString("key1"))
-        assertEquals("baz", events.getJSONArray(1)!!.getJSONObject(3)!!.getString("key1"))
+        assertEquals("bar", events.getJSONObject(0)!!.getJSONObject("extra")!!.getString("key1"))
+        assertEquals("baz", events.getJSONObject(1)!!.getJSONObject("extra")!!.getString("key1"))
     }
 }


### PR DESCRIPTION
This is currently pointing towards an unmerged schema update on the pipeline side.  Once that [PR](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/305) lands, `build.gradle` in service-glean will need updated to point the schema hash to the correct master commit.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
