### PR TITLE
No issue: add Intent.toSafeIntent.

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
@@ -98,3 +98,8 @@ class SafeIntent(val unsafe: Intent) {
         }
     }
 }
+
+/**
+ * Returns a [SafeIntent] for the given [Intent].
+ */
+fun Intent.toSafeIntent(): SafeIntent = SafeIntent(this)

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/SafeIntentTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/SafeIntentTest.kt
@@ -266,4 +266,11 @@ class SafeIntentTest {
 
         assertEquals(intent, SafeIntent(intent).unsafe)
     }
+
+    @Test
+    fun `WHEN toSafeIntent wraps an intent THEN it has the same unsafe intent as the SafeIntent constructor`() {
+
+        // SafeIntent does not override .equals so we have to do comparison with their underlying unsafe intents.
+        assertEquals(SafeIntent(intent).unsafe, intent.toSafeIntent().unsafe)
+    }
 }


### PR DESCRIPTION
This conversion function follows Kotlin convention.

It felt more appropriate to put this here, than in KTX, because KTX
doesn't not have a dependency on support-utils.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
