### PR TITLE
Fix #2839:  Expose methods to find a bookmark by its URL or guid

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.sync.SyncableStore
 /**
  * Implementation of the [BookmarksStorage] which is backed by a Rust Places lib via [PlacesApi].
  */
+@Suppress("TooManyFunctions")
 open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), BookmarksStorage, SyncableStore {
 
     /**
@@ -38,6 +39,30 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
             reader.getBookmarksTree(guid, recursive)?.let {
                 asBookmarkNode(it)
             }
+        }
+    }
+
+    /**
+     * Obtains the details of a bookmark without children, if one exists with that guid. Otherwise, null.
+     *
+     * @param guid The bookmark guid to obtain.
+     * @return The bookmark node or null if it does not exist.
+     */
+    override suspend fun getBookmark(guid: String): BookmarkNode? {
+        return withContext(scope.coroutineContext) {
+            asBookmarkNode(reader.getBookmark(guid))
+        }
+    }
+
+    /**
+     * Produces a list of all bookmarks with the given URL.
+     *
+     * @param url The URL string.
+     * @return The list of bookmarks that match the URL
+     */
+    override suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode> {
+        return withContext(scope.coroutineContext) {
+            reader.getBookmarksWithURL(url).mapNotNull(::asBookmarkNode)
         }
     }
 

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
@@ -63,6 +63,32 @@ class PlacesBookmarksStorageTest {
     }
 
     @Test
+    fun `get bookmarks by URL`() {
+        val reader = reader!!
+        val storage = storage!!
+
+        val url = "http://www.mozilla.org"
+
+        runBlocking {
+            storage.getBookmarksWithUrl(url)
+        }
+        verify(reader, times(1)).getBookmarksWithURL(url)
+    }
+
+    @Test
+    fun `get bookmark by guid`() {
+        val reader = reader!!
+        val storage = storage!!
+
+        val guid = "123"
+
+        runBlocking {
+            storage.getBookmark(guid)
+        }
+        verify(reader, times(1)).getBookmark(guid)
+    }
+
+    @Test
     fun `search bookmarks by keyword`() {
         val reader = reader!!
         val storage = storage!!

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/BookmarksStorage.kt
@@ -19,6 +19,22 @@ interface BookmarksStorage : Storage {
     suspend fun getTree(guid: String, recursive: Boolean = false): BookmarkNode?
 
     /**
+     * Obtains the details of a bookmark without children, if one exists with that guid. Otherwise, null.
+     *
+     * @param guid The bookmark guid to obtain.
+     * @return The bookmark node or null if it does not exist.
+     */
+    suspend fun getBookmark(guid: String): BookmarkNode?
+
+    /**
+     * Produces a list of all bookmarks with the given URL.
+     *
+     * @param url The URL string.
+     * @return The list of bookmarks that match the URL
+     */
+    suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode>
+
+    /**
      * Searches bookmarks with a query string.
      *
      * @param query The query string to search.
@@ -97,7 +113,7 @@ data class BookmarkNode(
     val position: Int?,
     val title: String?,
     val url: String?,
-    val children: List<BookmarkNode?>?
+    val children: List<BookmarkNode>?
 )
 
 /**

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -85,7 +85,18 @@ class BookmarksStorageSuggestionProviderTest {
         val bookmarkMap: HashMap<String, BookmarkNode> = hashMapOf()
 
         override suspend fun getTree(guid: String, recursive: Boolean): BookmarkNode? {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
+        }
+
+        override suspend fun getBookmark(guid: String): BookmarkNode? {
+            // "Not needed for the test"
+            throw NotImplementedError()
+        }
+
+        override suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode> {
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
 
         override suspend fun searchBookmarks(query: String, limit: Int): List<BookmarkNode> =
@@ -130,27 +141,33 @@ class BookmarksStorageSuggestionProviderTest {
         }
 
         override suspend fun addFolder(parentGuid: String, title: String, position: Int?): String {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
 
         override suspend fun addSeparator(parentGuid: String, position: Int?): String {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
 
         override suspend fun updateNode(guid: String, info: BookmarkInfo) {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
 
         override suspend fun deleteNode(guid: String): Boolean {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
 
         override suspend fun runMaintenance() {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
 
         override fun cleanup() {
-            TODO("Not needed for the test")
+            // "Not needed for the test"
+            throw NotImplementedError()
         }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,8 @@ permalink: /changelog/
   * ⚠️ **This is a breaking API change**
   * Added new method `getVisitsPaginated`; use it to paginate history.
   * Added `excludeTypes` param to `getDetailedVisits`; use it to query only subsets of history.
+  * Added new `getBookmarksWithUrl` method for checking if a site is already bookmarked
+  * Added new `getBookmark` method for obtaining the details of a single bookmark by GUID
 
 * **browser-storage-sync**
   * `PlacesBookmarksStorage` now supports synchronization!

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/MainActivity.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/MainActivity.kt
@@ -191,7 +191,7 @@ class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener,
                 } else {
                     var bookmarksRootAndChildren = "Bookmarks, root ->"
                     bookmarksRoot.children!!.forEach {
-                        bookmarksRootAndChildren += "\n-- ${it?.title}"
+                        bookmarksRootAndChildren += "\n-- ${it.title}"
                     }
                     bookmarksResultTextView.text = bookmarksRootAndChildren
                 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
