### PR TITLE
Closes #2674: Adds facts to custom tabs

### DIFF
--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -75,7 +75,6 @@ To customize the menu you could use separate properties 1 or full access to the 
 1) If you just want to change a specify property, just add one these dimen items to your ``dimes.xml`` file.
 
 ```xml
-
     <!--Menu Item -->
        <!--Change the text_size for ALL menu items NOT only for the BrowserMenuImageText -->
         <dimen name="mozac_browser_menu_item_text_size" tools:ignore="UnusedResources">16sp</dimen>
@@ -95,12 +94,11 @@ To customize the menu you could use separate properties 1 or full access to the 
             <dimen name="mozac_browser_menu_item_image_text_label_padding_start" tools:ignore="UnusedResources">20dp</dimen> <!--Default value-->
 
     <!--Label-->
-
 ```
 
 2) For full customization, override the default style of menu by adding this style item in your `style.xml` file, and customize to your liking.
-```xml
 
+```xml
     <!--Change the appearance of all text menu items-->
     <style name="Mozac.Browser.Menu.Item.Text" parent="@android:style/TextAppearance.Material.Menu" tools:ignore="UnusedResources">
         <item name="android:background">?android:attr/selectableItemBackground</item>
@@ -122,6 +120,7 @@ To customize the menu you could use separate properties 1 or full access to the 
         <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>
     </style>
 ```
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuBuilder.kt
@@ -10,13 +10,14 @@ import android.content.Context
  * Helper class for building browser menus.
  *
  * @param items List of BrowserMenuItem objects to compose the menu from.
+ * @param extras Map of extra values that are added to emitted facts
  */
 class BrowserMenuBuilder(
-    val items: List<BrowserMenuItem>
+    val items: List<BrowserMenuItem>,
+    val extras: Map<String, Any> = emptyMap()
 ) {
     fun build(context: Context): BrowserMenu {
         val adapter = BrowserMenuAdapter(context, items)
-
         return BrowserMenu(adapter)
     }
 }

--- a/components/browser/toolbar/README.md
+++ b/components/browser/toolbar/README.md
@@ -34,8 +34,10 @@ This component emits the following [Facts](../../support/base/README.md#Facts):
 
 | Action | Item    | Extras         | Description                        |
 |--------|---------|----------------|------------------------------------|
-| CLICK  | menu    |                | The user opened the overflow menu. |
+| CLICK  | menu    | `menuExtras`   | The user opened the overflow menu. |
 | COMMIT | toolbar | `commitExtras` | The user has edited the URL.       |
+
+`menuExtras` are additional extras set on the `BrowserMenuBuilder` passed to the `BrowserToolbar` (see [browser-menu](../menu/README.md)).
 
 #### `commitExtras`
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -137,7 +137,7 @@ internal class DisplayToolbar(
                 anchor = this,
                 orientation = BrowserMenu.determineMenuOrientation(toolbar))
 
-            emitOpenMenuFact()
+            emitOpenMenuFact(menuBuilder?.extras)
         }
     }
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/facts/ToolbarFacts.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/facts/ToolbarFacts.kt
@@ -30,7 +30,9 @@ private object ToolbarItems {
     const val MENU = "menu"
 }
 
-internal fun emitOpenMenuFact() = emitToolbarFact(Action.CLICK, ToolbarItems.MENU)
+internal fun emitOpenMenuFact(extras: Map<String, Any>?) {
+    emitToolbarFact(Action.CLICK, ToolbarItems.MENU, metadata = extras)
+}
 
 internal fun emitCommitFact(
     autocompleteResult: InlineAutocompleteEditText.AutocompleteResult?

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
+import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
@@ -805,15 +806,16 @@ class DisplayToolbarTest {
     }
 
     @Test
-    fun `clicking menu button emits fact`() {
+    fun `clicking menu button emits facts with additional extras from builder set`() {
         CollectionProcessor.withFactCollection { facts ->
             val toolbar = mock(BrowserToolbar::class.java)
             val displayToolbar = DisplayToolbar(context, toolbar)
             val menuView = extractMenuView(displayToolbar)
 
-            val menuBuilder = mock(BrowserMenuBuilder::class.java)
-            val menu = mock(BrowserMenu::class.java)
-            doReturn(menu).`when`(menuBuilder).build(context)
+            val menuBuilder = BrowserMenuBuilder(listOf(SimpleBrowserMenuItem("Mozilla")), mapOf(
+                "customTab" to true,
+                "test" to "23"
+            ))
             displayToolbar.menuBuilder = menuBuilder
 
             assertEquals(0, facts.size)
@@ -823,11 +825,20 @@ class DisplayToolbarTest {
             assertEquals(1, facts.size)
 
             val fact = facts[0]
+
             assertEquals(Component.BROWSER_TOOLBAR, fact.component)
             assertEquals(Action.CLICK, fact.action)
             assertEquals("menu", fact.item)
             assertNull(fact.value)
-            assertNull(fact.metadata)
+
+            assertNotNull(fact.metadata)
+
+            val metadata = fact.metadata!!
+            assertEquals(2, metadata.size)
+            assertTrue(metadata.containsKey("customTab"))
+            assertTrue(metadata.containsKey("test"))
+            assertEquals(true, metadata["customTab"])
+            assertEquals("23", metadata["test"])
         }
     }
 

--- a/components/feature/customtabs/README.md
+++ b/components/feature/customtabs/README.md
@@ -12,6 +12,17 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:feature-customtabs:{latest-version}"
 ```
 
+## Facts
+
+This component emits the following [Facts](../../support/base/README.md#Facts):
+
+| Action | Item              | Description                              |
+|--------|-------------------|------------------------------------------|
+| CLICK  | close             | The user clicked on the close button     |
+| CLICK  | action_button     | The user clicked on an action button     |
+
+In addition to the facts emitted above this feature will inject an addition extra (`customTab: true`) into the `BrowserMenuBuilder` passed to the `BrowserToolbar` (see [browser-menu](../../browser/menu/README.md)).
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsFacts.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsFacts.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+private fun emitCustomTabsFact(
+    action: Action,
+    item: String
+) {
+    Fact(
+        Component.FEATURE_CUSTOMTABS,
+        action,
+        item
+    ).collect()
+}
+
+private object CustomTabsItems {
+    const val CLOSE = "close"
+    const val ACTION_BUTTON = "action_button"
+}
+
+internal fun emitCloseFact() = emitCustomTabsFact(Action.CLICK, CustomTabsItems.CLOSE)
+internal fun emitActionButtonFact() = emitCustomTabsFact(Action.CLICK, CustomTabsItems.ACTION_BUTTON)

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -100,7 +100,10 @@ class CustomTabsToolbarFeature(
         }.also {
             val button = Toolbar.ActionButton(
                 it, context.getString(R.string.mozac_feature_customtabs_exit_button)
-            ) { closeListener.invoke() }
+            ) {
+                emitCloseFact()
+                closeListener.invoke()
+            }
             toolbar.addNavigationAction(button)
         }
     }
@@ -111,7 +114,10 @@ class CustomTabsToolbarFeature(
             val button = Toolbar.ActionButton(
                 BitmapDrawable(context.resources, config.icon),
                 config.description
-            ) { config.pendingIntent.send() }
+            ) {
+                emitActionButtonFact()
+                config.pendingIntent.send()
+            }
 
             toolbar.addBrowserAction(button)
         }
@@ -137,8 +143,10 @@ class CustomTabsToolbarFeature(
             SimpleBrowserMenuItem(it.name) { it.pendingIntent.send() }
         }.also { items ->
             val combinedItems = menuBuilder?.let { builder -> builder.items + items } ?: items
-
-            toolbar.setMenuBuilder(BrowserMenuBuilder(combinedItems))
+            val combinedExtras = menuBuilder?.let {
+                    builder -> builder.extras + Pair("customTab", true)
+            }
+            toolbar.setMenuBuilder(BrowserMenuBuilder(combinedItems, combinedExtras ?: emptyMap()))
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-customtabs**
+  * Added fact emitting.
+
 # 0.50.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.49.0...v0.50.0)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

**Note: I did not add a test for emitting close fact or action fact in `CustomTabsToolbarFeature` because those should be covered by `clicking on navigation action will execute listener of the action` inside `DisplayToolbarTest`**