### PR TITLE
Persist FxA account state via the persistence callback

### DIFF
--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -25,6 +25,7 @@ interface OAuthAccount : AutoCloseable {
     fun completeOAuthFlow(code: String, state: String): Deferred<Unit>
     fun getAccessToken(singleScope: String): Deferred<AccessTokenInfo>
     fun getTokenServerEndpointURL(): String
+    fun registerPersistenceCallback(callback: StatePersistenceCallback)
     fun toJSONString(): String
 
     suspend fun authInfo(singleScope: String): AuthInfo {
@@ -39,6 +40,16 @@ interface OAuthAccount : AutoCloseable {
                 tokenServerUrl = tokenServerURL
         )
     }
+}
+
+/**
+ * Describes a delegate object that is used by [OAuthAccount] to persist its internal state as it changes.
+ */
+interface StatePersistenceCallback {
+    /**
+     * @param data Account state representation as a string (e.g. as json).
+     */
+    fun persist(data: String)
 }
 
 /**

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/AccountStorage.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/AccountStorage.kt
@@ -14,7 +14,7 @@ const val FXA_STATE_KEY = "fxaState"
 interface AccountStorage {
     @Throws(Exception::class)
     fun read(): OAuthAccount?
-    fun write(account: OAuthAccount)
+    fun write(accountState: String)
     fun clear()
 }
 
@@ -30,10 +30,10 @@ class SharedPrefAccountStorage(val context: Context) : AccountStorage {
         return FirefoxAccount.fromJSONString(savedJSON)
     }
 
-    override fun write(account: OAuthAccount) {
+    override fun write(accountState: String) {
         accountPreferences()
             .edit()
-            .putString(FXA_STATE_KEY, account.toJSONString())
+            .putString(FXA_STATE_KEY, accountState)
             .apply()
     }
 

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -7,15 +7,19 @@ package mozilla.components.service.fxa
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
+import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
+import mozilla.components.concept.sync.StatePersistenceCallback
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -110,6 +114,177 @@ class FxaAccountManagerTest {
         assertNull(FxaAccountManager.nextState(state, Event.FailedToFetchProfile))
         assertNull(FxaAccountManager.nextState(state, Event.FailedToAuthenticate))
         assertEquals(AccountState.NotAuthenticated, FxaAccountManager.nextState(state, Event.Logout))
+    }
+
+    @Test
+    fun `restored account state persistence`() = runBlocking {
+        val accountStorage: AccountStorage = mock()
+        val profile = Profile("testUid", "test@example.com", null, "Test Profile")
+        val account = object : OAuthAccount {
+            var persistenceCallback: StatePersistenceCallback? = null
+
+            override fun beginOAuthFlow(scopes: Array<String>, wantsKeys: Boolean): Deferred<String> {
+                fail()
+                return CompletableDeferred()
+            }
+
+            override fun beginPairingFlow(pairingUrl: String, scopes: Array<String>): Deferred<String> {
+                fail()
+                return CompletableDeferred()
+            }
+
+            override fun getProfile(ignoreCache: Boolean): Deferred<Profile> {
+                return CompletableDeferred(profile)
+            }
+
+            override fun getProfile(): Deferred<Profile> {
+                return CompletableDeferred(profile)
+            }
+
+            override fun completeOAuthFlow(code: String, state: String): Deferred<Unit> {
+                fail()
+                return CompletableDeferred()
+            }
+
+            override fun getAccessToken(singleScope: String): Deferred<AccessTokenInfo> {
+                fail()
+                return CompletableDeferred()
+            }
+
+            override fun getTokenServerEndpointURL(): String {
+                fail()
+                return ""
+            }
+
+            override fun registerPersistenceCallback(callback: StatePersistenceCallback) {
+                persistenceCallback = callback
+            }
+
+            override fun toJSONString(): String {
+                fail()
+                return ""
+            }
+
+            override fun close() {
+                fail()
+            }
+        }
+
+        val manager = TestableFxaAccountManager(
+            context, Config.release("dummyId", "http://auth-url/redirect"), arrayOf("profile"), accountStorage
+        ) {
+            account
+        }
+
+        // We have an account at the start.
+        `when`(accountStorage.read()).thenReturn(account)
+
+        assertNull(account.persistenceCallback)
+        manager.initAsync().await()
+
+        // Assert that persistence callback is set.
+        assertNotNull(account.persistenceCallback)
+
+        // Assert that persistence callback is interacting with the storage layer.
+        account.persistenceCallback!!.persist("test")
+        verify(accountStorage).write("test")
+    }
+
+    @Test
+    fun `newly authenticated account state persistence`() = runBlocking {
+        val accountStorage: AccountStorage = mock()
+        val profile = Profile(uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile")
+        val account = StatePersistenceTestableAccount(profile)
+        val accountObserver: AccountObserver = mock()
+        // We are not using the "prepareHappy..." helper method here, because our account isn't a mock,
+        // but an actual implementation of the interface.
+        val manager = TestableFxaAccountManager(
+                context,
+                Config.release("dummyId", "bad://url"),
+                arrayOf("profile", "test-scope"),
+                accountStorage
+        ) {
+            account
+        }
+
+        // There's no account at the start.
+        `when`(accountStorage.read()).thenReturn(null)
+
+        manager.register(accountObserver)
+
+        // Kick it off, we'll get into a "NotAuthenticated" state.
+        runBlocking {
+            manager.initAsync().await()
+        }
+
+        assertNull(account.persistenceCallback)
+
+        // Perform authentication.
+        runBlocking {
+            assertEquals("auth://url", manager.beginAuthenticationAsync().await())
+        }
+        runBlocking {
+            manager.finishAuthenticationAsync("dummyCode", "dummyState").await()
+        }
+
+        // Assert that persistence callback is set.
+        assertNotNull(account.persistenceCallback)
+
+        // Assert that persistence callback is interacting with the storage layer.
+        account.persistenceCallback!!.persist("test")
+        verify(accountStorage).write("test")
+    }
+
+    class StatePersistenceTestableAccount(private val profile: Profile) : OAuthAccount {
+        var persistenceCallback: StatePersistenceCallback? = null
+
+        override fun beginOAuthFlow(scopes: Array<String>, wantsKeys: Boolean): Deferred<String> {
+            return CompletableDeferred("auth://url")
+        }
+
+        override fun beginPairingFlow(pairingUrl: String, scopes: Array<String>): Deferred<String> {
+            return CompletableDeferred("auth://url")
+        }
+
+        override fun getProfile(ignoreCache: Boolean): Deferred<Profile> {
+            return CompletableDeferred(profile)
+        }
+
+        override fun getProfile(): Deferred<Profile> {
+            return CompletableDeferred(profile)
+        }
+
+        override fun completeOAuthFlow(code: String, state: String): Deferred<Unit> {
+            // This ceremony is necessary because CompletableDeferred<Unit>() is created in an _active_ state,
+            // and threads will deadlock since it'll never be resolved while state machine is waiting for it.
+            // So we manually complete it here!
+            val unitDeferred = CompletableDeferred<Unit>()
+            unitDeferred.complete(Unit)
+            return unitDeferred
+        }
+
+        override fun getAccessToken(singleScope: String): Deferred<AccessTokenInfo> {
+            fail()
+            return CompletableDeferred()
+        }
+
+        override fun getTokenServerEndpointURL(): String {
+            fail()
+            return ""
+        }
+
+        override fun registerPersistenceCallback(callback: StatePersistenceCallback) {
+            persistenceCallback = callback
+        }
+
+        override fun toJSONString(): String {
+            fail()
+            return ""
+        }
+
+        override fun close() {
+            fail()
+        }
     }
 
     @Test
@@ -270,8 +445,6 @@ class FxaAccountManagerTest {
         }
 
         verify(accountStorage, times(1)).read()
-        // Confirm account is persisted after authentication.
-        verify(accountStorage, times(1)).write(mockAccount)
         verify(accountStorage, never()).clear()
 
         verify(accountObserver, never()).onError(any())
@@ -307,8 +480,6 @@ class FxaAccountManagerTest {
         }
 
         verify(accountStorage, times(1)).read()
-        // Confirm account is persisted after authentication.
-        verify(accountStorage, times(1)).write(mockAccount)
         verify(accountStorage, never()).clear()
 
         verify(accountObserver, never()).onError(any())
@@ -362,8 +533,6 @@ class FxaAccountManagerTest {
         }
 
         verify(accountStorage, times(1)).read()
-        // Confirm account is persisted after authentication.
-        verify(accountStorage, times(1)).write(mockAccount)
         verify(accountStorage, never()).clear()
 
         verify(accountObserver, never()).onError(any())
@@ -417,8 +586,6 @@ class FxaAccountManagerTest {
         }
 
         verify(accountStorage, times(1)).read()
-        // Confirm account is persisted after authentication.
-        verify(accountStorage, times(1)).write(mockAccount)
         verify(accountStorage, never()).clear()
 
         verify(accountObserver, never()).onError(any())
@@ -483,8 +650,6 @@ class FxaAccountManagerTest {
         }
 
         verify(accountStorage, times(1)).read()
-        // Confirm account is persisted after authentication.
-        verify(accountStorage, times(1)).write(mockAccount)
         verify(accountStorage, never()).clear()
 
         val captor = argumentCaptor<FxaException>()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -97,6 +97,13 @@ permalink: /changelog/
     - **Removed**: `String.isUrl()` and `String.toNormalizedUrl()`
     - use `URLStringUtils` `isURLLike()` and `toNormalizedURL()` instead.
 
+* **concept-sync**
+  * ⚠️ **This is a breaking API change**
+  * `OAuthAccount` now has a new method `registerPersistenceCallback`.
+
+* **service-fxa**
+  * `FxaAccountManager` is now using a state persistence callback to keep FxA account state up-to-date as it changes.
+
 # 0.50.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.49.0...v0.50.0)


### PR DESCRIPTION
Splitting this off of #2670.

This is the preferred way to make sure our persisted account state
is up-to-date.
In the future, various parts of FxA (like SendTab) may mutate
account's internal state, and so it's necessary to make sure we
persist account changes as they happen.

Before, this happened manually after account creation.
Now persistence process is entirely callback-driven.

 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
