### PR TITLE
Expose automaticLanguageAdjustment, and automatically detect the locale.

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import android.content.Context
 import android.util.AttributeSet
+import mozilla.components.browser.engine.gecko.integration.LocaleSettingUpdater
 import mozilla.components.browser.engine.gecko.mediaquery.from
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.Engine
@@ -34,6 +35,8 @@ class GeckoEngine(
     executorProvider: () -> GeckoWebExecutor = { GeckoWebExecutor(runtime) }
 ) : Engine {
     private val executor by lazy { executorProvider.invoke() }
+
+    private val localeUpdater = LocaleSettingUpdater(context, runtime)
 
     init {
         runtime.delegate = GeckoRuntime.Delegate {
@@ -114,6 +117,13 @@ class GeckoEngine(
             get() = runtime.settings.automaticFontSizeAdjustment
             set(value) { runtime.settings.automaticFontSizeAdjustment = value }
 
+        override var automaticLanguageAdjustment: Boolean
+            get() = localeUpdater.enabled
+            set(value) {
+                localeUpdater.enabled = value
+                defaultSettings?.automaticLanguageAdjustment = value
+            }
+
         override var trackingProtectionPolicy: TrackingProtectionPolicy?
             get() = TrackingProtectionPolicy.select(runtime.settings.contentBlocking.categories)
             set(value) {
@@ -147,6 +157,7 @@ class GeckoEngine(
             this.javascriptEnabled = it.javascriptEnabled
             this.webFontsEnabled = it.webFontsEnabled
             this.automaticFontSizeAdjustment = it.automaticFontSizeAdjustment
+            this.automaticLanguageAdjustment = it.automaticLanguageAdjustment
             this.trackingProtectionPolicy = it.trackingProtectionPolicy
             this.remoteDebuggingEnabled = it.remoteDebuggingEnabled
             this.testingModeEnabled = it.testingModeEnabled

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/integration/LocaleSettingUpdater.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/integration/LocaleSettingUpdater.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.integration
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.support.v4.os.LocaleListCompat as LocaleList
+import org.mozilla.geckoview.GeckoRuntime
+
+/**
+ * Class to set the locales setting for geckoview, updating from the locale of the device.
+ */
+class LocaleSettingUpdater(
+    private val context: Context,
+    private val runtime: GeckoRuntime
+) : SettingUpdater<Array<String>>() {
+
+    override var value: Array<String> = findValue()
+        set(value) {
+            runtime.settings.locales = value
+            field = value
+        }
+
+    private val localeChangedReceiver by lazy {
+        object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent?) {
+                updateValue()
+            }
+        }
+    }
+
+    override fun registerForUpdates() {
+        context.registerReceiver(localeChangedReceiver, IntentFilter(Intent.ACTION_LOCALE_CHANGED))
+    }
+
+    override fun unregisterForUpdates() {
+        context.unregisterReceiver(localeChangedReceiver)
+    }
+
+    override fun findValue(): Array<String> {
+        val localeList = LocaleList.getAdjustedDefault()
+        return arrayOfNulls<Unit>(localeList.size())
+            .mapIndexedNotNull { i, _ -> localeList.get(i).toLanguageTag() }
+            .toTypedArray()
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/integration/SettingUpdater.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/integration/SettingUpdater.kt
@@ -1,0 +1,41 @@
+package mozilla.components.browser.engine.gecko.integration
+
+abstract class SettingUpdater<T> {
+    /**
+     * Toggle the automatic tracking of a setting derived from the device state.
+     */
+    var enabled: Boolean = false
+        set(value) {
+            if (value) {
+                updateValue()
+                registerForUpdates()
+            } else {
+                unregisterForUpdates()
+            }
+            field = value
+        }
+
+    /**
+     * The setter for this property should change the GeckoView setting.
+     */
+    abstract var value: T
+
+    internal fun updateValue() {
+        value = findValue()
+    }
+
+    /**
+     * Register for updates from the device state. This is setting specific.
+     */
+    abstract fun registerForUpdates()
+
+    /**
+     * Unregister for updates from the device state.
+     */
+    abstract fun unregisterForUpdates()
+
+    /**
+     * Find the value of the setting from the device state. This is setting specific.
+     */
+    abstract fun findValue(): T
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
@@ -1,0 +1,68 @@
+package mozilla.components.browser.engine.gecko.integration
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.runner.RunWith
+import org.junit.Test
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingUpdaterTest {
+
+    @Test
+    fun `test updateValue`() {
+        val subject = DummySettingUpdater("current", "new")
+        assertEquals("current", subject.value)
+
+        subject.updateValue()
+        assertEquals("new", subject.value)
+    }
+
+    @Test
+    fun `test enabled updates value`() {
+        val subject = DummySettingUpdater("current", "new")
+        assertEquals("current", subject.value)
+
+        subject.enabled = true
+        assertEquals("new", subject.value)
+
+        // disabling doesn't update the value.
+        subject.nextValue = "disabled"
+        subject.enabled = false
+        assertEquals("new", subject.value)
+    }
+
+    @Test
+    fun `test registering and deregistering for updates`() {
+        val subject = DummySettingUpdater("current", "new")
+        assertFalse("Initialized not registering for updates", subject.registered)
+
+        subject.updateValue()
+        assertFalse("updateValue not registering for updates", subject.registered)
+
+        subject.enabled = true
+        assertTrue("enabled = true registering for updates", subject.registered)
+
+        subject.enabled = false
+        assertFalse("enabled = false deregistering for updates", subject.registered)
+    }
+}
+
+class DummySettingUpdater(
+    override var value: String = "",
+    var nextValue: String
+) : SettingUpdater<String>() {
+
+    var registered = false
+
+    override fun registerForUpdates() {
+        registered = true
+    }
+
+    override fun unregisterForUpdates() {
+        registered = false
+    }
+
+    override fun findValue() = nextValue
+}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -38,6 +38,12 @@ abstract class Settings {
     open var automaticFontSizeAdjustment: Boolean by UnsupportedSetting()
 
     /**
+     * Setting to control whether the [Accept-Language] headers are altered with system locale
+     * settings.
+     */
+    open var automaticLanguageAdjustment: Boolean by UnsupportedSetting()
+
+    /**
      * Setting to control tracking protection.
      */
     open var trackingProtectionPolicy: TrackingProtectionPolicy? by UnsupportedSetting()
@@ -140,6 +146,7 @@ data class DefaultSettings(
     override var domStorageEnabled: Boolean = true,
     override var webFontsEnabled: Boolean = true,
     override var automaticFontSizeAdjustment: Boolean = true,
+    override var automaticLanguageAdjustment: Boolean = true,
     override var mediaPlaybackRequiresUserGesture: Boolean = true,
     override var trackingProtectionPolicy: TrackingProtectionPolicy? = null,
     override var requestInterceptor: RequestInterceptor? = null,

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -31,6 +31,8 @@ class SettingsTest {
             { settings.webFontsEnabled = false },
             { settings.automaticFontSizeAdjustment },
             { settings.automaticFontSizeAdjustment = false },
+            { settings.automaticLanguageAdjustment },
+            { settings.automaticLanguageAdjustment = false },
             { settings.trackingProtectionPolicy },
             { settings.trackingProtectionPolicy = TrackingProtectionPolicy.all() },
             { settings.historyTrackingDelegate },
@@ -89,6 +91,7 @@ class SettingsTest {
         assertFalse(settings.javaScriptCanOpenWindowsAutomatically)
         assertTrue(settings.displayZoomControls)
         assertTrue(settings.automaticFontSizeAdjustment)
+        assertTrue(settings.automaticLanguageAdjustment)
         assertFalse(settings.loadWithOverviewMode)
         assertTrue(settings.allowContentAccess)
         assertTrue(settings.allowFileAccess)
@@ -109,6 +112,7 @@ class SettingsTest {
             domStorageEnabled = false,
             webFontsEnabled = false,
             automaticFontSizeAdjustment = false,
+            automaticLanguageAdjustment = false,
             trackingProtectionPolicy = TrackingProtectionPolicy.all(),
             historyTrackingDelegate = historyTrackingDelegate,
             requestInterceptor = interceptor,
@@ -132,6 +136,7 @@ class SettingsTest {
         assertFalse(defaultSettings.javascriptEnabled)
         assertFalse(defaultSettings.webFontsEnabled)
         assertFalse(defaultSettings.automaticFontSizeAdjustment)
+        assertFalse(defaultSettings.automaticLanguageAdjustment)
         assertEquals(TrackingProtectionPolicy.all(), defaultSettings.trackingProtectionPolicy)
         assertEquals(historyTrackingDelegate, defaultSettings.historyTrackingDelegate)
         assertEquals(interceptor, defaultSettings.requestInterceptor)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,10 @@ permalink: /changelog/
      labeled counter, rather than using `type: counter` and `labeled: true`, use
      `type: labeled_counter`. See bugzilla 1540725.
 
+* **concept-engine**
+   * Adds `automaticLanguageAdjustment` setting, which should hint to implementations to send 
+   language specific headers to websites. Implementation in `browser-engine-gecko-nightly`.
+
 # 0.49.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.48.0...v0.49.0)


### PR DESCRIPTION
This PR adds a setting to the `concept-engine` to track the locale the device is set to and hint to the engine to change the `Accept-Language` headers sent to server.

Fixes [fenix#942][1]. 

[1]: https://github.com/mozilla-mobile/fenix/issues/942

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
~- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
