### PR TITLE
Register FxA state persistence callback earlier during auth flow

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaAccountManager.kt
@@ -385,9 +385,9 @@ open class FxaAccountManager(
             AccountState.AuthenticatedNoProfile -> {
                 when (via) {
                     is Event.Authenticated -> {
-                        account.completeOAuthFlow(via.code, via.state).await()
-
                         account.registerPersistenceCallback(statePersistenceCallback)
+
+                        account.completeOAuthFlow(via.code, via.state).await()
 
                         notifyObservers { onAuthenticated(account) }
 


### PR DESCRIPTION
Currently it's registered after we call into `completeOAuthFlow`, which means
that state mutations that happen as account is logged in aren't persisted. This patch registers callback before we complete auth, which fixes the problem.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

Ordering of these calls isn't covered, unfortunately.

- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
