### PR TITLE
Closes #2816: Add TabTouchCallback for swipe support.

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
@@ -23,7 +23,7 @@ class BrowserTabsTray @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-    private val tabsAdapter: TabsAdapter = TabsAdapter()
+    val tabsAdapter: TabsAdapter = TabsAdapter()
 ) : RecyclerView(context, attrs, defStyleAttr),
     TabsTray by tabsAdapter {
 

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabTouchCallback.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabTouchCallback.kt
@@ -1,0 +1,54 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.tabstray
+
+import android.graphics.Canvas
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.helper.ItemTouchHelper
+import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.support.base.observer.Observable
+
+/**
+ * An [ItemTouchHelper.Callback] for support gestures on tabs in the tray.
+ */
+open class TabTouchCallback(
+    private val observable: Observable<TabsTray.Observer>
+) : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
+
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+        with(viewHolder as TabViewHolder) {
+            session?.let { observable.notifyObservers { onTabClosed(it) } }
+        }
+    }
+
+    override fun onChildDraw(
+        c: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
+        if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
+            // Alpha on an itemView being swiped should decrease to a min over a distance equal to
+            // the width of the item being swiped.
+            viewHolder.itemView.alpha = alphaForItemSwipe(dX, viewHolder.itemView.width)
+        }
+
+        super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+    }
+
+    /**
+     * Sets the alpha value for a swipe gesture. This is useful for inherited classes to provide their own values.
+     */
+    open fun alphaForItemSwipe(dX: Float, distanceToAlphaMin: Int): Float {
+        return 1f
+    }
+
+    override fun onMove(p0: RecyclerView, p1: RecyclerView.ViewHolder, p2: RecyclerView.ViewHolder): Boolean = false
+}

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -29,7 +29,7 @@ class TabViewHolder(
     private val closeView: AppCompatImageButton = itemView.findViewById(R.id.mozac_browser_tabstray_close)
     private val thumbnailView: TabThumbnailView = itemView.findViewById(R.id.mozac_browser_tabstray_thumbnail)
 
-    private var session: Session? = null
+    internal var session: Session? = null
 
     /**
      * Displays the data of the given session and notifies the given observable about events.

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
@@ -1,0 +1,82 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.tabstray
+
+import android.content.Context
+import android.support.v7.widget.helper.ItemTouchHelper
+import android.view.LayoutInflater
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TabTouchCallbackTest {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `onSwiped notifies observers`() {
+        val observer: TabsTray.Observer = mock()
+        val observable: Observable<TabsTray.Observer> = ObserverRegistry()
+        observable.register(observer)
+
+        val touchCallback = TabTouchCallback(observable)
+        val viewHolder: TabViewHolder = mock()
+
+        touchCallback.onSwiped(viewHolder, 0)
+
+        verify(observer, never()).onTabClosed(any())
+
+        // With a session available.
+        `when`(viewHolder.session).thenReturn(mock())
+
+        touchCallback.onSwiped(viewHolder, 0)
+
+        verify(observer).onTabClosed(any())
+    }
+
+    @Test
+    fun `onChildDraw alters alpha of ViewHolder on swipe gesture`() {
+        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val holder = TabViewHolder(view, TabViewHolderTest.mockTabsTrayWithStyles())
+        val callback = TabTouchCallback(mock())
+
+        holder.itemView.alpha = 0f
+
+        callback.onChildDraw(mock(), mock(), holder, 0f, 0f, ItemTouchHelper.ACTION_STATE_DRAG, true)
+
+        assertEquals(0f, holder.itemView.alpha)
+
+        callback.onChildDraw(mock(), mock(), holder, 0f, 0f, ItemTouchHelper.ACTION_STATE_SWIPE, true)
+
+        assertEquals(1f, holder.itemView.alpha)
+    }
+
+    @Test
+    fun `alpha default is full`() {
+        val touchCallback = TabTouchCallback(mock())
+        assertEquals(1f, touchCallback.alphaForItemSwipe(0f, 0))
+    }
+
+    @Test
+    fun `onMove is not implemented`() {
+        val touchCallback = TabTouchCallback(mock())
+        assertFalse(touchCallback.onMove(mock(), mock(), mock()))
+    }
+}

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
@@ -75,10 +75,7 @@ class TabsTrayPresenter(
         sessions = updatedSessions
         selectedIndex = updatedIndex
 
-        tabsTray.apply {
-            displaySessions(updatedSessions, updatedIndex)
-            updateSessions(updatedSessions, updatedIndex)
-        }
+        tabsTray.updateSessions(updatedSessions, updatedIndex)
 
         result.dispatchUpdatesTo(object : ListUpdateCallback {
             override fun onChanged(position: Int, count: Int, payload: Any?) {

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -232,9 +232,9 @@ class TabsTrayPresenterTest {
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
         val presenter = TabsTrayPresenter(tabsTray, sessionManager, mock())
 
+        presenter.start()
         presenter.calculateDiffAndUpdateTabsTray()
 
-        verify(tabsTray).displaySessions(anyList(), anyInt())
         verify(tabsTray).updateSessions(anyList(), anyInt())
     }
 
@@ -248,6 +248,7 @@ class TabsTrayPresenterTest {
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
         val presenter = TabsTrayPresenter(tabsTray, sessionManager, mock(), { it.private })
 
+        presenter.start()
         presenter.calculateDiffAndUpdateTabsTray()
 
         assertTrue(tabsTray.displaySessionsList?.size == 1)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,7 @@ permalink: /changelog/
 
 * **browser-tabstray**
   * Add `TabThumbnailView` to Tabs Tray show the top of the thumbnail and fill up the width of the tile.
+  * Added swipe gesture support with a `TabTouchCallback` for the TabsTray.
 
 # 0.50.0
 


### PR DESCRIPTION
### Pull Request checklist 
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
