### PR TITLE
Closes #2243: Add engine API for WebExtension messaging

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -1,0 +1,30 @@
+package mozilla.components.browser.engine.gecko.webextension
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.WebExtension
+import org.mozilla.geckoview.WebExtension as GeckoNativeWebExtension
+
+/**
+ * Gecko-based implementation of [WebExtension], wrapping the native web
+ * extension object provided by GeckoView.
+ */
+class GeckoWebExtension(
+    id: String,
+    url: String,
+    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(url, id)
+) : WebExtension(id, url) {
+
+    // Not supported in beta
+    override fun registerContentMessageHandler(
+        session: EngineSession,
+        name: String,
+        messageHandler: MessageHandler
+    ) = Unit
+
+    // Not supported in beta
+    override fun registerBackgroundMessageHandler(name: String, messageHandler: MessageHandler) = Unit
+
+    // Not supported in beta
+    override fun hasContentMessageHandler(session: EngineSession, name: String): Boolean = false
+}

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -9,7 +9,6 @@ import android.content.Context
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.UnsupportedSettingException
-import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
@@ -174,7 +173,8 @@ class GeckoEngineTest {
 
         `when`(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension(
-                WebExtension("test-webext", "resource://android/assets/extensions/test"),
+                "test-webext",
+                "resource://android/assets/extensions/test",
                 onSuccess = { onSuccessCalled = true },
                 onError = { _, _ -> onErrorCalled = true }
         )
@@ -198,7 +198,7 @@ class GeckoEngineTest {
 
         var throwable: Throwable? = null
         `when`(runtime.registerWebExtension(any())).thenReturn(result)
-        engine.installWebExtension(WebExtension("test-webext-error", "resource://android/assets/extensions/error")) { _, e ->
+        engine.installWebExtension("test-webext-error", "resource://android/assets/extensions/error") { _, e ->
             onErrorCalled = true
             throwable = e
         }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.prompt
+
+import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoWebExtensionTest {
+
+    // There is not much to test here in beta. All functionality is in nightly only.
+    @Test
+    fun `create gecko web extension`() {
+        val session: EngineSession = mock()
+        val contentMessageHandler: MessageHandler = mock()
+        val backgroundMessageHandler: MessageHandler = mock()
+        val appName = "mozac-test"
+
+        val ext = GeckoWebExtension(appName, "url")
+
+        ext.registerBackgroundMessageHandler(appName, backgroundMessageHandler)
+        ext.registerContentMessageHandler(session, appName, contentMessageHandler)
+        assertFalse(ext.hasContentMessageHandler(session, appName))
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -1,0 +1,104 @@
+package mozilla.components.browser.engine.gecko.webextension
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
+import mozilla.components.concept.engine.webextension.WebExtension
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.WebExtension as GeckoNativeWebExtension
+
+/**
+ * Gecko-based implementation of [WebExtension], wrapping the native web
+ * extension object provided by GeckoView.
+ */
+class GeckoWebExtension(
+    id: String,
+    url: String,
+    allowContentMessaging: Boolean = true,
+    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(url, id, allowContentMessaging)
+) : WebExtension(id, url) {
+
+    /**
+     * See [WebExtension.registerBackgroundMessageHandler].
+     */
+    override fun registerBackgroundMessageHandler(name: String, messageHandler: MessageHandler) {
+        val portDelegate = object : GeckoNativeWebExtension.PortDelegate {
+
+            override fun onPortMessage(message: Any, port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortMessage(message, GeckoPort(port))
+            }
+
+            override fun onDisconnect(port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortDisconnected(GeckoPort(port))
+            }
+        }
+
+        val messageDelegate = object : GeckoNativeWebExtension.MessageDelegate {
+
+            override fun onConnect(port: GeckoNativeWebExtension.Port) {
+                port.setDelegate(portDelegate)
+                messageHandler.onPortConnected(GeckoPort(port))
+            }
+
+            override fun onMessage(message: Any, sender: GeckoNativeWebExtension.MessageSender): GeckoResult<Any>? {
+                return GeckoResult.fromValue(messageHandler.onMessage(message, null))
+            }
+        }
+
+        nativeExtension.setMessageDelegate(messageDelegate, name)
+    }
+
+    /**
+     * See [WebExtension.registerContentMessageHandler].
+     */
+    override fun registerContentMessageHandler(session: EngineSession, name: String, messageHandler: MessageHandler) {
+        val portDelegate = object : GeckoNativeWebExtension.PortDelegate {
+
+            override fun onPortMessage(message: Any, port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortMessage(message, GeckoPort(port, session))
+            }
+
+            override fun onDisconnect(port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortDisconnected(GeckoPort(port, session))
+            }
+        }
+
+        val messageDelegate = object : GeckoNativeWebExtension.MessageDelegate {
+
+            override fun onConnect(port: GeckoNativeWebExtension.Port) {
+                port.setDelegate(portDelegate)
+                messageHandler.onPortConnected(GeckoPort(port, session))
+            }
+
+            override fun onMessage(message: Any, sender: GeckoNativeWebExtension.MessageSender): GeckoResult<Any>? {
+                return GeckoResult.fromValue(messageHandler.onMessage(message, session))
+            }
+        }
+
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        geckoSession.setMessageDelegate(messageDelegate, name)
+    }
+
+    /**
+     * See [WebExtension.hasContentMessageHandler].
+     */
+    override fun hasContentMessageHandler(session: EngineSession, name: String): Boolean {
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        return geckoSession.getMessageDelegate(name) != null
+    }
+}
+
+/**
+ * Gecko-based implementation of [Port], wrapping the native port provided by GeckoView.
+ */
+class GeckoPort(
+    internal val nativePort: GeckoNativeWebExtension.Port,
+    engineSession: EngineSession? = null
+) : Port(engineSession) {
+
+    override fun postMessage(message: Any) {
+        nativePort.postMessage(message as JSONObject)
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.prompt
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.webextension.GeckoPort
+import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.WebExtension
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoWebExtensionTest {
+
+    @Test
+    fun `register background message handler`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val portCaptor = argumentCaptor<Port>()
+        val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
+
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
+
+        verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Verify messages are forwarded to message handler
+        val message: Any = mock()
+        val sender: WebExtension.MessageSender = mock()
+        messageDelegateCaptor.value.onMessage(message, sender)
+        verify(messageHandler).onMessage(eq(message), eq(null))
+
+        // Verify connected port is forwarded to message handler
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        verify(messageHandler).onPortConnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+
+        // Verify port messages are forwarded to message handler
+        verify(port).setDelegate(portDelegateCaptor.capture())
+        val portDelegate = portDelegateCaptor.value
+        val portMessage: JSONObject = mock()
+        portDelegate.onPortMessage(portMessage, port)
+        verify(messageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+
+        // Verify disconnected port is forwarded to message handler
+        portDelegate.onDisconnect(port)
+        verify(messageHandler).onPortDisconnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+    }
+
+    @Test
+    fun `register content message handler`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val session: GeckoEngineSession = mock()
+        val geckoSession: GeckoSession = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val portCaptor = argumentCaptor<Port>()
+        val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
+
+        `when`(session.geckoSession).thenReturn(geckoSession)
+
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
+        extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
+        verify(geckoSession).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Verify messages are forwarded to message handler
+        val message: Any = mock()
+        val sender: WebExtension.MessageSender = mock()
+        messageDelegateCaptor.value.onMessage(message, sender)
+        verify(messageHandler).onMessage(eq(message), eq(session))
+
+        // Verify connected port is forwarded to message handler
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        verify(messageHandler).onPortConnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+
+        // Verify port messages are forwarded to message handler
+        verify(port).setDelegate(portDelegateCaptor.capture())
+        val portDelegate = portDelegateCaptor.value
+        val portMessage: JSONObject = mock()
+        portDelegate.onPortMessage(portMessage, port)
+        verify(messageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+
+        // Verify disconnected port is forwarded to message handler
+        portDelegate.onDisconnect(port)
+        verify(messageHandler).onPortDisconnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -27,7 +27,6 @@ import mozilla.components.browser.icons.processor.IconProcessor
 import mozilla.components.browser.icons.processor.MemoryIconProcessor
 import mozilla.components.browser.icons.utils.MemoryCache
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.fetch.Client
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.res.pxToDp
@@ -103,10 +102,8 @@ class BrowserIcons(
      */
     fun install(engine: Engine) {
         engine.installWebExtension(
-            WebExtension(
-                id = "browser-icons",
-                url = "resource://android/assets/extensions/browser-icons/"
-            ),
+            id = "mozacBrowserIcons",
+            url = "resource://android/assets/extensions/browser-icons/",
             onSuccess = {
                 Logger.debug("Installed browser-icons extension")
             },

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -61,17 +61,24 @@ interface Engine {
     /**
      * Installs the provided extension in this engine.
      *
-     * @param ext the [WebExtension] to install.
-     * @param onSuccess (optional) callback invoked if the extension was installed successfully.
+     * @param id the unique ID of the extension.
+     * @param url the url pointing to a resources path for locating the extension
+     * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+     * @param allowContentMessaging whether or not the web extension is allowed
+     * to send messages from content scripts, defaults to true.
+     * @param onSuccess (optional) callback invoked if the extension was installed successfully,
+     * providing access to the [WebExtension] object for bi-directional messaging.
      * @param onError (optional) callback invoked if there was an error installing the extension.
      * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
      * have web extension support.
      */
     fun installWebExtension(
-        ext: WebExtension,
+        id: String,
+        url: String,
+        allowContentMessaging: Boolean = true,
         onSuccess: ((WebExtension) -> Unit) = { },
-        onError: ((WebExtension, Throwable) -> Unit) = { _, _ -> }
-    ): Unit = onError(ext, UnsupportedOperationException("Web extension support is not available in this engine"))
+        onError: ((String, Throwable) -> Unit) = { _, _ -> }
+    ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
 
     /**
      * Provides access to the settings of this engine.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.concept.engine.webextension
 
+import mozilla.components.concept.engine.EngineSession
+
 /**
  * Represents a browser extension based on the WebExtension API:
  * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions
@@ -12,7 +14,114 @@ package mozilla.components.concept.engine.webextension
  * @property url the url pointing to a resources path for locating the extension
  * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
  */
-data class WebExtension(
+abstract class WebExtension(
     val id: String,
     val url: String
-)
+) {
+    /**
+     * Registers a [MessageHandler] for message events from background scripts.
+     *
+     * @param name the name of the native "application". This can either be the
+     * name of an application, web extension or a specific feature in case
+     * the web extension opens multiple [Port]s. There can only be one handler
+     * with this name per extension and the same name has to be used in
+     * JavaScript when calling `browser.runtime.connectNative` or
+     * `browser.runtime.sendNativeMessage`. Note that name must match
+     * /^\w+(\.\w+)*$/).
+     * @param messageHandler the message handler to be notified of messaging
+     * events e.g. a port was connected or a message received.
+     */
+    abstract fun registerBackgroundMessageHandler(name: String, messageHandler: MessageHandler)
+
+    /**
+     * Registers a [MessageHandler] for message events from content scripts.
+     *
+     * @param session the session to be observed / attach the message handler to.
+     * @param name the name of the native "application". This can either be the
+     * name of an application, web extension or a specific feature in case
+     * the web extension opens multiple [Port]s. There can only be one handler
+     * with this name per extension and session, and the same name has to be
+     * used in JavaScript when calling `browser.runtime.connectNative` or
+     * `browser.runtime.sendNativeMessage`. Note that name must match
+     * /^\w+(\.\w+)*$/).
+     * @param messageHandler the message handler to be notified of messaging
+     * events e.g. a port was connected or a message received.
+     */
+    abstract fun registerContentMessageHandler(session: EngineSession, name: String, messageHandler: MessageHandler)
+
+    /**
+     * Checks whether there is an existing content message handler for the provided
+     * session and "application" name.
+     *
+     * @param session the session the message handler was registered for.
+     * @param name the "application" name the message handler was registered for.
+     * @return true if a content message handler is active, otherwise false.
+     */
+    abstract fun hasContentMessageHandler(session: EngineSession, name: String): Boolean
+}
+
+/**
+ * A handler for all messaging related events, usable for both content and
+ * background scripts.
+ *
+ * [Port]s are exposed to consumers (higher level components) because
+ * how ports are used, how many there are and how messages map to it
+ * is feature-specific and depends on the design of the web extension.
+ * Therefore it makes most sense to let the extensions (higher-level
+ * features) deal with the management of ports.
+ */
+interface MessageHandler {
+
+    /**
+     * Invoked when a [Port] was connected as a result of a
+     * `browser.runtime.connectNative` call in JavaScript.
+     *
+     * @param port the connected port.
+     */
+    fun onPortConnected(port: Port) = Unit
+
+    /**
+     * Invoked when a [Port] was disconnected or the corresponding session was
+     * destroyed.
+     *
+     * @param port the disconnected port.
+     */
+    fun onPortDisconnected(port: Port) = Unit
+
+    /**
+     * Invoked when a message was received on the provided port.
+     *
+     * @param message the received message, either be a primitive type
+     * or a org.json.JSONObject.
+     * @param port the port the message was received on.
+     */
+    fun onPortMessage(message: Any, port: Port) = Unit
+
+    /**
+     * Invoked when a message was received as a result of a
+     * `browser.runtime.sendNativeMessage` call in JavaScript.
+     *
+     * @param message the received message, either be a primitive type
+     * or a org.json.JSONObject.
+     * @param source the session this message originated from if from a content
+     * script, otherwise null.
+     * @return the response to be sent for this message, either a primitive
+     * type or a org.json.JSONObject.
+     */
+    fun onMessage(message: Any, source: EngineSession?): Any = Unit
+}
+
+/**
+ * Represents a port for exchanging messages:
+ * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port
+ */
+abstract class Port(val engineSession: EngineSession? = null) {
+
+    /**
+     * Sends a message to this port.
+     *
+     * @param message the message to send, either a primitive type
+     * or a org.json.JSONObject.
+     */
+    abstract fun postMessage(message: Any)
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.concept.engine
 
 import android.content.Context
 import android.util.AttributeSet
-import mozilla.components.concept.engine.webextension.WebExtension
 import org.json.JSONObject
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -43,7 +42,7 @@ class EngineTest {
         }
 
         var exception: Throwable? = null
-        engine.installWebExtension(WebExtension("my-ext", "resource://path"), onError = { _, e -> exception = e })
+        engine.installWebExtension("my-ext", "resource://path", onError = { _, e -> exception = e })
         assertNotNull(exception)
         assertTrue(exception is UnsupportedOperationException)
     }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -1,23 +1,29 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package mozilla.components.concept.engine.webextension
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 class WebExtensionTest {
 
     @Test
-    fun createWebExtension() {
-        val ext1 = WebExtension("1", "url1")
-        val ext2 = WebExtension("2", "url2")
+    fun `message handler has default methods`() {
+        val messageHandler = object : MessageHandler {}
 
-        assertNotEquals(ext1, ext2)
-        assertEquals(ext1, WebExtension("1", "url1"))
-        assertEquals("1", ext1.id)
-        assertEquals("url1", ext1.url)
+        messageHandler.onPortConnected(mock())
+        messageHandler.onPortDisconnected(mock())
+        messageHandler.onPortMessage(mock(), mock())
+        messageHandler.onMessage(mock(), mock())
+    }
+
+    @Test
+    fun `port holds engine session`() {
+        val engineSession: EngineSession = mock()
+        val port = object : Port(engineSession) {
+            override fun postMessage(message: Any) { }
+        }
+
+        assertSame(engineSession, port.engineSession)
     }
 }

--- a/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
@@ -9,5 +9,9 @@
       "css": ["readerview.css"],
       "run_at": "document_end"
     }
+  ],
+  "permissions": [
+    "geckoViewAddons",
+    "nativeMessaging"
   ]
 }

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -261,6 +261,15 @@ class ReaderView {
    }
 }
 
+// TODO remove (for testing purposes only)
+let port = browser.runtime.connectNative("mozacReaderview");
+port.postMessage(`Hello from ReaderView on page ${location.hostname}`);
+
+port.onMessage.addListener((response) => {
+  console.log(`Received: ${JSON.stringify(response)} on page ${location.hostname}`);
+});
+
+
 // TODO remove hostname check (for testing purposes only)
 // e.g. https://blog.mozilla.org/firefox/reader-view
 if (ReaderView.isReaderable() && location.hostname.endsWith("blog.mozilla.org")) {

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -11,6 +11,9 @@ import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.feature.readerview.internal.ReaderViewControlsInteractor
 import mozilla.components.feature.readerview.internal.ReaderViewControlsPresenter
@@ -18,6 +21,9 @@ import mozilla.components.feature.readerview.view.ReaderViewControlsView
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONObject
+import java.lang.IllegalStateException
+import java.util.WeakHashMap
 import kotlin.properties.Delegates
 
 typealias OnReaderViewAvailableChange = (available: Boolean) -> Unit
@@ -25,7 +31,7 @@ typealias OnReaderViewAvailableChange = (available: Boolean) -> Unit
 /**
  * Feature implementation that provides a reader view for the selected
  * session. This feature is implemented as a web extension and
- * needs to be installed prior to use see [ReaderViewFeature.install].
+ * needs to be installed prior to use (see [ReaderViewFeature.install]).
  *
  * @property context a reference to the context.
  * @property engine a reference to the application's browser engine.
@@ -46,8 +52,6 @@ class ReaderViewFeature(
     private val controlsPresenter = ReaderViewControlsPresenter(controlsView, config)
     private val controlsInteractor = ReaderViewControlsInteractor(controlsView, config)
 
-    // TODO this object will be manipulated by the ReaderViewAppearanceFragment:
-    // https://github.com/mozilla-mobile/android-components/issues/2623
     class Config(prefs: SharedPreferences) {
         enum class FontType { SANS_SERIF, SERIF }
         enum class ColorScheme { LIGHT, SEPIA, DARK }
@@ -81,11 +85,42 @@ class ReaderViewFeature(
     }
 
     override fun start() {
-        if (!ReaderViewFeature.installed) {
+        observeSelected()
+
+        registerContentMessageHandler(activeSession)
+
+        if (ReaderViewFeature.installedWebExt == null) {
             ReaderViewFeature.install(engine)
         }
-        observeSelected()
+
         controlsInteractor.start()
+    }
+
+    private fun registerContentMessageHandler(session: Session?) {
+        if (session == null) {
+            return
+        }
+
+        // TODO https://github.com/mozilla-mobile/android-components/issues/2624
+        val messageHandler = object : MessageHandler {
+            override fun onPortConnected(port: Port) {
+                ReaderViewFeature.ports[port.engineSession] = port
+            }
+
+            override fun onPortDisconnected(port: Port) {
+                ReaderViewFeature.ports.remove(port.engineSession)
+            }
+
+            override fun onPortMessage(message: Any, port: Port) {
+                Logger.info("Received message: $message")
+                val response = JSONObject().apply {
+                    put("response", "Message received! Hello from Android!")
+                }
+                ReaderViewFeature.sendMessage(response, port.engineSession!!)
+            }
+        }
+
+        ReaderViewFeature.registerMessageHandler(sessionManager.getOrCreateEngineSession(session), messageHandler)
     }
 
     override fun stop() {
@@ -98,21 +133,14 @@ class ReaderViewFeature(
         return true
     }
 
-    override fun onSessionAdded(session: Session) {
-        // TODO make sure we start listening to reader view web extension
-        // messages for this session: Here we will just hook things up
-        // using the readerViewWebExt WebExtension object which will
-        // provide the functionality for bi-directional messaging
-        // (bridge to GeckoView's setSessionMessageDelegate).
+    override fun onSessionSelected(session: Session) {
+        // TODO restore selected state of whether the controls are open or not
+        registerContentMessageHandler(activeSession)
+        super.onSessionSelected(session)
     }
 
     override fun onSessionRemoved(session: Session) {
-        // TODO stop listening to reader view web extension messages of this session
-    }
-
-    override fun onSessionSelected(session: Session) {
-        // TODO restore selected state of whether the controls are open or not
-        super.onSessionSelected(session)
+        ReaderViewFeature.ports.remove(sessionManager.getEngineSession(session))
     }
 
     fun showReaderView() {
@@ -137,19 +165,18 @@ class ReaderViewFeature(
         controlsPresenter.hide()
     }
 
-    // TODO observe messages delivered from the web extension to the selected session
-    // e.g. to know whether or not reader view is available for the current page.
-    // The session will be updated by the messaging delegate integration logic in our
-    // WebExtension object. So here we can just observe the message on the session.
-    // override fun onWebExtensionMessage() { }
-
     companion object {
-        @VisibleForTesting
-        internal val readerViewWebExt =
-                WebExtension("mozac-readerview", "resource://android/assets/extensions/readerview/")
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val READER_VIEW_EXTENSION_ID = "mozacReaderview"
+        internal const val READER_VIEW_EXTENSION_URL = "resource://android/assets/extensions/readerview/"
 
         @Volatile
-        internal var installed = false
+        internal var installedWebExt: WebExtension? = null
+
+        @Volatile
+        private var registerContentMessageHandler: (WebExtension) -> Unit? = { }
+
+        internal var ports = WeakHashMap<EngineSession, Port>()
 
         /**
          * Installs the readerview web extension in the provided engine.
@@ -157,17 +184,31 @@ class ReaderViewFeature(
          * @param engine a reference to the application's browser engine.
          */
         fun install(engine: Engine) {
-            engine.installWebExtension(readerViewWebExt,
+            engine.installWebExtension(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL,
                 onSuccess = {
                     Logger.debug("Installed extension: ${it.id}")
+                    registerContentMessageHandler(it)
+                    installedWebExt = it
                 },
                 onError = { ext, throwable ->
-                    installed = false
-                    Logger.error("Failed to install extension: ${ext.id}", throwable)
+                    Logger.error("Failed to install extension: $ext", throwable)
                 }
             )
-            // TODO move install state to our WebExtension object.
-            installed = true
+        }
+
+        fun registerMessageHandler(session: EngineSession, messageHandler: MessageHandler) {
+            registerContentMessageHandler = {
+                if (!it.hasContentMessageHandler(session, READER_VIEW_EXTENSION_ID)) {
+                    it.registerContentMessageHandler(session, READER_VIEW_EXTENSION_ID, messageHandler)
+                }
+            }
+
+            installedWebExt?.let { registerContentMessageHandler(it) }
+        }
+
+        fun sendMessage(msg: Any, engineSession: EngineSession) {
+            val port = ports[engineSession]
+            port?.postMessage(msg) ?: throw IllegalStateException("No port connected for the provided session")
         }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,42 @@ permalink: /changelog/
 
 * **browser-engine-gecko-nightly**
   * Implement `allowAutoplayMedia` in terms of `autoplayDefault`.
+  * ⚠️ **This is a breaking API change**
+  * Added API for bidirectional messaging between Android and installed web extensions:
+    ```kotlin
+       engine.installWebExtension(EXTENSION_ID, EXTENSION_URL,
+            onSuccess = { installedExt -> it }
+        )
+
+      val messageHandler = object : MessageHandler {
+          override fun onPortConnected(port: Port) {
+            // Called when a port was connected as a result of a
+            // browser.runtime.connectNative call in JavaScript.
+            // The port can be used to send messages to the web extension:
+            port.postMessage(jsonObject)
+          }
+
+          override fun onPortDisconnected(port: Port) {
+            // Called when the port was disconnected or the corresponding session closed.
+          }
+
+          override fun onPortMessage(message: Any, port: Port) {
+            // Called when a messsage was received on the provided port as a
+            // result of a call to port.postMessage in JavaScript.
+          }
+
+          override fun onMessage(message: Any, source: EngineSession?): Any {
+            // Called when a message was recieved as a result of a
+            // browser.runtime.sendNativeMessage call in JavaScript.
+          }
+      }
+
+      // To listen to message events from content scripts call:
+      installedExt.registerContentMessageHandler(session, EXTENSION_ID, messageHandler)
+
+      // To listen to message events from background scripts call:
+      installedExt.registerBackgroundMessageHandler(EXTENSION_ID, messageHandler)  
+    ```
 
 * **browser-icons**
   * Added an in-memory caching mechanism reducing disk/network loads.

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -6,7 +6,6 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.support.base.log.Log
 
 /**
@@ -15,8 +14,8 @@ import mozilla.components.support.base.log.Log
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
         GeckoEngine(applicationContext, engineSettings).apply {
-            installWebExtension(WebExtension("mozac-borderify", "resource://android/assets/extensions/borderify/")) {
-                ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install ${ext.id}")
+            installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
+                ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }
 
             icons.install(this)


### PR DESCRIPTION
This brings in the web extension messaging functionality (+ tests and Kdoc). 

I want to commit a working example with this so I added a simply bidirectional message exchange to our stub reader view feature. Once this PR lands, work on reader view will continue in https://github.com/mozilla-mobile/android-components/issues/2624 and these simple example messages will replaced with the actual reader view messages.

As we now need the engine to return a `WebExtension` instance (abstracting over the concrete engine-specific implementation), there is a slight API change to install extensions by `id` and `url` and pass along the installed web extension in `onSuccess`. 
