### PR TITLE
[glean] 1529204: Another round of warning fixing

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Dispatchers.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Dispatchers.kt
@@ -50,7 +50,7 @@ internal object Dispatchers {
             assert(
                 testingMode,
                 {
-                    "To use the testing API, glean must be in testing mode by calling "
+                    "To use the testing API, glean must be in testing mode by calling " +
                     "Glean.enableTestingMode() (for example, in a @Before method)."
                 }
             )

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -371,6 +371,7 @@ open class GleanInternalAPI internal constructor () {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun enableTestingMode() {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.enableTestingMode()
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
@@ -101,6 +101,7 @@ object ErrorRecording {
         errorType: ErrorType,
         pingName: String? = null
     ): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         val usePingName = pingName?.let {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/BooleanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/BooleanMetricType.kt
@@ -61,6 +61,7 @@ data class BooleanMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return BooleansStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -78,6 +79,7 @@ data class BooleanMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return BooleansStorageEngine.getSnapshot(pingName, false)!![identifier]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/CounterMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/CounterMetricType.kt
@@ -63,6 +63,7 @@ data class CounterMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return CountersStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -80,6 +81,7 @@ data class CounterMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): Int {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return CountersStorageEngine.getSnapshot(pingName, false)!![identifier]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/DatetimeMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/DatetimeMetricType.kt
@@ -88,6 +88,7 @@ data class DatetimeMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return DatetimesStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -106,6 +107,7 @@ data class DatetimeMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValueAsString(pingName: String = getStorageNames().first()): String {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return DatetimesStorageEngine.getSnapshot(pingName, false)!![identifier]!!
@@ -127,6 +129,7 @@ data class DatetimeMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): Date {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return parseISOTimeString(DatetimesStorageEngine.getSnapshot(pingName, false)!![identifier]!!)!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/EventMetricType.kt
@@ -99,6 +99,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         val snapshot = EventsStorageEngine.getSnapshot(pingName, false) ?: return false
@@ -119,6 +120,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): List<RecordedEventData> {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return EventsStorageEngine.getSnapshot(pingName, false)!!.filter { event ->

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/StringListMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/StringListMetricType.kt
@@ -85,6 +85,7 @@ data class StringListMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return StringListsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -102,6 +103,7 @@ data class StringListMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): List<String> {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return StringListsStorageEngine.getSnapshot(pingName, false)!![identifier]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/StringMetricType.kt
@@ -63,6 +63,7 @@ data class StringMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return StringsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -80,6 +81,7 @@ data class StringMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): String {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return StringsStorageEngine.getSnapshot(pingName, false)!![identifier]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/TimingDistributionMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/TimingDistributionMetricType.kt
@@ -65,6 +65,7 @@ data class TimingDistributionMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return TimingDistributionsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -82,6 +83,7 @@ data class TimingDistributionMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): TimingDistributionData {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return TimingDistributionsStorageEngine.getSnapshot(pingName, false)!![identifier]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/metrics/UuidMetricType.kt
@@ -81,6 +81,7 @@ data class UuidMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return UuidsStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
@@ -98,6 +99,7 @@ data class UuidMetricType(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun testGetValue(pingName: String = getStorageNames().first()): UUID {
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
         return UuidsStorageEngine.getSnapshot(pingName, false)!![identifier]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -102,11 +102,12 @@ internal object EventsStorageEngine : StorageEngine {
      *
      * @param context The application context
      */
-    internal fun onReadyToSendPings(context: Context) {
+    internal fun onReadyToSendPings(@Suppress("UNUSED_PARAMETER") context: Context) {
         // We want this to run off of the main thread, because it might perform I/O.
         // However, we don't use the built-in KotlinDispatchers.IO since we need
         // to make sure this work is done before any other glean API calls, and this
         // will force them to be queued after this work.
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.launch {
             // Load events from disk
             storageDirectory.listFiles()?.forEach { file ->

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericStorageEngine.kt
@@ -129,9 +129,7 @@ internal abstract class GenericStorageEngine<MetricType> : StorageEngine {
             val storeData = dataStores[lifetime.ordinal].getOrPut(storeName) { mutableMapOf() }
             // Only set the stored value if we're able to deserialize the persisted data.
             deserializeSingleMetric(metricName, metricValue)?.let { value ->
-                storeData?.let {
-                    it[metricName] = value
-                }
+                storeData[metricName] = value
             } ?: logger.warn("Failed to deserialize $metricStoragePath")
         }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
@@ -18,6 +18,7 @@ class DispatchersTest {
     fun `API scope runs off the main thread`() {
         val mainThread = Thread.currentThread()
         var threadCanary = false
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.testingMode = false
 
         runBlocking {
@@ -31,6 +32,7 @@ class DispatchersTest {
             }!!.join()
         }
 
+        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.testingMode = true
         assertEquals(true, threadCanary)
         assertSame(mainThread, Thread.currentThread())

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -319,7 +319,7 @@ class GleanTest {
         // and first_run_date to the new location in glean_client_info.  We
         // need to clear those out again so we can test what happens when they
         // are missing.
-        val storageManager = StorageEngineManager(
+        StorageEngineManager(
             applicationContext = ApplicationProvider.getApplicationContext()
         ).clearAllStores()
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -215,7 +215,7 @@ internal class TestPingTagClient(
 
         // Have to return a response here.
         return Response(
-            responseUrl ?: request.url,
+            responseUrl,
             responseStatus,
             request.headers ?: responseHeaders,
             responseBody)


### PR DESCRIPTION
In all the major work since #2200, a number of glean's compiler warnings have reappeared.  This squashes them back down again.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
