### PR TITLE
Closes #2821: Show full width of the top of thumbnail in TabsTray

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -9,9 +9,9 @@ import android.support.v7.widget.AppCompatImageButton
 import android.support.v7.widget.CardView
 import android.support.v7.widget.RecyclerView
 import android.view.View
-import android.widget.ImageView
 import android.widget.TextView
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
 
@@ -27,7 +27,7 @@ class TabViewHolder(
     }
     private val tabView: TextView = itemView.findViewById(R.id.mozac_browser_tabstray_url)
     private val closeView: AppCompatImageButton = itemView.findViewById(R.id.mozac_browser_tabstray_close)
-    private val thumbnailView: ImageView = itemView.findViewById(R.id.mozac_browser_tabstray_thumbnail)
+    private val thumbnailView: TabThumbnailView = itemView.findViewById(R.id.mozac_browser_tabstray_thumbnail)
 
     private var session: Session? = null
 

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/thumbnail/TabThumbnailView.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/thumbnail/TabThumbnailView.kt
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.tabstray.thumbnail
+
+import android.content.Context
+import android.support.annotation.VisibleForTesting
+import android.support.v7.widget.AppCompatImageView
+import android.util.AttributeSet
+
+class TabThumbnailView(context: Context, attrs: AttributeSet) : AppCompatImageView(context, attrs) {
+
+    init {
+        scaleType = ScaleType.MATRIX
+    }
+
+    @VisibleForTesting
+    public override fun setFrame(l: Int, t: Int, r: Int, b: Int): Boolean {
+        val changed = super.setFrame(l, t, r, b)
+        if (changed) {
+            val matrix = imageMatrix
+            val scaleFactor = width / drawable.intrinsicWidth.toFloat()
+            matrix.setScale(scaleFactor, scaleFactor, 0f, 0f)
+            imageMatrix = matrix
+        }
+        return changed
+    }
+}

--- a/components/browser/tabstray/src/main/res/layout/mozac_browser_tabstray_item.xml
+++ b/components/browser/tabstray/src/main/res/layout/mozac_browser_tabstray_item.xml
@@ -35,12 +35,12 @@
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:src="@drawable/mozac_ic_close" />
 
-        <ImageView
+        <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
             android:id="@+id/mozac_browser_tabstray_thumbnail"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@id/mozac_browser_tabstray_url"
-            android:contentDescription="@string/mozac_browser_tabstray_close_tab" />
+            android:contentDescription="@string/mozac_browser_tabstray_open_tab" />
 
     </RelativeLayout>
 </android.support.v7.widget.CardView>

--- a/components/browser/tabstray/src/main/res/values/mozac_browser_tabstray_strings.xml
+++ b/components/browser/tabstray/src/main/res/values/mozac_browser_tabstray_strings.xml
@@ -6,4 +6,5 @@
 
     <!-- Content description (not visible, for screen readers etc.): Description for button closing a tab. -->
     <string name="mozac_browser_tabstray_close_tab">Close Tab</string>
+    <string name="mozac_browser_tabstray_open_tab">Open Tab</string>
 </resources>

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/thumbnail/TabThumbnailViewTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/thumbnail/TabThumbnailViewTest.kt
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.tabstray.thumbnail
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TabThumbnailViewTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `view should always use Matrix ScaleType`() {
+        val view = TabThumbnailView(context, mock())
+        assertEquals(ImageView.ScaleType.MATRIX, view.scaleType)
+    }
+
+    @Test
+    fun `view updates matrix when changed`() {
+        val view = TabThumbnailView(context, mock())
+        val matrix = view.imageMatrix
+        val drawable: Drawable = mock()
+
+        `when`(drawable.intrinsicWidth).thenReturn(5)
+        `when`(drawable.intrinsicHeight).thenReturn(5)
+
+        view.setImageDrawable(drawable)
+        view.setFrame(5, 5, 5, 5)
+
+        val matrix2 = view.imageMatrix
+
+        assertNotEquals(matrix, matrix2)
+    }
+
+    @Test
+    fun `view updates don't change matrix if no changes to frame`() {
+        val view = TabThumbnailView(context, mock())
+        val drawable: Drawable = mock()
+
+        `when`(drawable.intrinsicWidth).thenReturn(5)
+        `when`(drawable.intrinsicHeight).thenReturn(5)
+
+        view.setImageDrawable(drawable)
+        view.setFrame(5, 5, 5, 5)
+
+        val matrix = view.imageMatrix
+
+        view.setFrame(5, 5, 5, 5)
+
+        val matrix2 = view.imageMatrix
+
+        assertEquals(matrix, matrix2)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,9 @@ permalink: /changelog/
 * **browser-icons**
   * Added an in-memory caching mechanism reducing disk/network loads.
 
+* **browser-tabstray**
+  * Add `TabThumbnailView` to Tabs Tray show the top of the thumbnail and fill up the width of the tile.
+
 # 0.50.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.49.0...v0.50.0)
@@ -62,7 +65,7 @@ permalink: /changelog/
 * **browser-toolbar**
    * Adds `browserToolbarProgressBarGravity` attr with options `top` and `bottom` (default).
    * Adds the ability to long click the urlView
-   
+
 * **service-glean**
    * ⚠️ **This is a breaking API change**: The technically public, but not
      intended for public use, part of the glean API has been renamed from
@@ -74,7 +77,7 @@ permalink: /changelog/
      `type: labeled_counter`. See bugzilla 1540725.
 
 * **concept-engine**
-   * Adds `automaticLanguageAdjustment` setting, which should hint to implementations to send 
+   * Adds `automaticLanguageAdjustment` setting, which should hint to implementations to send
    language specific headers to websites. Implementation in `browser-engine-gecko-nightly`.
 
 * **service-firefox-accounts**


### PR DESCRIPTION
The default right now is to try and fit the full thumbnail in an ImageView, but I think we can do better:

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/1370580/56479619-59689e80-6484-11e9-9e4a-8dd135ec6324.png"> 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
