### PR TITLE
Closes reference-browser#623 - Select custom tabs on add to enable menu items

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
@@ -97,18 +97,22 @@ class CustomTabConfig internal constructor(
                 null
             }
 
-            val closeButtonIcon = run {
-                val icon = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
-                val density = displayMetrics?.density ?: 1f
-                if (icon != null &&
-                    icon.width / density <= MAX_CLOSE_BUTTON_SIZE_DP &&
-                    icon.height / density <= MAX_CLOSE_BUTTON_SIZE_DP
-                ) {
+            val closeButtonIcon = if (intent.hasExtra(EXTRA_CLOSE_BUTTON_ICON)) {
+                val bitmap = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
+                bitmap?.let { icon ->
+                    val density = displayMetrics?.density ?: 1f
+                    if (icon.width / density <= MAX_CLOSE_BUTTON_SIZE_DP &&
+                        icon.height / density <= MAX_CLOSE_BUTTON_SIZE_DP
+                    ) {
+                        icon
+                    } else {
+                        null
+                    }
+                }?.also {
                     options.add(CLOSE_BUTTON_OPTION)
-                    icon
-                } else {
-                    null
                 }
+            } else {
+                null
             }
 
             val disableUrlbarHiding = !intent.getBooleanExtra(EXTRA_ENABLE_URLBAR_HIDING, true)

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -51,7 +51,7 @@ class IntentProcessor(
                     val displayMetrics = context.resources.displayMetrics
                     this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
                 }
-                sessionManager.add(session)
+                sessionManager.add(session, selected = true)
                 sessionUseCases.loadUrl.invoke(url, session)
                 intent.putExtra(ACTIVE_SESSION_ID, session.id)
                 true

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
@@ -175,7 +175,7 @@ class IntentProcessorTest {
         `when`(intent.dataString).thenReturn("http://mozilla.org")
 
         handler.process(intent)
-        verify(sessionManager).add(anySession(), eq(false), eq(null), eq(null))
+        verify(sessionManager).add(anySession(), eq(true), eq(null), eq(null))
         verify(engineSession).loadUrl("http://mozilla.org")
 
         val customTabSession = sessionManager.all[0]


### PR DESCRIPTION
Fixes [#623][1].

The intent processor now selects the custom tab as it is loaded. This will allow the toolbar buttons to update with respect to the session state (`hasBack`, `hasForward`, `isLoading` etc), and direct the actions to currently selected session.

<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~

[1]: https://github.com/mozilla-mobile/reference-browser/issues/623