### PR TITLE
History tracking delegate improvements

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -22,6 +22,7 @@ import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
@@ -396,9 +397,22 @@ class GeckoEngineSession(
                 (flags and GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL) == 0 ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0) {
 
-                // Don't track visits in private mode, redirects, or error
-                // pages, even if they're top-level visits.
+                // Don't track visits in private mode, or error pages, even if they're top-level visits.
                 return GeckoResult.fromValue(false)
+            }
+
+            val isReload = lastVisitedURL?.let { it == url } ?: false
+
+            val visitType = if (isReload) {
+                VisitType.RELOAD
+            } else {
+                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0) {
+                    VisitType.REDIRECT_PERMANENT
+                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0) {
+                    VisitType.REDIRECT_TEMPORARY
+                } else {
+                    VisitType.LINK
+                }
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
@@ -408,10 +422,9 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(false)
             }
 
-            val isReload = lastVisitedURL?.let { it == url } ?: false
             val result = GeckoResult<Boolean>()
             launch {
-                delegate.onVisited(url, isReload)
+                delegate.onVisited(url, visitType)
                 result.complete(true)
             }
             return result

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -393,11 +393,13 @@ class GeckoEngineSession(
             lastVisitedURL: String?,
             flags: Int
         ): GeckoResult<Boolean>? {
+            // Don't track:
+            // - private visits
+            // - error pages
+            // - non-top level visits (i.e. iframes).
             if (privateMode ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL) == 0 ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0) {
-
-                // Don't track visits in private mode, or error pages, even if they're top-level visits.
                 return GeckoResult.fromValue(false)
             }
 

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -385,6 +385,7 @@ class GeckoEngineSession(
 
     @Suppress("ComplexMethod")
     internal fun createHistoryDelegate() = object : GeckoSession.HistoryDelegate {
+        @SuppressWarnings("ReturnCount")
         override fun onVisited(
             session: GeckoSession,
             url: String,
@@ -401,6 +402,11 @@ class GeckoEngineSession(
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
+
+            // Check if the delegate wants this type of url.
+            if (!delegate.shouldStoreUri(url)) {
+                return GeckoResult.fromValue(false)
+            }
 
             val isReload = lastVisitedURL?.let { it == url } ?: false
             val result = GeckoResult<Boolean>()

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -18,6 +18,8 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.concept.storage.VisitType
+import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
@@ -33,8 +35,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
@@ -554,7 +554,7 @@ class GeckoEngineSessionTest {
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate, never()).onVisited(anyString(), anyBoolean())
+            verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
         }
     }
 
@@ -572,7 +572,7 @@ class GeckoEngineSessionTest {
         historyDelegate.value.onVisited(geckoSession, "about:neterror", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL or GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate, never()).onVisited(anyString(), anyBoolean())
+            verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
         }
     }
 
@@ -586,11 +586,12 @@ class GeckoEngineSessionTest {
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(false))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
         }
     }
 
@@ -605,10 +606,110 @@ class GeckoEngineSessionTest {
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
+
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(true))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
+        }
+    }
+
+    @Test
+    fun `checks with the delegate before trying to record a visit`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+                geckoSessionProvider = geckoSessionProvider,
+                context = testMainScope.coroutineContext)
+        val historyTrackingDelegate: HistoryTrackingDelegate = mock()
+
+        captureDelegates()
+
+        engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/allowed")).thenReturn(true)
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/not-allowed")).thenReturn(false)
+
+        historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(VisitType.LINK))
+        }
+
+        historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/not-allowed")
+            verify(historyTrackingDelegate, never()).onVisited(eq("https://www.mozilla.com/not-allowed"), mozilla.components.support.test.any())
+        }
+    }
+
+    @Test
+    fun `correctly processes redirect visit flags`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+                geckoSessionProvider = geckoSessionProvider,
+                context = testMainScope.coroutineContext)
+        val historyTrackingDelegate: HistoryTrackingDelegate = mock()
+
+        captureDelegates()
+
+        engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        `when`(historyTrackingDelegate.shouldStoreUri(mozilla.components.support.test.any())).thenReturn(true)
+
+        historyDelegate.value.onVisited(
+                geckoSession,
+                "https://www.mozilla.com/tempredirect",
+                null,
+                // bitwise 'or'
+                GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))
+        }
+
+        historyDelegate.value.onVisited(
+                geckoSession,
+                "https://www.mozilla.com/permredirect",
+                null,
+                GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))
+        }
+
+        // Visits below are targets of redirects, not redirects themselves.
+        // Check that they're mapped to "link".
+        historyDelegate.value.onVisited(
+                geckoSession,
+                "https://www.mozilla.com/targettemp",
+                null,
+                GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(VisitType.LINK))
+        }
+
+        historyDelegate.value.onVisited(
+                geckoSession,
+                "https://www.mozilla.com/targetperm",
+                null,
+                GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(VisitType.LINK))
         }
     }
 
@@ -627,7 +728,7 @@ class GeckoEngineSessionTest {
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate, never()).onVisited(anyString(), anyBoolean())
+            verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
         }
     }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -393,6 +393,7 @@ class GeckoEngineSession(
 
     @Suppress("ComplexMethod")
     internal fun createHistoryDelegate() = object : GeckoSession.HistoryDelegate {
+        @SuppressWarnings("ReturnCount")
         override fun onVisited(
             session: GeckoSession,
             url: String,
@@ -409,6 +410,11 @@ class GeckoEngineSession(
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
+
+            // Check if the delegate wants this type of url.
+            if (!delegate.shouldStoreUri(url)) {
+                return GeckoResult.fromValue(false)
+            }
 
             val isReload = lastVisitedURL?.let { it == url } ?: false
             val result = GeckoResult<Boolean>()

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -401,11 +401,13 @@ class GeckoEngineSession(
             lastVisitedURL: String?,
             flags: Int
         ): GeckoResult<Boolean>? {
+            // Don't track:
+            // - private visits
+            // - error pages
+            // - non-top level visits (i.e. iframes).
             if (privateMode ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL) == 0 ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0) {
-
-                // Don't track visits in private mode, or error pages, even if they're top-level visits.
                 return GeckoResult.fromValue(false)
             }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -22,6 +22,7 @@ import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
@@ -394,9 +395,22 @@ class GeckoEngineSession(
                 (flags and GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL) == 0 ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0) {
 
-                // Don't track visits in private mode, redirects, or error
-                // pages, even if they're top-level visits.
+                // Don't track visits in private mode, or error pages, even if they're top-level visits.
                 return GeckoResult.fromValue(false)
+            }
+
+            val isReload = lastVisitedURL?.let { it == url } ?: false
+
+            val visitType = if (isReload) {
+                VisitType.RELOAD
+            } else {
+                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0) {
+                    VisitType.REDIRECT_PERMANENT
+                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0) {
+                    VisitType.REDIRECT_TEMPORARY
+                } else {
+                    VisitType.LINK
+                }
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
@@ -406,10 +420,9 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(false)
             }
 
-            val isReload = lastVisitedURL?.let { it == url } ?: false
             val result = GeckoResult<Boolean>()
             launch {
-                delegate.onVisited(url, isReload)
+                delegate.onVisited(url, visitType)
                 result.complete(true)
             }
             return result

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -391,11 +391,13 @@ class GeckoEngineSession(
             lastVisitedURL: String?,
             flags: Int
         ): GeckoResult<Boolean>? {
+            // Don't track:
+            // - private visits
+            // - error pages
+            // - non-top level visits (i.e. iframes).
             if (privateMode ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL) == 0 ||
                 (flags and GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR) != 0) {
-
-                // Don't track visits in private mode, or error pages, even if they're top-level visits.
                 return GeckoResult.fromValue(false)
             }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -383,6 +383,7 @@ class GeckoEngineSession(
 
     @Suppress("ComplexMethod")
     internal fun createHistoryDelegate() = object : GeckoSession.HistoryDelegate {
+        @SuppressWarnings("ReturnCount")
         override fun onVisited(
             session: GeckoSession,
             url: String,
@@ -399,6 +400,11 @@ class GeckoEngineSession(
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
+
+            // Check if the delegate wants this type of url.
+            if (!delegate.shouldStoreUri(url)) {
+                return GeckoResult.fromValue(false)
+            }
 
             val isReload = lastVisitedURL?.let { it == url } ?: false
             val result = GeckoResult<Boolean>()

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -18,6 +18,8 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.concept.storage.VisitType
+import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
@@ -33,8 +35,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
@@ -552,7 +552,7 @@ class GeckoEngineSessionTest {
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate, never()).onVisited(anyString(), anyBoolean())
+            verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
         }
     }
 
@@ -570,7 +570,7 @@ class GeckoEngineSessionTest {
         historyDelegate.value.onVisited(geckoSession, "about:neterror", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL or GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate, never()).onVisited(anyString(), anyBoolean())
+            verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
         }
     }
 
@@ -584,16 +584,17 @@ class GeckoEngineSessionTest {
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(false))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
         }
     }
 
     @Test
-    fun `notifies configured history delegate of reloads`() = runBlocking {
+    fun `notifies configured history delegate of reloads`() {
         val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider,
                 context = testMainScope.coroutineContext)
@@ -603,10 +604,110 @@ class GeckoEngineSessionTest {
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
+
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(true))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
+        }
+    }
+
+    @Test
+    fun `checks with the delegate before trying to record a visit`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+                geckoSessionProvider = geckoSessionProvider,
+                context = testMainScope.coroutineContext)
+        val historyTrackingDelegate: HistoryTrackingDelegate = mock()
+
+        captureDelegates()
+
+        engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/allowed")).thenReturn(true)
+        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/not-allowed")).thenReturn(false)
+
+        historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(VisitType.LINK))
+        }
+
+        historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/not-allowed")
+            verify(historyTrackingDelegate, never()).onVisited(eq("https://www.mozilla.com/not-allowed"), any())
+        }
+    }
+
+    @Test
+    fun `correctly processes redirect visit flags`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+                geckoSessionProvider = geckoSessionProvider,
+                context = testMainScope.coroutineContext)
+        val historyTrackingDelegate: HistoryTrackingDelegate = mock()
+
+        captureDelegates()
+
+        engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
+        `when`(historyTrackingDelegate.shouldStoreUri(any())).thenReturn(true)
+
+        historyDelegate.value.onVisited(
+            geckoSession,
+            "https://www.mozilla.com/tempredirect",
+            null,
+            // bitwise 'or'
+            GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                    or GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))
+        }
+
+        historyDelegate.value.onVisited(
+            geckoSession,
+            "https://www.mozilla.com/permredirect",
+            null,
+            GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                    or GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))
+        }
+
+        // Visits below are targets of redirects, not redirects themselves.
+        // Check that they're mapped to "link".
+        historyDelegate.value.onVisited(
+                geckoSession,
+                "https://www.mozilla.com/targettemp",
+                null,
+                GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(VisitType.LINK))
+        }
+
+        historyDelegate.value.onVisited(
+                geckoSession,
+                "https://www.mozilla.com/targetperm",
+                null,
+                GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+        )
+
+        runBlocking(testMainScope.coroutineContext) {
+            engineSession.job.children.forEach { it.join() }
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(VisitType.LINK))
         }
     }
 
@@ -625,7 +726,7 @@ class GeckoEngineSessionTest {
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
         runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate, never()).onVisited(anyString(), anyBoolean())
+            verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
         }
     }
 

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -129,6 +129,13 @@ class SystemEngineView @JvmOverloads constructor(
         override fun doUpdateVisitedHistory(view: WebView, url: String, isReload: Boolean) {
             // TODO private browsing not supported for SystemEngine
             // https://github.com/mozilla-mobile/android-components/issues/649
+            // Check if the delegate wants this type of url.
+            val delegate = session?.settings?.historyTrackingDelegate ?: return
+
+            if (!delegate.shouldStoreUri(url)) {
+                return
+            }
+
             runBlocking {
                 session?.settings?.historyTrackingDelegate?.onVisited(url, isReload)
             }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -48,6 +48,7 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.utils.DownloadUtils
 import java.util.Date
 
@@ -136,8 +137,13 @@ class SystemEngineView @JvmOverloads constructor(
                 return
             }
 
+            val visitType = when (isReload) {
+                true -> VisitType.RELOAD
+                false -> VisitType.LINK
+            }
+
             runBlocking {
-                session?.settings?.historyTrackingDelegate?.onVisited(url, isReload)
+                session?.settings?.historyTrackingDelegate?.onVisited(url, visitType)
             }
         }
 

--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     // consumer to have to manually import "base".
     api project(':support-base')
     api project(':browser-errorpages')
+    api project(':concept-storage')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
@@ -31,4 +31,10 @@ interface HistoryTrackingDelegate {
      * An engine needs to know a list of all visited URIs.
      */
     suspend fun getVisited(): List<String>
+
+    /**
+     * Allows an engine to check if this URI is going to be accepted by the delegate.
+     * This helps avoid unnecessary coroutine overhead for URIs which won't be accepted.
+     */
+    fun shouldStoreUri(uri: String): Boolean
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.concept.engine.history
 
+import mozilla.components.concept.storage.VisitType
+
 /**
  * An interface used for providing history information to an engine (e.g. for link highlighting),
  * and receiving history updates from the engine (visits to URLs, title changes).
@@ -15,7 +17,7 @@ interface HistoryTrackingDelegate {
     /**
      * A URI visit happened that an engine considers worthy of being recorded in browser's history.
      */
-    suspend fun onVisited(uri: String, isReload: Boolean = false)
+    suspend fun onVisited(uri: String, type: VisitType)
 
     /**
      * Title changed for a given URI.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
@@ -14,15 +14,11 @@ import mozilla.components.concept.storage.VisitType
  * Implementation of the [HistoryTrackingDelegate] which delegates work to an instance of [HistoryStorage].
  */
 class HistoryDelegate(private val historyStorage: HistoryStorage) : HistoryTrackingDelegate {
-    override suspend fun onVisited(uri: String, isReload: Boolean) {
+    override suspend fun onVisited(uri: String, type: VisitType) {
         // While we expect engine implementations to check URIs against `shouldStoreUri`, we don't
         // depend on them to actually do this check.
-        val visitType = when (isReload) {
-            true -> VisitType.RELOAD
-            false -> VisitType.LINK
-        }
         if (shouldStoreUri(uri)) {
-            historyStorage.recordVisit(uri, visitType)
+            historyStorage.recordVisit(uri, type)
         }
     }
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.session
 
+import android.net.Uri
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.PageObservation
@@ -14,15 +15,22 @@ import mozilla.components.concept.storage.VisitType
  */
 class HistoryDelegate(private val historyStorage: HistoryStorage) : HistoryTrackingDelegate {
     override suspend fun onVisited(uri: String, isReload: Boolean) {
+        // While we expect engine implementations to check URIs against `shouldStoreUri`, we don't
+        // depend on them to actually do this check.
         val visitType = when (isReload) {
             true -> VisitType.RELOAD
             false -> VisitType.LINK
         }
-        historyStorage.recordVisit(uri, visitType)
+        if (shouldStoreUri(uri)) {
+            historyStorage.recordVisit(uri, visitType)
+        }
     }
 
     override suspend fun onTitleChanged(uri: String, title: String) {
-        historyStorage.recordObservation(uri, PageObservation(title = title))
+        // Ignore title changes for URIs which we're ignoring.
+        if (shouldStoreUri(uri)) {
+            historyStorage.recordObservation(uri, PageObservation(title = title))
+        }
     }
 
     override suspend fun getVisited(uris: List<String>): List<Boolean> {
@@ -31,5 +39,34 @@ class HistoryDelegate(private val historyStorage: HistoryStorage) : HistoryTrack
 
     override suspend fun getVisited(): List<String> {
         return historyStorage.getVisited()
+    }
+
+    /**
+     * Filter out unwanted URIs, such as "chrome:", "about:", etc.
+     * Ported from nsAndroidHistory::CanAddURI
+     * See https://dxr.mozilla.org/mozilla-central/source/mobile/android/components/build/nsAndroidHistory.cpp#326
+     */
+    @SuppressWarnings("ReturnCount")
+    override fun shouldStoreUri(uri: String): Boolean {
+        val parsedUri = Uri.parse(uri)
+        val scheme = parsedUri.scheme ?: return false
+
+        // Short-circuit most common schemes.
+        if (scheme == "http" || scheme == "https") {
+            return true
+        }
+
+        // Allow about about:reader uris. They are of the form:
+        // about:reader?url=http://some.interesting.page/to/read.html
+        if (uri.startsWith("about:reader")) {
+            return true
+        }
+
+        val schemasToIgnore = listOf(
+            "about", "imap", "news", "mailbox", "moz-anno", "moz-extension",
+            "view-source", "chrome", "resource", "data", "javascript", "blob"
+        )
+
+        return !schemasToIgnore.contains(scheme)
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -32,11 +32,14 @@ class HistoryDelegateTest {
         delegate.onVisited("about:blank", VisitType.TYPED)
         verify(storage, never()).recordVisit("about:blank", VisitType.TYPED)
 
-        delegate.onVisited("http://www.mozilla.org", false)
+        delegate.onVisited("http://www.mozilla.org", VisitType.LINK)
         verify(storage).recordVisit("http://www.mozilla.org", VisitType.LINK)
 
-        delegate.onVisited("http://www.firefox.com", true)
+        delegate.onVisited("http://www.firefox.com", VisitType.RELOAD)
         verify(storage).recordVisit("http://www.firefox.com", VisitType.RELOAD)
+
+        delegate.onVisited("http://www.firefox.com", VisitType.BOOKMARK)
+        verify(storage).recordVisit("http://www.firefox.com", VisitType.BOOKMARK)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,6 +48,7 @@ permalink: /changelog/
   * Add boolean `allowAutoplayMedia` setting.
   * ⚠️ **This is a breaking API change:**
   * Added new method to `HistoryTrackingDelegate` interface: `shouldStoreUri(uri: String): Boolean`.
+  * `VisitType` is now part of `HistoryTrackingDelegate`'s `onVisited` method signature
 
 * **feature-session**
   * `HistoryDelegate` now implements a blacklist of URI schemas.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,11 @@ permalink: /changelog/
 
 * **concept-engine**
   * Add boolean `allowAutoplayMedia` setting.
+  * ⚠️ **This is a breaking API change:**
+  * Added new method to `HistoryTrackingDelegate` interface: `shouldStoreUri(uri: String): Boolean`.
+
+* **feature-session**
+  * `HistoryDelegate` now implements a blacklist of URI schemas.
 
 * **browser-engine-gecko-nightly**
   * Implement `allowAutoplayMedia` in terms of `autoplayDefault`.


### PR DESCRIPTION
Changes:
- added a scheme blacklist to HistoryDelegate
- added `VisitType` to `HistoryTrackingDelegate`'d public API, forcing consumers to generate a visit type
- mapped available GV flags to our internal visit types. Same for SystemEngine.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
