### PR TITLE
Issue #2624: Reader view controls should hide when back button pressed

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -111,7 +111,11 @@ class ReaderViewFeature(
     override fun onBackPressed(): Boolean {
         activeSession?.let {
             if (it.readerMode) {
-                hideReaderView()
+                if (controlsPresenter.areControlsVisible()) {
+                    hideControls()
+                } else {
+                    hideReaderView()
+                }
                 return true
             }
         }

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenter.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenter.kt
@@ -8,6 +8,7 @@ package mozilla.components.feature.readerview.internal
 
 import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
+import mozilla.components.support.ktx.android.view.isVisible
 
 /**
  * Presenter implementation that will update the view whenever the feature is started.
@@ -26,6 +27,13 @@ internal class ReaderViewControlsPresenter(
             setFontSize(config.fontSize)
             showControls()
         }
+    }
+
+    /**
+     * Checks whether or not the ReaderView controls are visible.
+     */
+    fun areControlsVisible(): Boolean {
+        return view.asView().isVisible()
     }
 
     /**

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.readerview
 
 import android.content.Context
+import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -400,6 +401,35 @@ class ReaderViewFeatureTest {
         readerViewFeature.updateReaderViewState(selectedSession)
         verify(readerViewFeature).checkReaderable(eq(selectedSession))
         verify(readerViewFeature).showReaderView(eq(selectedSession))
+    }
+
+    @Test
+    fun `on back pressed closes controls then reader view`() {
+        val engine: Engine = mock()
+        val session: Session = mock()
+        val sessionManager: SessionManager = mock()
+        `when`(sessionManager.selectedSession).thenReturn(session)
+
+        val controlsView: ReaderViewControlsView = mock()
+        val view: View = mock()
+        `when`(controlsView.asView()).thenReturn(view)
+
+        val readerViewFeature = spy(ReaderViewFeature(context, engine, sessionManager, controlsView))
+        assertFalse(readerViewFeature.onBackPressed())
+
+        readerViewFeature.observeSelected()
+        assertFalse(readerViewFeature.onBackPressed())
+
+        `when`(session.readerMode).thenReturn(true)
+        `when`(view.visibility).thenReturn(View.VISIBLE)
+        assertTrue(readerViewFeature.onBackPressed())
+        verify(readerViewFeature, never()).hideReaderView()
+        verify(readerViewFeature, times(1)).hideControls()
+
+        `when`(view.visibility).thenReturn(View.GONE)
+        assertTrue(readerViewFeature.onBackPressed())
+        verify(readerViewFeature, times(1)).hideReaderView()
+        verify(readerViewFeature, times(1)).hideControls()
     }
 
     private fun prepareFeatureForTest(port: Port, session: Session = mock()): ReaderViewFeature {

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenterTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenterTest.kt
@@ -6,10 +6,13 @@
 
 package mozilla.components.feature.readerview.internal
 
+import android.view.View
 import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
@@ -31,6 +34,20 @@ class ReaderViewControlsPresenterTest {
         verify(view).setFontSize(5)
         verify(view).setFont(any())
         verify(view).showControls()
+    }
+
+    @Test
+    fun `are controls visible`() {
+        val controlsView: ReaderViewControlsView = mock()
+        val view: View = mock()
+        `when`(controlsView.asView()).thenReturn(view)
+        val presenter = ReaderViewControlsPresenter(controlsView, mock())
+
+        `when`(view.visibility).thenReturn(View.GONE)
+        assertFalse(presenter.areControlsVisible())
+
+        `when`(view.visibility).thenReturn(View.VISIBLE)
+        assertTrue(presenter.areControlsVisible())
     }
 
     @Test

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
@@ -78,7 +78,6 @@ class ReaderViewIntegration(
     }
 
     override fun onBackPressed(): Boolean {
-        readerViewButton.setSelected(false)
         return feature.onBackPressed()
     }
 }


### PR DESCRIPTION
This also removes a left-over (unneeded) call to `readerViewButton.setSelected` in our sample browser integration back handler. 