### PR TITLE
Closes #2978 runWithSessionIdOrSelected incorrectly runs for provided AND selected session.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -232,16 +232,15 @@ fun SessionManager.runWithSessionIdOrSelected(
     sessionId: String?,
     block: SessionManager.(Session) -> Unit
 ): Boolean {
-    var blockWasRun = false
     sessionId?.let {
         findSessionById(sessionId)?.let { session ->
             block(session)
-            blockWasRun = true
+            return true
         }
     }
     selectedSession?.let {
         block(it)
-        blockWasRun = true
+        return true
     }
-    return blockWasRun
+    return false
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -1176,4 +1176,23 @@ class SessionManagerTest {
         assertTrue(executed)
         assertTrue(selectedSessionId == "selectedSessionId")
     }
+
+    @Test
+    fun `SessionManager#unWithSessionIdOrSelected should run for either provided or selected session, but not both`() {
+        val sessionManager = spy(SessionManager(mock()))
+        val anotherSession = Session("", id = "anotherSessionId")
+        val selectedSession = Session("", id = "selectedSessionId")
+
+        sessionManager.add(anotherSession)
+        sessionManager.add(selectedSession)
+        sessionManager.select(selectedSession)
+
+        var runSessionId = "123"
+        val executed = sessionManager.runWithSessionIdOrSelected("anotherSessionId") { session ->
+            runSessionId = session.id
+        }
+
+        assertTrue(executed)
+        assertTrue(runSessionId == "anotherSessionId")
+    }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
