### PR TITLE
1541493: Add timer utility for measuring timespans

### DIFF
--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -329,18 +329,16 @@ rendering:
     ...
 ```
 
-Now you can use the timespan from the application's code:
+Now you can use the timespan from the application's code. The timespan metric's
+`start` method, returns a `Timespan` object. Call `stop()` on this object when
+you are done timing.
 
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Rendering
 
-Rendering.imageDecodeTime.start() // start the timer
-try {
-   // ... decode an image ...
-} catch (e: Exception) {
-   Rendering.imageDecodeTime.cancel() // cancel the timer -- nothing is recorded
-}
-Rendering.imageDecodeTime.stopAndSum() // stop the timer
+val timer = Rendering.imageDecodeTime.start() // start the timer
+// ... decode an image ...
+timer.stop() // stop the timer
 ```
 
 The time reported in the telemetry ping will be the sum of all of these
@@ -389,14 +387,14 @@ pages:
 
 
 Now that the timing distribution is defined in `metrics.yaml` you can use the metric to record data
-in the application code:
+in the application code.  The timing distribution metric's `start` method returns a `Timespan` object.  Call `stop` on this object to stop timing and record a sample to the metric.
 
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Pages
 
-// ...
-pages.pageLoad.accumulate(1L) // Accumulates a sample of 1 millisecond
-pages.pageLoad.accumulate(10L) // Accumulates a sample of 10 milliseconds
+var timer = pages.pageLoad.start()
+// load a page...
+timer.stop()
 ```
 
 There are test APIs available too.  For convenience, properties `sum` and `count` are exposed to 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Timespan.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Timespan.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean
+
+import android.os.SystemClock
+
+/**
+ * A helper class for recording timespans for the [TimespanMetricType] and
+ * [TimingDistributionMetricType].
+ *
+ * To get an instance of a [Timespan] class, use [TimespanMetricType.start] or
+ * [TimingDistributionMetricType.start].  Once you have one, when you are
+ * done timing, call [Timespan.stop].  This will record the result to the
+ * appropriate metric.
+ *
+ * @param recorder A function to record the resulting time, in nanoseconds
+ * @param recordError A function to call to record an error, currently if stop is called twice
+ */
+class Timespan internal constructor(
+    private val recorder: ((Long) -> Unit),
+    private val recordError: (() -> Unit)
+) {
+    private var startTime: Long? = getElapsedNanos()
+
+    companion object {
+        /**
+         * Helper function used for getting the elapsed time, since the process
+         * started, using a monotonic clock.
+         * We need to have this as an helper so that we can override it in tests.
+         *
+         * @return the time, in nanoseconds, since the process started.
+         */
+        internal var getElapsedNanos = { SystemClock.elapsedRealtimeNanos() }
+    }
+
+    /**
+     * Call to stop the timespan and record in the appropriate metric.
+     */
+    fun stop() {
+        startTime?.let {
+            val endTime = getElapsedNanos()
+            val time = endTime - it
+            recorder(time)
+            startTime = null
+        } ?: run {
+            recordError()
+        }
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
@@ -9,12 +9,15 @@ import android.arch.lifecycle.LifecycleObserver
 import android.arch.lifecycle.OnLifecycleEvent
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.GleanMetrics.GleanBaseline
+import mozilla.components.service.glean.Timespan
 
 /**
  * Connects process lifecycle events from Android to Glean's handleEvent
  * functionality (where the actual work of sending pings is done).
  */
 internal class GleanLifecycleObserver : LifecycleObserver {
+    var backgroundTimer: Timespan? = null
+
     /**
      * Calls the "background" event when entering the background.
      */
@@ -22,7 +25,7 @@ internal class GleanLifecycleObserver : LifecycleObserver {
     fun onEnterBackground() {
         // We're going to background, so store how much time we spent
         // on foreground.
-        GleanBaseline.duration.stopAndSum()
+        backgroundTimer?.stop()
         Glean.handleBackgroundEvent()
     }
 
@@ -39,6 +42,6 @@ internal class GleanLifecycleObserver : LifecycleObserver {
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.
-        GleanBaseline.duration.start()
+        backgroundTimer = GleanBaseline.duration.start()
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimespansStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimespansStorageEngine.kt
@@ -6,17 +6,14 @@ package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
-import android.os.SystemClock
 import android.support.annotation.VisibleForTesting
-import mozilla.components.service.glean.error.ErrorRecording.ErrorType
-import mozilla.components.service.glean.error.ErrorRecording.recordError
 import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.service.glean.utils.getAdjustedTime
 
 import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONArray
 import org.json.JSONObject
-import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 /**
  * This singleton handles the in-memory storage logic for timespans. It is meant to be used by
@@ -32,12 +29,6 @@ internal object TimespansStorageEngine : TimespansStorageEngineImplementation()
 internal open class TimespansStorageEngineImplementation(
     override val logger: Logger = Logger("glean/TimespansStorageEngine")
 ) : GenericStorageEngine<Long>() {
-
-    /**
-     * A map that stores the start times from the API consumers, not yet
-     * committed to any store (i.e. [start] was called but no [stopAndSum] yet).
-     */
-    private val uncommittedStartTimes = mutableMapOf<String, Long>()
 
     /**
      * An internal map to keep track of the desired time units for the recorded timespans.
@@ -103,60 +94,6 @@ internal open class TimespansStorageEngineImplementation(
     }
 
     /**
-     * Helper function used for getting the elapsed time, since the process
-     * started, using a monotonic clock.
-     * We need to have this as an helper so that we can override it in tests.
-     *
-     * @return the time, in nanoseconds, since the process started.
-     */
-    internal fun getElapsedNanos(): Long = SystemClock.elapsedRealtimeNanos()
-
-    /**
-     * Convenience method to get a time in a different, supported time unit.
-     *
-     * @param timeUnit the required time unit, one in [TimeUnit]
-     * @param elapsedNanos a time in nanoseconds
-     *
-     * @return the time in the desired time unit
-     */
-    private fun getAdjustedTime(timeUnit: TimeUnit, elapsedNanos: Long): Long {
-        return when (timeUnit) {
-            TimeUnit.Nanosecond -> elapsedNanos
-            TimeUnit.Microsecond -> AndroidTimeUnit.NANOSECONDS.toMicros(elapsedNanos)
-            TimeUnit.Millisecond -> AndroidTimeUnit.NANOSECONDS.toMillis(elapsedNanos)
-            TimeUnit.Second -> AndroidTimeUnit.NANOSECONDS.toSeconds(elapsedNanos)
-            TimeUnit.Minute -> AndroidTimeUnit.NANOSECONDS.toMinutes(elapsedNanos)
-            TimeUnit.Hour -> AndroidTimeUnit.NANOSECONDS.toHours(elapsedNanos)
-            TimeUnit.Day -> AndroidTimeUnit.NANOSECONDS.toDays(elapsedNanos)
-        }
-    }
-
-    /**
-     * Start tracking time for the provided metric. This records an error if it’s
-     * already tracking time (i.e. start was already called with no corresponding
-     * [stopAndSum]): in that case the original start time will be preserved.
-     *
-     * @param metricData the metric information for the timespan
-     */
-    fun start(metricData: CommonMetricData) {
-        val timespanName = metricData.identifier
-
-        if (timespanName in uncommittedStartTimes) {
-            recordError(
-                metricData,
-                ErrorType.InvalidValue,
-                "Timespan already started",
-                logger
-            )
-            return
-        }
-
-        synchronized(this) {
-            uncommittedStartTimes[timespanName] = getElapsedNanos()
-        }
-    }
-
-    /**
      * Stop tracking time for the provided metric. Add the elapsed time to the time currently
      * stored in the metric. This will record an error if no [start] was called.
      *
@@ -166,35 +103,23 @@ internal open class TimespansStorageEngineImplementation(
     @Synchronized
     fun stopAndSum(
         metricData: CommonMetricData,
-        timeUnit: TimeUnit
+        timeUnit: TimeUnit,
+        elapsedNanos: Long
     ) {
         // Look for the start time: if it's there, commit the timespan.
         val timespanName = metricData.identifier
-        uncommittedStartTimes.remove(timespanName)?.let { startTime ->
-            val elapsedNanos = getElapsedNanos() - startTime
 
-            // Store the time unit: we'll need it when snapshotting.
-            timeUnitsMap[timespanName] = timeUnit
+        // Store the time unit: we'll need it when snapshotting.
+        timeUnitsMap[timespanName] = timeUnit
 
-            // Use a custom combiner to sum the new timespan to the one already stored. We
-            // can't adjust the time unit before storing so that we still allow for values
-            // lower than the desired time unit to accumulate.
-            super.recordMetric(metricData, elapsedNanos, timeUnit) { currentValue, newValue ->
-                currentValue?.let {
-                    it + newValue
-                } ?: newValue
-            }
+        // Use a custom combiner to sum the new timespan to the one already stored. We
+        // can't adjust the time unit before storing so that we still allow for values
+        // lower than the desired time unit to accumulate.
+        super.recordMetric(metricData, elapsedNanos, timeUnit) { currentValue, newValue ->
+            currentValue?.let {
+                it + newValue
+            } ?: newValue
         }
-    }
-
-    /**
-     * Abort a previous [start] call. No error is recorded if no [start] was called.
-     *
-     * @param metricData the metric information for the timespan
-     */
-    @Synchronized
-    fun cancel(metricData: CommonMetricData) {
-        uncommittedStartTimes.remove(metricData.identifier)
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
@@ -11,7 +11,7 @@ import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.HistogramType
 import mozilla.components.service.glean.private.TimeUnit
-
+import mozilla.components.service.glean.utils.getAdjustedTime
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.org.json.tryGetInt
 import mozilla.components.support.ktx.android.org.json.tryGetLong
@@ -58,7 +58,8 @@ internal open class TimingDistributionsStorageEngineImplementation(
      * Accumulate value for the provided metric.
      *
      * @param metricData the metric information for the timing distribution
-     * @param sample the value to accumulate
+     * @param sample the value to accumulate, in nanoseconds
+     * @param timeUnit the time unit to convert to
      */
     @Synchronized
     fun accumulate(
@@ -76,6 +77,8 @@ internal open class TimingDistributionsStorageEngineImplementation(
             return
         }
 
+        val sampleInUnit = getAdjustedTime(timeUnit, sample)
+
         // Since the custom combiner closure captures this value, we need to just create a dummy
         // value here that won't be used by the combine function, and create a fresh
         // TimingDistributionData for each value that doesn't have an existing current value.
@@ -83,12 +86,12 @@ internal open class TimingDistributionsStorageEngineImplementation(
             timeUnit = timeUnit)
         super.recordMetric(metricData, dummy, null) { currentValue, newValue ->
             currentValue?.let {
-                it.accumulate(sample)
+                it.accumulate(sampleInUnit)
                 it
             } ?: let {
                 val newTD = TimingDistributionData(category = metricData.category, name = metricData.name,
                     timeUnit = timeUnit)
-                newTD.accumulate(sample)
+                newTD.accumulate(sampleInUnit)
                 return@let newTD
             }
         }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/utils/DateUtils.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/utils/DateUtils.kt
@@ -10,6 +10,7 @@ import mozilla.components.service.glean.private.TimeUnit
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 @Suppress("TopLevelPropertyNaming")
 internal val DATE_FORMAT_PATTERNS = mapOf(
@@ -99,4 +100,24 @@ internal fun parseISOTimeString(date: String): Date? {
     }
 
     return null
+}
+
+/**
+ * Convenience method to get a time in a different, supported time unit.
+ *
+ * @param timeUnit the required time unit, one in [TimeUnit]
+ * @param elapsedNanos a time in nanoseconds
+ *
+ * @return the time in the desired time unit
+ */
+internal fun getAdjustedTime(timeUnit: TimeUnit, elapsedNanos: Long): Long {
+    return when (timeUnit) {
+        TimeUnit.Nanosecond -> elapsedNanos
+        TimeUnit.Microsecond -> AndroidTimeUnit.NANOSECONDS.toMicros(elapsedNanos)
+        TimeUnit.Millisecond -> AndroidTimeUnit.NANOSECONDS.toMillis(elapsedNanos)
+        TimeUnit.Second -> AndroidTimeUnit.NANOSECONDS.toSeconds(elapsedNanos)
+        TimeUnit.Minute -> AndroidTimeUnit.NANOSECONDS.toMinutes(elapsedNanos)
+        TimeUnit.Hour -> AndroidTimeUnit.NANOSECONDS.toHours(elapsedNanos)
+        TimeUnit.Day -> AndroidTimeUnit.NANOSECONDS.toDays(elapsedNanos)
+    }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -119,6 +120,8 @@ internal fun resetGlean(
     clearStores: Boolean = true
 ) {
     Glean.enableTestingMode()
+
+    Timespan.getElapsedNanos = { SystemClock.elapsedRealtimeNanos() }
 
     // We're using the WorkManager in a bunch of places, and glean will crash
     // in tests without this line. Let's simply put it here.

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -24,6 +24,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import java.util.UUID
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
@@ -296,11 +297,10 @@ class LabeledMetricTypeTest {
             subMetric = timespanMetric
         )
 
-        TimespansStorageEngine.start(labeledTimespanMetric["label1"])
-        TimespansStorageEngine.stopAndSum(labeledTimespanMetric["label1"], TimeUnit.Nanosecond)
-        TimespansStorageEngine.start(labeledTimespanMetric["label2"])
-        TimespansStorageEngine.stopAndSum(labeledTimespanMetric["label2"], TimeUnit.Nanosecond)
-
+        labeledTimespanMetric["label1"].start().stop()
+        labeledTimespanMetric["label2"].start().stop()
+        assertTrue(labeledTimespanMetric["label1"].testHasValue())
+        assertTrue(labeledTimespanMetric["label2"].testHasValue())
         collectAndCheckPingSchema("metrics").getJSONObject("metrics")!!
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
@@ -33,8 +33,7 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.stopAndSum()
+        metric.start().stop()
 
         // Check that data was properly recorded.
         assertTrue(metric.testHasValue())
@@ -55,10 +54,6 @@ class TimespanMetricTypeTest {
 
         // Record a timespan.
         metric.start()
-        metric.stopAndSum()
-
-        // Let's also call cancel() to make sure it's a no-op.
-        metric.cancel()
 
         // Check that data was not recorded.
         assertFalse("The API should not record a counter if metric is disabled",
@@ -79,8 +74,6 @@ class TimespanMetricTypeTest {
 
         // Record a timespan.
         metric.start()
-        metric.cancel()
-        metric.stopAndSum()
 
         // Check that data was not recorded.
         assertFalse("The API should not record a counter if metric is cancelled",
@@ -113,8 +106,7 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.stopAndSum()
+        metric.start().stop()
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))
@@ -122,7 +114,7 @@ class TimespanMetricTypeTest {
     }
 
     @Test
-    fun `Records an error if started twice`() {
+    fun `Records an error if stopped twice`() {
         // Define a timespan metric, which will be stored in "store1" and "store2"
         val metric = TimespanMetricType(
             disabled = false,
@@ -134,12 +126,14 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.start()
-        metric.stopAndSum()
+        val timespan = metric.start()
+        timespan.stop()
+        timespan.stop()
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))
+
+        // Check that an error was reported
         assertTrue(metric.testGetValue("store2") >= 0)
         assertEquals(1, testGetNumRecordedErrors(metric, ErrorType.InvalidValue))
     }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.private
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.service.glean.Timespan
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -53,9 +54,12 @@ class TimingDistributionMetricTypeTest {
         )
 
         // Accumulate a few values
-        metric.accumulate(1L)
-        metric.accumulate(2L)
-        metric.accumulate(3L)
+        for (i in 1L..3L) {
+            Timespan.getElapsedNanos = { 0 }
+            val timespan = metric.start()
+            Timespan.getElapsedNanos = { i * 1000000 } // ms to ns
+            timespan.stop()
+        }
 
         // Check that data was properly recorded.
         assertTrue(metric.testHasValue())
@@ -83,10 +87,14 @@ class TimingDistributionMetricTypeTest {
             timeUnit = TimeUnit.Millisecond
         )
 
-        // Attempt to store the string list using set
-        metric.accumulate(1L)
+        // Attempt to store the timespan using set
+        Timespan.getElapsedNanos = { 0 }
+        val timespan = metric.start()
+        Timespan.getElapsedNanos = { 1 }
+        timespan.stop()
+
         // Check that nothing was recorded.
-        assertFalse("StringLists without a lifetime should not record data",
+        assertFalse("TimingDistributions without a lifetime should not record data.",
             metric.testHasValue())
     }
 
@@ -117,9 +125,12 @@ class TimingDistributionMetricTypeTest {
         )
 
         // Accumulate a few values
-        metric.accumulate(1L)
-        metric.accumulate(2L)
-        metric.accumulate(3L)
+        for (i in 1L..3L) {
+            Timespan.getElapsedNanos = { 0 }
+            val timespan = metric.start()
+            Timespan.getElapsedNanos = { i * 1000000 } // ms to ns
+            timespan.stop()
+        }
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -6,49 +6,28 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.service.glean.Timespan
+import mozilla.components.service.glean.private.TimespanMetricType
+import mozilla.components.service.glean.resetGlean
 
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
-import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.eq
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class TimespansStorageEngineTest {
-
-    private data class TestMetricData(
-        override val disabled: Boolean,
-        override val category: String,
-        override val lifetime: Lifetime,
-        override val name: String,
-        override val sendInPings: List<String>,
-        override val defaultStorageDestinations: List<String> = listOf()
-    ) : CommonMetricData
-
-    /**
-     * Helper that returns a spied mocked engine.
-     */
-    private fun getSpiedEngine(): TimespansStorageEngineImplementation {
-        // We need to initialize `engine` and `spiedEngine` separately, otherwise
-        // it will throw a RuntimeException because of the `applicationContext` not being
-        // initialized.
-        val engine = TimespansStorageEngineImplementation()
-        engine.applicationContext = ApplicationProvider.getApplicationContext()
-        return spy<TimespansStorageEngineImplementation>(engine)
-    }
-
     @Before
     fun setUp() {
+        resetGlean()
         TimespansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         TimespansStorageEngine.clearAllStores()
     }
@@ -89,25 +68,26 @@ class TimespansStorageEngineTest {
     fun `a single elapsed time must be correctly recorded`() {
         val expectedTimespanNanos: Long = 37
 
-        val metric = TestMetricData(
+        val metric = TimespanMetricType(
             false,
             "telemetry",
             Lifetime.Ping,
             "single_elapsed_test",
-            listOf("store1"))
+            listOf("store1"),
+            timeUnit = TimeUnit.Nanosecond
+        )
 
-        // Initialize a mocked engine so that we can return a custom elapsed time.
-        val spiedEngine = getSpiedEngine()
-
-        // Return 0 the first time we get the time.
-        doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
+        // Return 0 the first time we get the time
+        Timespan.getElapsedNanos = { 0 }
+        val timespan = metric.start()
 
         // Return the expected time when we stop the timer.
-        doReturn(expectedTimespanNanos).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
+        Timespan.getElapsedNanos = { expectedTimespanNanos }
+        timespan.stop()
 
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
+        assertTrue(metric.testHasValue())
+
+        val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
         assertEquals(Pair("nanosecond", expectedTimespanNanos), snapshot["telemetry.single_elapsed_test"])
     }
@@ -116,109 +96,31 @@ class TimespansStorageEngineTest {
     fun `multiple elapsed times must be correctly accumulated`() {
         val expectedChunkNanos: Long = 37
 
-        val metric = TestMetricData(
+        val metric = TimespanMetricType(
             false,
             "telemetry",
             Lifetime.Ping,
             "single_elapsed_test",
-            listOf("store1"))
-
-        // Initialize a mocked engine so that we can return a custom elapsed time.
-        val spiedEngine = getSpiedEngine()
+            listOf("store1"),
+            timeUnit = TimeUnit.Nanosecond
+        )
 
         // Record the time for the first chunk.
-        doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-        doReturn(expectedChunkNanos).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
+        Timespan.getElapsedNanos = { 0 }
+        val timespan = metric.start()
+        Timespan.getElapsedNanos = { expectedChunkNanos }
+        timespan.stop()
 
         // Record the time for the second chunk of time.
-        spiedEngine.start(metric)
-        doReturn(expectedChunkNanos * 2).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
+        val timespan2 = metric.start()
+        Timespan.getElapsedNanos = { expectedChunkNanos * 2 }
+        timespan2.stop()
 
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
+        assertTrue(metric.testHasValue())
+
+        val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
         assertEquals(Pair("nanosecond", expectedChunkNanos * 2), snapshot["telemetry.single_elapsed_test"])
-    }
-
-    @Test
-    fun `the API must not crash nor throw errors when called in unexpected ways`() {
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "single_elapsed_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
-        // Check that a call to cancel() without any previous start doesn't fail.
-        spiedEngine.cancel(metric)
-
-        // Same for stopAndSum().
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
-    }
-
-    @Test
-    fun `start() must preserve the original time if called twice for the same metric`() {
-        val expectedChunkNanos: Long = 37
-
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "single_elapsed_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
-        // Call start() the first time.
-        doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-
-        // Change the elapsed time and call start the second time.
-        doReturn(10.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-
-        // Call stopAndSum and make sure the elapsed time is still referred to the first
-        // start() call.
-        doReturn(expectedChunkNanos).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
-
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
-        assertEquals(1, snapshot!!.size)
-        assertEquals(
-            Pair("nanosecond", expectedChunkNanos),
-            snapshot["telemetry.single_elapsed_test"]
-        )
-    }
-
-    @Test
-    fun `calling cancel() after start() should clear the uncomitted elapsed time`() {
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "single_elapsed_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
-        // Call start() the first time.
-        doReturn(10.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-
-        // Cancel the current timespan.
-        spiedEngine.cancel(metric)
-
-        // Call stopAndSum: since the time was cleared we don't expected anything in the
-        // snapshot.
-        doReturn(20.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
-
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
-        assertNull(snapshot)
     }
 
     @Test
@@ -234,23 +136,24 @@ class TimespansStorageEngineTest {
             TimeUnit.Day to AndroidTimeUnit.NANOSECONDS.toDays(expectedLengthInNanos)
         )
 
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "resolution_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
         expectedResults.forEach { (res, expectedTimespan) ->
-            // Record the timespan in the provided resolution.
-            doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.start(metric)
-            doReturn(expectedLengthInNanos).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.stopAndSum(metric, res)
+            val metric = TimespanMetricType(
+                false,
+                "telemetry",
+                Lifetime.Ping,
+                "resolution_test",
+                listOf("store1"),
+                timeUnit = res
+            )
 
-            val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
+            // Record the timespan in the provided resolution.
+            Timespan.getElapsedNanos = { 0 }
+            val timespan = metric.start()
+            Timespan.getElapsedNanos = { expectedLengthInNanos }
+            timespan.stop()
+            assertTrue(metric.testHasValue())
+
+            val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
             assertEquals(1, snapshot!!.size)
             assertEquals(Pair(res.name.toLowerCase(), expectedTimespan), snapshot["telemetry.resolution_test"])
         }
@@ -263,31 +166,32 @@ class TimespansStorageEngineTest {
         val expectedTimespanSeconds: Long = 1
         val timespanFraction: Long = AndroidTimeUnit.SECONDS.toNanos(expectedTimespanSeconds) / steps
 
-        val metric = TestMetricData(
+        val metric = TimespanMetricType(
             false,
             "telemetry",
             Lifetime.Ping,
             "many_short_lived_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
+            listOf("store1"),
+            timeUnit = TimeUnit.Second
+        )
 
         // Accumulate enough timespans with a duration lower than the
         // expected resolution. Their sum should still be >= than our
         // resolution, and thus be reported.
         for (i in 0..steps) {
             val timespanStart: Long = i * timespanFraction
-            doReturn(timespanStart).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.start(metric)
+            Timespan.getElapsedNanos = { timespanStart }
+            val timespan = metric.start()
 
             val timespanEnd: Long = timespanStart + timespanFraction
-            doReturn(timespanEnd).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.stopAndSum(metric, TimeUnit.Second)
+            Timespan.getElapsedNanos = { timespanEnd }
+            timespan.stop()
         }
 
+        assertTrue(metric.testHasValue())
         // Since the sum of the short-lived timespans is >= our resolution, we
         // expect the accumulated value to be in the snapshot.
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
+        val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
         assertEquals(1, snapshot!!.size)
         assertEquals(
             Pair("second", expectedTimespanSeconds),

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -10,7 +10,6 @@ import mozilla.components.service.experiments.Experiments
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import org.mozilla.samples.glean.GleanMetrics.Basic
-import org.mozilla.samples.glean.GleanMetrics.Test
 
 class GleanApplication : Application() {
 
@@ -26,8 +25,6 @@ class GleanApplication : Application() {
         // Initialize the Experiments library right afterwards. Experiments can
         // not be activated before this, so it's important to do this early.
         Experiments.initialize(applicationContext)
-
-        Test.testTimespan.start()
 
         // Set a sample value for a metric.
         Basic.os.set("Android")

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -16,6 +16,8 @@ open class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val timer = Test.testTimespan.start()
+
         setContentView(R.layout.activity_main)
 
         // Generate an event when user clicks on the button.
@@ -49,7 +51,7 @@ open class MainActivity : AppCompatActivity() {
             Glean.handleBackgroundEvent()
         }
 
-        Test.testTimespan.stopAndSum()
+        timer.stop()
 
         // Update some metrics from a third-party library
         SamplesGleanLibrary.recordMetric()


### PR DESCRIPTION
This adds a utility class to measure timings, used by both timespans and timing distributions.

This should be threadsafe and fix some of the potential foot-guns in the original API.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
