### PR TITLE
(Documentation) Fix broken links to Photon Design System[ci-skip]

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -41,10 +41,10 @@ Components for Android apps - browsers and other apps.
 Independent, small visual UI elements to use in applications.
 
 * [ui-autocomplete](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/autocomplete) - A user interface element for entering and modifying text with the ability to inline autocomplete.
-* [ui-colors](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/colors) - The standard set of [colors](https://design.firefox.com/photon/visuals/color.html) used in the [Photon Design System](https://design.firefox.com/photon/welcome.html) for Firefox products.
+* [ui-colors](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/colors) - The standard set of [colors](https://design.firefox.com/photon/visuals/color.html) used in the [Photon Design System](https://design.firefox.com/photon/) for Firefox products.
 * [ui-fonts](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/fonts) - The standard set of fonts used by Mozilla Android products.
-* [ui-icons]({{ site.baseurl }}/components/ui/icons) - Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/welcome.html).
-* [ui-progress](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/progress) - An animated progress bar following the [Photon Design System](https://design.firefox.com/photon/welcome.html)..
+* [ui-icons]({{ site.baseurl }}/components/ui/icons) - Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/).
+* [ui-progress](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/progress) - An animated progress bar following the [Photon Design System](https://design.firefox.com/photon/)..
 * [ui-tabcounter](https://github.com/mozilla-mobile/android-components/tree/master/components/ui/tabcounter) - A button that shows the current tab count and can animate state changes.
 
 ### Services


### PR DESCRIPTION
Links to Photon Design System are broken because webpage [https://design.firefox.com/photon/welcome.html](https://design.firefox.com/photon/welcome.html) not exists.

Using [https://design.firefox.com/photon/](https://design.firefox.com/photon/) instead.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
