### PR TITLE
Refactor GenericScalarStorageEngine and ScalarType to remove "Scalar"

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/BooleansStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/BooleansStorageEngine.kt
@@ -22,7 +22,7 @@ internal object BooleansStorageEngine : BooleansStorageEngineImplementation()
 
 internal open class BooleansStorageEngineImplementation(
     override val logger: Logger = Logger("glean/BooleansStorageEngine")
-) : GenericScalarStorageEngine<Boolean>() {
+) : GenericStorageEngine<Boolean>() {
 
     override fun deserializeSingleMetric(metricName: String, value: Any?): Boolean? {
         return value as? Boolean
@@ -47,6 +47,6 @@ internal open class BooleansStorageEngineImplementation(
         metricData: CommonMetricData,
         value: Boolean
     ) {
-        super.recordScalar(metricData, value)
+        super.recordMetric(metricData, value)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/CountersStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/CountersStorageEngine.kt
@@ -24,7 +24,7 @@ internal object CountersStorageEngine : CountersStorageEngineImplementation()
 
 internal open class CountersStorageEngineImplementation(
     override val logger: Logger = Logger("glean/CountersStorageEngine")
-) : GenericScalarStorageEngine<Int>() {
+) : GenericStorageEngine<Int>() {
 
     override fun deserializeSingleMetric(metricName: String, value: Any?): Int? {
         return (value as? Int)?.let {
@@ -63,7 +63,7 @@ internal open class CountersStorageEngineImplementation(
         }
 
         // Use a custom combiner to add the amount to the existing counters rather than overwriting
-        super.recordScalar(metricData, amount, null) { currentValue, newAmount ->
+        super.recordMetric(metricData, amount, null) { currentValue, newAmount ->
             currentValue?.let { it + newAmount } ?: newAmount
         }
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/DatetimesStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/DatetimesStorageEngine.kt
@@ -30,7 +30,7 @@ internal object DatetimesStorageEngine : DatetimesStorageEngineImplementation()
 
 internal open class DatetimesStorageEngineImplementation(
     override val logger: Logger = Logger("glean/DatetimesStorageEngine")
-) : GenericScalarStorageEngine<String>() {
+) : GenericStorageEngine<String>() {
 
     override fun deserializeSingleMetric(metricName: String, value: Any?): String? {
         // This parses the date strings on ingestion as a sanity check, but we
@@ -61,7 +61,7 @@ internal open class DatetimesStorageEngineImplementation(
      * @param date the date value to set this metric to
      */
     fun set(metricData: DatetimeMetricType, date: Date = Date()) {
-        super.recordScalar(
+        super.recordMetric(
             metricData as CommonMetricData,
             getISOTimeString(date, metricData.timeUnit)
         )
@@ -75,7 +75,7 @@ internal open class DatetimesStorageEngineImplementation(
      * @param date the date value to set this metric to
      */
     fun set(metricData: DatetimeMetricType, calendar: Calendar) {
-        super.recordScalar(
+        super.recordMetric(
             metricData as CommonMetricData,
             getISOTimeString(calendar, metricData.timeUnit)
         )

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringListsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringListsStorageEngine.kt
@@ -26,7 +26,7 @@ internal object StringListsStorageEngine : StringListsStorageEngineImplementatio
 
 internal open class StringListsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/StringsListsStorageEngine")
-) : GenericScalarStorageEngine<List<String>>() {
+) : GenericStorageEngine<List<String>>() {
     companion object {
         // Maximum length of any list
         const val MAX_LIST_LENGTH_VALUE = 20
@@ -92,7 +92,7 @@ internal open class StringListsStorageEngineImplementation(
         }
 
         // Use a custom combiner to add the string to the existing list rather than overwriting
-        super.recordScalar(metricData, listOf(truncatedValue), null) { currentValue, newValue ->
+        super.recordMetric(metricData, listOf(truncatedValue), null) { currentValue, newValue ->
             currentValue?.let {
                 if (it.count() + 1 > MAX_LIST_LENGTH_VALUE) {
                     recordError(
@@ -141,6 +141,6 @@ internal open class StringListsStorageEngineImplementation(
             )
         }
 
-        super.recordScalar(metricData, stringList.take(MAX_LIST_LENGTH_VALUE))
+        super.recordMetric(metricData, stringList.take(MAX_LIST_LENGTH_VALUE))
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -24,7 +24,7 @@ internal object StringsStorageEngine : StringsStorageEngineImplementation()
 
 internal open class StringsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/StringsStorageEngine")
-) : GenericScalarStorageEngine<String>() {
+) : GenericStorageEngine<String>() {
     companion object {
         // Maximum length of any passed value string, in characters.
         private const val MAX_LENGTH_VALUE = 50
@@ -66,6 +66,6 @@ internal open class StringsStorageEngineImplementation(
             it
         }
 
-        super.recordScalar(metricData, truncatedValue)
+        super.recordMetric(metricData, truncatedValue)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimespansStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimespansStorageEngine.kt
@@ -31,7 +31,7 @@ internal object TimespansStorageEngine : TimespansStorageEngineImplementation()
 
 internal open class TimespansStorageEngineImplementation(
     override val logger: Logger = Logger("glean/TimespansStorageEngine")
-) : GenericScalarStorageEngine<Long>() {
+) : GenericStorageEngine<Long>() {
 
     /**
      * A map that stores the start times from the API consumers, not yet
@@ -179,7 +179,7 @@ internal open class TimespansStorageEngineImplementation(
             // Use a custom combiner to sum the new timespan to the one already stored. We
             // can't adjust the time unit before storing so that we still allow for values
             // lower than the desired time unit to accumulate.
-            super.recordScalar(metricData, elapsedNanos, timeUnit) { currentValue, newValue ->
+            super.recordMetric(metricData, elapsedNanos, timeUnit) { currentValue, newValue ->
                 currentValue?.let {
                     it + newValue
                 } ?: newValue

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
@@ -33,7 +33,7 @@ internal object TimingDistributionsStorageEngine : TimingDistributionsStorageEng
 
 internal open class TimingDistributionsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/TimingDistributionsStorageEngine")
-) : GenericScalarStorageEngine<TimingDistributionData>() {
+) : GenericStorageEngine<TimingDistributionData>() {
 
     override fun deserializeSingleMetric(metricName: String, value: Any?): TimingDistributionData? {
         return try {
@@ -82,7 +82,7 @@ internal open class TimingDistributionsStorageEngineImplementation(
         // TimingDistributionData for each value that doesn't have an existing current value.
         val dummy = TimingDistributionData(category = metricData.category, name = metricData.name,
             timeUnit = timeUnit)
-        super.recordScalar(metricData, dummy, null) { currentValue, newValue ->
+        super.recordMetric(metricData, dummy, null) { currentValue, newValue ->
             currentValue?.let {
                 it.accumulate(sample)
                 it

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/UuidsStorageEngine.kt
@@ -23,7 +23,7 @@ internal object UuidsStorageEngine : UuidsStorageEngineImplementation()
 
 internal open class UuidsStorageEngineImplementation(
     override val logger: Logger = Logger("glean/UuidsStorageEngine")
-) : GenericScalarStorageEngine<UUID>() {
+) : GenericStorageEngine<UUID>() {
 
     override fun deserializeSingleMetric(metricName: String, value: Any?): UUID? {
         return try {
@@ -52,6 +52,6 @@ internal open class UuidsStorageEngineImplementation(
         metricData: CommonMetricData,
         value: UUID
     ) {
-        super.recordScalar(metricData, value)
+        super.recordMetric(metricData, value)
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/LabeledMetricTypeTest.kt
@@ -9,7 +9,7 @@ import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.storages.BooleansStorageEngine
 import mozilla.components.service.glean.storages.CountersStorageEngine
-import mozilla.components.service.glean.storages.MockScalarStorageEngine
+import mozilla.components.service.glean.storages.MockGenericStorageEngine
 import mozilla.components.service.glean.storages.StringListsStorageEngine
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.storages.TimespansStorageEngine
@@ -440,17 +440,17 @@ class LabeledMetricTypeTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.all).thenAnswer { persistedSample }
         `when`(context.getSharedPreferences(
-            eq(MockScalarStorageEngine::class.java.canonicalName),
+            eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
         `when`(context.getSharedPreferences(
-            eq("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime"),
+            eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime",
+            .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = context
 
         val metric = GenericMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
@@ -22,7 +22,7 @@ import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class GenericScalarStorageEngineTest {
+class GenericStorageEngineTest {
     private data class GenericMetricType(
         override val disabled: Boolean,
         override val category: String,
@@ -38,7 +38,7 @@ class GenericScalarStorageEngineTest {
         val dataUserLifetime = 37
         val dataPingLifetime = 3
 
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val metric1 = GenericMetricType(
@@ -86,7 +86,7 @@ class GenericScalarStorageEngineTest {
 
     @Test
     fun `metrics with empty 'category' must be properly recorded`() {
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val metric = GenericMetricType(
@@ -124,13 +124,13 @@ class GenericScalarStorageEngineTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.all).thenAnswer { persistedSample }
         `when`(context.getSharedPreferences(
-            eq(MockScalarStorageEngine::class.java.canonicalName),
+            eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
 
         // Instantiate our mock engine and check that it correctly unpersists the
         // data and makes it available in the snapshot.
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = context
 
         val metric = GenericMetricType(
@@ -163,19 +163,19 @@ class GenericScalarStorageEngineTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.all).thenAnswer { brokenSample }
         `when`(context.getSharedPreferences(
-            eq(MockScalarStorageEngine::class.java.canonicalName),
+            eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
         `when`(context.getSharedPreferences(
-            eq("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime"),
+            eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime",
+            .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
         // Instantiate our mock engine and check that it correctly unpersists the
         // data and makes it available in the snapshot.
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = context
 
         val metric = GenericMetricType(
@@ -210,19 +210,19 @@ class GenericScalarStorageEngineTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.all).thenAnswer { brokenSample }
         `when`(context.getSharedPreferences(
-            eq(MockScalarStorageEngine::class.java.canonicalName),
+            eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
         `when`(context.getSharedPreferences(
-            eq("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime"),
+            eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime",
+            .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
         // Instantiate our mock engine and check that it correctly unpersists the
         // data and makes it available in the snapshot.
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = context
 
         val snapshot = storageEngine.getSnapshot(storeName = "store_name", clearStore = true)
@@ -237,19 +237,19 @@ class GenericScalarStorageEngineTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.all).thenThrow(NullPointerException())
         `when`(context.getSharedPreferences(
-            eq(MockScalarStorageEngine::class.java.canonicalName),
+            eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
         `when`(context.getSharedPreferences(
-            eq("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime"),
+            eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime",
+            .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
         // Instantiate our mock engine and check that it correctly unpersists the
         // data and makes it available in the snapshot.
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = context
 
         // Make sure we attempt to load data to trigger the exception.
@@ -273,19 +273,19 @@ class GenericScalarStorageEngineTest {
         val sharedPreferences = mock(SharedPreferences::class.java)
         `when`(sharedPreferences.all).thenAnswer { persistedSample }
         `when`(context.getSharedPreferences(
-            eq(MockScalarStorageEngine::class.java.canonicalName),
+            eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
         `when`(context.getSharedPreferences(
-            eq("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime"),
+            eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("${MockScalarStorageEngine::class.java.canonicalName}.PingLifetime",
+            .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
         // Instantiate our mock engine and check that it correctly unpersists the
         // data and makes it available in the snapshot.
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = context
 
         val store1Snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = true)
@@ -300,7 +300,7 @@ class GenericScalarStorageEngineTest {
 
     @Test
     fun `snapshotting must only clear 'ping' lifetime`() {
-        val storageEngine = MockScalarStorageEngine()
+        val storageEngine = MockGenericStorageEngine()
         storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
         val stores = listOf("store1", "store2")
@@ -371,7 +371,7 @@ class GenericScalarStorageEngineTest {
         // context otherwise the test environment will use a different underlying file
         // for the SharedPreferences.
         run {
-            val storageEngine = MockScalarStorageEngine()
+            val storageEngine = MockGenericStorageEngine()
             storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val metric1 = GenericMetricType(
@@ -411,7 +411,7 @@ class GenericScalarStorageEngineTest {
 
         // Re-instantiate the engine: application lifetime probes should have been cleared.
         run {
-            val storageEngine = MockScalarStorageEngine()
+            val storageEngine = MockGenericStorageEngine()
             storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val snapshot = storageEngine.getSnapshot("store1", true)
@@ -426,7 +426,7 @@ class GenericScalarStorageEngineTest {
         // context otherwise the test environment will use a different underlying file
         // for the SharedPreferences.
         run {
-            val storageEngine = MockScalarStorageEngine()
+            val storageEngine = MockGenericStorageEngine()
             storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val metric1 = GenericMetricType(
@@ -471,7 +471,7 @@ class GenericScalarStorageEngineTest {
 
         // Re-instantiate the engine: ping lifetime metrics should be persisted.
         run {
-            val storageEngine = MockScalarStorageEngine()
+            val storageEngine = MockGenericStorageEngine()
             storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val snapshot = storageEngine.getSnapshot("store1", true)
@@ -489,7 +489,7 @@ class GenericScalarStorageEngineTest {
 
         // Now that the store was cleared, ping lifetime should have nothing persisted
         run {
-            val storageEngine = MockScalarStorageEngine()
+            val storageEngine = MockGenericStorageEngine()
             storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
 
             val snapshot = storageEngine.getSnapshot("store1", true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/MockGenericStorageEngine.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/MockGenericStorageEngine.kt
@@ -8,9 +8,9 @@ import android.content.SharedPreferences
 import mozilla.components.service.glean.CommonMetricData
 import mozilla.components.support.base.log.logger.Logger
 
-internal class MockScalarStorageEngine(
+internal class MockGenericStorageEngine(
     override val logger: Logger = Logger("test")
-) : GenericScalarStorageEngine<Int>() {
+) : GenericStorageEngine<Int>() {
     override fun deserializeSingleMetric(metricName: String, value: Any?): Int? {
         if (value is String) {
             return value.toIntOrNull()
@@ -32,6 +32,6 @@ internal class MockScalarStorageEngine(
         metricData: CommonMetricData,
         value: Int
     ) {
-        super.recordScalar(metricData, value)
+        super.recordMetric(metricData, value)
     }
 }


### PR DESCRIPTION
Since the generic storage engine implementation is no longer for just scalars only, it made sense to rename these classes, functions, and type identifiers to better reflect their actual use.  Now it will be the `GenericStorageEngine` and `MetricType`, etc...

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
