### PR TITLE
1536792:  Reinstate disabled MetricsPingSchedulerTests.

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -218,14 +218,14 @@ class GleanTest {
             name = "string_metric",
             sendInPings = listOf("store1")
         )
-        Glean.initialized = false
+        Glean.initState = GleanInternalAPI.GleanInitStates.UNINITIALIZED
         stringMetric.set("foo")
         assertNull(
             "Metrics should not be recorded if glean is not initialized",
             StringsStorageEngine.getSnapshot(storeName = "store1", clearStore = false)
         )
 
-        Glean.initialized = true
+        Glean.initState = GleanInternalAPI.GleanInitStates.INITIALIZED
     }
 
     @Test
@@ -243,7 +243,7 @@ class GleanTest {
     fun `Don't handle events when uninitialized`() {
         val gleanSpy = spy<GleanInternalAPI>(GleanInternalAPI::class.java)
 
-        gleanSpy.initialized = false
+        gleanSpy.initState = GleanInternalAPI.GleanInitStates.UNINITIALIZED
         runBlocking {
             gleanSpy.handleBackgroundEvent()
         }
@@ -349,7 +349,7 @@ class GleanTest {
         assertFalse(GleanInternalMetrics.firstRunDate.testHasValue())
 
         // This should copy the values to their new locations
-        Glean.initialized = false
+        Glean.initState = GleanInternalAPI.GleanInitStates.UNINITIALIZED
         Glean.initialize(ApplicationProvider.getApplicationContext())
 
         assertEquals(clientIdValue, GleanInternalMetrics.clientId.testGetValue())
@@ -388,7 +388,7 @@ class GleanTest {
         assertTrue(GleanInternalMetrics.firstRunDate.testHasValue())
 
         // This should copy the values to their new locations
-        Glean.initialized = false
+        Glean.initState = GleanInternalAPI.GleanInitStates.UNINITIALIZED
         Glean.initialize(ApplicationProvider.getApplicationContext())
 
         assertNotEquals(clientIdValue, GleanInternalMetrics.clientId.testGetValue())
@@ -417,7 +417,7 @@ class GleanTest {
         firstRunDetector.createFirstRunFile()
 
         // This should copy the values to their new locations
-        Glean.initialized = false
+        Glean.initState = GleanInternalAPI.GleanInitStates.UNINITIALIZED
         Glean.initialize(ApplicationProvider.getApplicationContext())
 
         assertTrue(GleanInternalMetrics.clientId.testHasValue())

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -137,7 +137,7 @@ internal fun resetGlean(
     val firstRun = FileFirstRunDetector(File(context.applicationInfo.dataDir, Glean.GLEAN_DATA_DIR))
     firstRun.reset()
     // Init glean.
-    Glean.initialized = false
+    Glean.initState = GleanInternalAPI.GleanInitStates.UNINITIALIZED
     Glean.setUploadEnabled(true)
     Glean.initialize(context, config)
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -54,7 +54,7 @@ class EventsStorageEngineTest {
     @Before
     fun setUp() {
         resetGlean()
-        assert(Glean.initialized)
+        assert(Glean.isInitialized())
         EventsStorageEngine.clearAllStores()
 
         // Initialize WorkManager using the WorkManagerTestInitHelper.


### PR DESCRIPTION
In order to accomplish this, a window in `Glean.initialize()` where metrics could be recorded before init was complete needed to be closed.  In order to do this, a new `initializing` flag/state was added to allow for uploading of pings while still preventing recording of metrics during initialization.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
