### PR TITLE
glean: 1547273: Display error from GleanDebugActivity when glean isn't initialized

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
@@ -41,6 +41,14 @@ class GleanDebugActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        if (!Glean.isInitialized()) {
+            logger.error(
+                "Glean is not initialized. " +
+                "It may be disabled by the application."
+            )
+            return
+        }
+
         // Enable debugging options and start the application.
         intent.extras?.let {
             // Check for ping debug view tag to apply to the X-Debug-ID header when uploading the


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
