### PR TITLE
Add preferredColorScheme to Settings

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -6,6 +6,8 @@ package mozilla.components.browser.engine.gecko
 
 import android.content.Context
 import android.util.AttributeSet
+import mozilla.components.browser.engine.gecko.mediaquery.from
+import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
@@ -13,6 +15,7 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.webextension.WebExtension
 import org.json.JSONObject
 import org.mozilla.geckoview.GeckoResult
@@ -135,6 +138,10 @@ class GeckoEngine(
         override var userAgentString: String?
             get() = defaultSettings?.userAgentString ?: GeckoSession.getDefaultUserAgent()
             set(value) { defaultSettings?.userAgentString = value }
+
+        override var preferredColorScheme: PreferredColorScheme
+            get() = PreferredColorScheme.from(runtime.settings.preferredColorScheme)
+            set(value) { runtime.settings.preferredColorScheme = value.toGeckoValue() }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled
@@ -144,6 +151,7 @@ class GeckoEngine(
             this.remoteDebuggingEnabled = it.remoteDebuggingEnabled
             this.testingModeEnabled = it.testingModeEnabled
             this.userAgentString = it.userAgentString
+            this.preferredColorScheme = it.preferredColorScheme
         }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/mediaquery/PreferredColorScheme.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/mediaquery/PreferredColorScheme.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.browser.engine.gecko.mediaquery
+
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import org.mozilla.geckoview.GeckoRuntimeSettings
+
+internal fun PreferredColorScheme.Companion.from(geckoValue: Int) =
+        when (geckoValue) {
+            GeckoRuntimeSettings.COLOR_SCHEME_DARK -> PreferredColorScheme.Dark
+            GeckoRuntimeSettings.COLOR_SCHEME_LIGHT -> PreferredColorScheme.Light
+            GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM -> PreferredColorScheme.System
+            else -> PreferredColorScheme.System
+        }
+
+internal fun PreferredColorScheme.toGeckoValue() =
+    when (this) {
+        is PreferredColorScheme.Dark -> GeckoRuntimeSettings.COLOR_SCHEME_DARK
+        is PreferredColorScheme.Light -> GeckoRuntimeSettings.COLOR_SCHEME_LIGHT
+        is PreferredColorScheme.System -> GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM
+    }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -6,9 +6,11 @@ package mozilla.components.browser.engine.gecko
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.UnsupportedSettingException
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -69,6 +71,7 @@ class GeckoEngineTest {
         `when`(runtimeSettings.webFontsEnabled).thenReturn(true)
         `when`(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
         `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
+        `when`(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
         `when`(runtime.settings).thenReturn(runtimeSettings)
         val engine = GeckoEngine(context, runtime = runtime, defaultSettings = defaultSettings)
 
@@ -91,6 +94,10 @@ class GeckoEngineTest {
         assertFalse(engine.settings.testingModeEnabled)
         engine.settings.testingModeEnabled = true
         assertTrue(engine.settings.testingModeEnabled)
+
+        assertEquals(PreferredColorScheme.System, engine.settings.preferredColorScheme)
+        engine.settings.preferredColorScheme = PreferredColorScheme.Dark
+        verify(runtimeSettings).preferredColorScheme = PreferredColorScheme.Dark.toGeckoValue()
 
         // Specifying no ua-string default should result in GeckoView's default.
         assertEquals(GeckoSession.getDefaultUserAgent(), engine.settings.userAgentString)
@@ -131,14 +138,17 @@ class GeckoEngineTest {
         `when`(runtime.settings).thenReturn(runtimeSettings)
         `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
 
-        val engine = GeckoEngine(context, DefaultSettings(
+        val engine = GeckoEngine(context,
+            DefaultSettings(
                 trackingProtectionPolicy = TrackingProtectionPolicy.all(),
                 javascriptEnabled = false,
                 webFontsEnabled = false,
                 automaticFontSizeAdjustment = false,
                 remoteDebuggingEnabled = true,
                 testingModeEnabled = true,
-                userAgentString = "test-ua"), runtime)
+                userAgentString = "test-ua",
+                preferredColorScheme = PreferredColorScheme.Light
+            ), runtime)
 
         verify(runtimeSettings).javaScriptEnabled = false
         verify(runtimeSettings).webFontsEnabled = false
@@ -154,6 +164,7 @@ class GeckoEngineTest {
         ).categories, contentBlockingSettings.categories)
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
+        assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
     }
 
     @Test

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.request.RequestInterceptor
 import kotlin.reflect.KProperty
 
@@ -123,6 +124,12 @@ abstract class Settings {
      * Setting to control whether or not testing mode is enabled.
      */
     open var testingModeEnabled: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to alert the content that the user prefers a particular theme. This affects the
+     * [@media(prefers-color-scheme)] query.
+     */
+    open var preferredColorScheme: PreferredColorScheme by UnsupportedSetting()
 }
 
 /**
@@ -149,6 +156,7 @@ data class DefaultSettings(
     override var horizontalScrollBarEnabled: Boolean = true,
     override var remoteDebuggingEnabled: Boolean = false,
     override var supportMultipleWindows: Boolean = false,
+    override var preferredColorScheme: PreferredColorScheme = PreferredColorScheme.System,
     override var testingModeEnabled: Boolean = false
 ) : Settings()
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/mediaquery/PreferredColorScheme.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/mediaquery/PreferredColorScheme.kt
@@ -1,0 +1,13 @@
+package mozilla.components.concept.engine.mediaquery
+
+/**
+ * A simple data class used to suggest to page content that the user prefers a particular color
+ * scheme.
+ */
+sealed class PreferredColorScheme {
+    companion object
+
+    object Light : PreferredColorScheme()
+    object Dark : PreferredColorScheme()
+    object System : PreferredColorScheme()
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
@@ -62,6 +63,8 @@ class SettingsTest {
             { settings.remoteDebuggingEnabled = false },
             { settings.supportMultipleWindows },
             { settings.supportMultipleWindows = false },
+            { settings.preferredColorScheme },
+            { settings.preferredColorScheme = PreferredColorScheme.System },
             { settings.testingModeEnabled },
             { settings.testingModeEnabled = false }
         )
@@ -95,6 +98,7 @@ class SettingsTest {
         assertTrue(settings.horizontalScrollBarEnabled)
         assertFalse(settings.remoteDebuggingEnabled)
         assertFalse(settings.supportMultipleWindows)
+        assertEquals(PreferredColorScheme.System, settings.preferredColorScheme)
         assertFalse(settings.testingModeEnabled)
 
         val interceptor: RequestInterceptor = mock()
@@ -121,6 +125,7 @@ class SettingsTest {
             horizontalScrollBarEnabled = false,
             remoteDebuggingEnabled = true,
             supportMultipleWindows = true,
+            preferredColorScheme = PreferredColorScheme.Dark,
             testingModeEnabled = true)
 
         assertFalse(defaultSettings.domStorageEnabled)
@@ -143,6 +148,7 @@ class SettingsTest {
         assertFalse(defaultSettings.horizontalScrollBarEnabled)
         assertTrue(defaultSettings.remoteDebuggingEnabled)
         assertTrue(defaultSettings.supportMultipleWindows)
+        assertEquals(PreferredColorScheme.Dark, defaultSettings.preferredColorScheme)
         assertTrue(defaultSettings.testingModeEnabled)
     }
 }


### PR DESCRIPTION
Fixes [fenix#1164][1].

This PR links up the `preferredColorScheme` gecko view setting to the respective `browser-gecko-engine` component.

It introduces a sealed data class for the purpose in `engine-concept`. This is mapped to the gecko runtime settings in the browser component.

[1]: https://github.com/mozilla-mobile/fenix/issues/1164