### PR TITLE
Increase the timeout for Glean events in tests

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -7,7 +7,6 @@ package mozilla.components.service.glean.storages
 import mozilla.components.service.glean.Glean
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.Dispatchers as KotlinDispatchers
 import kotlinx.coroutines.GlobalScope
@@ -60,11 +59,6 @@ internal object EventsStorageEngine : StorageEngine {
         dir
     }
 
-    // The timestamp of recorded events is computed relative to this point in time
-    // which should roughly match with the process start time. Note that, according
-    // to the docs, the used clock is guaranteed to be monotonic.
-    private val startTime: Long = SystemClock.elapsedRealtime()
-
     // Maximum length of any string value in the extra dictionary, in characters
     internal const val MAX_LENGTH_EXTRA_KEY_VALUE = 100
 
@@ -78,7 +72,7 @@ internal object EventsStorageEngine : StorageEngine {
 
     // Timeout for waiting on async IO (during testing only)
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal const val JOB_TIMEOUT_MS = 250L
+    internal const val JOB_TIMEOUT_MS = 5000L
 
     // A lock to prevent simultaneous writing of the event files
     private val eventFileLock = Any()
@@ -210,7 +204,7 @@ internal object EventsStorageEngine : StorageEngine {
         // Rewrite all of the timestamps to they are relative to the first
         // timestamp
         val events = eventStores[storeName]?.let { store ->
-            var firstTimestamp = store[0].timestamp
+            val firstTimestamp = store[0].timestamp
             store.map { event ->
                 event.copy(timestamp = event.timestamp - firstTimestamp)
             }


### PR DESCRIPTION
This increases the test timeout for I/O from 250ms to 5seconds, to make it on par with the other
timeouts used in our test suite. This additionally fixes 2 linter errors by removing vestigial code.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
