### PR TITLE
Closes #2848: Re-add the String.isUrl ext function

### DIFF
--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
@@ -6,7 +6,8 @@ package mozilla.components.feature.toolbar
 
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.support.utils.URLStringUtils
+import mozilla.components.support.ktx.kotlin.isUrl
+import mozilla.components.support.ktx.kotlin.toNormalizedUrl
 
 /**
  * Connects a toolbar instance to the browser engine via use cases
@@ -24,8 +25,8 @@ class ToolbarInteractor(
      */
     fun start() {
         toolbar.setOnUrlCommitListener { text ->
-            if (URLStringUtils.isURLLike(text)) {
-                loadUrlUseCase.invoke(URLStringUtils.toNormalizedURL(text))
+            if (text.isUrl()) {
+                loadUrlUseCase.invoke(text.toNormalizedUrl())
             } else {
                 searchUseCase?.invoke(text) ?: loadUrlUseCase.invoke(text)
             }

--- a/components/support/ktx/build.gradle
+++ b/components/support/ktx/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation Dependencies.support_compat
 
     implementation project(':support-base')
+    implementation project(':support-utils')
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.ktx.kotlin
 
 import android.net.Uri
+import mozilla.components.support.utils.URLStringUtils
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -17,6 +18,13 @@ private val re = object {
     val emailish = "^\\s*mailto:\\w+\\S*\\s*$".toRegex(RegexOption.IGNORE_CASE)
     val geoish = "^\\s*geo:\\S*\\d+\\S*\\s*$".toRegex(RegexOption.IGNORE_CASE)
 }
+
+/**
+ * Checks if this String is a URL.
+ */
+fun String.isUrl() = URLStringUtils.isURLLike(this)
+
+fun String.toNormalizedUrl() = URLStringUtils.toNormalizedURL(this)
 
 fun String.isPhone() = re.phoneish.matches(this)
 

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -17,6 +18,40 @@ import java.util.Calendar.MILLISECOND
 
 @RunWith(RobolectricTestRunner::class)
 class StringTest {
+
+    @Test
+    fun isUrl() {
+        assertTrue("mozilla.org".isUrl())
+        assertTrue(" mozilla.org ".isUrl())
+        assertTrue("http://mozilla.org".isUrl())
+        assertTrue("https://mozilla.org".isUrl())
+        assertTrue("file://somefile.txt".isUrl())
+        assertTrue("http://mozilla".isUrl())
+        assertTrue("http://192.168.255.255".isUrl())
+        assertTrue("about:crashcontent".isUrl())
+        assertTrue(" about:crashcontent ".isUrl())
+        assertTrue("sample:about ".isUrl())
+
+        assertFalse("mozilla".isUrl())
+        assertFalse("mozilla android".isUrl())
+        assertFalse(" mozilla android ".isUrl())
+        assertFalse("Tweet:".isUrl())
+        assertFalse("inurl:mozilla.org advanced search".isUrl())
+        assertFalse("what is about:crashes".isUrl())
+
+        val extraText = "Check out @asa’s Tweet: https://twitter.com/asa/status/123456789?s=09"
+        val url = extraText.split(" ").find { it.isUrl() }
+        assertNotEquals("Tweet:", url)
+    }
+
+    @Test
+    fun toNormalizedUrl() {
+        val expectedUrl = "http://mozilla.org"
+        assertEquals(expectedUrl, "http://mozilla.org".toNormalizedUrl())
+        assertEquals(expectedUrl, "  http://mozilla.org  ".toNormalizedUrl())
+        assertEquals(expectedUrl, "mozilla.org".toNormalizedUrl())
+    }
+
     @Test
     fun isPhone() {
         assertTrue("tel:+1234567890".isPhone())

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,7 +69,7 @@ permalink: /changelog/
       installedExt.registerContentMessageHandler(session, EXTENSION_ID, messageHandler)
 
       // To listen to message events from background scripts call:
-      installedExt.registerBackgroundMessageHandler(EXTENSION_ID, messageHandler)  
+      installedExt.registerBackgroundMessageHandler(EXTENSION_ID, messageHandler)
     ```
 
 * **browser-icons**
@@ -93,9 +93,8 @@ permalink: /changelog/
   * Add `URLStringUtils` to unify parsing of strings that may be URLs.
 
 * **support-ktx**
-  * ⚠️ **This is a breaking API change**:
-    - **Removed**: `String.isUrl()` and `String.toNormalizedUrl()`
-    - use `URLStringUtils` `isURLLike()` and `toNormalizedURL()` instead.
+    - Add `URLStringUtils` `isURLLike()` and `toNormalizedURL()`.
+    - Update the implementation for `String.isUrl()` and `String.toNormalizedUrl()` to the new one above.
 
 # 0.50.0
 


### PR DESCRIPTION
This is a helpful extension function that's worth keeping around in hindsight that some dependents also use.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
