### PR TITLE
Glean: fix an issue in testing background pings

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -125,6 +125,10 @@ class GleanTest {
     @Test
     fun `test sending of background pings`() {
         val server = MockWebServer()
+
+        // It's important to note here that we expect to receive two pings back, the baseline and
+        // the events ping so we need to enqueue a response back for EACH of them.
+        server.enqueue(MockResponse().setBody("OK"))
         server.enqueue(MockResponse().setBody("OK"))
 
         val click = EventMetricType<NoExtraKeys>(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -11,6 +11,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
+import junit.framework.Assert.assertTrue
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers
 import mozilla.components.concept.fetch.MutableHeaders
@@ -194,7 +195,8 @@ internal fun triggerWorkManager() {
         isWorkScheduled(PingUploadWorker.PING_WORKER_TAG))
 
     // Since WorkManager does not properly run in tests, simulate the work being done
-    PingUploadWorker.uploadPings()
+    // We also assertTrue here to ensure that uploadPings() was successful
+    assertTrue("Upload Pings must return true", PingUploadWorker.uploadPings())
 }
 
 /**


### PR DESCRIPTION
- Fixes and issue with `test sending of background pings` that was causing it to timeout when `triggerWorkManager()` was called due to only enqueueing a single response when we actually need two, one for events ping and one for baseline ping.
- Adds an assert to `triggerWorkManager()` around the `PingUploadWorker.uploadPings()` function to help catch similar issues in the future 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
