### PR TITLE
Closes #2364: Prevent duplicate ViewHolder IDs in AwesomeBar

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
@@ -108,7 +108,7 @@ internal class SuggestionsAdapter(
 
     override fun getItemId(position: Int): Long {
         val suggestion = suggestions[position]
-        return suggestion.generatedUniqueId
+        return awesomeBar.getUniqueSuggestionId(suggestion)
     }
 
     override fun getItemViewType(position: Int): Int = synchronized(suggestions) {

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -7,7 +7,6 @@ package mozilla.components.concept.awesomebar
 import android.graphics.Bitmap
 import android.view.View
 import java.util.UUID
-import java.util.zip.CRC32
 
 /**
  * Interface to be implemented by awesome bar implementations.
@@ -92,21 +91,6 @@ interface AwesomeBar {
         val onChipClicked: ((Chip) -> Unit)? = null,
         val score: Int = 0
     ) {
-        /**
-         * A generated unique ID ([Long]), based on the provider and suggestion id (having a reasonable expectation of
-         * generating mostly-non-colliding IDs).
-         */
-        val generatedUniqueId: Long by lazy {
-            // A non-cryptographic "hash-suitable" function is used for speed.
-            // CRC32 is quite fast - several orders of magnitude faster than md5, and likely
-            // good-enough for our purposes (having a reasonable expectation of generating
-            // mostly-non-colliding IDs).
-            val crc32 = CRC32()
-            crc32.update(provider.id.toByteArray())
-            crc32.update(id.toByteArray())
-            crc32.value
-        }
-
         /**
          * Chips are compact actions that are shown as part of a suggestion. For example a [Suggestion] from a search
          * engine may offer multiple search suggestion chips for different search terms.

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
@@ -12,7 +12,7 @@ import mozilla.components.feature.awesomebar.internal.loadLambda
 import mozilla.components.feature.session.SessionUseCases
 import java.util.UUID
 
-private const val HISTORY_SUGGESTION_LIMIT = 20
+internal const val HISTORY_SUGGESTION_LIMIT = 20
 
 /**
  * A [AwesomeBar.SuggestionProvider] implementation that provides suggestions based on the browsing
@@ -30,7 +30,11 @@ class HistoryStorageSuggestionProvider(
         if (text.isEmpty()) {
             return emptyList()
         }
-        return historyStorage.getSuggestions(text, HISTORY_SUGGESTION_LIMIT).into()
+
+        val suggestions = historyStorage.getSuggestions(text, HISTORY_SUGGESTION_LIMIT)
+        // In case of duplicates we want to pick the suggestion with the highest score.
+        // See: https://github.com/mozilla/application-services/issues/970
+        return suggestions.sortedByDescending { it.score }.distinctBy { it.id }.into()
     }
 
     override val shouldClearSuggestions: Boolean

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
@@ -6,12 +6,16 @@ package mozilla.components.feature.awesomebar.provider
 
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
+import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.concept.storage.SearchResult
 import mozilla.components.concept.storage.VisitType
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mockito.`when`
 
 class HistoryStorageSuggestionProviderTest {
     @Test
@@ -51,5 +55,44 @@ class HistoryStorageSuggestionProviderTest {
     fun `Provider suggestion should not get cleared when text changes`() {
         val provider = HistoryStorageSuggestionProvider(mock(), mock())
         assertFalse(provider.shouldClearSuggestions)
+    }
+
+    @Test
+    fun `Provider dedupes suggestions`() = runBlocking {
+        val storage: HistoryStorage = mock()
+
+        val provider = HistoryStorageSuggestionProvider(storage, mock())
+
+        val mozSuggestions = listOf(
+            SearchResult(id = "http://www.mozilla.com/", url = "http://www.mozilla.com/", score = 1),
+            SearchResult(id = "http://www.mozilla.com/", url = "http://www.mozilla.com/", score = 2),
+            SearchResult(id = "http://www.mozilla.com/", url = "http://www.mozilla.com/", score = 3)
+        )
+
+        val pocketSuggestions = listOf(
+            SearchResult(id = "http://www.getpocket.com/", url = "http://www.getpocket.com/", score = 5)
+        )
+
+        val exampleSuggestions = listOf(
+            SearchResult(id = "http://www.example.com", url = "http://www.example.com/", score = 2)
+        )
+
+        `when`(storage.getSuggestions(eq("moz"), eq(HISTORY_SUGGESTION_LIMIT))).thenReturn(mozSuggestions)
+        `when`(storage.getSuggestions(eq("pocket"), eq(HISTORY_SUGGESTION_LIMIT))).thenReturn(pocketSuggestions)
+        `when`(storage.getSuggestions(eq("www"), eq(HISTORY_SUGGESTION_LIMIT))).thenReturn(pocketSuggestions + mozSuggestions + exampleSuggestions)
+
+        var results = provider.onInputChanged("moz")
+        assertEquals(1, results.size)
+        assertEquals(3, results[0].score)
+
+        results = provider.onInputChanged("pocket")
+        assertEquals(1, results.size)
+        assertEquals(5, results[0].score)
+
+        results = provider.onInputChanged("www")
+        assertEquals(3, results.size)
+        assertEquals(5, results[0].score)
+        assertEquals(3, results[1].score)
+        assertEquals(2, results[2].score)
     }
 }


### PR DESCRIPTION
- This also fixes the HistoryStorageSuggestionProvider to dedupe history suggestions based on the ID, picking the one with the highest score.

- Should other providers still return suggestions with duplicate IDs we now throw an exception containing the provider class name.
