### PR TITLE
Add ExperimentsDebugActivity to service-experiments.

### DIFF
--- a/components/service/experiments/README.md
+++ b/components/service/experiments/README.md
@@ -51,6 +51,36 @@ Experiments.withExperiment("button-color-experiment") {
 }
 ```
 
+### ExperimentsDebugActivity usage
+Experiments exports the [`ExperimentsDebugActivity`](src/main/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivity.kt)
+that can be used to trigger functionality or toggle debug features on or off. Users can invoke this special activity, at
+run-time, using the following [`adb`](https://developer.android.com/studio/command-line/adb) command:
+
+`adb shell am start -n [applicationId]/mozilla.components.service.experiments.debug.ExperimentsDebugActivity [extra keys]`
+
+In the above:
+
+- `[applicationId]` is the product's application id as defined in the manifest
+  file and/or build script. For the glean sample application, this is
+  `org.mozilla.samples.glean` for a release build and
+  `org.mozilla.samples.glean.debug` for a debug build.
+
+- `[extra keys]` is a list of extra keys to be passed to the debug activity. See the
+  [documentation](https://developer.android.com/studio/command-line/adb#IntentSpec)
+  for the command line switches used to pass the extra keys. These are the
+  currently supported keys:
+
+    |key|type|description|
+    |---|----|-----------|
+    | updateExperiments | boolean (--ez) | forces the experiments updater to run and fetch experiments immediately |
+
+For example, to direct a release build of the glean sample application to update experiments immediately, the following command
+can be used:
+
+```
+adb shell am start -n org.mozilla.samples.glean.debug/mozilla.components.service.experiments.debug.ExperimentsDebugActivity --ez updateExperiments true
+```
+
 ## Experiments format for Kinto
 
 The library loads its list of experiments from Kinto. Kinto provides data in the following JSON format:

--- a/components/service/experiments/src/main/AndroidManifest.xml
+++ b/components/service/experiments/src/main/AndroidManifest.xml
@@ -2,4 +2,9 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="mozilla.components.service.experiments" />
+    package="mozilla.components.service.experiments">
+    <application>
+        <activity android:name=".debug.ExperimentsDebugActivity"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
@@ -137,7 +137,6 @@ open class ExperimentsInternalAPI internal constructor() {
      * Requests new experiments from the server and
      * saves them to local storage
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     @Synchronized
     internal fun onExperimentsUpdated(serverState: ExperimentsSnapshot) {
         assert(experimentsLoaded) { "Experiments should have been loaded." }

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentsUpdater.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentsUpdater.kt
@@ -116,7 +116,6 @@ internal class ExperimentsUpdater(
      *
      * @return true if the experiments were updated, false if there was an [ExperimentDownloadException]
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     @Synchronized
     internal fun updateExperiments(): Boolean {
         return try {

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivity.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivity.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.experiments.debug
+
+import android.app.Activity
+import android.os.Bundle
+import android.support.annotation.VisibleForTesting
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import mozilla.components.service.experiments.Experiments
+import mozilla.components.support.base.log.logger.Logger
+
+class ExperimentsDebugActivity : Activity() {
+    private val logger = Logger(LOG_TAG)
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal var updateJob: Job? = null
+
+    companion object {
+        private const val LOG_TAG = "ExperimentsDebugActivity"
+
+        // This is a list of the currently accepted commands
+        const val UPDATE_EXPERIMENTS_EXTRA_KEY = "updateExperiments"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        logger.debug("onCreate")
+
+        if (intent.hasExtra(UPDATE_EXPERIMENTS_EXTRA_KEY)) {
+            updateJob = GlobalScope.launch(Dispatchers.IO) {
+                Experiments.updater.updateExperiments()
+            }
+        }
+
+        val intent = packageManager.getLaunchIntentForPackage(packageName)
+        startActivity(intent)
+
+        finish()
+    }
+}

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivityTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivityTest.kt
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.experiments.debug
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
+import junit.framework.Assert.assertNotNull
+import kotlinx.coroutines.runBlocking
+import mozilla.components.service.experiments.Configuration
+import mozilla.components.service.experiments.Experiments
+import mozilla.components.service.experiments.ExperimentsUpdater
+import mozilla.components.service.glean.Glean
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+@RunWith(RobolectricTestRunner::class)
+class ExperimentsDebugActivityTest {
+
+    private val testPackageName = "mozilla.components.service.experiments"
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() {
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+
+        Glean.initialize(context)
+        Experiments.initialize(context)
+
+        // This makes sure we have a "launch" intent in our package, otherwise
+        // it will fail looking for it in `GleanDebugActivityTest`.
+        val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+        val launchIntent = Intent(Intent.ACTION_MAIN)
+        launchIntent.setPackage(testPackageName)
+        launchIntent.addCategory(Intent.CATEGORY_LAUNCHER)
+        val resolveInfo = ResolveInfo()
+        resolveInfo.activityInfo = ActivityInfo()
+        resolveInfo.activityInfo.packageName = testPackageName
+        resolveInfo.activityInfo.name = "LauncherActivity"
+        @Suppress("DEPRECATION")
+        Shadows.shadowOf(pm).addResolveInfoForIntent(launchIntent, resolveInfo)
+    }
+
+    @Test
+    fun `the main activity is correctly started`() {
+        // Build the intent that will call our debug activity, with no extra.
+        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
+            ExperimentsDebugActivity::class.java)
+        // Start the activity through our intent.
+        val activity = Robolectric.buildActivity(ExperimentsDebugActivity::class.java, intent)
+        activity.create().start().resume()
+
+        // Check that our main activity was launched.
+        Assert.assertEquals(testPackageName,
+            Shadows.shadowOf(activity.get()).peekNextStartedActivityForResult().intent.`package`!!)
+    }
+
+    @Test
+    fun `command line extra updateExperiments updates experiments`() {
+        // Set the extra values and start the intent.
+        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
+            ExperimentsDebugActivity::class.java)
+        intent.putExtra(ExperimentsDebugActivity.UPDATE_EXPERIMENTS_EXTRA_KEY, true)
+        val activity = Robolectric.buildActivity(ExperimentsDebugActivity::class.java, intent)
+
+        val updater: ExperimentsUpdater = spy(ExperimentsUpdater(ApplicationProvider.getApplicationContext<Context>(), Experiments))
+        updater.initialize(Configuration())
+        Experiments.updater = updater
+
+        activity.create().start().resume()
+
+        // updateJob will not be null if the onCreate method was invoked with the intent extra for
+        // updateExperiments
+        assertNotNull(activity.get().updateJob)
+
+        // Wait for the update task to join
+        runBlocking {
+            activity.get().updateJob?.join()
+        }
+
+        // Verify that updateExperiments() was called exactly once
+        verify(updater, times(1)).updateExperiments()
+    }
+}


### PR DESCRIPTION
This adds the first command, "updateExperiments" that will force the ExperimentsUpdater to update immediately.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
