### PR TITLE
Closes #2802: Dismiss ReaderView controls

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/view/ReaderViewControlsBar.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/view/ReaderViewControlsBar.kt
@@ -7,6 +7,7 @@
 package mozilla.components.feature.readerview.view
 
 import android.content.Context
+import android.graphics.Rect
 import android.support.annotation.IdRes
 import android.support.constraint.ConstraintLayout
 import android.support.v7.widget.AppCompatButton
@@ -110,6 +111,13 @@ class ReaderViewControlsBar @JvmOverloads constructor(
      */
     override fun hideControls() {
         visibility = View.GONE
+    }
+
+    override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        if (!gainFocus) {
+            hideControls()
+        }
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
     }
 
     private fun bindViews() {

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/view/ReaderViewControlsBarTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/view/ReaderViewControlsBarTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
@@ -132,6 +133,21 @@ class ReaderViewControlsBarTest {
         bar.hideControls()
 
         verify(bar).visibility = View.GONE
+    }
+
+    @Test
+    fun `when focus is lost, hide controls`() {
+        val bar = spy(ReaderViewControlsBar(context))
+
+        bar.clearFocus()
+
+        verify(bar, never()).hideControls()
+
+        bar.requestFocus()
+
+        bar.clearFocus()
+
+        verify(bar).hideControls()
     }
 
     @Test


### PR DESCRIPTION
This was removed by myself during [initial implementation in error](https://github.com/mozilla-mobile/android-components/compare/600983d1190ddaef0401622f66081132a83ffc6b..0db538390128c6b2174c1c14032f7ae2e9af1427#diff-61f33bbdf1c876be85e755d57a196a47L121).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
