### PR TITLE
Update jacoco to 0.8.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
     afterEvaluate {
         if (it.hasProperty('android')) {
             jacoco {
-                toolVersion = "0.8.3"
+                toolVersion = "0.8.4"
             }
 
             // Format test output


### PR DESCRIPTION
Released today. Comes with at least one improvement for Kotlin code:

> Branches added by the Kotlin compiler version 1.3.30 for suspending lambdas and functions are filtered out during generation of report