### PR TITLE
Fixes 2812 - Unify string url detection to use Fennec patterns.

### DIFF
--- a/components/feature/toolbar/build.gradle
+++ b/components/feature/toolbar/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':concept-toolbar')
     implementation project(':concept-storage')
     implementation project(':lib-publicsuffixlist')
+    implementation project(':support-utils')
     implementation project(':support-ktx')
 
     implementation Dependencies.kotlin_stdlib

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
@@ -6,8 +6,7 @@ package mozilla.components.feature.toolbar
 
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.support.ktx.kotlin.isUrl
-import mozilla.components.support.ktx.kotlin.toNormalizedUrl
+import mozilla.components.support.utils.URLStringUtils
 
 /**
  * Connects a toolbar instance to the browser engine via use cases
@@ -25,8 +24,8 @@ class ToolbarInteractor(
      */
     fun start() {
         toolbar.setOnUrlCommitListener { text ->
-            if (text.isUrl()) {
-                loadUrlUseCase.invoke(text.toNormalizedUrl())
+            if (URLStringUtils.isURLLike(text)) {
+                loadUrlUseCase.invoke(URLStringUtils.toNormalizedURL(text))
             } else {
                 searchUseCase?.invoke(text) ?: loadUrlUseCase.invoke(text)
             }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -5,37 +5,18 @@
 package mozilla.components.support.ktx.kotlin
 
 import android.net.Uri
-import android.text.TextUtils
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
 /**
- * Normalizes a URL String.
- */
-fun String.toNormalizedUrl(): String {
-    val trimmedInput = this.trim()
-    var uri = Uri.parse(trimmedInput)
-    if (TextUtils.isEmpty(uri.scheme)) {
-        uri = Uri.parse("http://$trimmedInput")
-    }
-    return uri.toString()
-}
-
-/**
  * A collection of regular expressions used in the `is*` methods below.
  */
 private val re = object {
-    val urlish = "^\\s*\\w+(://|:|\\.)\\w+\\S*\\s*$".toRegex()
     val phoneish = "^\\s*tel:\\S?\\d+\\S*\\s*$".toRegex(RegexOption.IGNORE_CASE)
     val emailish = "^\\s*mailto:\\w+\\S*\\s*$".toRegex(RegexOption.IGNORE_CASE)
     val geoish = "^\\s*geo:\\S*\\d+\\S*\\s*$".toRegex(RegexOption.IGNORE_CASE)
 }
-
-/**
- * Checks if this String is a URL.
- */
-fun String.isUrl() = re.urlish.matches(this)
 
 fun String.isPhone() = re.phoneish.matches(this)
 

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,40 +17,6 @@ import java.util.Calendar.MILLISECOND
 
 @RunWith(RobolectricTestRunner::class)
 class StringTest {
-
-    @Test
-    fun toNormalizedUrl() {
-        val expectedUrl = "http://mozilla.org"
-        assertEquals(expectedUrl, "http://mozilla.org".toNormalizedUrl())
-        assertEquals(expectedUrl, "  http://mozilla.org  ".toNormalizedUrl())
-        assertEquals(expectedUrl, "mozilla.org".toNormalizedUrl())
-    }
-
-    @Test
-    fun isUrl() {
-        assertTrue("mozilla.org".isUrl())
-        assertTrue(" mozilla.org ".isUrl())
-        assertTrue("http://mozilla.org".isUrl())
-        assertTrue("https://mozilla.org".isUrl())
-        assertTrue("file://somefile.txt".isUrl())
-        assertTrue("http://mozilla".isUrl())
-        assertTrue("http://192.168.255.255".isUrl())
-        assertTrue("about:crashcontent".isUrl())
-        assertTrue(" about:crashcontent ".isUrl())
-        assertTrue("sample:about ".isUrl())
-
-        assertFalse("mozilla".isUrl())
-        assertFalse("mozilla android".isUrl())
-        assertFalse(" mozilla android ".isUrl())
-        assertFalse("Tweet:".isUrl())
-        assertFalse("inurl:mozilla.org advanced search".isUrl())
-        assertFalse("what is about:crashes".isUrl())
-
-        val extraText = "Check out @asa’s Tweet: https://twitter.com/asa/status/123456789?s=09"
-        val url = extraText.split(" ").find { it.isUrl() }
-        assertNotEquals("Tweet:", url)
-    }
-
     @Test
     fun isPhone() {
         assertTrue("tel:+1234567890".isPhone())

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import android.net.Uri
+import android.text.TextUtils
+
+object URLStringUtils {
+    fun isURLLike(string: String, safe: Boolean = false) =
+        if (safe) {
+            string.matches(WebURLFinder.fuzzyUrlRegex)
+        } else {
+            string.matches(WebURLFinder.fuzzyUrlNonWebRegex)
+        }
+
+    fun isSearchTerm(string: String) = !isURLLike(string, false)
+
+    /**
+     * Normalizes a URL String.
+     */
+    fun toNormalizedURL(string: String): String {
+        val trimmedInput = string.trim()
+        var uri = Uri.parse(trimmedInput)
+        if (TextUtils.isEmpty(uri.scheme)) {
+            uri = Uri.parse("http://$trimmedInput")
+        }
+        return uri.toString()
+    }
+}

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
@@ -291,6 +291,19 @@ class WebURLFinder {
                 WORD_BOUNDARY +
                 ")")
 
+        private const val WILDCARD_PROTOCOL = "(?i:[a-z]+)(://|:)"
+
+        private const val UNSUPPORTED_URL_WITH_PROTOCOL = ("(" +
+            WORD_BOUNDARY +
+            "(?:" +
+            "(?:" + WILDCARD_PROTOCOL + "(?:" + USER_INFO + ")?" + ")" +
+            "(?:" + RELAXED_DOMAIN_NAME + ")" +
+            "(?:" + PORT_NUMBER + ")?" +
+            ")" +
+            "(?:" + PATH_AND_QUERY + ")?" +
+            WORD_BOUNDARY +
+            ")")
+
         /**
          * Regular expression pattern to match IRIs. If a string starts with http(s):// the expression
          * tries to match the URL structure with a relaxed rule for TLDs. If the string does not start
@@ -299,6 +312,22 @@ class WebURLFinder {
         private val autolinkWebUrl = Pattern.compile(
             "($WEB_URL_WITH_PROTOCOL|$WEB_URL_WITHOUT_PROTOCOL)"
         )
+
+        internal val fuzzyUrlRegex = (
+                "^" +
+                "\\s*" +
+                "($WEB_URL_WITH_PROTOCOL|$WEB_URL_WITHOUT_PROTOCOL)" +
+                "\\s*" +
+                "$"
+            ).toRegex(RegexOption.IGNORE_CASE)
+
+        internal val fuzzyUrlNonWebRegex = (
+            "^" +
+                "\\s*" +
+                "($WEB_URL_WITH_PROTOCOL|$WEB_URL_WITHOUT_PROTOCOL|$UNSUPPORTED_URL_WITH_PROTOCOL)" +
+                "\\s*" +
+                "$"
+            ).toRegex(RegexOption.IGNORE_CASE)
 
         /**
          * Check if string is a Web URL.
@@ -310,7 +339,7 @@ class WebURLFinder {
          * @param string to check.
          * @return `true` if `string` is a Web URL.
          */
-        private fun isWebURL(string: String): Boolean {
+        fun isWebURL(string: String): Boolean {
             try {
                 URI(string)
             } catch (e: Exception) {

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+import mozilla.components.support.utils.URLStringUtils.isURLLike
+import mozilla.components.support.utils.URLStringUtils.toNormalizedURL
+import mozilla.components.support.utils.URLStringUtils.isSearchTerm
+
+@RunWith(RobolectricTestRunner::class)
+class URLStringUtilsTest {
+
+    @Test
+    fun toNormalizedURL() {
+        val expectedUrl = "http://mozilla.org"
+        assertEquals(expectedUrl, toNormalizedURL("http://mozilla.org"))
+        assertEquals(expectedUrl, toNormalizedURL("  http://mozilla.org  "))
+        assertEquals(expectedUrl, toNormalizedURL("mozilla.org"))
+    }
+
+    @Test
+    fun isURLLike() {
+        assertTrue(isURLLike("mozilla.org"))
+        assertTrue(isURLLike(" mozilla.org "))
+        assertTrue(isURLLike("http://mozilla.org"))
+        assertTrue(isURLLike("https://mozilla.org"))
+        assertTrue(isURLLike("file://somefile.txt"))
+        assertFalse(isURLLike("file://somefile.txt", true))
+
+        assertTrue(isURLLike("http://mozilla"))
+        assertTrue(isURLLike("http://192.168.255.255"))
+        assertTrue(isURLLike("192.167.255.255"))
+        assertTrue(isURLLike("about:crashcontent"))
+        assertTrue(isURLLike(" about:crashcontent "))
+        assertTrue(isURLLike("sample:about "))
+        assertTrue(isURLLike("https://mozilla-mobile.com"))
+
+        assertTrue(isURLLike("link.info"))
+        assertFalse(isURLLike("link.unknown"))
+
+        assertFalse(isURLLike("mozilla"))
+        assertFalse(isURLLike("mozilla android"))
+        assertFalse(isURLLike(" mozilla android "))
+        assertFalse(isURLLike("Tweet:"))
+        assertFalse(isURLLike("inurl:mozilla.org advanced search"))
+        assertFalse(isURLLike("what is about:crashes"))
+
+        val extraText = "Check out @asa’s Tweet: https://twitter.com/asa/status/123456789?s=09"
+        val url = extraText.split(" ").find { isURLLike(it) }
+        assertNotEquals("Tweet:", url)
+
+        assertFalse(isURLLike("3.14"))
+        assertFalse(isURLLike("3.14.2019"))
+
+        assertFalse(isURLLike("file://somefile.txt", true))
+        assertFalse(isURLLike("about:config", true))
+    }
+
+    @Test
+    fun isSearchTerm() {
+        assertTrue(isSearchTerm("inurl:mozilla.org advanced search"))
+        assertTrue(isSearchTerm("3.14.2019"))
+
+        assertFalse(isSearchTerm("about:config"))
+        assertFalse(isSearchTerm("http://192.168.255.255"))
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -89,6 +89,14 @@ permalink: /changelog/
 * **browser-storage-sync**
   * `PlacesBookmarksStorage` now supports synchronization!
 
+* **support-utils**
+  * Add `URLStringUtils` to unify parsing of strings that may be URLs.
+
+* **support-ktx**
+  * ⚠️ **This is a breaking API change**:
+    - **Removed**: `String.isUrl()` and `String.toNormalizedUrl()`
+    - use `URLStringUtils` `isURLLike()` and `toNormalizedURL()` instead.
+
 # 0.50.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.49.0...v0.50.0)


### PR DESCRIPTION
Fixes #2812 Re-evaluate url parsing regex 

This PR unifies string parsing of URL like strings into a `URLStringUtils` class, which uses the Fennec regular expressions for same. 

It also deprecates (but doesn't remove) string extension methods.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
