### PR TITLE
Await ping serialization before enqueueing PingUploadWorker.

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -263,8 +263,6 @@ class GleanTest {
             Glean.handleBackgroundEvent()
         }
 
-        Glean.pingStorageEngine.testWait()
-
         // We should only have a baseline ping and no events or metrics pings since nothing was
         // recorded
         val files = Glean.pingStorageEngine.storageDirectory.listFiles()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -59,6 +59,8 @@ class MetricsPingSchedulerTest {
     fun setup() {
         WorkManagerTestInitHelper.initializeTestWorkManager(
             ApplicationProvider.getApplicationContext())
+
+        Glean.enableTestingMode()
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -282,9 +282,6 @@ class EventsStorageEngineTest {
 
             Assert.assertTrue(click.testHasValue())
 
-            // Wait for the ping to be written to disk.
-            Glean.pingStorageEngine.testWait()
-
             // Trigger worker task to upload the pings in the background
             triggerWorkManager()
 


### PR DESCRIPTION
This collects all ping serialization tasks in order to await them prior to enqueueing the `PingUploadWorker`.  

This also changes `EventsStorageEngine` to utilize the `Glean.sendPings()` function to funnel all ping sending through a single function rather than having duplication of ping sending also embedded into the `EventsStorageEngine`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
