### PR TITLE
Issue #1843: Introduce experimental (unpublished) browser-state component.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -152,6 +152,10 @@ projects:
     path: components/browser/session
     description: 'An abstract layer hiding the actual browser engine implementation.'
     publish: true
+  browser-state:
+    path: components/browser/state
+    description: 'Component responsible for maintaining the centralized state of a browser engine.'
+    publish: false
   browser-storage-memory:
     path: components/browser/storage-memory
     description: 'A memory-backed implementation of core data storage.'
@@ -316,3 +320,4 @@ projects:
     path: samples/dataprotect
     description: 'An app demoing how to use the Dataprotect component to load and store encrypted data in SharedPreferences.'
     publish: false
+

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,6 @@ task docs(type: org.jetbrains.dokka.gradle.DokkaAndroidTask, overwrite: true) {
     })
 }
 
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/components/browser/state/README.md
+++ b/components/browser/state/README.md
@@ -1,0 +1,25 @@
+# [Android Components](../../../README.md) > Browser > State
+
+🔴 **Note:** This is an **experimental component** still under development. APIs may change at any time. It's not recommended to directly use this component in products yet.
+
+The `browser-state` component is responsible for maintaining the centralized state of a [browser engine](../../concept/engine/README.md).
+
+The immutable `BrowserState` can be accessed and observed via the `BrowserStore`. Apps and other components can dispatch `Action`s on the store in order to trigger the creation of a new `BrowserState`.
+
+Patterns and concepts this component uses are heavily inspired by Redux. Therefore the [Redux documentation](https://redux.js.org/introduction/getting-started) is an excellent resource for learning about some of those concepts.
+
+## Usage
+
+### Setting up the dependency
+
+Use gradle to download the library from JCenter:
+
+```Groovy
+implementation "org.mozilla.components:browser-state:{latest-version}
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/browser/state/build.gradle
+++ b/components/browser/state/build.gradle
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion Config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion Config.minSdkVersion
+        targetSdkVersion Config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':concept-engine')
+    implementation project(':support-utils')
+    implementation project(':support-ktx')
+
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+    implementation Dependencies.support_customtabs
+
+    testImplementation project(':support-test')
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/browser/state/proguard-rules.pro
+++ b/components/browser/state/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/browser/state/src/main/AndroidManifest.xml
+++ b/components/browser/state/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.browser.state" />

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/action/Action.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/action/Action.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.action
+
+import mozilla.components.browser.session.store.BrowserStore
+import mozilla.components.browser.session.state.BrowserState
+
+/**
+ * Generic interface for actions to be dispatched on a [BrowserStore].
+ *
+ * Actions are used to send data from the application to a [BrowserStore]. The [BrowserStore] will use the [Action] to
+ * derive a new [BrowserState].
+ */
+interface Action

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/action/BrowserAction.kt
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.action
+
+import mozilla.components.browser.session.state.SessionState
+import mozilla.components.browser.session.state.BrowserState
+import mozilla.components.concept.engine.HitResult
+
+/**
+ * [Action] implementation related to [BrowserState].
+ */
+sealed class BrowserAction : Action
+
+/**
+ * [BrowserAction] implementations related to updating the list of [SessionState] inside [BrowserState].
+ */
+sealed class SessionListAction : BrowserAction() {
+    /**
+     * Adds a new [SessionState] to the list.
+     */
+    data class AddSessionAction(val session: SessionState, val select: Boolean = false) : SessionListAction()
+
+    /**
+     * Marks the [SessionState] with the given [sessionId] as selected session.
+     */
+    data class SelectSessionAction(val sessionId: String) : SessionListAction()
+
+    /**
+     * Removes the [SessionState] with the given [sessionId] from the list of sessions.
+     */
+    data class RemoveSessionAction(val sessionId: String) : SessionListAction()
+}
+
+/**
+ * [BrowserAction] implementations related to updating the a single [SessionState] inside [BrowserState].
+ */
+sealed class SessionAction : BrowserAction() {
+    /**
+     * Updates the URL of the [SessionState] with the given [sessionId].
+     */
+    data class UpdateUrlAction(val sessionId: String, val url: String) : SessionAction()
+
+    /**
+     * Updates the progress of the [SessionState] with the given [sessionId].
+     */
+    data class UpdateProgressAction(val sessionId: String, val progress: Int) : SessionAction()
+
+    /**
+     * Updates the "canGoBack" state of the [SessionState] with the given [sessionId].
+     */
+    data class CanGoBackAction(val sessionId: String, val canGoBack: Boolean) : SessionAction()
+
+    /**
+     * Updates the "canGoForward" state of the [SessionState] with the given [sessionId].
+     */
+    data class CanGoForward(val sessionId: String, val canGoForward: Boolean) : SessionAction()
+
+    /**
+     * Sets the [HitResult] state of the [SessionState] with the given [sessionId].
+     */
+    data class AddHitResultAction(val sessionId: String, val hitResult: HitResult) : SessionAction()
+
+    /**
+     * Clears the [HitResult] state of the [SessionState] with the given [sessionId].
+     */
+    data class ConsumeHitResultAction(val sessionId: String) : SessionAction()
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/ext/StoreExtensions.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/ext/StoreExtensions.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.ext
+
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.OnLifecycleEvent
+import android.view.View
+import mozilla.components.browser.session.store.BrowserStore
+import mozilla.components.browser.session.store.Observer
+
+/**
+ * Registers an [Observer] function that will be invoked whenever the state changes. The [BrowserStore.Subscription]
+ * will be bound to the passed in [LifecycleOwner]. Once the [Lifecycle] state changes to DESTROYED the [Observer] will
+ * be unregistered automatically.
+ */
+fun BrowserStore.observe(
+    owner: LifecycleOwner,
+    receiveInitialState: Boolean = true,
+    observer: Observer
+): BrowserStore.Subscription {
+    return observe(receiveInitialState, observer).apply {
+        binding = LifecycleBoundObserver(owner, this)
+    }
+}
+
+/**
+ * Registers an [Observer] function that will be invoked whenever the state changes. The [BrowserStore.Subscription]
+ * will be bound to the passed in [View]. Once the [View] gets detached the [Observer] will be unregistered
+ * automatically.
+ */
+fun BrowserStore.observe(
+    view: View,
+    observer: Observer,
+    receiveInitialState: Boolean = true
+): BrowserStore.Subscription {
+    return observe(receiveInitialState, observer).apply {
+        binding = ViewBoundObserver(view, this)
+    }
+}
+
+/**
+ * GenericLifecycleObserver implementation to bind an observer to a Lifecycle.
+ */
+private class LifecycleBoundObserver(
+    private val owner: LifecycleOwner,
+    private val subscription: BrowserStore.Subscription
+) : LifecycleObserver, BrowserStore.Subscription.Binding {
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    override fun unbind() {
+        subscription.unsubscribe()
+
+        owner.lifecycle.removeObserver(this)
+    }
+}
+
+/**
+ * View.OnAttachStateChangeListener implementation to bind an observer to a View.
+ */
+private class ViewBoundObserver(
+    private val view: View,
+    private val subscription: BrowserStore.Subscription
+) : View.OnAttachStateChangeListener, BrowserStore.Subscription.Binding {
+    override fun onViewAttachedToWindow(v: View?) = Unit
+
+    override fun onViewDetachedFromWindow(view: View) {
+        subscription.unsubscribe()
+    }
+
+    override fun unbind() {
+        view.removeOnAttachStateChangeListener(this)
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/helper/Helpers.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/helper/Helpers.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.helper
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import mozilla.components.browser.session.state.BrowserState
+import mozilla.components.browser.session.store.Observer
+
+/**
+ * Creates an [Observer] that will map the received [BrowserState] to [T] (using [map]) and will invoke the callback
+ * [then] only if the value has changed from the last mapped value.
+ *
+ * @param onMainThread Whether or not the [then] function should be executed on the main thread.
+ * @param map A function that maps [BrowserState] to the value we want to observe for changes.
+ * @param then Function that gets invoked whenever the mapped value changed.
+ */
+@Suppress("FunctionNaming")
+fun <T> onlyIfChanged(
+    onMainThread: Boolean = false,
+    map: (BrowserState) -> T?,
+    then: (BrowserState, T) -> Unit
+): Observer {
+    var lastValue: T? = null
+
+    return fun (value: BrowserState) {
+        val mapped = map(value)
+
+        if (mapped !== null && mapped !== lastValue) {
+            if (onMainThread) {
+                GlobalScope.launch(Dispatchers.Main) {
+                    then(value, mapped)
+                }
+            } else {
+                then(value, mapped)
+            }
+            lastValue = mapped
+        }
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/reducer/BrowserReducers.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/reducer/BrowserReducers.kt
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.reducer
+
+import mozilla.components.browser.session.action.Action
+import mozilla.components.browser.session.action.BrowserAction
+import mozilla.components.browser.session.action.SessionAction
+import mozilla.components.browser.session.action.SessionListAction
+import mozilla.components.browser.session.selector.findSession
+import mozilla.components.browser.session.state.BrowserState
+import mozilla.components.browser.session.state.SessionState
+import mozilla.components.browser.session.store.BrowserStore
+import mozilla.components.browser.session.store.Reducer
+
+/**
+ * Reducers for [BrowserStore].
+ *
+ * A reducer is a function that receives the current [BrowserState] and an [Action] and then returns a new
+ * [BrowserState].
+ */
+internal object BrowserReducers {
+    fun get(): List<Reducer> = listOf(
+        ::reduce
+    )
+
+    private fun reduce(state: BrowserState, action: Action): BrowserState {
+        if (action !is BrowserAction) {
+            return state
+        }
+
+        return when (action) {
+            is SessionListAction -> reduceSessionListAction(state, action)
+            is SessionAction -> reduceSessionAction(state, action)
+        }
+    }
+
+    /**
+     * (SessionListAction) Reducer function for modifying the list of [SessionState] objects in [BrowserState.sessions].
+     */
+    private fun reduceSessionListAction(state: BrowserState, action: SessionListAction): BrowserState {
+        return when (action) {
+            is SessionListAction.AddSessionAction -> state.copy(
+                    sessions = state.sessions + action.session,
+                    selectedSessionId = if (action.select) action.session.id else state.selectedSessionId)
+            is SessionListAction.SelectSessionAction -> state.copy(selectedSessionId = action.sessionId)
+            is SessionListAction.RemoveSessionAction -> {
+                val session = state.findSession(action.sessionId)
+                if (session == null) {
+                    state
+                } else {
+                    state.copy(sessions = state.sessions - session)
+                }
+            }
+        }
+    }
+
+    /**
+     * (SessionAction) Reducer function for modifying a specific [SessionState].
+     */
+    private fun reduceSessionAction(state: BrowserState, action: SessionAction): BrowserState {
+        return when (action) {
+            is SessionAction.UpdateUrlAction -> updateSessionInState(state, action.sessionId) {
+                it.copy(url = action.url)
+            }
+            is SessionAction.UpdateProgressAction -> updateSessionInState(state, action.sessionId) {
+                it.copy(progress = action.progress)
+            }
+            is SessionAction.CanGoBackAction -> updateSessionInState(state, action.sessionId) {
+                it.copy(canGoBack = action.canGoBack)
+            }
+            is SessionAction.CanGoForward -> updateSessionInState(state, action.sessionId) {
+                it.copy(canGoForward = action.canGoForward)
+            }
+            is SessionAction.AddHitResultAction -> updateSessionInState(state, action.sessionId) {
+                it.copy(hitResult = action.hitResult)
+            }
+            is SessionAction.ConsumeHitResultAction -> updateSessionInState(state, action.sessionId) {
+                it.copy(hitResult = null)
+            }
+        }
+    }
+}
+
+/**
+ * Helper for updating a specific [SessionState] inside a [BrowserState]
+ */
+private fun updateSessionInState(
+    state: BrowserState,
+    sessionId: String,
+    update: (SessionState) -> SessionState
+): BrowserState {
+    return state.copy(sessions = state.sessions.map { current ->
+        if (current.id == sessionId) {
+            update.invoke(current)
+        } else {
+            current
+        }
+    })
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/selector/Selectors.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/selector/Selectors.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.selector
+
+import mozilla.components.browser.session.state.BrowserState
+import mozilla.components.browser.session.state.SessionState
+
+// Extension functions for querying and dissecting [BrowserState]
+
+/**
+ * The currently selected [SessionState] if there's one.
+ *
+ * Only one [SessionState] can be selected at a given time.
+ */
+val BrowserState.selectedSessionState: SessionState?
+    get() = if (selectedSessionId.isNullOrEmpty()) {
+        null
+    } else {
+        sessions.firstOrNull { it.id == selectedSessionId }
+    }
+
+/**
+ * Finds and returns the session with the given id. Returns null if no matching session could be
+ * found.
+ */
+fun BrowserState.findSession(sessionId: String): SessionState? {
+    return sessions.firstOrNull { it.id == sessionId }
+}
+
+/**
+ * Finds and returns the session with the given id or the selected session if no id was provided (null). Returns null
+ * if no matching session could be found or if no selected session exists.
+ */
+fun BrowserState.findSessionOrSelected(sessionId: String? = null): SessionState? {
+    return if (sessionId != null) {
+        findSession(sessionId)
+    } else {
+        selectedSessionState
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/state/BrowserState.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.state
+
+/**
+ * Value type that represents the complete state of the browser/engine.
+ *
+ * @property sessions List of currently open sessions ("tabs").
+ * @property selectedSessionId The ID of the currently selected session (present in the [sessions] list].
+ */
+data class BrowserState(
+    val sessions: List<SessionState> = emptyList(),
+    val selectedSessionId: String? = null
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/state/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/state/DownloadState.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.state
+
+import android.os.Environment
+
+/**
+ * Value type that represents a Download.
+ *
+ * @property url The full url to the content that should be downloaded.
+ * @property fileName A canonical filename for this download.
+ * @property contentType Content type (MIME type) to indicate the media type of the download.
+ * @property contentLength The file size reported by the server.
+ * @property userAgent The user agent to be used for the download.
+ * @property destinationDirectory The matching destination directory for this type of download.
+ */
+data class DownloadState(
+    val url: String,
+    val fileName: String? = null,
+    val contentType: String? = null,
+    val contentLength: Long? = null,
+    val userAgent: String? = null,
+    val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/state/SecurityInfoState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/state/SecurityInfoState.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.state
+
+/**
+ * A value type holding security information for a Session.
+ *
+ * @property secure true if the session is currently pointed to a URL with
+ * a valid SSL certificate, otherwise false.
+ * @property host domain for which the SSL certificate was issued.
+ * @property issuer name of the certificate authority who issued the SSL certificate.
+ */
+data class SecurityInfoState(
+    val secure: Boolean = false,
+    val host: String = "",
+    val issuer: String = ""
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/state/SessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/state/SessionState.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.state
+
+import mozilla.components.browser.session.store.BrowserStore
+import mozilla.components.concept.engine.HitResult
+import java.util.UUID
+
+/**
+ * Value type that represents the state of a browser session ("tab").
+ *
+ * [SessionState] instances are immutable and state changes are communicated as new state objects emitted by the
+ * [BrowserStore].
+ *
+ * @property url The URL of the currently loading or loaded resource/page.
+ * @property private Whether or not this session is in private mode (automatically erasing browsing information,
+ * such as passwords, cookies and history, leaving no trace after the end of the session).
+ * @property id A unique ID identifying this session.
+ * @property source The source that created this session (e.g. a VIEW intent).
+ * @property title The title of the currently displayed page (or an empty String).
+ * @property progress The loading progress of the current page.
+ * @property canGoBack Navigation state, true if there's an history item to go back to, otherwise false.
+ * @property canGoForward Navigation state, true if there's an history item to go forward to, otherwise false.
+ * @property searchTerms The search terms used for the currently loaded page (or an empty string) if this page was
+ * loaded by performing a search.
+ * @property securityInfo security information indicating whether or not the current session is for a secure URL, as
+ * well as the host and SSL certificate authority, if applicable.
+ * @property download A download request triggered by this session (or null).
+ * @property trackerBlockingEnabled Tracker blocking state, true if blocking trackers is enabled, otherwise false.
+ * @property trackersBlocked List of URIs that have been blocked on the currently displayed page.
+ * @property hitResult The target of the latest long click operation on the currently displayed page.
+ */
+data class SessionState(
+    val url: String,
+    val private: Boolean = false,
+    val id: String = UUID.randomUUID().toString(),
+    val source: SourceState = SourceState.NONE,
+    val title: String = "",
+    val progress: Int = 0,
+    val loading: Boolean = false,
+    val canGoBack: Boolean = false,
+    val canGoForward: Boolean = false,
+    val searchTerms: String = "",
+    val securityInfo: SecurityInfoState = SecurityInfoState(),
+    val download: DownloadState? = null,
+    val trackerBlockingEnabled: Boolean = false,
+    val trackersBlocked: List<String> = emptyList(),
+    val hitResult: HitResult? = null
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/state/SourceState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/state/SourceState.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.state
+
+/**
+ * Represents the source/origin of a session to describe how and why it was created.
+ */
+enum class SourceState {
+    /**
+     * Created to handle an ACTION_SEND (share) intent
+     */
+    ACTION_SEND,
+
+    /**
+     * Created to handle an ACTION_VIEW intent
+     */
+    ACTION_VIEW,
+
+    /**
+     * Created to handle a CustomTabs intent
+     */
+    CUSTOM_TAB,
+
+    /**
+     * User interacted with the home screen
+     */
+    HOME_SCREEN,
+
+    /**
+     * User interacted with a menu
+     */
+    MENU,
+
+    /**
+     * User opened a new tab
+     */
+    NEW_TAB,
+
+    /**
+     * Default value and for testing purposes
+     */
+    NONE,
+
+    /**
+     * Default value and for testing purposes
+     */
+    TEXT_SELECTION,
+
+    /**
+     * User entered a URL or search term
+     */
+    USER_ENTERED
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/session/store/BrowserStore.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/session/store/BrowserStore.kt
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.store
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import mozilla.components.browser.session.action.Action
+import mozilla.components.browser.session.reducer.BrowserReducers
+import mozilla.components.browser.session.state.BrowserState
+import java.util.concurrent.Executors
+
+typealias Reducer = (BrowserState, Action) -> BrowserState
+typealias Observer = (BrowserState) -> Unit
+
+/**
+ * The [BrowserStore] holds the [BrowserState] (state tree).
+ *
+ * The only way to change the [BrowserState] inside [BrowserStore] is to dispatch an [Action] on it.
+ */
+class BrowserStore(
+    initialState: BrowserState
+) {
+    private val reducers: List<Reducer> = BrowserReducers.get()
+    private val storeContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    private val storeScope = CoroutineScope(storeContext)
+    private val subscriptions: MutableList<Subscription> = mutableListOf()
+    private var currentState = initialState
+
+    /**
+     * Dispatch an [Action] to the store in order to trigger a [BrowserState] change.
+     *
+     *
+     */
+    fun dispatch(action: Action) = storeScope.launch(storeContext) {
+        dispatchInternal(action)
+    }
+
+    @Synchronized
+    private fun dispatchInternal(action: Action) {
+        val newState = reduceState(currentState, action, reducers)
+
+        if (newState == currentState) {
+            // Nothing has changed.
+            return
+        }
+
+        currentState = newState
+
+        synchronized(subscriptions) {
+            subscriptions.forEach { it.observer.invoke(currentState) }
+        }
+    }
+
+    /**
+     * Returns the current state.
+     */
+    val state: BrowserState
+        get() = currentState
+
+    /**
+     * Registers an observer function that will be invoked whenever the state changes.
+     *
+     * @param receiveInitialState If true the observer function will be invoked immediately with the current state.
+     * @return A subscription object that can be used to unsubscribe from further state changes.
+     */
+    fun observe(receiveInitialState: Boolean = true, observer: Observer): Subscription {
+        val subscription = Subscription(observer, store = this)
+
+        synchronized(subscriptions) {
+            subscriptions.add(subscription)
+        }
+
+        if (receiveInitialState) {
+            observer.invoke(currentState)
+        }
+
+        return subscription
+    }
+
+    private fun removeSubscription(subscription: Subscription) {
+        synchronized(subscriptions) {
+            subscriptions.remove(subscription)
+        }
+    }
+
+    /**
+     * A [Subscription] is returned whenever an observer is registered via the [observe] method. Calling [unsubscribe]
+     * on the [Subscription] will unregister the observer.
+     */
+    class Subscription internal constructor(
+        internal val observer: Observer,
+        private val store: BrowserStore
+    ) {
+        var binding: Binding? = null
+
+        fun unsubscribe() {
+            store.removeSubscription(this)
+
+            binding?.unbind()
+        }
+
+        interface Binding {
+            fun unbind()
+        }
+    }
+}
+
+private fun reduceState(state: BrowserState, action: Action, reducers: List<Reducer>): BrowserState {
+    var current = state
+
+    reducers.forEach { reducer ->
+        current = reducer.invoke(current, action)
+    }
+
+    return current
+}

--- a/components/browser/state/src/test/java/mozilla/components/browser/session/action/SessionListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/session/action/SessionListActionTest.kt
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.action
+
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.session.state.BrowserState
+import mozilla.components.browser.session.state.SessionState
+import mozilla.components.browser.session.store.BrowserStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SessionListActionTest {
+    @Test
+    fun `AddSessionAction - Adds provided SessionState`() = runBlocking {
+        val state = BrowserState()
+        val store = BrowserStore(state)
+
+        assertEquals(0, store.state.sessions.size)
+        assertNull(store.state.selectedSessionId)
+
+        val session = SessionState(url = "https://www.mozilla.org")
+
+        store.dispatch(SessionListAction.AddSessionAction(session))
+            .join()
+
+        assertEquals(1, store.state.sessions.size)
+        assertNull(store.state.selectedSessionId)
+    }
+
+    @Test
+    fun `SelectSessionAction - Selects SessionState by id`() = runBlocking {
+        val state = BrowserState(
+            sessions = listOf(
+                SessionState(id = "a", url = "https://www.mozilla.org"),
+                SessionState(id = "b", url = "https://www.firefox.com")
+            )
+        )
+        val store = BrowserStore(state)
+
+        assertNull(store.state.selectedSessionId)
+
+        store.dispatch(SessionListAction.SelectSessionAction("a"))
+            .join()
+
+        assertEquals("a", store.state.selectedSessionId)
+    }
+
+    @Test
+    fun `RemoveSessionAction - Removes SessionState`() = runBlocking {
+        val state = BrowserState(
+            sessions = listOf(
+                SessionState(id = "a", url = "https://www.mozilla.org"),
+                SessionState(id = "b", url = "https://www.firefox.com")
+            )
+        )
+        val store = BrowserStore(state)
+
+        store.dispatch(SessionListAction.RemoveSessionAction("a"))
+            .join()
+
+        assertEquals(1, store.state.sessions.size)
+        assertEquals("https://www.firefox.com", store.state.sessions[0].url)
+    }
+
+    @Test
+    fun `RemoveSessionAction - Noop for unknown id`() = runBlocking {
+        val state = BrowserState(
+            sessions = listOf(
+                SessionState(id = "a", url = "https://www.mozilla.org"),
+                SessionState(id = "b", url = "https://www.firefox.com")
+            )
+        )
+        val store = BrowserStore(state)
+
+        store.dispatch(SessionListAction.RemoveSessionAction("c"))
+            .join()
+
+        assertEquals(2, store.state.sessions.size)
+        assertEquals("https://www.mozilla.org", store.state.sessions[0].url)
+        assertEquals("https://www.firefox.com", store.state.sessions[1].url)
+    }
+}

--- a/components/browser/state/src/test/java/mozilla/components/browser/session/store/BrowserStoreTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/session/store/BrowserStoreTest.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.store
+
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.session.action.SessionListAction
+import mozilla.components.browser.session.state.BrowserState
+import mozilla.components.browser.session.state.SessionState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BrowserStoreTest {
+    @Test
+    fun `Adding SessionState`() = runBlocking {
+        val state = BrowserState()
+        val store = BrowserStore(state)
+
+        assertEquals(0, store.state.sessions.size)
+        assertNull(store.state.selectedSessionId)
+
+        val session = SessionState(url = "https://www.mozilla.org")
+
+        store.dispatch(SessionListAction.AddSessionAction(session))
+            .join()
+
+        assertEquals(1, store.state.sessions.size)
+        assertNull(store.state.selectedSessionId)
+    }
+}

--- a/components/browser/state/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/browser/state/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)


### PR DESCRIPTION
@csadilek This is a cleaner version of just `browser-state` - without using it in any other component. I documented the API and added some tests. But there's a lot more to test and iterate on. However that's probably easier once the foundation is in the tree and we can argue about distinct changes

I removed a lot of complexity that we do not need yet (e.g. middlewares). I would like to iterate on those pieces more and then build/test/land them in one distinct piece.

The next steps would be:
* Add more tests
* Add necessary actions for modifying the state
* Extend `BrowserState` for parity with `browser-session`
* Iterate on `BrowserState` layout: We spoke about maybe breaking out custom tabs into a separate list. Maybe even for private tabs. Anyhow, that's something to play with.

... and once we are happy with that we can start with dispatching actions from `SessionManager` and `UseCases` :) 