### PR TITLE
Using DialogFragment for site permissions prompts

### DIFF
--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragment.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragment.kt
@@ -1,0 +1,141 @@
+package mozilla.components.feature.sitepermissions
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.graphics.Color
+import android.os.Bundle
+import android.support.v4.graphics.ColorUtils
+import android.support.v7.app.AlertDialog
+import android.support.v7.app.AppCompatDialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.View.VISIBLE
+
+import android.widget.CheckBox
+import android.view.WindowManager.LayoutParams.*
+import android.widget.ImageView
+import android.widget.TextView
+
+internal const val KEY_SESSION_ID = "KEY_SESSION_ID"
+internal const val KEY_TITLE = "KEY_TITLE"
+
+private const val KEY_USER_CHECK_BOX = "KEY_USER_CHECK_BOX"
+private const val KEY_DIALOG_GRAVITY = "KEY_DIALOG_GRAVITY"
+private const val KEY_DIALOG_WIDTH_MATCH_PARENT = "KEY_DIALOG_WIDTH_MATCH_PARENT"
+private const val KEY_TITLE_ICON = "KEY_TITLE_ICON"
+private const val KEY_SHOULD_INCLUDE_CHECKBOX= "KEY_SHOULD_INCLUDE_CHECKBOX"
+private const val DIALOG_GRAVITY_NONE = -1
+
+class SitePermissionsDialogFragment : AppCompatDialogFragment() {
+
+    internal val feature: SitePermissionsFeature? = null
+
+    internal val sessionId: String by lazy { safeArguments.getString(KEY_SESSION_ID) }
+
+    internal val title: String by lazy { safeArguments.getString(KEY_TITLE) }
+
+    internal val dialogGravity: Int by lazy { safeArguments.getInt(KEY_DIALOG_GRAVITY, DIALOG_GRAVITY_NONE) }
+
+    internal val dialogShouldWidthMatchParent: Boolean by lazy { safeArguments.getBoolean(KEY_DIALOG_WIDTH_MATCH_PARENT) }
+
+    internal val shouldIncludeCheckBox: Boolean by lazy { safeArguments.getBoolean(KEY_SHOULD_INCLUDE_CHECKBOX) }
+
+    val safeArguments get() = requireNotNull(arguments)
+
+    internal val icon: Int by lazy { safeArguments.getInt(KEY_TITLE_ICON, DIALOG_GRAVITY_NONE) }
+
+    internal var userSelectionNoMoreDialogs: Boolean
+        get() = safeArguments.getBoolean(KEY_USER_CHECK_BOX)
+        set(value) {
+            safeArguments.putBoolean(KEY_USER_CHECK_BOX, value)
+        }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = if (dialogGravity != DIALOG_GRAVITY_NONE) {
+            AlertDialog.Builder(requireContext(), R.style.Mozac_SitePermissions_dialog)
+        } else {
+            AlertDialog.Builder(requireContext())
+        }
+
+        val rootView = LayoutInflater.from(context).inflate(
+            R.layout.mozac_site_permissions_prompt,
+            null,
+            false)
+
+        rootView.findViewById<TextView>(R.id.title).text = title
+        rootView.findViewById<ImageView>(R.id.icon).setImageResource(icon)
+
+        builder.setView(rootView)
+
+        builder.setCancelable(true)
+            .setPositiveButton(R.string.mozac_feature_sitepermissions_allow) { _, _ ->
+                //feature?.onContentPermissionGranted()
+            }
+            .setNegativeButton(R.string.mozac_feature_sitepermissions_not_allow){  _, _ ->
+                //feature?.onContentPermissionDeny()
+            }
+
+        if (shouldIncludeCheckBox){
+            addCheckbox(rootView)
+        }
+
+        val dialog = builder.create()
+        applyDialogStyles(dialog)
+        return dialog
+    }
+
+    private fun applyDialogStyles(dialog: Dialog) {
+        if (dialogGravity != DIALOG_GRAVITY_NONE) {
+            dialog.window?.setGravity(dialogGravity)
+            dialog.window?.addFlags(FLAG_DIM_BEHIND)
+            dialog.window?.setDimAmount(0.7f)
+
+            activity?.window?.navigationBarColor?.apply {
+                dialog.window?.navigationBarColor = ColorUtils.blendARGB(this, Color.BLACK, 0.5f)
+            }
+        }
+
+        if (dialogShouldWidthMatchParent) {
+            dialog.window?.setLayout(MATCH_PARENT, WRAP_CONTENT)
+        }
+    }
+
+    @SuppressLint("InflateParams")
+    private fun addCheckbox(containerView: View) {
+
+       val checkBox =  containerView.findViewById<CheckBox>(R.id.do_not_ask_again)
+        checkBox.visibility = VISIBLE
+        checkBox.setOnCheckedChangeListener { _, isChecked ->
+            userSelectionNoMoreDialogs = isChecked
+        }
+    }
+
+    companion object {
+        fun newInstance(
+            sessionId: String,
+            title: String,
+            titleIcon: Int,
+            feature: SitePermissionsFeature,
+            shouldIncludeCheckBox: Boolean
+        ): SitePermissionsDialogFragment {
+
+            val fragment = SitePermissionsDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putString(KEY_SESSION_ID, sessionId)
+                putString(KEY_TITLE, title)
+                putInt(KEY_TITLE_ICON, titleIcon)
+                putBoolean(KEY_SHOULD_INCLUDE_CHECKBOX, shouldIncludeCheckBox)
+
+                feature.promptsStyling?.apply {
+                    putInt(KEY_DIALOG_GRAVITY, gravity)
+                    putBoolean(KEY_DIALOG_WIDTH_MATCH_PARENT, shouldWithMatchParent)
+                }
+            }
+
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+}

--- a/components/feature/sitepermissions/src/main/res/layout/mozac_site_permissions_prompt.xml
+++ b/components/feature/sitepermissions/src/main/res/layout/mozac_site_permissions_prompt.xml
@@ -1,0 +1,48 @@
+<RelativeLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+    <ImageView
+            android:id="@+id/icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginStart="16dp"
+            android:scaleType="center"
+            tools:src="@android:drawable/ic_menu_camera"
+            android:importantForAccessibility="no"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="16dp"
+            android:tint="?android:attr/textColorPrimary"
+            tools:tint="#000000"/>
+
+    <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginStart="8dp"
+            tools:textColor="#000000"
+            android:textSize="18sp"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="16dp"
+            android:layout_toEndOf="@id/icon"
+            tools:text="Allow wikipedia.org to use your camera?"/>
+
+
+    <CheckBox
+            android:id="@+id/do_not_ask_again"
+            android:layout_marginTop="16dp"
+            android:layout_below="@id/title"
+            android:layout_alignStart="@id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:visibility="gone"
+            tools:visibility="visible"
+            android:text="@string/mozac_feature_sitepermissions_do_not_ask_again_on_this_site2"
+            android:checked="true"/>
+
+</RelativeLayout>

--- a/components/feature/sitepermissions/src/main/res/values/style.xml
+++ b/components/feature/sitepermissions/src/main/res/values/style.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <style name="Mozac.SitePermissions.dialog" parent="">
+        <item name="android:windowIsFloating">false</item>
+    </style>
+</resources>

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -129,7 +129,8 @@ class BrowserFragment : Fragment(), BackHandler {
         sitePermissionsFeature.set(
             feature = SitePermissionsFeature(
                 anchorView = layout.toolbar,
-                sessionManager = components.sessionManager
+                sessionManager = components.sessionManager,
+                fragmentManager = requireFragmentManager()
             ) { permissions ->
                 requestPermissions(permissions, REQUEST_CODE_APP_PERMISSIONS)
             },


### PR DESCRIPTION
@pocmo I was doing some tests using `DialogFragment` instead of `DoorhangerPrompt`. I want hear what do you think about this implementation before switching completely.

One use case that we need to support is changing the site permissions prompts position. If we are in normal browsing is should be at the bottom covering the toolbar and for custom tab should be at the top.

![image](https://user-images.githubusercontent.com/773158/57080676-003d0e00-6cc1-11e9-97ee-6c481c685ac1.png)

[An example of switching prompts position between normal browsing and custom tabs](https://drive.google.com/file/d/1Rnq4rsL6REES26tyUfHH1XoOP-mqQavd/view?usp=sharing)

Some advantages of `DialogFragment` as it a `Fragment` is can survive configuration changes.

I didn't change the internal implementation of `DoorhangerPrompt` to use `DialogFragment`:

* I don't know if we want to use it as is now for other purposes.
* For Site permissions goal creating a custom`DialogFragment` is just fine, I think. It seems over-killing to convert `DoorhangerPrompt` to a `DialogFragment` and support restoring all the dynamic `controlGroups` and `buttons` in case the Fragment is destroyed by the system.



 
