### PR TITLE
Update to Docker image 1.16.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -91,7 +91,7 @@ tasks:
             - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
           payload:
             maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
-            image: mozillamobile/android-components:1.15
+            image: mozillamobile/android-components:1.16
             command:
               - /bin/bash
               - --login

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -162,7 +162,7 @@ class TaskBuilder(object):
         payload = {
             "features": features,
             "maxRunTime": 7200,
-            "image": "mozillamobile/android-components:1.15",
+            "image": "mozillamobile/android-components:1.16",
             "command": [
                 "/bin/bash",
                 "--login",


### PR DESCRIPTION
Fresh image. 🎉 

This will avoid that our taskcluster tasks have to download a bunch of updated dependencies for a while again.