### PR TITLE
Change service-experiments tests to use a fake Kinto endpoint

### DIFF
--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentsTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentsTest.kt
@@ -73,7 +73,9 @@ class ExperimentsTest {
         // Initialize WorkManager (early) for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
-        configuration = Configuration()
+        // Setting the endpoint to a non-existent one to prevent actual experiments from being
+        // downloaded to tests.
+        configuration = Configuration(kintoEndpoint = "https://example.invalid")
         experiments = spy(ExperimentsInternalAPI())
         experiments.valuesProvider = valuesProvider
 
@@ -791,7 +793,9 @@ class ExperimentsTest {
         // order to get around this, we need to minimize the mocking of the updater to avoid the
         // error.
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
-        configuration = Configuration()
+        // Setting the endpoint to a non-existent one to prevent actual experiments from being
+        // downloaded to tests.
+        configuration = Configuration(kintoEndpoint = "https://example.invalid")
         experiments = spy(ExperimentsInternalAPI())
         experiments.valuesProvider = ValuesProvider()
 

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentsUpdaterTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentsUpdaterTest.kt
@@ -55,7 +55,9 @@ class ExperimentsUpdaterTest {
         // Initialize WorkManager (early) for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
-        configuration = Configuration()
+        // Setting the endpoint to a non-existent one to prevent actual experiments from being
+        // downloaded to tests.
+        configuration = Configuration(kintoEndpoint = "https://example.invalid")
         experiments = spy(ExperimentsInternalAPI())
         experiments.valuesProvider = valuesProvider
 


### PR DESCRIPTION
This is to prevent accidentally downloading experiments from the server and affecting test results.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
