### PR TITLE
FxA device & send tab integration

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -50,6 +50,7 @@ object Versions {
 object Dependencies {
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
+    const val kotlin_coroutines_test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
 
     const val testing_junit = "junit:junit:${Versions.junit}"

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/DeviceEvents.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/DeviceEvents.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.sync
+
+/**
+ * Allows monitoring events targeted at the current device.
+ */
+interface DeviceEventsObserver {
+    fun onEvents(events: List<DeviceEvent>)
+}
+
+/**
+ * Incoming device events, targeted at the current device.
+ */
+sealed class DeviceEvent {
+    class TabReceived(val from: Device?, val entries: List<TabData>) : DeviceEvent()
+}
+
+/**
+ * Outgoing device events, targeted at other devices.
+ */
+sealed class DeviceEventOutgoing {
+    class SendTab(val title: String, val url: String) : DeviceEventOutgoing()
+}
+
+data class TabData(
+    val title: String,
+    val url: String
+)

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+@file:SuppressWarnings("TooManyFunctions")
+package mozilla.components.concept.sync
+
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.Deferred
+import mozilla.components.support.base.observer.Observable
+
+/**
+ * Describes available interactions with the current device and other devices associated with an [OAuthAccount].
+ */
+interface DeviceConstellation : Observable<DeviceEventsObserver> {
+    /**
+     * Register current device in the associated [DeviceConstellation].
+     *
+     * @param name An initial name for the current device. This may be changed via [setDeviceNameAsync].
+     * @param type Type of the current device. This can't be changed.
+     * @param capabilities A list of capabilities that the current device claims to have.
+     * @return A [Deferred] that will be resolved once initialization is complete.
+     */
+    fun initDeviceAsync(
+        name: String,
+        type: DeviceType = DeviceType.MOBILE,
+        capabilities: List<DeviceCapability>
+    ): Deferred<Unit>
+
+    /**
+     * Ensure that all initialized [DeviceCapability], such as [DeviceCapability.SEND_TAB], are configured.
+     * This may involve backend service registration, or other work involving network/disc access.
+     * @return A [Deferred] that will be resolved once operation is complete.
+     */
+    fun ensureCapabilitiesAsync(): Deferred<Unit>
+
+    /**
+     * Current state of the constellation. May be missing if state was never queried.
+     * @return [ConstellationState] describes current and other known devices in the constellation.
+     */
+    fun state(): ConstellationState?
+
+    /**
+     * Allows monitoring state of the device constellation via [DeviceConstellationObserver].
+     * Use this to be notified of changes to the current device or other devices.
+     */
+    fun registerDeviceObserver(observer: DeviceConstellationObserver, owner: LifecycleOwner, autoPause: Boolean)
+
+    /**
+     * Get all devices in the constellation.
+     * @return A list of all devices in the constellation.
+     */
+    fun fetchAllDevicesAsync(): Deferred<List<Device>>
+
+    /**
+     * Set name of the current device.
+     * @param name New device name.
+     * @return A [Deferred] that will be resolved once operation is complete.
+     */
+    fun setDeviceNameAsync(name: String): Deferred<Unit>
+
+    /**
+     * Set a [DevicePushSubscription] for the current device.
+     * @param subscription A new [DevicePushSubscription].
+     * @return A [Deferred] that will be resolved once operation is complete.
+     */
+    fun setDevicePushSubscriptionAsync(subscription: DevicePushSubscription): Deferred<Unit>
+
+    /**
+     * Send an event to a specified device.
+     * @param targetDeviceId A device ID of the recipient.
+     * @param outgoingEvent An event to send.
+     * @return A [Deferred] that will be resolved once operation is complete.
+     */
+    fun sendEventToDeviceAsync(targetDeviceId: String, outgoingEvent: DeviceEventOutgoing): Deferred<Unit>
+
+    /**
+     * Process a raw event, obtained via a push message or some other out-of-band mechanism.
+     * @param payload A raw, plaintext payload to be processed.
+     */
+    fun processRawEvent(payload: String)
+
+    /**
+     * Poll for events targeted at the current [Device]. It's expected that if a [DeviceEvent] was
+     * returned after a poll, it will not be returned in consequent polls.
+     * @return A list of [DeviceEvent] instances that are currently pending for this [Device].
+     */
+    fun pollForEventsAsync(): Deferred<List<DeviceEvent>>
+
+    /**
+     * Begin periodically refreshing constellation state, including polling for events.
+     */
+    fun startPeriodicRefresh()
+
+    /**
+     * Stop periodically refreshing constellation state and polling for events.
+     */
+    fun stopPeriodicRefresh()
+
+    /**
+     * Refreshes internal state of the device constellation.
+     * @return A [Deferred] that will be resolved once operation is complete.
+     */
+    fun refreshDeviceStateAsync(): Deferred<Unit>
+}
+
+/**
+ * Describes current device and other devices in the constellation.
+ */
+data class ConstellationState(val currentDevice: Device?, val otherDevices: List<Device>)
+
+/**
+ * Allows monitoring constellation state.
+ */
+interface DeviceConstellationObserver {
+    fun onDevicesUpdate(constellation: ConstellationState)
+}
+
+/**
+ * Describes a type of the physical device in the constellation.
+ */
+enum class DeviceType {
+    DESKTOP,
+    MOBILE,
+    UNKNOWN
+}
+
+/**
+ * Describes an Autopush-compatible push channel subscription.
+ */
+data class DevicePushSubscription(
+    val endpoint: String,
+    val publicKey: String,
+    val authKey: String
+)
+
+/**
+ * Capabilities that a [Device] may have.
+ */
+enum class DeviceCapability {
+    SEND_TAB
+}
+
+/**
+ * Describes a device in the [DeviceConstellation].
+ */
+data class Device(
+    val id: String,
+    val displayName: String,
+    val deviceType: DeviceType,
+    val isCurrentDevice: Boolean,
+    val lastAccessTime: Long?,
+    val capabilities: List<DeviceCapability>,
+    val subscriptionExpired: Boolean,
+    val subscription: DevicePushSubscription?
+)

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.concept.sync
 
 import kotlinx.coroutines.Deferred
@@ -17,6 +21,7 @@ class AuthException(type: AuthExceptionType) : java.lang.Exception(type.msg)
 /**
  * Facilitates testing consumers of FirefoxAccount.
  */
+@SuppressWarnings("TooManyFunctions")
 interface OAuthAccount : AutoCloseable {
     fun beginOAuthFlow(scopes: Array<String>, wantsKeys: Boolean): Deferred<String>
     fun beginPairingFlow(pairingUrl: String, scopes: Array<String>): Deferred<String>
@@ -26,6 +31,7 @@ interface OAuthAccount : AutoCloseable {
     fun getAccessToken(singleScope: String): Deferred<AccessTokenInfo>
     fun getTokenServerEndpointURL(): String
     fun registerPersistenceCallback(callback: StatePersistenceCallback)
+    fun deviceConstellation(): DeviceConstellation
     fun toJSONString(): String
 
     suspend fun authInfo(singleScope: String): AuthInfo {

--- a/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeature.kt
+++ b/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeature.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.feature.tabs.TabsUseCases
-import mozilla.components.service.fxa.FxaAccountManager
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.FxaException
 import kotlin.coroutines.CoroutineContext
 

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
@@ -7,14 +7,16 @@ package mozilla.components.feature.accounts
 import android.content.Context
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.service.fxa.AccountStorage
 import mozilla.components.service.fxa.Config
-import mozilla.components.service.fxa.FxaAccountManager
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.FxaNetworkException
 import mozilla.components.service.fxa.SharedPrefAccountStorage
+import mozilla.components.service.fxa.manager.DeviceTuple
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Test
@@ -38,7 +40,7 @@ class TestableFxaAccountManager(
     scopes: Array<String>,
     accountStorage: AccountStorage = SharedPrefAccountStorage(context),
     val block: () -> OAuthAccount = { mock() }
-) : FxaAccountManager(context, config, scopes, null) {
+) : FxaAccountManager(context, config, scopes, DeviceTuple("test", DeviceType.MOBILE, listOf()), null) {
     override fun createAccount(config: Config): OAuthAccount {
         return block()
     }

--- a/components/feature/sync/src/main/java/mozilla/components/feature/sync/WorkManagerSyncDispatcher.kt
+++ b/components/feature/sync/src/main/java/mozilla/components/feature/sync/WorkManagerSyncDispatcher.kt
@@ -146,6 +146,11 @@ class WorkManagerSyncDispatcher(
         // Periodic interval must be at least PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS,
         // e.g. not more frequently than 15 minutes.
         return PeriodicWorkRequestBuilder<WorkManagerSyncWorker>(period, unit)
+                .setConstraints(
+                        Constraints.Builder()
+                                .setRequiredNetworkType(NetworkType.CONNECTED)
+                                .build()
+                )
                 .setInputData(data)
                 .addTag(SyncWorkerTag.Common.name)
                 .addTag(SyncWorkerTag.Periodic.name)

--- a/components/service/firefox-accounts/build.gradle
+++ b/components/service/firefox-accounts/build.gradle
@@ -40,11 +40,14 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 
+    implementation Dependencies.androidx_work_runtime
+
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.kotlin_coroutines_test
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fxa
+
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import mozilla.appservices.fxaclient.FirefoxAccount
+import mozilla.components.concept.sync.ConstellationState
+import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.DeviceConstellationObserver
+import mozilla.components.concept.sync.DeviceEvent
+import mozilla.components.concept.sync.DeviceEventOutgoing
+import mozilla.components.concept.sync.DeviceEventsObserver
+import mozilla.components.concept.sync.DevicePushSubscription
+import mozilla.components.concept.sync.DeviceType
+import mozilla.components.service.fxa.manager.DeviceManagerProvider
+import mozilla.components.service.fxa.manager.PollingDeviceManager
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+
+/**
+ * Provides an implementation of [DeviceConstellation] backed by a [FirefoxAccount].
+ */
+@SuppressWarnings("TooManyFunctions")
+class FxaDeviceConstellation(
+    private val account: FirefoxAccount,
+    private val scope: CoroutineScope
+) : DeviceConstellation, Observable<DeviceEventsObserver> by ObserverRegistry() {
+    private val logger = Logger("FxaDeviceConstellation")
+
+    private val deviceObserverRegistry = ObserverRegistry<DeviceConstellationObserver>()
+    private val deviceManager = PollingDeviceManager(this, scope, deviceObserverRegistry)
+
+    init {
+        DeviceManagerProvider.deviceManager = deviceManager
+
+        deviceManager.register(object : DeviceEventsObserver {
+            override fun onEvents(events: List<DeviceEvent>) {
+                // TODO notifyObserversOnMainThread
+                CoroutineScope(Dispatchers.Main).launch {
+                    notifyObservers { onEvents(events) }
+                }
+            }
+        })
+    }
+
+    override fun initDeviceAsync(name: String, type: DeviceType, capabilities: List<DeviceCapability>): Deferred<Unit> {
+        return scope.async {
+            account.initializeDevice(name, type.into(), capabilities.map { it.into() }.toSet())
+        }
+    }
+
+    override fun ensureCapabilitiesAsync(): Deferred<Unit> {
+        return scope.async {
+            account.ensureCapabilities()
+        }
+    }
+
+    override fun processRawEvent(payload: String) {
+        scope.launch {
+            val events = account.handlePushMessage(payload).filter {
+                it is mozilla.appservices.fxaclient.AccountEvent.TabReceived
+            }.map {
+                (it as mozilla.appservices.fxaclient.AccountEvent.TabReceived).into()
+            }
+            deviceManager.processEvents(events)
+        }
+    }
+
+    override fun pollForEventsAsync(): Deferred<List<DeviceEvent>> {
+        // Currently ignoring non-TabReceived events.
+        return scope.async {
+            account.pollDeviceCommands().filter {
+                it is mozilla.appservices.fxaclient.AccountEvent.TabReceived
+            }.map {
+                (it as mozilla.appservices.fxaclient.AccountEvent.TabReceived).into()
+            }
+        }
+    }
+
+    override fun fetchAllDevicesAsync(): Deferred<List<Device>> {
+        return scope.async {
+            account.getDevices().map { it.into() }
+        }
+    }
+
+    override fun registerDeviceObserver(
+        observer: DeviceConstellationObserver,
+        owner: LifecycleOwner,
+        autoPause: Boolean
+    ) {
+        deviceObserverRegistry.register(observer, owner, autoPause)
+    }
+
+    override fun setDeviceNameAsync(name: String): Deferred<Unit> {
+        return scope.async {
+            account.setDeviceDisplayName(name)
+        }
+    }
+
+    override fun setDevicePushSubscriptionAsync(subscription: DevicePushSubscription): Deferred<Unit> {
+        return scope.async {
+            account.setDevicePushSubscription(
+                    subscription.endpoint, subscription.publicKey, subscription.authKey
+            )
+        }
+    }
+
+    override fun sendEventToDeviceAsync(targetDeviceId: String, outgoingEvent: DeviceEventOutgoing): Deferred<Unit> {
+        return scope.async {
+            when (outgoingEvent) {
+                is DeviceEventOutgoing.SendTab -> {
+                    account.sendSingleTab(targetDeviceId, outgoingEvent.title, outgoingEvent.url)
+                }
+                else -> logger.debug("Skipped sending unsupported event type: $outgoingEvent")
+            }
+        }
+    }
+
+    override fun state(): ConstellationState? {
+        return deviceManager.constellationState()
+    }
+
+    override fun startPeriodicRefresh() {
+        deviceManager.startPolling()
+    }
+
+    override fun stopPeriodicRefresh() {
+        deviceManager.stopPolling()
+    }
+
+    override fun refreshDeviceStateAsync(): Deferred<Unit> {
+        return scope.async {
+            deviceManager.refreshDevicesAsync().await()
+            deviceManager.processEvents(pollForEventsAsync().await())
+        }
+    }
+}

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
@@ -1,17 +1,24 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+@file:SuppressWarnings("TooManyFunctions")
 package mozilla.components.service.fxa
 
 import mozilla.appservices.fxaclient.AccessTokenInfo
+import mozilla.appservices.fxaclient.AccountEvent
+import mozilla.appservices.fxaclient.Device
 import mozilla.appservices.fxaclient.Profile
 import mozilla.appservices.fxaclient.ScopedKey
+import mozilla.appservices.fxaclient.TabHistoryEntry
 import mozilla.components.concept.sync.Avatar
+import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthScopedKey
 
-// This file describes translations from fxaclient's internal type definitions into analogous
-// types defined by concept-sync.
+// This file describes translations between fxaclient's internal type definitions and analogous
+// types defined by concept-sync. It's a little tedious, but ensures decoupling between abstract
+// definitions and a concrete implementation. In practice, this means that concept-sync doesn't need
+// impose a dependency on fxaclient native library.
 
 fun AccessTokenInfo.into(): mozilla.components.concept.sync.AccessTokenInfo {
     return mozilla.components.concept.sync.AccessTokenInfo(
@@ -37,5 +44,103 @@ fun Profile.into(): mozilla.components.concept.sync.Profile {
             )
         },
         displayName = this.displayName
+    )
+}
+
+fun Device.Type.into(): mozilla.components.concept.sync.DeviceType {
+    return when (this) {
+        Device.Type.DESKTOP -> DeviceType.DESKTOP
+        Device.Type.MOBILE -> DeviceType.MOBILE
+        Device.Type.UNKNOWN -> DeviceType.UNKNOWN
+    }
+}
+
+fun mozilla.components.concept.sync.DeviceType.into(): Device.Type {
+    return when (this) {
+        DeviceType.DESKTOP -> Device.Type.DESKTOP
+        DeviceType.MOBILE -> Device.Type.MOBILE
+        DeviceType.UNKNOWN -> Device.Type.UNKNOWN
+    }
+}
+
+fun mozilla.components.concept.sync.DeviceCapability.into(): Device.Capability {
+    return when (this) {
+        DeviceCapability.SEND_TAB -> Device.Capability.SEND_TAB
+    }
+}
+
+fun Device.Capability.into(): mozilla.components.concept.sync.DeviceCapability {
+    return when (this) {
+        Device.Capability.SEND_TAB -> mozilla.components.concept.sync.DeviceCapability.SEND_TAB
+    }
+}
+
+fun mozilla.components.concept.sync.DevicePushSubscription.into(): Device.PushSubscription {
+    return Device.PushSubscription(
+        endpoint = this.endpoint,
+        authKey = this.authKey,
+        publicKey = this.publicKey
+    )
+}
+
+fun Device.PushSubscription.into(): mozilla.components.concept.sync.DevicePushSubscription {
+    return mozilla.components.concept.sync.DevicePushSubscription(
+        endpoint = this.endpoint,
+        authKey = this.authKey,
+        publicKey = this.publicKey
+    )
+}
+
+fun Device.into(): mozilla.components.concept.sync.Device {
+    return mozilla.components.concept.sync.Device(
+        id = this.id,
+        isCurrentDevice = this.isCurrentDevice,
+        deviceType = this.deviceType.into(),
+        displayName = this.displayName,
+        lastAccessTime = this.lastAccessTime,
+        subscriptionExpired = this.pushEndpointExpired,
+        capabilities = this.capabilities.map { it.into() },
+        subscription = this.pushSubscription?.into()
+    )
+}
+
+fun mozilla.components.concept.sync.Device.into(): Device {
+    return Device(
+        id = this.id,
+        isCurrentDevice = this.isCurrentDevice,
+        deviceType = this.deviceType.into(),
+        displayName = this.displayName,
+        lastAccessTime = this.lastAccessTime,
+        pushEndpointExpired = this.subscriptionExpired,
+        capabilities = this.capabilities.map { it.into() },
+        pushSubscription = this.subscription?.into()
+    )
+}
+
+fun TabHistoryEntry.into(): mozilla.components.concept.sync.TabData {
+    return mozilla.components.concept.sync.TabData(
+        title = this.title,
+        url = this.url
+    )
+}
+
+fun mozilla.components.concept.sync.TabData.into(): TabHistoryEntry {
+    return TabHistoryEntry(
+        title = this.title,
+        url = this.url
+    )
+}
+
+fun AccountEvent.TabReceived.into(): mozilla.components.concept.sync.DeviceEvent.TabReceived {
+    return mozilla.components.concept.sync.DeviceEvent.TabReceived(
+        from = this.from?.into(),
+        entries = this.entries.map { it.into() }
+    )
+}
+
+fun mozilla.components.concept.sync.DeviceEvent.TabReceived.into(): AccountEvent.TabReceived {
+    return AccountEvent.TabReceived(
+        from = this.from?.into(),
+        entries = this.entries.map { it.into() }.toTypedArray()
     )
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaDeviceManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaDeviceManager.kt
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fxa.manager
+
+import android.content.Context
+import androidx.annotation.GuardedBy
+import androidx.annotation.VisibleForTesting
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import mozilla.components.concept.sync.ConstellationState
+import mozilla.components.concept.sync.DeviceEvent
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.DeviceConstellationObserver
+import mozilla.components.concept.sync.DeviceEventsObserver
+import mozilla.components.support.base.log.logger.Logger
+
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+import java.util.concurrent.TimeUnit
+
+/**
+ * Device manager is responsible for providing information about the current device and other
+ * available devices in the constellation. Event polling is available and received events are
+ * exposed via an observable interface.
+ */
+internal open class PollingDeviceManager(
+    private val constellation: DeviceConstellation,
+    private val scope: CoroutineScope,
+    private val deviceObserverRegistry: ObserverRegistry<DeviceConstellationObserver>
+) : Observable<DeviceEventsObserver> by ObserverRegistry() {
+    private val logger = Logger("FxaEventsManager")
+
+    @GuardedBy("this")
+    @Volatile
+    private var constellationState: ConstellationState? = null
+
+    fun constellationState(): ConstellationState? = synchronized(this) {
+        return constellationState
+    }
+
+    fun startPolling() {
+        getRefreshManager().startRefresh()
+    }
+
+    fun stopPolling() {
+        getRefreshManager().stopRefresh()
+    }
+
+    fun pollAsync(): Deferred<Unit> {
+        return scope.async {
+            logger.debug("poll")
+            processEvents(constellation.pollForEventsAsync().await())
+        }
+    }
+
+    fun processEvents(events: List<DeviceEvent>) {
+        // In the future, this could be an internal device-related events processing layer.
+        // E.g., once we grow events such as "there is a new device in the constellation".
+        logger.debug("processing events: $events")
+        // NB: we don't use Dispatcher.Main here like in refresh method because our
+        // observer is internal, and we depend on it to relay using the Main dispatcher.
+        notifyObservers { onEvents(events) }
+    }
+
+    fun refreshDevicesAsync(): Deferred<Unit> = synchronized(this) {
+        return scope.async {
+            logger.info("Refreshing device list...")
+            val allDevices = constellation.fetchAllDevicesAsync().await()
+            // Find the current device.
+            val currentDevice = allDevices.find { it.isCurrentDevice }
+            // Filter out the current devices.
+            val otherDevices = allDevices.filter { !it.isCurrentDevice }
+
+            val newState = ConstellationState(currentDevice, otherDevices)
+            constellationState = newState
+
+            // TODO notifyObserversOnMainThread
+            CoroutineScope(Dispatchers.Main).launch {
+                // NB: at this point, 'constellationState' might have changed.
+                // Notify with an immutable, local 'newState' instead.
+                deviceObserverRegistry.notifyObservers { onDevicesUpdate(newState) }
+            }
+
+            // Check if our current device's push subscription needs to be renewed.
+            constellationState?.currentDevice?.let {
+                if (it.subscriptionExpired) {
+                    logger.info("Current device needs push endpoint registration")
+                }
+            }
+
+            logger.info("Refreshed device list; saw ${allDevices.size} device(s).")
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    open fun getRefreshManager(): PeriodicRefreshManager {
+        return FxaDeviceRefreshManager
+    }
+}
+
+// This interface exists to facilitate testing.
+interface PeriodicRefreshManager {
+    fun startRefresh()
+    fun stopRefresh()
+}
+
+/**
+ * Responsible for periodically checking for new device events and refreshing device constellation state.
+ */
+internal object FxaDeviceRefreshManager : PeriodicRefreshManager {
+    // Minimal interval supported by WorkManager is 15 minutes.
+    private const val DEVICE_EVENT_POLL_WORKER = "DeviceEventPolling"
+    private const val POLL_PERIOD = 15L
+    private val POLL_PERIOD_UNIT = TimeUnit.MINUTES
+
+    override fun startRefresh() {
+        WorkManager.getInstance().enqueueUniquePeriodicWork(
+                DEVICE_EVENT_POLL_WORKER,
+                ExistingPeriodicWorkPolicy.REPLACE,
+                PeriodicWorkRequestBuilder<WorkManagerDeviceRefreshWorker>(POLL_PERIOD, POLL_PERIOD_UNIT)
+                        .setConstraints(
+                                Constraints.Builder()
+                                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                                        .build()
+                        )
+                        .build()
+        )
+    }
+
+    override fun stopRefresh() {
+        WorkManager.getInstance().cancelUniqueWork(DEVICE_EVENT_POLL_WORKER)
+    }
+}
+
+internal object DeviceManagerProvider {
+    var deviceManager: PollingDeviceManager? = null
+}
+
+internal class WorkManagerDeviceRefreshWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+    private val logger = Logger("DeviceManagerPollWorker")
+
+    @Suppress("ReturnCount", "ComplexMethod")
+    override suspend fun doWork(): Result {
+        logger.debug("Polling for new events via ${DeviceManagerProvider.deviceManager}")
+
+        DeviceManagerProvider.deviceManager?.let { deviceManager ->
+            deviceManager.refreshDevicesAsync().await()
+            deviceManager.pollAsync().await()
+        }
+
+        return Result.success()
+    }
+}

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fxa.manager
+
+/**
+ * States of the [FxaAccountManager].
+ */
+enum class AccountState {
+    Start,
+    NotAuthenticated,
+    AuthenticatedNoProfile,
+    AuthenticatedWithProfile
+}
+
+/**
+ * Base class for [FxaAccountManager] state machine events.
+ * Events aren't a simple enum class because we might want to pass data along with some of the events.
+ */
+internal sealed class Event {
+    override fun toString(): String {
+        // For a better logcat experience.
+        return this.javaClass.simpleName
+    }
+
+    internal object Init : Event()
+
+    object AccountNotFound : Event()
+    object AccountRestored : Event()
+
+    object Authenticate : Event()
+    data class Authenticated(val code: String, val state: String) : Event() {
+        override fun toString(): String {
+            // data classes define their own toString, so we override it here as well as in the base
+            // class to avoid exposing 'code' and 'state' in logs.
+            return this.javaClass.simpleName
+        }
+    }
+    object FetchProfile : Event()
+    object FetchedProfile : Event()
+
+    object FailedToAuthenticate : Event()
+    object FailedToFetchProfile : Event()
+
+    object Logout : Event()
+
+    data class Pair(val pairingUrl: String) : Event() {
+        override fun toString(): String {
+            // data classes define their own toString, so we override it here as well as in the base
+            // class to avoid exposing the 'pairingUrl' in logs.
+            return this.javaClass.simpleName
+        }
+    }
+}

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/PollingDeviceManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/PollingDeviceManagerTest.kt
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fxa.manager
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.setMain
+import mozilla.components.concept.sync.ConstellationState
+import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.DeviceConstellationObserver
+import mozilla.components.concept.sync.DeviceEvent
+import mozilla.components.concept.sync.DeviceEventsObserver
+import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.TabData
+import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import java.util.concurrent.Executors
+
+class PollingDeviceManagerTest {
+    internal class TestableDeviceManager(
+        constellation: DeviceConstellation,
+        scope: CoroutineScope,
+        registry: ObserverRegistry<DeviceConstellationObserver> = ObserverRegistry(),
+        val block: () -> PeriodicRefreshManager
+    ) : PollingDeviceManager(constellation, scope, registry) {
+        override fun getRefreshManager(): PeriodicRefreshManager {
+            return block()
+        }
+    }
+
+    @Test
+    fun `starting and stopping refresh`() = runBlocking {
+        val refreshManager: PeriodicRefreshManager = mock()
+        val manager = TestableDeviceManager(mock(), this) { refreshManager }
+        verify(refreshManager, never()).startRefresh()
+        verify(refreshManager, never()).stopRefresh()
+
+        manager.startPolling()
+        verify(refreshManager).startRefresh()
+        verify(refreshManager, never()).stopRefresh()
+
+        manager.stopPolling()
+        verify(refreshManager).startRefresh()
+        verify(refreshManager).stopRefresh()
+    }
+
+    @Test
+    fun `polling for events triggers observers`() = runBlocking {
+        val constellation: DeviceConstellation = mock()
+        val manager = TestableDeviceManager(constellation, this) { mock() }
+
+        // No events, no observers.
+        `when`(constellation.pollForEventsAsync()).thenReturn(CompletableDeferred(listOf()))
+        manager.pollAsync().await()
+
+        val eventsObserver = object : DeviceEventsObserver {
+            var latestEvents: List<DeviceEvent>? = null
+
+            override fun onEvents(events: List<DeviceEvent>) {
+                latestEvents = events
+            }
+        }
+
+        // No events, with an observer.
+        manager.register(eventsObserver)
+        manager.pollAsync().await()
+        assertEquals(listOf<DeviceEvent>(), eventsObserver.latestEvents)
+
+        // Some events.
+        `when`(constellation.pollForEventsAsync()).thenReturn(CompletableDeferred(listOf(
+            DeviceEvent.TabReceived(null, listOf())
+        )))
+        manager.pollAsync().await()
+
+        var events = eventsObserver.latestEvents!!
+        assertEquals(null, (events[0] as DeviceEvent.TabReceived).from)
+        assertEquals(listOf<TabData>(), (events[0] as DeviceEvent.TabReceived).entries)
+
+        val testDevice1 = testDevice("test1", false)
+        val testDevice2 = testDevice("test2", false)
+        val testTab1 = TabData("Hello", "http://world.com/1")
+        val testTab2 = TabData("Hello", "http://world.com/2")
+        val testTab3 = TabData("Hello", "http://world.com/3")
+
+        // Zero tabs from a single device.
+        `when`(constellation.pollForEventsAsync()).thenReturn(CompletableDeferred(listOf(
+            DeviceEvent.TabReceived(testDevice1, listOf())
+        )))
+        manager.pollAsync().await()
+        assertNotNull(eventsObserver.latestEvents)
+        assertEquals(1, eventsObserver.latestEvents!!.size)
+        events = eventsObserver.latestEvents!!
+        assertEquals(testDevice1, (events[0] as DeviceEvent.TabReceived).from)
+        assertEquals(listOf<TabData>(), (events[0] as DeviceEvent.TabReceived).entries)
+
+        // Single tab from a single device.
+        `when`(constellation.pollForEventsAsync()).thenReturn(CompletableDeferred(listOf(
+            DeviceEvent.TabReceived(testDevice2, listOf(testTab1))
+        )))
+        manager.pollAsync().await()
+
+        events = eventsObserver.latestEvents!!
+        assertEquals(testDevice2, (events[0] as DeviceEvent.TabReceived).from)
+        assertEquals(listOf(testTab1), (events[0] as DeviceEvent.TabReceived).entries)
+
+        // Multiple tabs from a single device.
+        `when`(constellation.pollForEventsAsync()).thenReturn(CompletableDeferred(listOf(
+                DeviceEvent.TabReceived(testDevice2, listOf(testTab1, testTab3))
+        )))
+        manager.pollAsync().await()
+
+        events = eventsObserver.latestEvents!!
+        assertEquals(testDevice2, (events[0] as DeviceEvent.TabReceived).from)
+        assertEquals(listOf(testTab1, testTab3), (events[0] as DeviceEvent.TabReceived).entries)
+
+        // Multiple tabs received from multiple devices.
+        `when`(constellation.pollForEventsAsync()).thenReturn(CompletableDeferred(listOf(
+            DeviceEvent.TabReceived(testDevice2, listOf(testTab1, testTab2)),
+            DeviceEvent.TabReceived(testDevice1, listOf(testTab3))
+        )))
+        manager.pollAsync().await()
+
+        events = eventsObserver.latestEvents!!
+        assertEquals(testDevice2, (events[0] as DeviceEvent.TabReceived).from)
+        assertEquals(listOf(testTab1, testTab2), (events[0] as DeviceEvent.TabReceived).entries)
+        assertEquals(testDevice1, (events[1] as DeviceEvent.TabReceived).from)
+        assertEquals(listOf(testTab3), (events[1] as DeviceEvent.TabReceived).entries)
+    }
+
+    @Test
+    fun `refreshing devices triggers observers`() {
+        val testDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val testScope = CoroutineScope(testDispatcher)
+        Dispatchers.setMain(testDispatcher)
+
+        val constellation: DeviceConstellation = mock()
+        val registry = ObserverRegistry<DeviceConstellationObserver>()
+        val manager = TestableDeviceManager(constellation, testScope, registry) { mock() }
+
+        // No devices, no observers.
+        `when`(constellation.fetchAllDevicesAsync()).thenReturn(CompletableDeferred(listOf()))
+
+        runBlocking(testDispatcher) {
+            manager.refreshDevicesAsync().await()
+        }
+
+        val observer = object : DeviceConstellationObserver {
+            var state: ConstellationState? = null
+
+            override fun onDevicesUpdate(constellation: ConstellationState) {
+                state = constellation
+            }
+        }
+        registry.register(observer)
+
+        // No devices, with an observer.
+        runBlocking(testDispatcher) {
+            manager.refreshDevicesAsync().await()
+        }
+        assertEquals(ConstellationState(null, listOf()), observer.state)
+
+        val testDevice1 = testDevice("test1", false)
+        val testDevice2 = testDevice("test2", false)
+        val currentDevice = testDevice("currentTestDevice", true)
+
+        // Single device, no current device.
+        `when`(constellation.fetchAllDevicesAsync()).thenReturn(CompletableDeferred(listOf(
+            testDevice1
+        )))
+        runBlocking(testDispatcher) {
+            manager.refreshDevicesAsync().await()
+        }
+        assertEquals(ConstellationState(null, listOf(testDevice1)), observer.state)
+        assertEquals(ConstellationState(null, listOf(testDevice1)), manager.constellationState())
+
+        // Current device, no other devices.
+        `when`(constellation.fetchAllDevicesAsync()).thenReturn(CompletableDeferred(listOf(
+                currentDevice
+        )))
+        runBlocking(testDispatcher) {
+            manager.refreshDevicesAsync().await()
+        }
+        assertEquals(ConstellationState(currentDevice, listOf()), observer.state)
+        assertEquals(ConstellationState(currentDevice, listOf()), manager.constellationState())
+
+        // Current device with other devices.
+        `when`(constellation.fetchAllDevicesAsync()).thenReturn(CompletableDeferred(listOf(
+                currentDevice, testDevice1, testDevice2
+        )))
+        runBlocking(testDispatcher) {
+            manager.refreshDevicesAsync().await()
+        }
+        assertEquals(ConstellationState(currentDevice, listOf(testDevice1, testDevice2)), observer.state)
+        assertEquals(ConstellationState(currentDevice, listOf(testDevice1, testDevice2)), manager.constellationState())
+
+        // Current device with expired subscription.
+        val currentDeviceExpired = testDevice("currentExpired", true, expired = true)
+        `when`(constellation.fetchAllDevicesAsync()).thenReturn(CompletableDeferred(listOf(
+                currentDeviceExpired, testDevice2
+        )))
+        runBlocking(testDispatcher) {
+            manager.refreshDevicesAsync().await()
+        }
+        assertEquals(ConstellationState(currentDeviceExpired, listOf(testDevice2)), observer.state)
+        assertEquals(ConstellationState(currentDeviceExpired, listOf(testDevice2)), manager.constellationState())
+    }
+
+    private fun testDevice(id: String, current: Boolean, expired: Boolean = false): Device {
+        return Device(
+            id = id,
+            displayName = "testName",
+            deviceType = DeviceType.MOBILE,
+            isCurrentDevice = current,
+            lastAccessTime = 123L,
+            capabilities = listOf(),
+            subscriptionExpired = expired,
+            subscription = null
+        )
+    }
+}

--- a/components/service/firefox-accounts/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/service/firefox-accounts/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/samples/sync-logins/build.gradle
+++ b/samples/sync-logins/build.gradle
@@ -45,4 +45,5 @@ dependencies {
 
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.androidx_browser
+    implementation Dependencies.androidx_recyclerview
 }

--- a/samples/sync-logins/src/main/java/org/mozilla/samples/sync/logins/MainActivity.kt
+++ b/samples/sync-logins/src/main/java/org/mozilla/samples/sync/logins/MainActivity.kt
@@ -17,15 +17,17 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
 import mozilla.components.concept.sync.SyncStatusObserver
-import mozilla.components.service.fxa.FxaAccountManager
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.FxaException
 import mozilla.components.feature.sync.BackgroundSyncManager
 import mozilla.components.feature.sync.GlobalSyncableStoreProvider
+import mozilla.components.service.fxa.manager.DeviceTuple
 import mozilla.components.service.sync.logins.AsyncLoginsStorageAdapter
 import mozilla.components.service.sync.logins.SyncableLoginsStore
 import mozilla.components.support.base.log.Log
@@ -58,10 +60,11 @@ class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener,
     private lateinit var account: FirefoxAccount
     private val accountManager by lazy {
         FxaAccountManager(
-            applicationContext,
-            Config.release(CLIENT_ID, REDIRECT_URL),
-            arrayOf("profile", "https://identity.mozilla.com/apps/oldsync"),
-            syncManager
+                applicationContext,
+                Config.release(CLIENT_ID, REDIRECT_URL),
+                arrayOf("profile", "https://identity.mozilla.com/apps/oldsync"),
+                DeviceTuple("A-C Logins Sync Sample", DeviceType.MOBILE, listOf()),
+                syncManager
         )
     }
 

--- a/samples/sync/build.gradle
+++ b/samples/sync/build.gradle
@@ -41,5 +41,5 @@ dependencies {
     implementation project(':service-firefox-accounts')
     implementation project(':feature-sync')
 
-    implementation Dependencies.androidx_constraintlayout
+    implementation Dependencies.androidx_recyclerview
 }

--- a/samples/sync/src/main/AndroidManifest.xml
+++ b/samples/sync/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+        android:theme="@style/Theme.AppCompat.Light">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceFragment.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceFragment.kt
@@ -1,0 +1,76 @@
+package org.mozilla.samples.sync
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.sync.Device
+
+/**
+ * A fragment representing a list of Items.
+ * Activities containing this fragment MUST implement the
+ * [DeviceFragment.OnDeviceListInteractionListener] interface.
+ */
+class DeviceFragment : Fragment() {
+
+    private var listenerDevice: OnDeviceListInteractionListener? = null
+
+    private val adapter = DeviceRecyclerViewAdapter(listenerDevice)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_device_list, container, false)
+
+        // Set the adapter
+        if (view is RecyclerView) {
+            with(view) {
+                layoutManager = LinearLayoutManager(context)
+                adapter = this@DeviceFragment.adapter
+            }
+        }
+        return view
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        if (context is OnDeviceListInteractionListener) {
+            listenerDevice = context
+            adapter.mListenerDevice = context
+        } else {
+            throw IllegalArgumentException("$context must implement OnDeviceListInteractionListener")
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listenerDevice = null
+    }
+
+    fun updateDevices(devices: List<Device>) {
+        adapter.devices.clear()
+        adapter.devices.addAll(devices)
+        adapter.notifyDataSetChanged()
+    }
+
+    /**
+     * This interface must be implemented by activities that contain this
+     * fragment to allow an interaction in this fragment to be communicated
+     * to the activity and potentially other fragments contained in that
+     * activity.
+     *
+     *
+     * See the Android Training lesson
+     * [Communicating with Other Fragments](http://developer.android.com/training/basics/fragments/communicating.html)
+     * for more information.
+     */
+    interface OnDeviceListInteractionListener {
+        fun onDeviceInteraction(item: Device)
+    }
+}

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceRecyclerViewAdapter.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceRecyclerViewAdapter.kt
@@ -1,0 +1,61 @@
+package org.mozilla.samples.sync
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import org.mozilla.samples.sync.DeviceFragment.OnDeviceListInteractionListener
+import kotlinx.android.synthetic.main.fragment_device.view.*
+import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceType
+
+/**
+ * [RecyclerView.Adapter] that can display a [DummyItem] and makes a call to the
+ * specified [OnDeviceListInteractionListener].
+ */
+class DeviceRecyclerViewAdapter(
+    var mListenerDevice: OnDeviceListInteractionListener?
+) : RecyclerView.Adapter<DeviceRecyclerViewAdapter.ViewHolder>() {
+
+    val devices = mutableListOf<Device>()
+
+    private val mOnClickListener: View.OnClickListener
+
+    init {
+        mOnClickListener = View.OnClickListener { v ->
+            val item = v.tag as Device
+            // Notify the active callbacks interface (the activity, if the fragment is attached to
+            // one) that an item has been selected.
+            mListenerDevice?.onDeviceInteraction(item)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.fragment_device, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = devices[position]
+        holder.nameView.text = item.displayName
+        holder.typeView.text = when (item.deviceType) {
+            DeviceType.DESKTOP -> "Desktop"
+            DeviceType.MOBILE -> "Mobile"
+            DeviceType.UNKNOWN -> "Unknown"
+        }
+
+        with(holder.mView) {
+            tag = item
+            setOnClickListener(mOnClickListener)
+        }
+    }
+
+    override fun getItemCount(): Int = devices.size
+
+    inner class ViewHolder(val mView: View) : RecyclerView.ViewHolder(mView) {
+        val nameView: TextView = mView.device_name
+        val typeView: TextView = mView.device_type
+    }
+}

--- a/samples/sync/src/main/res/layout/activity_main.xml
+++ b/samples/sync/src/main/res/layout/activity_main.xml
@@ -11,64 +11,131 @@
     android:id="@+id/container"
     tools:context=".MainActivity">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:orientation="vertical"
-        android:id="@+id/buttonList"
-        tools:context=".MainActivity">
-
-        <Button
-            android:id="@+id/buttonSignIn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/sign_in" />
-
-        <Button
-            android:id="@+id/buttonSync"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/sync" />
-
-        <Button
-            android:id="@+id/buttonLogout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/log_out" />
-    </LinearLayout>
-
-    <TextView
-        android:id="@+id/fxaStatusView"
+    <ScrollView
+        tools:ignore="UselessParent"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/buttonList"
-        android:layout_gravity="center"
-        android:text="" />
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/syncStatus"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/fxaStatusView"
-        android:layout_gravity="center"
-        android:text="" />
+        <RelativeLayout
+            android:id="@+id/stuff"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/historySyncResult"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/syncStatus"
-        android:layout_gravity="center"
-        android:text="" />
+            <Button
+                android:id="@+id/buttonSignIn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sign_in" />
 
-    <TextView
-        android:id="@+id/bookmarksSyncResult"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/historySyncResult"
-        android:layout_gravity="center"
-        android:text="" />
+            <Button
+                android:id="@+id/buttonSync"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/buttonSignIn"
+                android:text="@string/sync" />
+
+            <Button
+                android:id="@+id/refreshDevice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/buttonSync"
+                android:text="@string/refresh_device" />
+
+            <Button
+                android:id="@+id/sendTab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/refreshDevice"
+                android:text="@string/send_tab" />
+
+            <Button
+                android:id="@+id/buttonLogout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/sendTab"
+                android:text="@string/log_out" />
+
+            <TextView
+                android:id="@+id/fxaStatusView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/buttonLogout"
+                android:text="" />
+
+            <TextView
+                android:id="@+id/syncStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/fxaStatusView"
+                android:text="" />
+
+            <TextView
+                android:id="@+id/historySyncResult"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/syncStatus"
+                android:text="" />
+
+            <TextView
+                android:id="@+id/bookmarksSyncResult"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/historySyncResult"
+                android:text="" />
+
+            <TextView
+                android:id="@+id/currentDeviceLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/bookmarksSyncResult"
+                style="?android:attr/listSeparatorTextViewStyle"
+                android:text="@string/current_device" />
+
+            <TextView
+                android:id="@+id/currentDevice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/currentDeviceLabel"
+                android:text="" />
+
+            <TextView
+                android:id="@+id/latestTabsLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/currentDevice"
+                style="?android:attr/listSeparatorTextViewStyle"
+                android:text="@string/latest_tabs" />
+
+            <TextView
+                android:id="@+id/latestTabs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/latestTabsLabel"
+                android:text="" />
+
+            <TextView
+                android:id="@+id/devicesLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_below="@id/latestTabs"
+                style="?android:attr/listSeparatorTextViewStyle"
+                android:text="@string/devices" />
+
+            <fragment android:name="org.mozilla.samples.sync.DeviceFragment"
+                android:id="@+id/devices_fragment"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/devicesLabel" />
+        </RelativeLayout>
+    </ScrollView>
 
 </RelativeLayout>

--- a/samples/sync/src/main/res/layout/fragment_device.xml
+++ b/samples/sync/src/main/res/layout/fragment_device.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/device_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/text_margin"
+        android:textAppearance="?attr/textAppearanceListItem" />
+
+    <TextView
+        android:id="@+id/device_type"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/text_margin"
+        android:textAppearance="?attr/textAppearanceListItem" />
+</LinearLayout>

--- a/samples/sync/src/main/res/layout/fragment_device_list.xml
+++ b/samples/sync/src/main/res/layout/fragment_device_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/list"
+    android:name="org.mozilla.samples.sync.DeviceFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginLeft="16dp"
+    android:layout_marginRight="16dp"
+    tools:context=".DeviceFragment"
+    tools:listitem="@layout/fragment_device" />

--- a/samples/sync/src/main/res/values/dimens.xml
+++ b/samples/sync/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="text_margin">16dp</dimen>
+</resources>

--- a/samples/sync/src/main/res/values/strings.xml
+++ b/samples/sync/src/main/res/values/strings.xml
@@ -19,5 +19,20 @@
     <string name="no_bookmarks_root">No Bookmarks Root node</string>
     <string name="log_out">FxA Log Out</string>
     <string name="logged_out">Logged out!</string>
-    <string name="sync">Sync history + bookmarks</string>
+    <string name="sync">Sync</string>
+    <string name="refresh_device">Refresh device</string>
+    <string name="send_tab">Send tab</string>
+    <string name="current_device">Current device</string>
+    <string name="current_device_unknown">Unknown</string>
+    <string name="full_device_details">
+        ID: %1$s\n
+        Name: %2$s\n
+        Type: %3$s\n
+        Subscription expired: %4$b\n
+        Subscription: %5$s\n
+        Capabilities: %6$s\n
+        Last access: %7$d
+    </string>
+    <string name="latest_tabs">Latest tabs</string>
+    <string name="devices">Devices</string>
 </resources>


### PR DESCRIPTION
Depends on https://github.com/mozilla/application-services/pull/676.

This still needs a light coat of polish, but should be good for a feedback round.

As a preparatory commit, this PR changes how account state is persisted. It's now callback-driven, ensuring we don't miss out on internal state mutations (such as would happen during device registration and events processing).

For the main show, the PR:
- describes various device-related functionality - registering, renaming, device events (such as Send Tab)
- adds a module-internal `PollingDeviceManager`, responsible for event polling and maintaining a cache of the current and all other devices
- FirefoxAccount has been expanded to provide relevant functionality, and it can now be observed for events targeting the current device (e.g. tabs received)
- FxaAccountManager was modified to include account lifecycle tie-ins with the device registration stuff

I expect consuming applications to interact with these changes as follows:
- to display information about current and/or other devices, query synchronous `currentDevice` and `otherDevices` methods, while also subscribing to changes via `DeviceConstellationObserver`
- to enable device event processing (i.e. to receive tabs), including periodic polling and fxa device registration, pass in an `EventsProcessor` instance to the FxaAccountManager. Account manager now also takes an initial device name.
- to rename current device, use appropriate methods exposed on FirefoxAccount
- to process events received and decrypted via Push, pass the plaintext payload to `processRawEvent` to an instance of FirefoxAccount obtained from the account manager. This will cause all of the currently registered events observers to be triggered.

Currently no extra work is performed if the application doesn't specify an EventsProcessor instance when initializing an FxaAccountManager. This means that it's possible to opt-out of FxA device registration; we may want to change that before shipping, I'm not sure. Currently there is no way to declare current device's capabilities, and so it's not possible to register a device while also opting out of being a Send Tab target. That'll need to change in the fxaclient library if we want to start splitting the two concepts.

I went back and forth on the complexity of this, and in the end tried to introduce minimal overhead on top of primitives exposed by the library.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
