### PR TITLE
Closes #2827: Expose suspendMediaWhenInactive in Settings

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -166,6 +166,10 @@ class GeckoEngine(
                     GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
                 }
             }
+
+        override var suspendMediaWhenInactive: Boolean
+            get() = defaultSettings?.suspendMediaWhenInactive ?: false
+            set(value) { defaultSettings?.suspendMediaWhenInactive = value }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled
@@ -178,6 +182,7 @@ class GeckoEngine(
             this.userAgentString = it.userAgentString
             this.preferredColorScheme = it.preferredColorScheme
             this.allowAutoplayMedia = it.allowAutoplayMedia
+            this.suspendMediaWhenInactive = it.suspendMediaWhenInactive
         }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -69,6 +69,9 @@ class GeckoEngineSession(
         override var userAgentString: String?
             get() = geckoSession.settings.userAgentOverride
             set(value) { geckoSession.settings.userAgentOverride = value }
+        override var suspendMediaWhenInactive: Boolean
+            get() = geckoSession.settings.suspendMediaWhenInactive
+            set(value) { geckoSession.settings.suspendMediaWhenInactive = value }
     }
 
     private var initialLoad = true
@@ -604,12 +607,9 @@ class GeckoEngineSession(
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
         defaultSettings?.historyTrackingDelegate?.let { settings.historyTrackingDelegate = it }
-        defaultSettings?.testingModeEnabled?.let {
-            geckoSession.settings.fullAccessibilityTree = it
-        }
-        defaultSettings?.userAgentString?.let {
-            geckoSession.settings.userAgentOverride = it
-        }
+        defaultSettings?.testingModeEnabled?.let { geckoSession.settings.fullAccessibilityTree = it }
+        defaultSettings?.userAgentString?.let { geckoSession.settings.userAgentOverride = it }
+        defaultSettings?.suspendMediaWhenInactive?.let { geckoSession.settings.suspendMediaWhenInactive = it }
 
         geckoSession.open(runtime)
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -911,6 +911,40 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun settingSuspendMediaWhenInactive() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        var engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
+        verify(geckoSession.settings, never()).suspendMediaWhenInactive = anyBoolean()
+
+        assertFalse(engineSession.settings.suspendMediaWhenInactive)
+        verify(geckoSession.settings).suspendMediaWhenInactive
+
+        engineSession.settings.suspendMediaWhenInactive = true
+        verify(geckoSession.settings).suspendMediaWhenInactive = true
+    }
+
+    @Test
+    fun settingSuspendMediaWhenInactiveDefault() {
+        val runtime = mock(GeckoRuntime::class.java)
+        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+
+        GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
+        verify(geckoSession.settings, never()).suspendMediaWhenInactive = anyBoolean()
+
+        GeckoEngineSession(runtime,
+            geckoSessionProvider = geckoSessionProvider,
+            defaultSettings = DefaultSettings())
+        verify(geckoSession.settings).suspendMediaWhenInactive = false
+
+        GeckoEngineSession(runtime,
+            geckoSessionProvider = geckoSessionProvider,
+            defaultSettings = DefaultSettings(suspendMediaWhenInactive = true))
+        verify(geckoSession.settings).suspendMediaWhenInactive = true
+    }
+
+    @Test
     fun unsupportedSettings() {
         val settings = GeckoEngineSession(mock(GeckoRuntime::class.java),
                 geckoSessionProvider = geckoSessionProvider).settings

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -102,6 +102,10 @@ class GeckoEngineTest {
         engine.settings.allowAutoplayMedia = false
         verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
 
+        assertFalse(engine.settings.suspendMediaWhenInactive)
+        engine.settings.suspendMediaWhenInactive = true
+        assertEquals(true, engine.settings.suspendMediaWhenInactive)
+
         // Specifying no ua-string default should result in GeckoView's default.
         assertEquals(GeckoSession.getDefaultUserAgent(), engine.settings.userAgentString)
         // It also should be possible to read and set a new default.
@@ -153,7 +157,8 @@ class GeckoEngineTest {
                 testingModeEnabled = true,
                 userAgentString = "test-ua",
                 preferredColorScheme = PreferredColorScheme.Light,
-                allowAutoplayMedia = false
+                allowAutoplayMedia = false,
+                suspendMediaWhenInactive = true
             ), runtime)
 
         verify(runtimeSettings).javaScriptEnabled = false
@@ -175,6 +180,7 @@ class GeckoEngineTest {
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
         assertFalse(engine.settings.allowAutoplayMedia)
+        assertTrue(engine.settings.suspendMediaWhenInactive)
     }
 
     @Test

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -141,6 +141,11 @@ abstract class Settings {
      * Setting to control whether media is allowed to auto-play on page load.
      */
     open var allowAutoplayMedia: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether media should be suspended when the session is inactive.
+     */
+    open var suspendMediaWhenInactive: Boolean by UnsupportedSetting()
 }
 
 /**
@@ -170,7 +175,8 @@ data class DefaultSettings(
     override var supportMultipleWindows: Boolean = false,
     override var preferredColorScheme: PreferredColorScheme = PreferredColorScheme.System,
     override var testingModeEnabled: Boolean = false,
-    override var allowAutoplayMedia: Boolean = true
+    override var allowAutoplayMedia: Boolean = true,
+    override var suspendMediaWhenInactive: Boolean = false
 ) : Settings()
 
 class UnsupportedSetting<T> {

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -70,7 +70,9 @@ class SettingsTest {
             { settings.testingModeEnabled },
             { settings.testingModeEnabled = false },
             { settings.allowAutoplayMedia },
-            { settings.allowAutoplayMedia = false }
+            { settings.allowAutoplayMedia = false },
+            { settings.suspendMediaWhenInactive },
+            { settings.suspendMediaWhenInactive = false }
         )
     }
 
@@ -106,6 +108,7 @@ class SettingsTest {
         assertEquals(PreferredColorScheme.System, settings.preferredColorScheme)
         assertFalse(settings.testingModeEnabled)
         assertTrue(settings.allowAutoplayMedia)
+        assertFalse(settings.suspendMediaWhenInactive)
 
         val interceptor: RequestInterceptor = mock()
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
@@ -134,7 +137,8 @@ class SettingsTest {
             supportMultipleWindows = true,
             preferredColorScheme = PreferredColorScheme.Dark,
             testingModeEnabled = true,
-            allowAutoplayMedia = false)
+            allowAutoplayMedia = false,
+            suspendMediaWhenInactive = true)
 
         assertFalse(defaultSettings.domStorageEnabled)
         assertFalse(defaultSettings.javascriptEnabled)
@@ -160,5 +164,6 @@ class SettingsTest {
         assertEquals(PreferredColorScheme.Dark, defaultSettings.preferredColorScheme)
         assertTrue(defaultSettings.testingModeEnabled)
         assertFalse(defaultSettings.allowAutoplayMedia)
+        assertTrue(defaultSettings.suspendMediaWhenInactive)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,6 +72,16 @@ permalink: /changelog/
 * **browser-engine-system**
   * Added support for Authentication dialogs on SystemEngineView.
 
+* **concept-engine**, **browser-engine-gecko-nightly**
+  * Added `suspendMediaWhenInactive` setting to control whether media should be suspended when the session is inactive. The default is `false`.
+  ```kotlin
+  // To provide a default when creating the engine:
+  GeckoEngine(runtime, DefaultSettings(suspendMediaWhenInactive = true))
+
+  // To change the value for a specific session:
+  engineSession.settings.suspendMediaWhenInactive = true
+  ```  
+
 # 0.51.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.50.0...v0.51.0)


### PR DESCRIPTION
Defaults to `false`, same as GeckoView.