### PR TITLE
1541493: Add thread-safe timing API

### DIFF
--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -329,18 +329,22 @@ rendering:
     ...
 ```
 
-Now you can use the timespan from the application's code:
+Now you can use the timespan from the application's code. Each time interval that
+the timespan metric records must be associated with an object provided by the user.
+This is so that intervals can be measured concurrently.  For example, to measure page
+load time on a number of tabs that are loading at the same time, each time interval
+should be associated with an object that uniquely represents each tab.
 
 ```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.Rendering
+import org.mozilla.yourApplication.GleanMetrics.Pages
 
-Rendering.imageDecodeTime.start() // start the timer
-try {
-   // ... decode an image ...
-} catch (e: Exception) {
-   Rendering.imageDecodeTime.cancel() // cancel the timer -- nothing is recorded
+fun onPageStart(e: Event) {
+    Pages.pageLoad.start(e.target)
 }
-Rendering.imageDecodeTime.stopAndSum() // stop the timer
+
+fun onPageLoaded(e: Event) {
+    Pages.pageLoad.stopAndSum(e.target)
+}
 ```
 
 The time reported in the telemetry ping will be the sum of all of these
@@ -349,13 +353,13 @@ timespans recorded during the lifetime of the ping.
 There are test APIs available too:
 
 ```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.Rendering
+import org.mozilla.yourApplication.GleanMetrics.Pages
 Glean.enableTestingMode()
 
 // Was anything recorded?
-assertTrue(Rendering.imageDecodeTime.testHasValue())
+assertTrue(Pages.pageLoad.testHasValue())
 // Does the timer have the expected value
-assertTrue(Rendering.imageDecodeTime.testGetValue() > 0)
+assertTrue(Pages.pageLoad.testGetValue() > 0)
 ```
 
 ## Timing Distributions
@@ -388,15 +392,22 @@ pages:
 ```
 
 
-Now that the timing distribution is defined in `metrics.yaml` you can use the metric to record data
-in the application code:
+Now you can use the timing distribution from the application's code. Each time interval that
+the timing distribution metric records must be associated with an object provided by the user.
+This is so that intervals can be measured concurrently.  For example, to measure page
+load time on a number of tabs that are loading at the same time, each time interval
+should be associated with an object that uniquely represents each tab.
 
 ```Kotlin
 import org.mozilla.yourApplication.GleanMetrics.Pages
 
-// ...
-pages.pageLoad.accumulate(1L) // Accumulates a sample of 1 millisecond
-pages.pageLoad.accumulate(10L) // Accumulates a sample of 10 milliseconds
+fun onPageStart(e: Event) {
+    Pages.pageLoad.start(e.target)
+}
+
+fun onPageLoaded(e: Event) {
+    Pages.pageLoad.stopAndAccumulate(e.target)
+}
 ```
 
 There are test APIs available too.  For convenience, properties `sum` and `count` are exposed to 

--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -316,34 +316,40 @@ of 500 nanoseconds will be truncated to 0 microseconds.
 
 ### Usage
 
-Say you're adding a new timespan for the time spent decoding images. First you need
+Say you're adding a new timespan for the time spent logging into the app. First you need
 to add an entry for the counter to the `metrics.yaml` file:
 
 ```YAML
-rendering:
-  image_decode_time:
+auth:
+  login_time:
     type: timespan
     description: >
-      Measures the time spent decoding images.
-    time_unit: microseconds
+      Measures the time spent logging in.
+    time_unit: milliseconds
     ...
 ```
 
-Now you can use the timespan from the application's code. Each time interval that
-the timespan metric records must be associated with an object provided by the user.
-This is so that intervals can be measured concurrently.  For example, to measure page
-load time on a number of tabs that are loading at the same time, each time interval
-should be associated with an object that uniquely represents each tab.
+Now you can use the timespan from the application's code. Each time interval
+that the timespan metric records must be associated with an object provided by
+the user. This is so that intervals can be measured concurrently. In our example
+using login time, this might be an object representing the login UI page.
 
 ```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.Pages
+import org.mozilla.yourApplication.GleanMetrics.Auth
 
-fun onPageStart(e: Event) {
-    Pages.pageLoad.start(e.target)
+fun onShowLogin(e: Event) {
+    Auth.loginTime.start(e.target)
+    // ...
 }
 
-fun onPageLoaded(e: Event) {
-    Pages.pageLoad.stopAndSum(e.target)
+fun onLogin(e: Event) {
+    Auth.loginTime.stop(e.target)
+    // ...
+}
+
+fun onLoginCancel(e: Event) {
+    Auth.loginTime.cancel(e.tart)
+    // ...
 }
 ```
 
@@ -353,13 +359,13 @@ timespans recorded during the lifetime of the ping.
 There are test APIs available too:
 
 ```Kotlin
-import org.mozilla.yourApplication.GleanMetrics.Pages
+import org.mozilla.yourApplication.GleanMetrics.Auth
 Glean.enableTestingMode()
 
 // Was anything recorded?
-assertTrue(Pages.pageLoad.testHasValue())
+assertTrue(Auth.loginTime.testHasValue())
 // Does the timer have the expected value
-assertTrue(Pages.pageLoad.testGetValue() > 0)
+assertTrue(Auth.loginTime.testGetValue() > 0)
 ```
 
 ## Timing Distributions

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
@@ -37,16 +37,16 @@ data class TimespanMetricType(
      * called with no corresponding [stopAndSum]): in that case the original
      * start time will be preserved.
      *
-     * @param anyObject The object to associate with this timing.  This allows
+     * @param timerId The object to associate with this timing.  This allows
      * for concurrent timing of events associated with different objects to the
      * same timespan metric.
      */
-    fun start(anyObject: Any) {
+    fun start(timerId: Any) {
         if (!shouldRecord(logger)) {
             return
         }
 
-        TimingManager.start(this, anyObject)
+        TimingManager.start(this, timerId)
     }
 
     /**
@@ -54,16 +54,16 @@ data class TimespanMetricType(
      * elapsed time to the time currently stored in the metric. This will record
      * an error if no [start] was called.
      *
-     * @param anyObject The object to associate with this timing.  This allows
+     * @param timerId The object to associate with this timing.  This allows
      * for concurrent timing of events associated with different objects to the
      * same timespan metric.
      */
-    fun stopAndSum(anyObject: Any) {
+    fun stopAndSum(timerId: Any) {
         if (!shouldRecord(logger)) {
             return
         }
 
-        TimingManager.stop(this, anyObject)?.let { elapsedNanos ->
+        TimingManager.stop(this, timerId)?.let { elapsedNanos ->
             @Suppress("EXPERIMENTAL_API_USAGE")
             Dispatchers.API.launch {
                 TimespansStorageEngine.sum(this@TimespanMetricType, timeUnit, elapsedNanos)
@@ -74,16 +74,16 @@ data class TimespanMetricType(
     /**
      * Abort a previous [start] call. No error is recorded if no [start] was called.
      *
-     * @param anyObject The object to associate with this timing.  This allows
+     * @param timerId The object to associate with this timing.  This allows
      * for concurrent timing of events associated with different objects to the
      * same timespan metric.
      */
-    fun cancel(anyObject: Any) {
+    fun cancel(timerId: Any) {
         if (!shouldRecord(logger)) {
             return
         }
 
-        TimingManager.cancel(this, anyObject)
+        TimingManager.cancel(this, timerId)
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
@@ -39,16 +39,16 @@ data class TimingDistributionMetricType(
      * called with no corresponding [stopAndAccumulate]): in that case the original
      * start time will be preserved.
      *
-     * @param anyObject The object to associate with this timing.  This allows
+     * @param timerId The object to associate with this timing.  This allows
      * for concurrent timing of events associated with different objects to the
      * same timespan metric.
      */
-    fun start(anyObject: Any) {
+    fun start(timerId: Any) {
         if (!shouldRecord(logger)) {
             return
         }
 
-        TimingManager.start(this, anyObject)
+        TimingManager.start(this, timerId)
     }
 
     /**
@@ -56,16 +56,16 @@ data class TimingDistributionMetricType(
      * count to the corresponding bucket in the timing distribution.
      * This will record an error if no [start] was called.
      *
-     * @param anyObject The object to associate with this timing.  This allows
+     * @param timerId The object to associate with this timing.  This allows
      * for concurrent timing of events associated with different objects to the
      * same timespan metric.
      */
-    fun stopAndAccumulate(anyObject: Any) {
+    fun stopAndAccumulate(timerId: Any) {
         if (!shouldRecord(logger)) {
             return
         }
 
-        TimingManager.stop(this, anyObject)?.let { elapsedNanos ->
+        TimingManager.stop(this, timerId)?.let { elapsedNanos ->
             @Suppress("EXPERIMENTAL_API_USAGE")
             Dispatchers.API.launch {
                 // Delegate storing the string to the storage engine.
@@ -81,16 +81,16 @@ data class TimingDistributionMetricType(
     /**
      * Abort a previous [start] call. No error is recorded if no [start] was called.
      *
-     * @param anyObject The object to associate with this timing.  This allows
+     * @param timerId The object to associate with this timing.  This allows
      * for concurrent timing of events associated with different objects to the
      * same timespan metric.
      */
-    fun cancel(anyObject: Any) {
+    fun cancel(timerId: Any) {
         if (!shouldRecord(logger)) {
             return
         }
 
-        TimingManager.cancel(this, anyObject)
+        TimingManager.cancel(this, timerId)
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/GleanLifecycleObserver.kt
@@ -22,7 +22,7 @@ internal class GleanLifecycleObserver : LifecycleObserver {
     fun onEnterBackground() {
         // We're going to background, so store how much time we spent
         // on foreground.
-        GleanBaseline.duration.stopAndSum()
+        GleanBaseline.duration.stopAndSum(this)
         Glean.handleBackgroundEvent()
     }
 
@@ -39,6 +39,6 @@ internal class GleanLifecycleObserver : LifecycleObserver {
         // Note that this is sending the length of the last foreground session
         // because it belongs to the baseline ping and that ping is sent every
         // time the app goes to background.
-        GleanBaseline.duration.start()
+        GleanBaseline.duration.start(this)
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimespansStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimespansStorageEngine.kt
@@ -6,17 +6,14 @@ package mozilla.components.service.glean.storages
 
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
-import android.os.SystemClock
 import android.support.annotation.VisibleForTesting
-import mozilla.components.service.glean.error.ErrorRecording.ErrorType
-import mozilla.components.service.glean.error.ErrorRecording.recordError
 import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.service.glean.utils.getAdjustedTime
 
 import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONArray
 import org.json.JSONObject
-import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 /**
  * This singleton handles the in-memory storage logic for timespans. It is meant to be used by
@@ -32,12 +29,6 @@ internal object TimespansStorageEngine : TimespansStorageEngineImplementation()
 internal open class TimespansStorageEngineImplementation(
     override val logger: Logger = Logger("glean/TimespansStorageEngine")
 ) : GenericStorageEngine<Long>() {
-
-    /**
-     * A map that stores the start times from the API consumers, not yet
-     * committed to any store (i.e. [start] was called but no [stopAndSum] yet).
-     */
-    private val uncommittedStartTimes = mutableMapOf<String, Long>()
 
     /**
      * An internal map to keep track of the desired time units for the recorded timespans.
@@ -103,98 +94,32 @@ internal open class TimespansStorageEngineImplementation(
     }
 
     /**
-     * Helper function used for getting the elapsed time, since the process
-     * started, using a monotonic clock.
-     * We need to have this as an helper so that we can override it in tests.
-     *
-     * @return the time, in nanoseconds, since the process started.
-     */
-    internal fun getElapsedNanos(): Long = SystemClock.elapsedRealtimeNanos()
-
-    /**
-     * Convenience method to get a time in a different, supported time unit.
-     *
-     * @param timeUnit the required time unit, one in [TimeUnit]
-     * @param elapsedNanos a time in nanoseconds
-     *
-     * @return the time in the desired time unit
-     */
-    private fun getAdjustedTime(timeUnit: TimeUnit, elapsedNanos: Long): Long {
-        return when (timeUnit) {
-            TimeUnit.Nanosecond -> elapsedNanos
-            TimeUnit.Microsecond -> AndroidTimeUnit.NANOSECONDS.toMicros(elapsedNanos)
-            TimeUnit.Millisecond -> AndroidTimeUnit.NANOSECONDS.toMillis(elapsedNanos)
-            TimeUnit.Second -> AndroidTimeUnit.NANOSECONDS.toSeconds(elapsedNanos)
-            TimeUnit.Minute -> AndroidTimeUnit.NANOSECONDS.toMinutes(elapsedNanos)
-            TimeUnit.Hour -> AndroidTimeUnit.NANOSECONDS.toHours(elapsedNanos)
-            TimeUnit.Day -> AndroidTimeUnit.NANOSECONDS.toDays(elapsedNanos)
-        }
-    }
-
-    /**
-     * Start tracking time for the provided metric. This records an error if it’s
-     * already tracking time (i.e. start was already called with no corresponding
-     * [stopAndSum]): in that case the original start time will be preserved.
-     *
-     * @param metricData the metric information for the timespan
-     */
-    fun start(metricData: CommonMetricData) {
-        val timespanName = metricData.identifier
-
-        if (timespanName in uncommittedStartTimes) {
-            recordError(
-                metricData,
-                ErrorType.InvalidValue,
-                "Timespan already started",
-                logger
-            )
-            return
-        }
-
-        synchronized(this) {
-            uncommittedStartTimes[timespanName] = getElapsedNanos()
-        }
-    }
-
-    /**
-     * Stop tracking time for the provided metric. Add the elapsed time to the time currently
-     * stored in the metric. This will record an error if no [start] was called.
+     * Add the elapsed time to the time currently stored in the metric.
      *
      * @param metricData the metric information for the timespan
      * @param timeUnit the time unit we want the data in when snapshotting
+     * @param elapsedNanos the time to record, in nanoseconds
      */
     @Synchronized
-    fun stopAndSum(
+    fun sum(
         metricData: CommonMetricData,
-        timeUnit: TimeUnit
+        timeUnit: TimeUnit,
+        elapsedNanos: Long
     ) {
         // Look for the start time: if it's there, commit the timespan.
         val timespanName = metricData.identifier
-        uncommittedStartTimes.remove(timespanName)?.let { startTime ->
-            val elapsedNanos = getElapsedNanos() - startTime
 
-            // Store the time unit: we'll need it when snapshotting.
-            timeUnitsMap[timespanName] = timeUnit
+        // Store the time unit: we'll need it when snapshotting.
+        timeUnitsMap[timespanName] = timeUnit
 
-            // Use a custom combiner to sum the new timespan to the one already stored. We
-            // can't adjust the time unit before storing so that we still allow for values
-            // lower than the desired time unit to accumulate.
-            super.recordMetric(metricData, elapsedNanos, timeUnit) { currentValue, newValue ->
-                currentValue?.let {
-                    it + newValue
-                } ?: newValue
-            }
+        // Use a custom combiner to sum the new timespan to the one already stored. We
+        // can't adjust the time unit before storing so that we still allow for values
+        // lower than the desired time unit to accumulate.
+        super.recordMetric(metricData, elapsedNanos, timeUnit) { currentValue, newValue ->
+            currentValue?.let {
+                it + newValue
+            } ?: newValue
         }
-    }
-
-    /**
-     * Abort a previous [start] call. No error is recorded if no [start] was called.
-     *
-     * @param metricData the metric information for the timespan
-     */
-    @Synchronized
-    fun cancel(metricData: CommonMetricData) {
-        uncommittedStartTimes.remove(metricData.identifier)
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
@@ -84,7 +84,7 @@ internal open class TimingDistributionsStorageEngineImplementation(
         // TimingDistributionData for each value that doesn't have an existing current value.
         val dummy = TimingDistributionData(category = metricData.category, name = metricData.name,
             timeUnit = timeUnit)
-        super.recordMetric(metricData, dummy, null) { currentValue, newValue ->
+        super.recordMetric(metricData, dummy, null) { currentValue, _ ->
             currentValue?.let {
                 it.accumulate(sampleInUnit)
                 it

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngine.kt
@@ -11,6 +11,7 @@ import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.HistogramType
 import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.service.glean.utils.getAdjustedTime
 
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.org.json.tryGetInt
@@ -76,6 +77,8 @@ internal open class TimingDistributionsStorageEngineImplementation(
             return
         }
 
+        val sampleInUnit = getAdjustedTime(timeUnit, sample)
+
         // Since the custom combiner closure captures this value, we need to just create a dummy
         // value here that won't be used by the combine function, and create a fresh
         // TimingDistributionData for each value that doesn't have an existing current value.
@@ -83,12 +86,12 @@ internal open class TimingDistributionsStorageEngineImplementation(
             timeUnit = timeUnit)
         super.recordMetric(metricData, dummy, null) { currentValue, newValue ->
             currentValue?.let {
-                it.accumulate(sample)
+                it.accumulate(sampleInUnit)
                 it
             } ?: let {
                 val newTD = TimingDistributionData(category = metricData.category, name = metricData.name,
                     timeUnit = timeUnit)
-                newTD.accumulate(sample)
+                newTD.accumulate(sampleInUnit)
                 return@let newTD
             }
         }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/timing/TimingManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/timing/TimingManager.kt
@@ -48,21 +48,21 @@ internal object TimingManager {
      */
     public fun start(metricData: CommonMetricData, timerId: Any) {
         val startTime = getElapsedNanos()
-        val metricName = metricData.identifier
-
-        uncommittedStartTimes[metricName]?.let { metricTimings ->
-            if (timerId in metricTimings) {
-                recordError(
-                    metricData,
-                    ErrorRecording.ErrorType.InvalidValue,
-                    "Timespan already started",
-                    logger
-                )
-                return
-            }
-        }
 
         synchronized(this) {
+            val metricName = metricData.identifier
+            uncommittedStartTimes[metricName]?.let { metricTimings ->
+                if (timerId in metricTimings) {
+                    recordError(
+                        metricData,
+                        ErrorRecording.ErrorType.InvalidValue,
+                        "Timespan already started",
+                        logger
+                    )
+                    return
+                }
+            }
+
             uncommittedStartTimes.getOrPut(metricName, { WeakHashMap<Any, Long>() })[timerId] = startTime
         }
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/timing/TimingManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/timing/TimingManager.kt
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.timing
+
+import android.os.SystemClock
+import mozilla.components.service.glean.error.ErrorRecording
+import mozilla.components.service.glean.error.ErrorRecording.recordError
+import mozilla.components.service.glean.private.CommonMetricData
+import mozilla.components.support.base.log.logger.Logger
+import java.util.WeakHashMap
+
+/**
+ * A class to record timing intervals associated with a given arbitrary object.
+ *
+ * A timings are recorded and returned in nanoseconds.
+ */
+internal object TimingManager {
+    private val logger = Logger("glean/TimingManager")
+
+    /**
+     * A map that stores the start times of running timers.
+     *
+     * A [WeakHashMap] is used so that we don't unintentionally leak memory
+     * by keeping references to otherwise destroyed objects around.
+     */
+    val uncommittedStartTimes = mutableMapOf<String, WeakHashMap<Any, Long>>()
+
+    /**
+     * Helper function used for getting the elapsed time, since the process
+     * started, using a monotonic clock.
+     * We need to have this as an helper so that we can override it in tests.
+     *
+     * @return the time, in nanoseconds, since the process started.
+     */
+    internal var getElapsedNanos = { SystemClock.elapsedRealtimeNanos() }
+
+    /**
+     * Start tracking time associated with the provided object. This records an
+     * error if it’s already tracking time (i.e. start was already called with
+     * no corresponding [stop]): in that case, the original start time will be
+     * preserved.
+     *
+     * @param metricData The metric managing the timing. Used for error reporting.
+     * @param anyObject The object to associate with this timing.
+     */
+    public fun start(metricData: CommonMetricData, anyObject: Any) {
+        val startTime = getElapsedNanos()
+        val metricName = metricData.identifier
+
+        uncommittedStartTimes[metricName]?.let { metricTimings ->
+            if (anyObject in metricTimings) {
+                recordError(
+                    metricData,
+                    ErrorRecording.ErrorType.InvalidValue,
+                    "Timespan already started",
+                    logger
+                )
+                return
+            }
+        }
+
+        synchronized(this) {
+            uncommittedStartTimes.getOrPut(metricName, { WeakHashMap<Any, Long>() })[anyObject] = startTime
+        }
+    }
+
+    /**
+     * Stop tracking time for the associated object. This will record
+     * an error if no [start] was called.
+     *
+     * @param metricData The metric managing the timing. Used for error reporting.
+     * @param anyObject The object to associate with this timing.
+     * @return The length of the timespan, in nanoseconds, or null if called on a stopped timer.
+     */
+    public fun stop(metricData: CommonMetricData, anyObject: Any): Long? {
+        val stopTime = getElapsedNanos()
+
+        return synchronized(this) {
+            val metricName = metricData.identifier
+            uncommittedStartTimes[metricName]?.remove(anyObject)?.let { startTime ->
+                stopTime - startTime
+            } ?: run {
+                recordError(
+                    metricData,
+                    ErrorRecording.ErrorType.InvalidValue,
+                    "Timespan not running",
+                    logger
+                )
+                null
+            }
+        }
+    }
+
+    /**
+     * Abort a previous [start] call. No error is recorded if no [start] was called.
+     *
+     * @param anyObject The object to associate with this timing.
+     */
+    public fun cancel(metricData: CommonMetricData, anyObject: Any) {
+        synchronized(this) {
+            val metricName = metricData.identifier
+            uncommittedStartTimes[metricName]?.remove(anyObject)
+        }
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/utils/TimeUtils.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/utils/TimeUtils.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.utils
+
+import mozilla.components.service.glean.private.TimeUnit
+import java.util.concurrent.TimeUnit as AndroidTimeUnit
+
+/**
+ * Convenience method to get a time in nanoseconds in a different, supported time unit.
+ *
+ * @param timeUnit the required time unit, one in [TimeUnit]
+ * @param elapsedNanos a time in nanoseconds
+ *
+ * @return the time in the desired time unit
+ */
+internal fun getAdjustedTime(timeUnit: TimeUnit, elapsedNanos: Long): Long {
+    return when (timeUnit) {
+        TimeUnit.Nanosecond -> elapsedNanos
+        TimeUnit.Microsecond -> AndroidTimeUnit.NANOSECONDS.toMicros(elapsedNanos)
+        TimeUnit.Millisecond -> AndroidTimeUnit.NANOSECONDS.toMillis(elapsedNanos)
+        TimeUnit.Second -> AndroidTimeUnit.NANOSECONDS.toSeconds(elapsedNanos)
+        TimeUnit.Minute -> AndroidTimeUnit.NANOSECONDS.toMinutes(elapsedNanos)
+        TimeUnit.Hour -> AndroidTimeUnit.NANOSECONDS.toHours(elapsedNanos)
+        TimeUnit.Day -> AndroidTimeUnit.NANOSECONDS.toDays(elapsedNanos)
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -7,7 +7,6 @@ package mozilla.components.service.glean
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -24,7 +23,6 @@ import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
-import mozilla.components.service.glean.timing.TimingManager
 import org.json.JSONObject
 import org.junit.Assert
 import org.mockito.ArgumentMatchers
@@ -120,8 +118,6 @@ internal fun resetGlean(
     config: Configuration = Configuration(),
     clearStores: Boolean = true
 ) {
-    TimingManager.getElapsedNanos = { SystemClock.elapsedRealtimeNanos() }
-
     Glean.enableTestingMode()
 
     // We're using the WorkManager in a bunch of places, and glean will crash

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -23,6 +24,7 @@ import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
+import mozilla.components.service.glean.timing.TimingManager
 import org.json.JSONObject
 import org.junit.Assert
 import org.mockito.ArgumentMatchers
@@ -118,6 +120,8 @@ internal fun resetGlean(
     config: Configuration = Configuration(),
     clearStores: Boolean = true
 ) {
+    TimingManager.getElapsedNanos = { SystemClock.elapsedRealtimeNanos() }
+
     Glean.enableTestingMode()
 
     // We're using the WorkManager in a bunch of places, and glean will crash

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -24,6 +24,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import java.util.UUID
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
@@ -296,10 +297,12 @@ class LabeledMetricTypeTest {
             subMetric = timespanMetric
         )
 
-        TimespansStorageEngine.start(labeledTimespanMetric["label1"])
-        TimespansStorageEngine.stopAndSum(labeledTimespanMetric["label1"], TimeUnit.Nanosecond)
-        TimespansStorageEngine.start(labeledTimespanMetric["label2"])
-        TimespansStorageEngine.stopAndSum(labeledTimespanMetric["label2"], TimeUnit.Nanosecond)
+        labeledTimespanMetric["label1"].start(this)
+        labeledTimespanMetric["label1"].stopAndSum(this)
+        labeledTimespanMetric["label2"].start(this)
+        labeledTimespanMetric["label2"].stopAndSum(this)
+
+        assertTrue(labeledTimespanMetric["label1"].testHasValue())
 
         collectAndCheckPingSchema("metrics").getJSONObject("metrics")!!
     }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
@@ -33,8 +33,8 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.stopAndSum()
+        metric.start(this)
+        metric.stopAndSum(this)
 
         // Check that data was properly recorded.
         assertTrue(metric.testHasValue())
@@ -54,11 +54,11 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.stopAndSum()
+        metric.start(this)
+        metric.stopAndSum(this)
 
         // Let's also call cancel() to make sure it's a no-op.
-        metric.cancel()
+        metric.cancel(this)
 
         // Check that data was not recorded.
         assertFalse("The API should not record a counter if metric is disabled",
@@ -78,13 +78,14 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.cancel()
-        metric.stopAndSum()
+        metric.start(this)
+        metric.cancel(this)
+        metric.stopAndSum(this)
 
         // Check that data was not recorded.
         assertFalse("The API should not record a counter if metric is cancelled",
             metric.testHasValue())
+        assertEquals(1, testGetNumRecordedErrors(metric, ErrorType.InvalidValue))
     }
 
     @Test(expected = NullPointerException::class)
@@ -113,8 +114,8 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.stopAndSum()
+        metric.start(this)
+        metric.stopAndSum(this)
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))
@@ -134,9 +135,9 @@ class TimespanMetricTypeTest {
         )
 
         // Record a timespan.
-        metric.start()
-        metric.start()
-        metric.stopAndSum()
+        metric.start(this)
+        metric.start(this)
+        metric.stopAndSum(this)
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean.private
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.timing.TimingManager
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -53,9 +54,12 @@ class TimingDistributionMetricTypeTest {
         )
 
         // Accumulate a few values
-        metric.accumulate(1L)
-        metric.accumulate(2L)
-        metric.accumulate(3L)
+        for (i in 1L..3L) {
+            TimingManager.getElapsedNanos = { 0 }
+            metric.start(this)
+            TimingManager.getElapsedNanos = { i * 1000000 } // ms to ns
+            metric.stopAndAccumulate(this)
+        }
 
         // Check that data was properly recorded.
         assertTrue(metric.testHasValue())
@@ -83,10 +87,14 @@ class TimingDistributionMetricTypeTest {
             timeUnit = TimeUnit.Millisecond
         )
 
-        // Attempt to store the string list using set
-        metric.accumulate(1L)
+        // Attempt to store the timespan using set
+        TimingManager.getElapsedNanos = { 0 }
+        metric.start(this)
+        TimingManager.getElapsedNanos = { 1 }
+        metric.stopAndAccumulate(this)
+
         // Check that nothing was recorded.
-        assertFalse("StringLists without a lifetime should not record data",
+        assertFalse("TimingDistributions without a lifetime should not record data.",
             metric.testHasValue())
     }
 
@@ -117,9 +125,12 @@ class TimingDistributionMetricTypeTest {
         )
 
         // Accumulate a few values
-        metric.accumulate(1L)
-        metric.accumulate(2L)
-        metric.accumulate(3L)
+        for (i in 1L..3L) {
+            TimingManager.getElapsedNanos = { 0 }
+            metric.start(this)
+            TimingManager.getElapsedNanos = { i * 1000000 } // ms to ns
+            metric.stopAndAccumulate(this)
+        }
 
         // Check that data was properly recorded in the second ping.
         assertTrue(metric.testHasValue("store2"))

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -25,6 +26,11 @@ class TimingDistributionMetricTypeTest {
     @Before
     fun setUp() {
         resetGlean()
+    }
+
+    @After
+    fun reset() {
+        TimingManager.testResetTimeSource()
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -6,49 +6,28 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.service.glean.private.TimespanMetricType
+import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.timing.TimingManager
 
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
-import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.eq
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class TimespansStorageEngineTest {
-
-    private data class TestMetricData(
-        override val disabled: Boolean,
-        override val category: String,
-        override val lifetime: Lifetime,
-        override val name: String,
-        override val sendInPings: List<String>,
-        override val defaultStorageDestinations: List<String> = listOf()
-    ) : CommonMetricData
-
-    /**
-     * Helper that returns a spied mocked engine.
-     */
-    private fun getSpiedEngine(): TimespansStorageEngineImplementation {
-        // We need to initialize `engine` and `spiedEngine` separately, otherwise
-        // it will throw a RuntimeException because of the `applicationContext` not being
-        // initialized.
-        val engine = TimespansStorageEngineImplementation()
-        engine.applicationContext = ApplicationProvider.getApplicationContext()
-        return spy<TimespansStorageEngineImplementation>(engine)
-    }
-
     @Before
     fun setUp() {
+        resetGlean()
         TimespansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         TimespansStorageEngine.clearAllStores()
     }
@@ -89,25 +68,26 @@ class TimespansStorageEngineTest {
     fun `a single elapsed time must be correctly recorded`() {
         val expectedTimespanNanos: Long = 37
 
-        val metric = TestMetricData(
+        val metric = TimespanMetricType(
             false,
             "telemetry",
             Lifetime.Ping,
             "single_elapsed_test",
-            listOf("store1"))
+            listOf("store1"),
+            timeUnit = TimeUnit.Nanosecond
+        )
 
-        // Initialize a mocked engine so that we can return a custom elapsed time.
-        val spiedEngine = getSpiedEngine()
-
-        // Return 0 the first time we get the time.
-        doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
+        // Return 0 the first time we get the time
+        TimingManager.getElapsedNanos = { 0 }
+        metric.start(this)
 
         // Return the expected time when we stop the timer.
-        doReturn(expectedTimespanNanos).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
+        TimingManager.getElapsedNanos = { expectedTimespanNanos }
+        metric.stopAndSum(this)
 
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
+        assertTrue(metric.testHasValue())
+
+        val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
         assertEquals(Pair("nanosecond", expectedTimespanNanos), snapshot["telemetry.single_elapsed_test"])
     }
@@ -116,109 +96,31 @@ class TimespansStorageEngineTest {
     fun `multiple elapsed times must be correctly accumulated`() {
         val expectedChunkNanos: Long = 37
 
-        val metric = TestMetricData(
+        val metric = TimespanMetricType(
             false,
             "telemetry",
             Lifetime.Ping,
             "single_elapsed_test",
-            listOf("store1"))
-
-        // Initialize a mocked engine so that we can return a custom elapsed time.
-        val spiedEngine = getSpiedEngine()
+            listOf("store1"),
+            timeUnit = TimeUnit.Nanosecond
+        )
 
         // Record the time for the first chunk.
-        doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-        doReturn(expectedChunkNanos).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
+        TimingManager.getElapsedNanos = { 0 }
+        metric.start(this)
+        TimingManager.getElapsedNanos = { expectedChunkNanos }
+        metric.stopAndSum(this)
 
         // Record the time for the second chunk of time.
-        spiedEngine.start(metric)
-        doReturn(expectedChunkNanos * 2).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
+        metric.start(this)
+        TimingManager.getElapsedNanos = { expectedChunkNanos * 2 }
+        metric.stopAndSum(this)
 
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
+        assertTrue(metric.testHasValue())
+
+        val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
         assertEquals(1, snapshot!!.size)
         assertEquals(Pair("nanosecond", expectedChunkNanos * 2), snapshot["telemetry.single_elapsed_test"])
-    }
-
-    @Test
-    fun `the API must not crash nor throw errors when called in unexpected ways`() {
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "single_elapsed_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
-        // Check that a call to cancel() without any previous start doesn't fail.
-        spiedEngine.cancel(metric)
-
-        // Same for stopAndSum().
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
-    }
-
-    @Test
-    fun `start() must preserve the original time if called twice for the same metric`() {
-        val expectedChunkNanos: Long = 37
-
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "single_elapsed_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
-        // Call start() the first time.
-        doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-
-        // Change the elapsed time and call start the second time.
-        doReturn(10.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-
-        // Call stopAndSum and make sure the elapsed time is still referred to the first
-        // start() call.
-        doReturn(expectedChunkNanos).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
-
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
-        assertEquals(1, snapshot!!.size)
-        assertEquals(
-            Pair("nanosecond", expectedChunkNanos),
-            snapshot["telemetry.single_elapsed_test"]
-        )
-    }
-
-    @Test
-    fun `calling cancel() after start() should clear the uncomitted elapsed time`() {
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "single_elapsed_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
-        // Call start() the first time.
-        doReturn(10.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.start(metric)
-
-        // Cancel the current timespan.
-        spiedEngine.cancel(metric)
-
-        // Call stopAndSum: since the time was cleared we don't expected anything in the
-        // snapshot.
-        doReturn(20.toLong()).`when`(spiedEngine).getElapsedNanos()
-        spiedEngine.stopAndSum(metric, TimeUnit.Nanosecond)
-
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = false)
-        assertNull(snapshot)
     }
 
     @Test
@@ -234,23 +136,24 @@ class TimespansStorageEngineTest {
             TimeUnit.Day to AndroidTimeUnit.NANOSECONDS.toDays(expectedLengthInNanos)
         )
 
-        val metric = TestMetricData(
-            false,
-            "telemetry",
-            Lifetime.Ping,
-            "resolution_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
-
         expectedResults.forEach { (res, expectedTimespan) ->
-            // Record the timespan in the provided resolution.
-            doReturn(0.toLong()).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.start(metric)
-            doReturn(expectedLengthInNanos).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.stopAndSum(metric, res)
+            val metric = TimespanMetricType(
+                false,
+                "telemetry",
+                Lifetime.Ping,
+                "resolution_test",
+                listOf("store1"),
+                timeUnit = res
+            )
 
-            val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
+            // Record the timespan in the provided resolution.
+            TimingManager.getElapsedNanos = { 0 }
+            metric.start(this)
+            TimingManager.getElapsedNanos = { expectedLengthInNanos }
+            metric.stopAndSum(this)
+            assertTrue(metric.testHasValue())
+
+            val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
             assertEquals(1, snapshot!!.size)
             assertEquals(Pair(res.name.toLowerCase(), expectedTimespan), snapshot["telemetry.resolution_test"])
         }
@@ -263,31 +166,32 @@ class TimespansStorageEngineTest {
         val expectedTimespanSeconds: Long = 1
         val timespanFraction: Long = AndroidTimeUnit.SECONDS.toNanos(expectedTimespanSeconds) / steps
 
-        val metric = TestMetricData(
+        val metric = TimespanMetricType(
             false,
             "telemetry",
             Lifetime.Ping,
             "many_short_lived_test",
-            listOf("store1"))
-
-        val spiedEngine = getSpiedEngine()
+            listOf("store1"),
+            timeUnit = TimeUnit.Second
+        )
 
         // Accumulate enough timespans with a duration lower than the
         // expected resolution. Their sum should still be >= than our
         // resolution, and thus be reported.
         for (i in 0..steps) {
             val timespanStart: Long = i * timespanFraction
-            doReturn(timespanStart).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.start(metric)
+            TimingManager.getElapsedNanos = { timespanStart }
+            metric.start(this)
 
             val timespanEnd: Long = timespanStart + timespanFraction
-            doReturn(timespanEnd).`when`(spiedEngine).getElapsedNanos()
-            spiedEngine.stopAndSum(metric, TimeUnit.Second)
+            TimingManager.getElapsedNanos = { timespanEnd }
+            metric.stopAndSum(this)
         }
 
+        assertTrue(metric.testHasValue())
         // Since the sum of the short-lived timespans is >= our resolution, we
         // expect the accumulated value to be in the snapshot.
-        val snapshot = spiedEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
+        val snapshot = TimespansStorageEngine.getSnapshotWithTimeUnit(storeName = "store1", clearStore = true)
         assertEquals(1, snapshot!!.size)
         assertEquals(
             Pair("second", expectedTimespanSeconds),

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimespanMetricType
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
+import org.junit.After
 
 import org.junit.Before
 import org.junit.Test
@@ -30,6 +31,11 @@ class TimespansStorageEngineTest {
         resetGlean()
         TimespansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         TimespansStorageEngine.clearAllStores()
+    }
+
+    @After
+    fun reset() {
+        TimingManager.testResetTimeSource()
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.service.glean.private.TimingDistributionMetricType
 import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
@@ -31,6 +32,11 @@ class TimingDistributionsStorageEngineTest {
     @Before
     fun setUp() {
         resetGlean()
+    }
+
+    @After
+    fun reset() {
+        TimingManager.testResetTimeSource()
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimingDistributionMetricType
 import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.timing.TimingManager
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
@@ -144,7 +145,7 @@ class TimingDistributionsStorageEngineTest {
             runBlocking {
                 storageEngine.accumulate(
                     metricData = metric,
-                    sample = 1L,
+                    sample = 1000000L,
                     timeUnit = metric.timeUnit
                 )
             }
@@ -188,7 +189,10 @@ class TimingDistributionsStorageEngineTest {
         )
 
         // Attempt to accumulate a negative sample
-        metric.accumulate(-1L)
+        TimingManager.getElapsedNanos = { 0 }
+        metric.start(this)
+        TimingManager.getElapsedNanos = { -1 }
+        metric.stopAndAccumulate(this)
         // Check that nothing was recorded.
         assertFalse("Timing distributions must not accumulate negative values",
             metric.testHasValue())
@@ -212,7 +216,11 @@ class TimingDistributionsStorageEngineTest {
         )
 
         // Attempt to accumulate an overflow sample
-        metric.accumulate(TimingDistributionData.DEFAULT_RANGE_MAX + 100)
+        TimingManager.getElapsedNanos = { 0 }
+        metric.start(this)
+        TimingManager.getElapsedNanos = { (TimingDistributionData.DEFAULT_RANGE_MAX + 100) * 1000000 }
+        metric.stopAndAccumulate(this)
+
         // Check that timing distribution was recorded.
         assertTrue("Accumulating overflow values records data",
             metric.testHasValue())
@@ -248,7 +256,11 @@ class TimingDistributionsStorageEngineTest {
         )
 
         // Accumulate a sample to force the lazy loading of `buckets` to occur
-        metric.accumulate(1L)
+        TimingManager.getElapsedNanos = { 0 }
+        metric.start(this)
+        TimingManager.getElapsedNanos = { 1 }
+        metric.stopAndAccumulate(this)
+
         // Check that timing distribution was recorded.
         assertTrue("Accumulating values records data", metric.testHasValue())
 
@@ -279,11 +291,13 @@ class TimingDistributionsStorageEngineTest {
         // to validate the linear bucket search algorithm
 
         // Attempt to accumulate a sample to force metric to be stored
-        metric.accumulate(1L)
-        metric.accumulate(10L)
-        metric.accumulate(100L)
-        metric.accumulate(1000L)
-        metric.accumulate(10000L)
+        for (i in listOf(1L, 10L, 100L, 1000L, 10000L)) {
+            TimingManager.getElapsedNanos = { 0 }
+            metric.start(this)
+            TimingManager.getElapsedNanos = { i * 1000000 } // Convert ms to ns
+            metric.stopAndAccumulate(this)
+        }
+
         // Check that timing distribution was recorded.
         assertTrue("Accumulating values records data", metric.testHasValue())
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,11 @@ permalink: /changelog/
   * Added fact emitting.
   * Bugfix to call with app-contributed pending intents from menu items and action buttons.
 
+* **service-glean**
+   * ⚠️ **This is a breaking API change**: Timespan and timing distribution
+     metrics now have a thread-safe API. See `adding-new-metrics.md` for more
+     information.
+     
 # 0.50.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.49.0...v0.50.0)

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -27,7 +27,7 @@ class GleanApplication : Application() {
         // not be activated before this, so it's important to do this early.
         Experiments.initialize(applicationContext)
 
-        Test.testTimespan.start()
+        Test.testTimespan.start(applicationContext)
 
         // Set a sample value for a metric.
         Basic.os.set("Android")

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -49,7 +49,7 @@ open class MainActivity : AppCompatActivity() {
             Glean.handleBackgroundEvent()
         }
 
-        Test.testTimespan.stopAndSum()
+        Test.testTimespan.stopAndSum(applicationContext)
 
         // Update some metrics from a third-party library
         SamplesGleanLibrary.recordMetric()


### PR DESCRIPTION
This adds the thread-safe timing API that doesn't require passing any (extra) objects around.

One thing to note -- I originally envisioned the `TimingManager` being a member variable of `TimespanMetricType`, which would avoid the need for using the metric name in the `Map`.  Unfortunately that doesn't work for labeled metrics where the metrics are created "on-the-fly" -- they end up getting a new map each time so you can't "stop" and timing interval.

Using a `WeakHashMap` might be a premature optimization, but I also felt like saying "here, hand us your big singleton carrying everything on the page, and we *promise* to not hold on to it" felt a little too risky.  Alternatively, we can require integers in the API and put the onus on the user to provide us with an int using `object.hashCode`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
