### PR TITLE
glean: 1547967: Support additional ping metadata

### DIFF
--- a/components/service/glean/docs/metrics/adding-new-metrics.md
+++ b/components/service/glean/docs/metrics/adding-new-metrics.md
@@ -31,11 +31,11 @@ toolbar:
     description: |
       Event to record toolbar clicks.
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     bugs:
       - 123456789
     data_reviews:
-      - http://test-only.com/path/to/data-review
+      - http://example.com/path/to/data-review
     expires:
       - 2019-06-01  # <-- Update to a date in the future
     

--- a/components/service/glean/docs/pings/custom.md
+++ b/components/service/glean/docs/pings/custom.md
@@ -10,9 +10,13 @@ directory alongside your app's `metrics.yaml` file.
 
 Each ping has the following parameters:
 
-- `description` (required): A human-readable description of the ping.
 - `include_client_id` (required): A boolean indicating whether to include the
   `client_id` in the [`client_info` section](pings.md#The-client_info-section)).
+
+In addition to these parameters, pings also support the parameters related to
+data review and expiration defined in [common metric
+parameters](../metrics/adding-new-metrics.md#common-metric-parameters):
+`description`, `notification_emails`, `bugs`, and `data_reviews`.
 
 For example, to define a custom ping called `search` specifically for search
 information:
@@ -25,6 +29,12 @@ search:
   description: >
     A ping to record search data.
   include_client_id: false
+  notification_emails:
+    - CHANGE-ME@example.com
+  bugs:
+    - 123456789
+  data_reviews:
+    - http://example.com/path/to/data-review
 ```
 
 ## Loading custom ping metadata into your application or library

--- a/components/service/glean/pings.yaml
+++ b/components/service/glean/pings.yaml
@@ -16,6 +16,12 @@ baseline:
     The `baseline` ping is automatically sent when the application is moved to
     the background.
   include_client_id: true
+  bugs:
+    - 1512938
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+  notification_emails:
+    - telemetry-client-dev@mozilla.com
 
 metrics:
   description: >
@@ -28,10 +34,21 @@ metrics:
     at 4AM. Data in the `ping_info` section of the ping can be used to infer the
     length of this window.
   include_client_id: true
-
+  bugs:
+    - 1512938
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+  notification_emails:
+    - telemetry-client-dev@mozilla.com
 events:
   description: >
     The events ping's purpose is to transport all of the event metric information.
     The `events` ping is automatically sent when the application is moved to
     the background.
   include_client_id: true
+  bugs:
+    - 1512938
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+  notification_emails:
+    - telemetry-client-dev@mozilla.com

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -20,7 +20,7 @@ import groovy.json.JsonOutput
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "0.25.0"
+String GLEAN_PARSER_VERSION = "0.27.1"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/samples/glean/metrics.yaml
+++ b/samples/glean/metrics.yaml
@@ -18,7 +18,7 @@ browser.engagement:
     data_reviews:
       - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     extra_keys:
       key1:
         description: "This is key one"
@@ -35,7 +35,7 @@ browser.engagement:
     data_reviews:
       - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
 basic:
@@ -48,7 +48,7 @@ basic:
     data_reviews:
       - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
 test:
@@ -64,7 +64,7 @@ test:
     data_reviews:
       - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
   test_counter:
@@ -79,7 +79,7 @@ test:
     data_reviews:
       - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
   test_timespan:
@@ -93,7 +93,7 @@ test:
     data_reviews:
       - N/A 
     notification_emails:
-      - CHANGE-ME@test-only.com
+      - CHANGE-ME@example.com
     expires: 2100-01-01
 
 custom:

--- a/samples/glean/pings.yaml
+++ b/samples/glean/pings.yaml
@@ -12,3 +12,9 @@ sample:
   description: |
     A sample custom ping.
   include_client_id: true
+  bugs:
+    - 123456789
+  data_reviews:
+    - N/A
+  notification_emails:
+    - CHANGE-ME@example.com


### PR DESCRIPTION
This PR won't work until https://github.com/mozilla/glean_parser/pull/61 is merged.

This adds the additional ping metadata to the built-in pings.  It also implements the `disabled` parameter for pings.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
