### PR TITLE
Closes #1974: Destroy FxA device record after logging out

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -23,7 +23,7 @@ object Versions {
     const val zxing = "3.3.0"
     const val jna = "5.2.0"
 
-    const val mozilla_appservices = "0.27.0"
+    const val mozilla_appservices = "0.27.1"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
@@ -27,6 +27,15 @@ interface DeviceConstellation : Observable<DeviceEventsObserver> {
     ): Deferred<Unit>
 
     /**
+     * Destroy current device record.
+     * Use this when device record is no longer relevant, e.g. while logging out. On success, other
+     * devices will no longer see the current device in their device lists.
+     *
+     * @return A boolean flag indicating if the operation succeeded.
+     */
+    fun destroyCurrentDeviceAsync(): Deferred<Boolean>
+
+    /**
      * Ensure that all initialized [DeviceCapability], such as [DeviceCapability.SEND_TAB], are configured.
      * This may involve backend service registration, or other work involving network/disc access.
      * @return A [Deferred] that will be resolved once operation is complete.

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Utils.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Utils.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fxa
+
+/**
+ * Runs a provided lambda, and if that throws non-panic FxA exception, runs the second lambda.
+ *
+ * @param block A lambda to execute which mail fail with an [FxaException].
+ * @param handleErrorBlock A lambda to execute if [block] fails with a non-panic [FxaException].
+ * @return object of type T, as defined by [block].
+ */
+fun <T> maybeExceptional(block: () -> T, handleErrorBlock: (e: FxaException) -> T): T {
+    return try {
+        block()
+    } catch (e: FxaException) {
+        when (e) {
+            is FxaPanicException -> {
+                throw e
+            }
+            else -> {
+                handleErrorBlock(e)
+            }
+        }
+    }
+}

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -319,6 +319,8 @@ open class FxaAccountManager(
             AccountState.NotAuthenticated -> {
                 when (via) {
                     Event.Logout -> {
+                        // Destroy the current device record.
+                        account.deviceConstellation().destroyCurrentDeviceAsync().await()
                         // Clean up resources.
                         profile = null
                         account.close()

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -386,12 +386,15 @@ class FxaAccountManagerTest {
         // Make sure 'logoutAsync' clears out state and fires correct observers.
         reset(accountObserver)
         reset(accountStorage)
+        `when`(constellation.destroyCurrentDeviceAsync()).thenReturn(CompletableDeferred(true))
+        verify(constellation, never()).destroyCurrentDeviceAsync()
         manager.logoutAsync().await()
 
         verify(accountObserver, never()).onError(any())
         verify(accountObserver, never()).onAuthenticated(any())
         verify(accountObserver, never()).onProfileUpdated(any())
         verify(accountObserver, times(1)).onLoggedOut()
+        verify(constellation, times(1)).destroyCurrentDeviceAsync()
 
         verify(accountStorage, never()).read()
         verify(accountStorage, never()).write(any())

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/UtilsKtTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/UtilsKtTest.kt
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.fxa
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class UtilsKtTest {
+    @Test
+    fun `maybeExceptional returns correct data back`() {
+        assertEquals(1, maybeExceptional({
+            1
+        }, {
+            fail()
+        }))
+
+        assertEquals("Hello", maybeExceptional({
+            "Hello"
+        }, {
+            fail()
+        }))
+    }
+
+    @Test
+    fun `maybeExceptional does not swallow non-panics`() {
+        // Network.
+        assertEquals("pass!", maybeExceptional({
+            throw FxaNetworkException("oops")
+        }, {
+            assertEquals("oops", it.message)
+            assertTrue(it is FxaNetworkException)
+            "pass!"
+        }))
+
+        assertEquals("pass!", maybeExceptional({
+            throw FxaUnauthorizedException("auth!")
+        }, {
+            assertEquals("auth!", it.message)
+            assertTrue(it is FxaUnauthorizedException)
+            "pass!"
+        }))
+
+        assertEquals("pass!", maybeExceptional({
+            throw FxaUnspecifiedException("dunno")
+        }, {
+            assertEquals("dunno", it.message)
+            assertTrue(it is FxaUnspecifiedException)
+            "pass!"
+        }))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `maybeExceptional re-throws non-fxa exceptions`() {
+        maybeExceptional({
+            throw IllegalStateException("bad state")
+        }, {
+            fail()
+        })
+    }
+
+    @Test(expected = FxaPanicException::class)
+    fun `maybeExceptional re-throws fxa panic exceptions`() {
+        maybeExceptional({
+            throw FxaPanicException("don't panic!")
+        }, {
+            fail()
+        })
+    }
+}


### PR DESCRIPTION
This destroys the FxA device record for the current device on logout.

Tests on the constellation manager are lacking because mockito really doesn't want to mock fxaclient/FirefoxAccount, it doesn't have an interface it implements, and even though we're able to use the real object + native stack in tests now (see https://github.com/mozilla-mobile/android-components/pull/2943), we can't do it in this case yet because tests involving the network aren't a supported use case.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
