### PR TITLE
Closes #2392 - Add ability for progress bar to be displayed on top of…

### DIFF
--- a/components/browser/toolbar/README.md
+++ b/components/browser/toolbar/README.md
@@ -26,6 +26,7 @@ implementation "org.mozilla.components:browser-toolbar:{latest-version}"
 | browserToolbarSuggestionBackgroundColor | color     | Background color of the autocomplete suggestion.        |
 | browserToolbarSuggestionForegroundColor | color     | Foreground (text) color of the autocomplete suggestion. |
 | browserToolbarFadingEdgeSize            | dimension | Size of the fading edge shown when the URL is too long. |
+| browserToolbarProgressBarGravity        | int       | Enum with options `bottom` (0, default) or `top` (1)    |
 
 ## Facts
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.display.DisplayToolbar
+import mozilla.components.browser.toolbar.display.DisplayToolbar.Companion.BOTTOM_PROGRESS_BAR
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.AutocompleteResult
@@ -316,7 +317,7 @@ class BrowserToolbar @JvmOverloads constructor(
             attrs?.let {
                 progressBarGravity = getInt(
                     R.styleable.BrowserToolbar_browserToolbarProgressBarGravity,
-                    0
+                    BOTTOM_PROGRESS_BAR
                 )
                 hintColor = getColor(
                     R.styleable.BrowserToolbar_browserToolbarHintColor,

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -183,6 +183,15 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     /**
+     * Set progress bar to be at the top of the toolbar. It's on bottom by default.
+     */
+    var progressBarGravity: Int
+        get() = displayToolbar.progressBarGravity
+        set(value) {
+            displayToolbar.progressBarGravity = value
+        }
+
+    /**
      * Sets the colour of the text for the URL/search term displayed in the toolbar.
      */
     var textColor: Int
@@ -305,6 +314,10 @@ class BrowserToolbar @JvmOverloads constructor(
     init {
         context.obtainStyledAttributes(attrs, R.styleable.BrowserToolbar, defStyleAttr, 0).run {
             attrs?.let {
+                progressBarGravity = getInt(
+                    R.styleable.BrowserToolbar_browserToolbarProgressBarGravity,
+                    0
+                )
                 hintColor = getColor(
                     R.styleable.BrowserToolbar_browserToolbarHintColor,
                     hintColor

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -436,7 +436,7 @@ internal class DisplayToolbar(
     companion object {
         internal const val URL_FADING_EDGE_SIZE_DP = 24
 
-        private const val BOTTOM_PROGRESS_BAR = 0
+        const val BOTTOM_PROGRESS_BAR = 0
         private const val TOP_PROGRESS_BAR = 1
         private const val ICON_PADDING_DP = 16
         private const val MENU_PADDING_DP = 16

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -154,6 +154,9 @@ internal class DisplayToolbar(
     // Margin between browser actions.
     internal var browserActionMargin = 0
 
+    // Location of progress bar
+    internal var progressBarGravity = BOTTOM_PROGRESS_BAR
+
     // Horizontal margin of URL Box (surrounding URL and page actions).
     internal var urlBoxMargin = 0
 
@@ -323,6 +326,7 @@ internal class DisplayToolbar(
     }
 
     // We layout the toolbar ourselves to avoid the overhead from using complex ViewGroup implementations
+    @Suppress("ComplexMethod")
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         // First we layout the navigation actions if there are any:
         //   +-------------+------------------------------------------------+
@@ -413,9 +417,13 @@ internal class DisplayToolbar(
         val urlLeft = navigationActionsWidth + iconWidth + urlBoxMargin
         urlView.layout(urlLeft, 0, urlLeft + urlView.measuredWidth, measuredHeight)
 
-        // The progress bar is going to be drawn at the bottom of the toolbar:
-
-        progressView.layout(0, measuredHeight - progressView.measuredHeight, measuredWidth, measuredHeight)
+        // The progress bar by default is going to be drawn at the bottom of the toolbar, top if defined:
+        progressView.layout(
+            0,
+            if (progressBarGravity == TOP_PROGRESS_BAR) 0 else measuredHeight - progressView.measuredHeight,
+            measuredWidth,
+            if (progressBarGravity == TOP_PROGRESS_BAR) progressView.measuredHeight else measuredHeight
+        )
 
         // The URL box view (if exists) is positioned behind the icon, the url and page actions:
 
@@ -428,6 +436,8 @@ internal class DisplayToolbar(
     companion object {
         internal const val URL_FADING_EDGE_SIZE_DP = 24
 
+        private const val BOTTOM_PROGRESS_BAR = 0
+        private const val TOP_PROGRESS_BAR = 1
         private const val ICON_PADDING_DP = 16
         private const val MENU_PADDING_DP = 16
         private const val URL_TEXT_SIZE = 15f

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -15,5 +15,9 @@
     <attr name="browserToolbarSuggestionForegroundColor" format="color" />
     <attr name="browserToolbarClearColor" format="color"/>
     <attr name="browserToolbarFadingEdgeSize" format="dimension" />
+    <attr name="browserToolbarProgressBarGravity">
+      <enum name="bottom" value="0" />
+      <enum name="top" value="1" />
+    </attr>
   </declare-styleable>
 </resources>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -109,6 +109,21 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `progress view changes with gravity`() {
+        val toolbar = mock(BrowserToolbar::class.java)
+        val displayToolbar = DisplayToolbar(context, toolbar)
+        val progressView = extractProgressView(displayToolbar)
+
+        displayToolbar.progressBarGravity = 1
+        assertEquals(1, displayToolbar.progressBarGravity)
+        assertEquals(progressView.measuredHeight, progressView.bottom)
+
+        displayToolbar.progressBarGravity = 0
+        assertEquals(0, displayToolbar.progressBarGravity)
+        assertEquals(toolbar.measuredHeight, progressView.bottom)
+    }
+
+    @Test
     fun `menu view is gone by default`() {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(context, toolbar)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,9 @@ permalink: /changelog/
 * **feature-findinpage**
    * Find in Page now emits facts
 
+* **browser-toolbar**
+   * Adds `browserToolbarProgressBarGravity` attr with options `top` and `bottom` (default).
+
 # 0.49.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.48.0...v0.49.0)


### PR DESCRIPTION
… toolbar

Hi @pocmo this has UX now :) https://github.com/mozilla-mobile/fenix/issues/1049#issuecomment-479178216
I tested it in Fenix and I don't think we need a drawable attr here, I am able to override the progress bar style and set the drawable, so just the ability for the top layout for now. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
