### PR TITLE
1538745: Make TimingDistributionData.values use Int as key

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/metrics/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/metrics/TimingDistributionMetricTypeTest.kt
@@ -63,11 +63,11 @@ class TimingDistributionMetricTypeTest {
         // Check the sum
         assertEquals(6L, snapshot.sum)
         // Check that the 1L fell into the first bucket
-        assertEquals(1L, snapshot.values["0"])
+        assertEquals(1L, snapshot.values[0])
         // Check that the 2L fell into the second bucket
-        assertEquals(1L, snapshot.values["1"])
+        assertEquals(1L, snapshot.values[1])
         // Check that the 3L fell into the third bucket
-        assertEquals(1L, snapshot.values["2"])
+        assertEquals(1L, snapshot.values[2])
     }
 
     @Test
@@ -127,11 +127,11 @@ class TimingDistributionMetricTypeTest {
         // Check the sum
         assertEquals(6L, snapshot.sum)
         // Check that the 1L fell into the first bucket
-        assertEquals(1L, snapshot.values["0"])
+        assertEquals(1L, snapshot.values[0])
         // Check that the 2L fell into the second bucket
-        assertEquals(1L, snapshot.values["1"])
+        assertEquals(1L, snapshot.values[1])
         // Check that the 3L fell into the third bucket
-        assertEquals(1L, snapshot.values["2"])
+        assertEquals(1L, snapshot.values[2])
 
         // Check that data was properly recorded in the third ping.
         assertTrue(metric.testHasValue("store3"))
@@ -139,10 +139,10 @@ class TimingDistributionMetricTypeTest {
         // Check the sum
         assertEquals(6L, snapshot2.sum)
         // Check that the 1L fell into the first bucket
-        assertEquals(1L, snapshot2.values["0"])
+        assertEquals(1L, snapshot2.values[0])
         // Check that the 2L fell into the second bucket
-        assertEquals(1L, snapshot2.values["1"])
+        assertEquals(1L, snapshot2.values[1])
         // Check that the 3L fell into the third bucket
-        assertEquals(1L, snapshot2.values["2"])
+        assertEquals(1L, snapshot2.values[2])
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
@@ -61,7 +61,7 @@ class TimingDistributionsStorageEngineTest {
                 clearStore = true
             )
             assertEquals(1, snapshot!!.size)
-            assertEquals(1L, snapshot["telemetry.test_timing_distribution"]?.values!!["0"])
+            assertEquals(1L, snapshot["telemetry.test_timing_distribution"]?.values!![0])
         }
     }
 
@@ -213,7 +213,7 @@ class TimingDistributionsStorageEngineTest {
         val snapshot = metric.testGetValue()
         assertEquals("Accumulating overflow values should increment last bucket",
             1L,
-            snapshot.values["${TimingDistributionData.DEFAULT_BUCKET_COUNT - 1}"])
+            snapshot.values[TimingDistributionData.DEFAULT_BUCKET_COUNT - 1])
     }
 
     @Test
@@ -245,7 +245,7 @@ class TimingDistributionsStorageEngineTest {
         // Make sure that the sample in the correct (first) bucket
         val snapshot = metric.testGetValue()
         assertEquals("Accumulating should increment correct bucket",
-            1L, snapshot.values["0"])
+            1L, snapshot.values[0])
 
         // verify buckets lists worked
         assertNotNull("Buckets must not be null", snapshot.buckets)
@@ -285,15 +285,15 @@ class TimingDistributionsStorageEngineTest {
         assertEquals("Accumulating updates the count", 5, snapshot.count)
 
         assertEquals("Accumulating should increment correct bucket",
-            1L, snapshot.values["0"])
+            1L, snapshot.values[0])
         assertEquals("Accumulating should increment correct bucket",
-            1L, snapshot.values["9"])
+            1L, snapshot.values[9])
         assertEquals("Accumulating should increment correct bucket",
-            1L, snapshot.values["33"])
+            1L, snapshot.values[33])
         assertEquals("Accumulating should increment correct bucket",
-            1L, snapshot.values["57"])
+            1L, snapshot.values[57])
         assertEquals("Accumulating should increment correct bucket",
-            1L, snapshot.values["80"])
+            1L, snapshot.values[80])
     }
 
     @Test
@@ -327,11 +327,11 @@ class TimingDistributionsStorageEngineTest {
             tdd.histogramType.ordinal, jsonTdd.getInt("histogramType"))
         val jsonValue = jsonTdd.getJSONObject("values")
         assertEquals("JSON values must match Timing Distribution values",
-            tdd.values["0"], jsonValue.getLong("0"))
+            tdd.values[0], jsonValue.getLong("0"))
         assertEquals("JSON values must match Timing Distribution values",
-            tdd.values["1"], jsonValue.getLong("1"))
+            tdd.values[1], jsonValue.getLong("1"))
         assertEquals("JSON values must match Timing Distribution values",
-            tdd.values["2"], jsonValue.getLong("2"))
+            tdd.values[2], jsonValue.getLong("2"))
         assertEquals("JSON sum must match Timing Distribution sum",
             tdd.sum, jsonTdd.getLong("sum"))
         assertEquals("JSON time unit must match Timing Distribution time unit",


### PR DESCRIPTION
This reduces the overhead of having to do string interpolation from Int to String every time `accumulate` is called and only has to convert this to a map with String keys when serializing.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
