### PR TITLE
Issue #2800: Isolate and clean up readerview css styles [ci skip]

### DIFF
--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.css
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.css
@@ -5,7 +5,7 @@
 /* Avoid adding ID selector rules in this style sheet, since they could
  * inadvertently match elements in the article content. */
 
-.readerview-body {
+.mozac-readerview-body {
   padding: 20px;
   transition-property: background-color, color;
   transition-duration: 0.4s;
@@ -14,123 +14,115 @@
   margin-right: auto;
 }
 
-.readerview-body.light {
+.mozac-readerview-body.light {
   background-color: #ffffff;
   color: #222222;
 }
 
-.readerview-body.sepia {
+.mozac-readerview-body.sepia {
   color: #5b4636;
   background-color: #f4ecd8;
 }
 
-.readerview-body.dark {
+.mozac-readerview-body.dark {
   background-color: #222222;
   color: #eeeeee;
 }
 
-.readerview-body.sans-serif {
+.mozac-readerview-body.sans-serif {
   font-family: sans-serif;
 }
 
-.readerview-body.serif {
+.mozac-readerview-body.serif {
   font-family: serif;
 }
 
 /* Override some controls and content styles based on color scheme */
 
-.readerview-body.light > .container > .header > .domain {
+.mozac-readerview-body.light > .container > .header > .domain {
   color: #ee7600;
   border-bottom-color: #d0d0d0;
 }
 
-.readerview-body.light > .container > .header > h1 {
+.mozac-readerview-body.light > .container > .header > h1 {
   color: #222222;
 }
 
-.readerview-body.light > .container > .header > .credits {
+.mozac-readerview-body.light > .container > .header > .credits {
   color: #898989;
 }
 
-.readerview-body.dark > .container > .header > .domain {
+.mozac-readerview-body.dark > .container > .header > .domain {
   color: #ff9400;
   border-bottom-color: #777777;
 }
 
-.readerview-body.dark > .container > .header > h1 {
+.mozac-readerview-body.dark > .container > .header > h1 {
   color: #eeeeee;
 }
 
-.readerview-body.dark > .container > .header > .credits {
+.mozac-readerview-body.dark > .container > .header > .credits {
   color: #aaaaaa;
 }
 
-.readerview-body.sepia > .container > .header > .domain {
+.mozac-readerview-body.sepia > .container > .header > .domain {
   border-bottom-color: #5b4636 !important;
 }
 
-.readerview-body.sepia > .container > .footer {
+.mozac-readerview-body.sepia > .container > .footer {
   background-color: #dedad4 !important;
 }
 
-.readerview-body.light > .container > .content .caption,
-.readerview-body.light > .container > .content .wp-caption-text,
-.readerview-body.light > .container > .content figcaption {
+.mozac-readerview-body.light > .container > .content .caption,
+.mozac-readerview-body.light > .container > .content .wp-caption-text,
+.mozac-readerview-body.light > .container > .content figcaption {
   color: #898989;
 }
 
-.readerview-body.dark > .container > .content .caption,
-.readerview-body.dark > .container > .content .wp-caption-text,
-.readerview-body.dark > .container > .content figcaption {
+.mozac-readerview-body.dark > .container > .content .caption,
+.mozac-readerview-body.dark > .container > .content .wp-caption-text,
+.mozac-readerview-body.dark > .container > .content figcaption {
   color: #aaaaaa;
 }
 
-.readerview-body.light > .container > .content blockquote {
+.mozac-readerview-body.light > .container > .content blockquote {
   color: #898989 !important;
   border-left-color: #d0d0d0 !important;
 }
 
-.readerview-body.sepia blockquote {
+.mozac-readerview-body.sepia blockquote {
   border-inline-start: 2px solid #5b4636 !important;
 }
 
-.readerview-body.dark > .container > .content blockquote {
+.mozac-readerview-body.dark > .container > .content blockquote {
   color: #aaaaaa !important;
   border-left-color: #777777 !important;
 }
 
-.reader-message {
-  margin-top: 40px;
-  text-align: center;
-  width: 100%;
-  font-size: 0.9em;
-}
-
-.header {
+.mozac-readerview-body > .container > .header {
   text-align: start;
   padding-bottom: 10px;
 }
 
-.domain,
-.credits {
+.mozac-readerview-body > .container > .header > .credits {
   font-size: 0.9em;
   font-family: sans-serif;
 }
 
-.domain {
+.mozac-readerview-body > .container > .header > .domain {
   margin-top: 10px;
   padding-bottom: 10px;
   color: #00acff !important;
   text-decoration: none;
 }
 
-.domain-border {
+.mozac-readerview-body > .container > .header > .domain-border {
   margin-top: 15px;
   border-bottom: 1.5px solid #777777;
   width: 50%;
 }
 
-.header > h1 {
+.mozac-readerview-body > .container > .header > h1 {
   font-size: 1.33em;
   font-weight: 700;
   line-height: 1.1em;
@@ -141,45 +133,44 @@
   padding: 0px;
 }
 
-.header > .credits {
+.mozac-readerview-body > .container > .header > .credits {
   padding: 0px;
   margin: 0px;
   margin-bottom: 32px;
 }
 
-/*======= Article content =======*/
-
-.content {
+.mozac-readerview-body > .container > .content {
   padding-left: 0px;
   padding-right: 0px;
 }
 
-.moz-reader-content {
+/*======= Article content =======*/
+.mozac-readerview-content {
   font-size: 1em;
 }
 
-.moz-reader-content a {
+.mozac-readerview-content a {
   text-decoration: underline !important;
   font-weight: normal;
 }
 
-.moz-reader-content a,
-.moz-reader-content a:visited,
-.moz-reader-content a:hover,
-.moz-reader-content a:active {
+.mozac-readerview-content a,
+.mozac-readerview-content a:visited,
+.mozac-readerview-content a:hover,
+.mozac-readerview-content a:active {
   color: #00acff !important;
 }
 
-.moz-reader-content h2 {
+.mozac-readerview-content h2 {
   margin-bottom: 20px !important;
 }
 
-.moz-reader-content * {
+.mozac-readerview-content * {
   max-width: 100% !important;
   height: auto !important;
 }
 
-.moz-reader-content p {
+.mozac-readerview-content p {
   line-height: 1.4em !important;
   margin: 0px !important;
   margin-bottom: 20px !important;
@@ -187,8 +178,8 @@
 
 /* Covers all images showing edge-to-edge using a
    an optional caption text */
-.moz-reader-content .wp-caption,
-.moz-reader-content figure {
+.mozac-readerview-content .wp-caption,
+.mozac-readerview-content figure {
   display: block !important;
   width: 100% !important;
   margin: 0px !important;
@@ -197,17 +188,17 @@
 
 /* Images marked to be shown edge-to-edge with an
    optional captio ntext */
-.moz-reader-content p > img:only-child,
-.moz-reader-content p > a:only-child > img:only-child,
-.moz-reader-content .wp-caption img,
-.moz-reader-content figure img {
+.mozac-readerview-content p > img:only-child,
+.mozac-readerview-content p > a:only-child > img:only-child,
+.mozac-readerview-content .wp-caption img,
+.mozac-readerview-content figure img {
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
 
 /* Account for body padding to make image full width */
-.moz-reader-content img[moz-reader-full-width] {
+.mozac-readerview-content img[moz-reader-full-width] {
   width: calc(100% + 40px);
   margin-left: -20px;
   margin-right: -20px;
@@ -215,9 +206,9 @@
 }
 
 /* Image caption text */
-.moz-reader-content .caption,
-.moz-reader-content .wp-caption-text,
-.moz-reader-content figcaption {
+.mozac-readerview-content .caption,
+.mozac-readerview-content .wp-caption-text,
+.mozac-readerview-content figcaption {
   font-size: 0.9em;
   font-family: sans-serif;
   margin: 0px !important;
@@ -226,13 +217,13 @@
 
 /* Ensure all pre-formatted code inside the reader content
    are properly wrapped inside content width */
-.moz-reader-content code,
-.moz-reader-content pre {
+.mozac-readerview-content code,
+.mozac-readerview-content pre {
   white-space: pre-wrap !important;
   margin-bottom: 20px !important;
 }
 
-.moz-reader-content blockquote {
+.mozac-readerview-content blockquote {
   margin: 0px !important;
   margin-bottom: 20px !important;
   padding: 0px !important;
@@ -241,44 +232,40 @@
   border-left: 2px solid !important;
 }
 
-.moz-reader-content ul,
-.moz-reader-content ol {
+.mozac-readerview-content ul,
+.mozac-readerview-content ol {
   margin: 0px !important;
   margin-bottom: 20px !important;
   padding: 0px !important;
   line-height: 1.5em;
 }
 
-.moz-reader-content ul {
+.mozac-readerview-content ul {
   padding-inline-start: 30px !important;
   list-style: disc !important;
 }
 
-.moz-reader-content ol {
+.mozac-readerview-content ol {
   padding-inline-start: 35px !important;
   list-style: decimal !important;
 }
 
 /* Hide elements with common "hidden" class names */
-.moz-reader-content .visually-hidden,
-.moz-reader-content .visuallyhidden,
-.moz-reader-content .hidden,
-.moz-reader-content .invisible,
-.moz-reader-content .sr-only {
+.mozac-readerview-content .visually-hidden,
+.mozac-readerview-content .visuallyhidden,
+.mozac-readerview-content .hidden,
+.mozac-readerview-content .invisible,
+.mozac-readerview-content .sr-only {
 }
 
 /* Enforce wordpress and similar emoji/smileys aren't sized to be full-width,
  * see bug 1399616 for context. */
-.moz-reader-content img.wp-smiley,
-.moz-reader-content img.emoji {
+.mozac-readerview-content img.wp-smiley,
+.mozac-readerview-content img.emoji {
   display: inline-block;
   border-width: 0;
-  /* height: auto is implied from `.moz-reader-content *` rule. */
+  /* height: auto is implied from `.mozac-readerview-content *` rule. */
   width: 1em;
   margin: 0 .07em;
   padding: 0;
-}
-
-.reader-show-element {
-  display: initial;
 }

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -66,7 +66,7 @@ class ReaderView {
    */
   setFontSize(fontSize) {
     let size = (10 + 2 * fontSize) + "px";
-    let readerView = document.getElementById("readerview");
+    let readerView = document.getElementById("mozac-readerview-container");
     readerView.style.setProperty("font-size", size);
     this.fontSize = fontSize;
   }
@@ -119,21 +119,21 @@ class ReaderView {
 
   createHtml(article) {
     return `
-      <body class="readerview-body">
-        <div id="readerview" class="container" dir=${article.dir}>
-          <div class="header reader-header">
-            <a class="domain reader-domain">${article.url}</a>
+      <body class="mozac-readerview-body">
+        <div id="mozac-readerview-container" class="container" dir=${article.dir}>
+          <div class="header">
+            <a class="domain">${article.url}</a>
             <div class="domain-border"></div>
-            <h1 class="reader-title">${article.title}</h1>
-            <div class="credits reader-credits">${article.byline}</div>
-            <div class="meta-data">
-              <div class="reader-estimated-time">${article.readingTime}</div>
+            <h1>${article.title}</h1>
+            <div class="credits">${article.byline}</div>
+            <div>
+              <div>${article.readingTime}</div>
             </div>
           </div>
           <hr>
 
           <div class="content">
-            <div class="moz-reader-content">${article.content}</div>
+            <div class="mozac-readerview-content">${article.content}</div>
           </div>
         </div>
       </body>


### PR DESCRIPTION
The previous fix was too quick :). This is now making sure we select only if nested under a root we control. I've put those roots under `mozac-readerview-*` now as well. Also found some unused styles which I removed.