### PR TITLE
Closes #2044: browser-icons: Cache loaded icons in memory.

### DIFF
--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
-
     implementation Dependencies.support_annotations
 
     testImplementation project(':support-test')

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/Icon.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/Icon.kt
@@ -35,6 +35,11 @@ data class Icon(
         /**
          * This icon was inlined in the document.
          */
-        INLINE
+        INLINE,
+
+        /**
+         * This icon was loaded from an in-memory cache.
+         */
+        MEMORY
     }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/DataUriIconLoader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/DataUriIconLoader.kt
@@ -12,23 +12,23 @@ import mozilla.components.browser.icons.IconRequest
  * An [IconLoader] implementation that will base64 decode the image bytes from a data:image uri.
  */
 class DataUriIconLoader : IconLoader {
-    override fun load(request: IconRequest, resource: IconRequest.Resource): ByteArray? {
+    override fun load(request: IconRequest, resource: IconRequest.Resource): IconLoader.Result {
         if (!resource.url.startsWith("data:image/")) {
-            return null
+            return IconLoader.Result.NoResult
         }
 
         val offset = resource.url.indexOf(',') + 1
         if (offset == 0) {
-            return null
+            return IconLoader.Result.NoResult
         }
 
         @Suppress("TooGenericExceptionCaught")
         return try {
-            Base64.decode(resource.url.substring(offset), Base64.DEFAULT)
+            IconLoader.Result.BytesResult(
+                Base64.decode(resource.url.substring(offset), Base64.DEFAULT),
+                Icon.Source.INLINE)
         } catch (e: Exception) {
-            null
+            IconLoader.Result.NoResult
         }
     }
-
-    override val source: Icon.Source = Icon.Source.INLINE
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/HttpIconLoader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/HttpIconLoader.kt
@@ -17,11 +17,9 @@ import mozilla.components.support.ktx.kotlin.toUri
 class HttpIconLoader(
     private val httpClient: Client
 ) : IconLoader {
-    override val source: Icon.Source = Icon.Source.DOWNLOAD
-
-    override fun load(request: IconRequest, resource: IconRequest.Resource): ByteArray? {
+    override fun load(request: IconRequest, resource: IconRequest.Resource): IconLoader.Result {
         if (!resource.url.toUri().isHttpOrHttps) {
-            return null
+            return IconLoader.Result.NoResult
         }
 
         // Right now we always perform a download. We shouldn't retry to download from URLs that have failed just
@@ -37,7 +35,8 @@ class HttpIconLoader(
         val response = httpClient.fetch(downloadRequest)
 
         return response.body.useStream {
-            it.readBytes()
+            IconLoader.Result.BytesResult(it.readBytes(),
+                Icon.Source.DOWNLOAD)
         }
     }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/IconLoader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/IconLoader.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.icons.loader
 
+import android.graphics.Bitmap
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 
@@ -14,7 +15,19 @@ interface IconLoader {
     /**
      * Tries to load the [IconRequest.Resource] for the given [IconRequest].
      */
-    fun load(request: IconRequest, resource: IconRequest.Resource): ByteArray?
+    fun load(request: IconRequest, resource: IconRequest.Resource): Result
 
-    val source: Icon.Source
+    sealed class Result {
+        object NoResult : Result()
+
+        class BitmapResult(
+            val bitmap: Bitmap,
+            val source: Icon.Source
+        ) : Result()
+
+        class BytesResult(
+            val bytes: ByteArray,
+            val source: Icon.Source
+        ) : Result()
+    }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/MemoryIconLoader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/MemoryIconLoader.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.loader
+
+import android.graphics.Bitmap
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * An [IconLoader] implementation that loads icons from an in-memory cache.
+ */
+class MemoryIconLoader(
+    private val cache: LoaderMemoryCache
+) : IconLoader {
+    interface LoaderMemoryCache {
+        fun getBitmap(request: IconRequest, resource: IconRequest.Resource): Bitmap?
+    }
+
+    override fun load(request: IconRequest, resource: IconRequest.Resource): IconLoader.Result {
+        return cache.getBitmap(request, resource)?.let { bitmap ->
+            IconLoader.Result.BitmapResult(bitmap, Icon.Source.MEMORY)
+        } ?: IconLoader.Result.NoResult
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/preparer/IconPreprarer.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/preparer/IconPreprarer.kt
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.preparer
+
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * An [IconPreparer] implementation receives an [IconRequest] before it is getting loaded. The preparer has the option
+ * to rewrite the [IconRequest] and return a new instance.
+ */
+interface IconPreprarer {
+    fun prepare(request: IconRequest): IconRequest
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/preparer/MemoryIconPreparer.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/preparer/MemoryIconPreparer.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.preparer
+
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * An [IconPreprarer] implementation that will add known resource URLs (from an in-memory cache) to the request if the
+ * request doesn't contain a list of resources yet.
+ */
+class MemoryIconPreparer(
+    private val cache: PreparerMemoryCache
+) : IconPreprarer {
+    interface PreparerMemoryCache {
+        fun getResources(request: IconRequest): List<IconRequest.Resource>
+    }
+
+    override fun prepare(request: IconRequest): IconRequest {
+        return if (request.resources.isNotEmpty()) {
+            request
+        } else {
+            val resources = cache.getResources(request)
+            request.copy(resources = resources)
+        }
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/IconProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/IconProcessor.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.processor
+
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * An [IconProcessor] implementation receives the [Icon] with the [IconRequest] and [IconRequest.Resource] after
+ * the icon was loaded. The [IconProcessor] has the option to rewrite a loaded [Icon] and return a new instance.
+ */
+interface IconProcessor {
+    fun process(request: IconRequest, resource: IconRequest.Resource?, icon: Icon): Icon
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/MemoryIconProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/MemoryIconProcessor.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.processor
+
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+
+/**
+ * An [IconProcessor] implementation that saves icons in the in-memory cache.
+ */
+class MemoryIconProcessor(
+    private val cache: ProcessorMemoryCache
+) : IconProcessor {
+    interface ProcessorMemoryCache {
+        fun put(request: IconRequest, resource: IconRequest.Resource, icon: Icon)
+    }
+
+    override fun process(request: IconRequest, resource: IconRequest.Resource?, icon: Icon): Icon {
+        if (resource != null && icon.shouldCacheInMemory) {
+            cache.put(request, resource, icon)
+        }
+
+        return icon
+    }
+}
+
+private val Icon.shouldCacheInMemory: Boolean
+    get() = when (source) {
+        Icon.Source.GENERATOR -> false
+        Icon.Source.DOWNLOAD -> true
+        Icon.Source.INLINE -> true
+        Icon.Source.MEMORY -> false
+    }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/MemoryCache.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/MemoryCache.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.utils
+
+import android.graphics.Bitmap
+import android.support.annotation.VisibleForTesting
+import android.util.LruCache
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.icons.loader.MemoryIconLoader.LoaderMemoryCache
+import mozilla.components.browser.icons.preparer.MemoryIconPreparer
+import mozilla.components.browser.icons.processor.MemoryIconProcessor.ProcessorMemoryCache
+
+private const val MAXIMUM_CACHE_URLS = 1000
+
+// Use a better mechanism for determining the cache size:
+// https://github.com/mozilla-mobile/android-components/issues/2764
+private const val MAXIMUM_CACHE_BITMAP_BYTES = 1024 * 1024 * 25 // 25 MB
+
+internal class MemoryCache : ProcessorMemoryCache, LoaderMemoryCache, MemoryIconPreparer.PreparerMemoryCache {
+    private val iconResourcesCache = LruCache<String, List<IconRequest.Resource>>(MAXIMUM_CACHE_URLS)
+    private val iconBitmapCache = object : LruCache<String, Bitmap>(MAXIMUM_CACHE_BITMAP_BYTES) {
+        override fun sizeOf(key: String, value: Bitmap): Int {
+            return value.byteCount
+        }
+    }
+
+    override fun getResources(request: IconRequest): List<IconRequest.Resource> {
+        return iconResourcesCache[request.url] ?: emptyList()
+    }
+
+    override fun getBitmap(request: IconRequest, resource: IconRequest.Resource): Bitmap? {
+        println("Cache(${hashCode()}: GET(${resource.url}")
+        return iconBitmapCache[resource.url]
+    }
+
+    override fun put(request: IconRequest, resource: IconRequest.Resource, icon: Icon) {
+        if (icon.source.shouldCacheInMemory) {
+            println("Cache(${hashCode()}: PUT:BITMAP:(${resource.url}")
+            iconBitmapCache.put(resource.url, icon.bitmap)
+        }
+
+        if (request.resources.isNotEmpty()) {
+            println("Cache(${hashCode()}: PUT:RESOURCE:${request.url} => (${resource.url}")
+            iconResourcesCache.put(request.url, request.resources)
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal fun clear() {
+        iconResourcesCache.evictAll()
+        iconBitmapCache.evictAll()
+    }
+}
+
+private val Icon.Source.shouldCacheInMemory: Boolean
+    get() {
+        return when (this) {
+            Icon.Source.DOWNLOAD -> true
+            Icon.Source.INLINE -> true
+
+            Icon.Source.GENERATOR -> false
+            Icon.Source.MEMORY -> false
+        }
+    }

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/HttpIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/HttpIconLoaderTest.kt
@@ -13,8 +13,6 @@ import mozilla.components.support.test.mock
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,14 +42,17 @@ class HttpIconLoaderTest {
 
             try {
                 val loader = HttpIconLoader(client)
-                val data = loader.load(
+                val result = loader.load(
                     mock(), IconRequest.Resource(
                         url = server.url("/some/path").toString(),
                         type = IconRequest.Resource.Type.APPLE_TOUCH_ICON
                     )
                 )
 
-                assertNotNull(data!!)
+                assertTrue(result is IconLoader.Result.BytesResult)
+
+                val data = (result as IconLoader.Result.BytesResult).bytes
+
                 assertTrue(data.isNotEmpty())
 
                 val text = String(data, Charsets.UTF_8)
@@ -76,13 +77,13 @@ class HttpIconLoaderTest {
     fun `Loader will not perform any requests for data uris`() {
         val client: Client = mock()
 
-        val data = HttpIconLoader(client).load(mock(), IconRequest.Resource(
+        val result = HttpIconLoader(client).load(mock(), IconRequest.Resource(
             url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAA" +
                 "AAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
             type = IconRequest.Resource.Type.FAVICON
         ))
 
-        assertNull(data)
+        assertEquals(IconLoader.Result.NoResult, result)
         verify(client, never()).fetch(any())
     }
 }

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/MemoryIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/MemoryIconLoaderTest.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.loader
+
+import android.graphics.Bitmap
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MemoryIconLoaderTest {
+    @Test
+    fun `MemoryIconLoader returns bitmap from cache`() {
+        val bitmap: Bitmap = mock()
+
+        val cache = object : MemoryIconLoader.LoaderMemoryCache {
+            override fun getBitmap(request: IconRequest, resource: IconRequest.Resource): Bitmap? {
+                return bitmap
+            }
+        }
+
+        val loader = MemoryIconLoader(cache)
+
+        val request = IconRequest("https://www.mozilla.org")
+        val resource = IconRequest.Resource(
+            url = "https://www.mozilla.org/favicon.ico",
+            type = IconRequest.Resource.Type.FAVICON)
+
+        val result = loader.load(request, resource)
+
+        assertTrue(result is IconLoader.Result.BitmapResult)
+
+        val bitmapResult = result as IconLoader.Result.BitmapResult
+
+        assertEquals(bitmap, bitmapResult.bitmap)
+    }
+
+    @Test
+    fun `MemoryIconLoader returns NoResult if cache does not contain entry`() {
+        val cache = object : MemoryIconLoader.LoaderMemoryCache {
+            override fun getBitmap(request: IconRequest, resource: IconRequest.Resource): Bitmap? {
+                return null
+            }
+        }
+
+        val loader = MemoryIconLoader(cache)
+
+        val request = IconRequest("https://www.mozilla.org")
+        val resource = IconRequest.Resource(
+            url = "https://www.mozilla.org/favicon.ico",
+            type = IconRequest.Resource.Type.FAVICON)
+
+        val result = loader.load(request, resource)
+
+        assertTrue(result is IconLoader.Result.NoResult)
+    }
+}

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/preparer/MemoryIconPreparerTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/preparer/MemoryIconPreparerTest.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.preparer
+
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+
+class MemoryIconPreparerTest {
+    @Test
+    fun `Preparer will add resources from cache`() {
+        val resources = listOf(
+            IconRequest.Resource("https://www.mozilla.org", type = IconRequest.Resource.Type.FAVICON),
+            IconRequest.Resource("https://www.firefox.com", type = IconRequest.Resource.Type.APPLE_TOUCH_ICON)
+        )
+
+        val cache: MemoryIconPreparer.PreparerMemoryCache = mock()
+        doReturn(resources).`when`(cache).getResources(any())
+
+        val preparer = MemoryIconPreparer(cache)
+
+        val initialRequest = IconRequest(url = "example.org")
+
+        val request = preparer.prepare(initialRequest)
+
+        assertEquals(2, request.resources.size)
+        assertEquals(
+            listOf(
+                "https://www.mozilla.org",
+                "https://www.firefox.com"
+            ),
+            request.resources.map { it.url }
+        )
+    }
+
+    @Test
+    fun `Preparer will not add resources if request already has resources`() {
+        val resources = listOf(
+            IconRequest.Resource("https://www.mozilla.org", type = IconRequest.Resource.Type.FAVICON),
+            IconRequest.Resource("https://www.firefox.com", type = IconRequest.Resource.Type.APPLE_TOUCH_ICON)
+        )
+
+        val cache: MemoryIconPreparer.PreparerMemoryCache = mock()
+        doReturn(resources).`when`(cache).getResources(any())
+
+        val preparer = MemoryIconPreparer(cache)
+
+        val initialRequest = IconRequest(url = "https://www.example.org", resources = listOf(
+            IconRequest.Resource("https://getpocket.com", type = IconRequest.Resource.Type.FAVICON)
+        ))
+
+        val request = preparer.prepare(initialRequest)
+
+        assertEquals(
+            listOf(
+                "https://getpocket.com"
+            ),
+            request.resources.map { it.url }
+        )
+    }
+}

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/MemoryIconProcessorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/MemoryIconProcessorTest.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.processor
+
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+class MemoryIconProcessorTest {
+    @Test
+    fun `Generated icons are not saved in cache`() {
+        val icon = Icon(mock(), source = Icon.Source.GENERATOR)
+        val cache: MemoryIconProcessor.ProcessorMemoryCache = mock()
+
+        val processor = MemoryIconProcessor(cache)
+        processor.process(request = mock(), resource = mock(), icon = icon)
+
+        verify(cache, never()).put(any(), any(), any())
+    }
+
+    @Test
+    fun `Icon loaded from memory cache are not saved in cache`() {
+        val icon = Icon(mock(), source = Icon.Source.MEMORY)
+        val cache: MemoryIconProcessor.ProcessorMemoryCache = mock()
+
+        val processor = MemoryIconProcessor(cache)
+        processor.process(request = mock(), resource = mock(), icon = icon)
+
+        verify(cache, never()).put(any(), any(), any())
+    }
+
+    @Test
+    fun `Downloaded icon is saved in cache`() {
+        val icon = Icon(mock(), source = Icon.Source.DOWNLOAD)
+        val cache: MemoryIconProcessor.ProcessorMemoryCache = mock()
+
+        val processor = MemoryIconProcessor(cache)
+        val request: IconRequest = mock()
+        val resource: IconRequest.Resource = mock()
+        processor.process(request, resource, icon)
+
+        verify(cache).put(request, resource, icon)
+    }
+
+    @Test
+
+    fun `Inlined icon is saved in cache`() {
+        val icon = Icon(mock(), source = Icon.Source.INLINE)
+        val cache: MemoryIconProcessor.ProcessorMemoryCache = mock()
+
+        val processor = MemoryIconProcessor(cache)
+        val request: IconRequest = mock()
+        val resource: IconRequest.Resource = mock()
+        processor.process(request, resource, icon)
+
+        verify(cache).put(request, resource, icon)
+    }
+
+    @Test
+    fun `Icon without resource is not saved in cache`() {
+        val icon = Icon(mock(), source = Icon.Source.MEMORY)
+        val cache: MemoryIconProcessor.ProcessorMemoryCache = mock()
+
+        val processor = MemoryIconProcessor(cache)
+        processor.process(request = mock(), resource = null, icon = icon)
+
+        verify(cache, never()).put(any(), any(), any())
+    }
+}

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/MemoryCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/MemoryCacheTest.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.utils
+
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.icons.loader.IconLoader
+import mozilla.components.browser.icons.loader.MemoryIconLoader
+import mozilla.components.browser.icons.preparer.MemoryIconPreparer
+import mozilla.components.browser.icons.processor.MemoryIconProcessor
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MemoryCacheTest {
+    @Test
+    fun `Verify memory components interaction`() {
+        val cache = MemoryCache()
+
+        val preparer = MemoryIconPreparer(cache)
+        val loader = MemoryIconLoader(cache)
+        val processor = MemoryIconProcessor(cache)
+
+        val icon = Icon(bitmap = mock(), source = Icon.Source.DOWNLOAD)
+        val resource = IconRequest.Resource(
+            url = "https://www.mozilla.org/favicon64.ico", type = IconRequest.Resource.Type.FAVICON)
+        val request = IconRequest("https://www.mozilla.org", resources = listOf(resource))
+
+        assertEquals(IconLoader.Result.NoResult, loader.load(request, resource))
+
+        // First, save something in the memory cache using the processor
+        processor.process(request, resource, icon)
+
+        // Then load the same icon from the loader
+        val result = loader.load(request, resource)
+        assertTrue(result is IconLoader.Result.BitmapResult)
+        assertSame(icon.bitmap, (result as IconLoader.Result.BitmapResult).bitmap)
+        assertEquals(Icon.Source.MEMORY, result.source)
+
+        // Prepare a new request with the same URL
+        val newRequest = IconRequest("https://www.mozilla.org")
+        assertTrue(newRequest.resources.isEmpty())
+        val preparedRequest = preparer.prepare(newRequest)
+        assertEquals(1, preparedRequest.resources.size)
+
+        // Load prepared request
+        val preparedResult = loader.load(preparedRequest, preparedRequest.resources[0])
+        assertTrue(preparedResult is IconLoader.Result.BitmapResult)
+        assertSame(icon.bitmap, (preparedResult as IconLoader.Result.BitmapResult).bitmap)
+        assertEquals(Icon.Source.MEMORY, preparedResult.source)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,9 @@ permalink: /changelog/
 * **browser-engine-gecko-nightly**
   * Implement `allowAutoplayMedia` in terms of `autoplayDefault`.
 
+* **browser-icons**
+  * Added an in-memory caching mechanism reducing disk/network loads.
+
 # 0.50.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.49.0...v0.50.0)


### PR DESCRIPTION
Started working on this before Toronto and finally was able to come back to it. This implements the same kind of pipeline that Fennec uses (`perparer -> loader -> processor`). There may be the opportunity to move all this functionality into a single middleware/interceptor. But that's something to explore after all the functionality has landed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
