### PR TITLE
Fixed issue on SitePermissionsFeature that doesn't allow its usage on custom tabs

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -224,21 +224,24 @@ fun SessionManager.runWithSession(
 }
 
 /**
- * Tries to find a session with the provided session ID or uses them selectedSession and runs the block if found.
+ * Tries to find a session with the provided session ID or uses the selected session and runs the block if found.
  *
  * @return True if the session was found and run successfully.
  */
-inline fun SessionManager.runWithSessionIdOrSelected(
+fun SessionManager.runWithSessionIdOrSelected(
     sessionId: String?,
-    block: SessionManager.(Session) -> Boolean
+    block: SessionManager.(Session) -> Unit
 ): Boolean {
+    var blockWasRun = false
     sessionId?.let {
         findSessionById(sessionId)?.let { session ->
-            return block(session)
+            block(session)
+            blockWasRun = true
         }
     }
     selectedSession?.let {
-        return block(it)
+        block(it)
+        blockWasRun = true
     }
-    return false
+    return blockWasRun
 }

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -222,3 +222,23 @@ fun SessionManager.runWithSession(
     }
     return false
 }
+
+/**
+ * Tries to find a session with the provided session ID or uses them selectedSession and runs the block if found.
+ *
+ * @return True if the session was found and run successfully.
+ */
+inline fun SessionManager.runWithSessionIdOrSelected(
+    sessionId: String?,
+    block: SessionManager.(Session) -> Boolean
+): Boolean {
+    sessionId?.let {
+        findSessionById(sessionId)?.let { session ->
+            return block(session)
+        }
+    }
+    selectedSession?.let {
+        return block(it)
+    }
+    return false
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -1144,7 +1144,7 @@ class SessionManagerTest {
 
         `when`(sessionManager.findSessionById(anyString())).thenReturn(mock())
 
-        val executed = sessionManager.runWithSessionIdOrSelected("123") { true }
+        val executed = sessionManager.runWithSessionIdOrSelected("123") { }
 
         assertTrue(executed)
     }
@@ -1153,11 +1153,11 @@ class SessionManagerTest {
     fun `SessionManager#runWithSessionIdOrSelected with null or empty session ID`() {
         val sessionManager = spy(SessionManager(mock()))
 
-        var executed = sessionManager.runWithSessionIdOrSelected(null) { true }
+        var executed = sessionManager.runWithSessionIdOrSelected(null) { }
 
         assertFalse(executed)
 
-        executed = sessionManager.runWithSessionIdOrSelected("") { true }
+        executed = sessionManager.runWithSessionIdOrSelected("") { }
         assertFalse(executed)
     }
 
@@ -1171,7 +1171,6 @@ class SessionManagerTest {
         var selectedSessionId = "123"
         val executed = sessionManager.runWithSessionIdOrSelected(null) { session ->
             selectedSessionId = session.id
-            true
         }
 
         assertTrue(executed)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -1137,4 +1137,44 @@ class SessionManagerTest {
 
         assertFalse(executed)
     }
+
+    @Test
+    fun `SessionManager#runWithSessionIdOrSelected executes the block when session found`() {
+        val sessionManager = spy(SessionManager(mock()))
+
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(mock())
+
+        val executed = sessionManager.runWithSessionIdOrSelected("123") { true }
+
+        assertTrue(executed)
+    }
+
+    @Test
+    fun `SessionManager#runWithSessionIdOrSelected with null or empty session ID`() {
+        val sessionManager = spy(SessionManager(mock()))
+
+        var executed = sessionManager.runWithSessionIdOrSelected(null) { true }
+
+        assertFalse(executed)
+
+        executed = sessionManager.runWithSessionIdOrSelected("") { true }
+        assertFalse(executed)
+    }
+
+    @Test
+    fun `SessionManager#runWithSessionIdOrSelected with null session will use the selected session`() {
+        val sessionManager = spy(SessionManager(mock()))
+        val selectedSession = Session("", id = "selectedSessionId")
+        sessionManager.add(selectedSession)
+        sessionManager.select(selectedSession)
+
+        var selectedSessionId = "123"
+        val executed = sessionManager.runWithSessionIdOrSelected(null) { session ->
+            selectedSessionId = session.id
+            true
+        }
+
+        assertTrue(executed)
+        assertTrue(selectedSessionId == "selectedSessionId")
+    }
 }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -21,6 +21,7 @@ import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.runWithSession
+import mozilla.components.browser.session.runWithSessionIdOrSelected
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.concept.engine.permission.Permission.ContentAudioCapture
 import mozilla.components.concept.engine.permission.Permission.ContentAudioMicrophone
@@ -99,8 +100,8 @@ class SitePermissionsFeature(
      * @see [onNeedToRequestPermissions].
      */
     fun onPermissionsResult(grantResults: IntArray) {
-        sessionManager.selectedSession?.apply {
-            appPermissionRequest.consume { permissionsRequest ->
+        sessionManager.runWithSessionIdOrSelected(sessionId) { session ->
+            session.appPermissionRequest.consume { permissionsRequest ->
 
                 val allPermissionWereGranted = grantResults.all { grantResult ->
                     grantResult == PackageManager.PERMISSION_GRANTED

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
@@ -652,6 +652,32 @@ class SitePermissionsFeatureTest {
     }
 
     @Test
+    fun `calling onPermissionsResult on a feature session with a sessionId will call grant on the permissionsRequest and consume it`() {
+        val session = Session("", id = "sessionIdCustomTabs")
+        sitePermissionFeature = SitePermissionsFeature(
+            context = context,
+            sessionId = "sessionIdCustomTabs",
+            sessionManager = mockSessionManager,
+            onNeedToRequestPermissions = mockOnNeedToRequestPermissions,
+            storage = mockStorage,
+            fragmentManager = mockFragmentManager
+        )
+
+        mockSessionManager.add(session)
+
+        val mockPermissionRequest: PermissionRequest = mock()
+
+        sitePermissionFeature.start()
+
+        session.appPermissionRequest = Consumable.from(mockPermissionRequest)
+
+        sitePermissionFeature.onPermissionsResult(intArrayOf(PERMISSION_GRANTED))
+
+        verify(mockPermissionRequest).grant(emptyList())
+        assertTrue(session.appPermissionRequest.isConsumed())
+    }
+
+    @Test
     fun `calling onPermissionsResult with NOT all permissions granted will call reject on the permissionsRequest and consume it`() {
         val session = getSelectedSession()
         val mockPermissionRequest: PermissionRequest = mock()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -136,6 +136,9 @@ permalink: /changelog/
   accountManager.registerForDeviceEvents(deviceEventsObserver, owner = this, autoPause = true)
   ```
 
+* **browser-session**
+  * Added `SessionManager.runWithSessionIdOrSelected(sessionId: String?)` run function block on a session ID. If the session does not exist, then uses the selected session.
+
 # 0.51.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.50.0...v0.51.0)


### PR DESCRIPTION
`SitePermissionsFeature` was using the selected session `onPermissionsResult`, instead of checking the custom session id. This didn't allow its usage on custom tabs. Related issue https://github.com/mozilla-mobile/fenix/issues/2343

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
