### PR TITLE
For #2988. Added configuration for "Remember choice" checkbox in Permissions dialog

### DIFF
--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragment.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragment.kt
@@ -21,7 +21,6 @@ import android.widget.Button
 import android.widget.LinearLayout.LayoutParams
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.content.ContextCompat
-import kotlin.properties.Delegates
 
 internal const val KEY_SESSION_ID = "KEY_SESSION_ID"
 internal const val KEY_TITLE = "KEY_TITLE"
@@ -69,7 +68,7 @@ internal class SitePermissionsDialogFragment : AppCompatDialogFragment() {
     // State
 
     internal var feature: SitePermissionsFeature? = null
-    internal var userSelectionCheckBox: Boolean by Delegates.notNull()
+    internal var userSelectionCheckBox: Boolean = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         userSelectionCheckBox = shouldPreselectDoNotAskAgainCheckBox

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -55,6 +55,7 @@ internal const val FRAGMENT_TAG = "mozac_feature_sitepermissions_prompt_dialog"
  * @property sitePermissionsRules indicates how permissions should behave per permission category.
  * @property fragmentManager a reference to a [FragmentManager], used to show permissions prompts.
  * @property promptsStyling optional styling for prompts.
+ * @property dialogConfig optional customization for dialog initial state. See [DialogConfig].
  * @property onNeedToRequestPermissions a callback invoked when permissions
  * need to be requested. Once the request is completed, [onPermissionsResult] needs to be invoked.
  **/
@@ -68,6 +69,7 @@ class SitePermissionsFeature(
     var sitePermissionsRules: SitePermissionsRules? = null,
     private val fragmentManager: FragmentManager,
     var promptsStyling: PromptsStyling? = null,
+    private val dialogConfig: DialogConfig? = null,
     private val onNeedToRequestPermissions: OnNeedToRequestPermissions
 ) : LifecycleAwareFeature {
 
@@ -344,7 +346,9 @@ class SitePermissionsFeature(
                 host,
                 R.string.mozac_feature_sitepermissions_camera_and_microphone,
                 R.drawable.mozac_ic_microphone,
-                showDoNotAskAgainCheckBox = true
+                showDoNotAskAgainCheckBox = true,
+                shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
+                    ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
             )
         }
     }
@@ -362,7 +366,9 @@ class SitePermissionsFeature(
                     host,
                     R.string.mozac_feature_sitepermissions_location_title,
                     R.drawable.mozac_ic_location,
-                    showDoNotAskAgainCheckBox = true
+                    showDoNotAskAgainCheckBox = true,
+                    shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
+                        ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
                 )
             }
             is ContentNotification -> {
@@ -373,6 +379,7 @@ class SitePermissionsFeature(
                     R.string.mozac_feature_sitepermissions_notification_title,
                     R.drawable.mozac_ic_notification,
                     showDoNotAskAgainCheckBox = false,
+                    shouldSelectRememberChoice = false,
                     isNotificationRequest = true
                 )
             }
@@ -383,7 +390,9 @@ class SitePermissionsFeature(
                     host,
                     R.string.mozac_feature_sitepermissions_microfone_title,
                     R.drawable.mozac_ic_microphone,
-                    showDoNotAskAgainCheckBox = true
+                    showDoNotAskAgainCheckBox = true,
+                    shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
+                        ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
                 )
             }
             is ContentVideoCamera, is ContentVideoCapture -> {
@@ -393,7 +402,9 @@ class SitePermissionsFeature(
                     host,
                     R.string.mozac_feature_sitepermissions_camera_title,
                     R.drawable.mozac_ic_video,
-                    showDoNotAskAgainCheckBox = true
+                    showDoNotAskAgainCheckBox = true,
+                    shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
+                        ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN
                 )
             }
             else ->
@@ -409,7 +420,8 @@ class SitePermissionsFeature(
         host: String,
         @StringRes titleId: Int,
         @DrawableRes iconId: Int,
-        showDoNotAskAgainCheckBox: Boolean = false,
+        showDoNotAskAgainCheckBox: Boolean,
+        shouldSelectRememberChoice: Boolean,
         isNotificationRequest: Boolean = false
     ): SitePermissionsDialogFragment {
         val title = context.getString(titleId, host)
@@ -420,7 +432,8 @@ class SitePermissionsFeature(
             iconId,
             this,
             showDoNotAskAgainCheckBox,
-            isNotificationRequest = isNotificationRequest
+            isNotificationRequest = isNotificationRequest,
+            shouldSelectDoNotAskAgainCheckBox = shouldSelectRememberChoice
         )
     }
 
@@ -472,6 +485,20 @@ class SitePermissionsFeature(
         @ColorRes
         val positiveButtonTextColor: Int? = null
     )
+
+    /**
+     * Customization options for feature request dialog
+     */
+    data class DialogConfig(
+        /** Use **true** to pre-select "Do not ask again" checkbox. */
+        val shouldPreselectDoNotAskAgain: Boolean = false
+    ) {
+
+        companion object {
+            /** Default values for [DialogConfig.shouldPreselectDoNotAskAgain] */
+            internal const val DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN = false
+        }
+    }
 
     /**
      * Re-attaches a fragment that is still visible but not linked to this feature anymore.

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
@@ -42,7 +42,7 @@ class SitePermissionsDialogFragmentTest {
                 "title",
                 R.drawable.notification_icon_background,
                 mock(),
-                true
+                shouldShowDoNotAskAgainCheckBox = true
             )
         )
 
@@ -52,18 +52,68 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertTrue(checkBox.isVisible())
+        assertTrue("Checkbox should be displayed", checkBox.isVisible())
+        assertFalse("Checkbox shouldn't be checked", checkBox.isChecked)
+        assertFalse("User selection property should be false", fragment.userSelectionCheckBox)
     }
 
     @Test
-    fun `dialog with shouldIncludeCheckBox equals false should not have a checkbox`() {
+    fun `display dialog with unselected "don't ask again"`() {
         val fragment = spy(
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
                 R.drawable.notification_icon_background,
                 mock(),
-                false
+                true,
+                shouldSelectDoNotAskAgainCheckBox = false
+            )
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
+
+        assertTrue("Checkbox should be displayed", checkBox.isVisible())
+        assertFalse("Checkbox shouldn't be checked", checkBox.isChecked)
+        assertFalse("User selection property should be false", fragment.userSelectionCheckBox)
+    }
+
+    @Test
+    fun `display dialog with preselected "don't ask again"`() {
+        val fragment = spy(
+            SitePermissionsDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                R.drawable.notification_icon_background,
+                mock(),
+                shouldShowDoNotAskAgainCheckBox = true,
+                shouldSelectDoNotAskAgainCheckBox = true
+            )
+        )
+
+        doReturn(context).`when`(fragment).requireContext()
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
+
+        assertTrue("Checkbox should be displayed", checkBox.isVisible())
+        assertTrue("Checkbox should be checked", checkBox.isChecked)
+        assertTrue("User selection property should be true", fragment.userSelectionCheckBox)
+    }
+
+    @Test
+    fun `dialog with shouldShowDoNotAskAgainCheckBox equals false should not have a checkbox`() {
+        val fragment = spy(
+            SitePermissionsDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                R.drawable.notification_icon_background,
+                mock(),
+                shouldShowDoNotAskAgainCheckBox = false
             )
         )
 
@@ -74,11 +124,12 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertFalse(checkBox.isVisible())
+        assertFalse("Checkbox shouldn't be displayed", checkBox.isVisible())
+        assertFalse("User selection property should be false", fragment.userSelectionCheckBox)
     }
 
     @Test
-    fun `clicking on positive button notifies the feature`() {
+    fun `clicking on positive button notifies the feature (temporary)`() {
         val mockFeature: SitePermissionsFeature = mock()
 
         val fragment = spy(
@@ -87,7 +138,8 @@ class SitePermissionsDialogFragmentTest {
                 "title",
                 R.drawable.notification_icon_background,
                 mockFeature,
-                false
+                shouldShowDoNotAskAgainCheckBox = false,
+                shouldSelectDoNotAskAgainCheckBox = false
             )
         )
 
@@ -105,7 +157,7 @@ class SitePermissionsDialogFragmentTest {
     }
 
     @Test
-    fun `clicking on negative button notifies the feature`() {
+    fun `clicking on negative button notifies the feature (temporary)`() {
         val mockFeature: SitePermissionsFeature = mock()
 
         val fragment = spy(
@@ -114,7 +166,8 @@ class SitePermissionsDialogFragmentTest {
                 "title",
                 R.drawable.notification_icon_background,
                 mockFeature,
-                false
+                shouldShowDoNotAskAgainCheckBox = false,
+                shouldSelectDoNotAskAgainCheckBox = false
             )
         )
 
@@ -132,6 +185,62 @@ class SitePermissionsDialogFragmentTest {
     }
 
     @Test
+    fun `clicking on positive button notifies the feature (permanent)`() {
+        val mockFeature: SitePermissionsFeature = mock()
+
+        val fragment = spy(
+            SitePermissionsDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                R.drawable.notification_icon_background,
+                mockFeature,
+                shouldShowDoNotAskAgainCheckBox = false,
+                shouldSelectDoNotAskAgainCheckBox = true
+            )
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+        doReturn(mockFragmentManager()).`when`(fragment).fragmentManager
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val positiveButton = dialog.findViewById<Button>(R.id.allow_button)
+        positiveButton.performClick()
+        verify(mockFeature).onPositiveButtonPress("sessionId", true)
+    }
+
+    @Test
+    fun `clicking on negative button notifies the feature (permanent)`() {
+        val mockFeature: SitePermissionsFeature = mock()
+
+        val fragment = spy(
+            SitePermissionsDialogFragment.newInstance(
+                "sessionId",
+                "title",
+                R.drawable.notification_icon_background,
+                mockFeature,
+                shouldShowDoNotAskAgainCheckBox = false,
+                shouldSelectDoNotAskAgainCheckBox = true
+            )
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(context).`when`(fragment).requireContext()
+        doReturn(mockFragmentManager()).`when`(fragment).fragmentManager
+
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val positiveButton = dialog.findViewById<Button>(R.id.deny_button)
+        positiveButton.performClick()
+        verify(mockFeature).onNegativeButtonPress("sessionId", true)
+    }
+
+    @Test
     fun `dialog must have all the styles of the feature promptsStyling object`() {
         val mockFeature: SitePermissionsFeature = mock()
 
@@ -143,7 +252,7 @@ class SitePermissionsDialogFragmentTest {
                 "title",
                 R.drawable.notification_icon_background,
                 mockFeature,
-                false
+                shouldShowDoNotAskAgainCheckBox = false
             )
         )
 
@@ -167,7 +276,8 @@ class SitePermissionsDialogFragmentTest {
                 "title",
                 R.drawable.notification_icon_background,
                 mock(),
-                shouldIncludeCheckBox = true,
+                shouldShowDoNotAskAgainCheckBox = true,
+                shouldSelectDoNotAskAgainCheckBox = false,
                 isNotificationRequest = true
             )
         )
@@ -179,8 +289,8 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertTrue(fragment.userSelectionCheckBox)
-        assertFalse(checkBox.isVisible())
+        assertFalse("Checkbox shouldn't be displayed", checkBox.isVisible())
+        assertTrue("User selection property should be true", fragment.userSelectionCheckBox)
     }
 
     private fun mockFragmentManager(): FragmentManager {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,7 @@ permalink: /changelog/
   * Fix disappearing title in Custom Tab toolbar.
 
 * **feature-sitepermissions**
+  * Added ability to configure default (checked/unchecked) state for "Remember decision" checkbox. Provide `dialogConfig` into `SitePermissionsFeature` for this. Checkbox is checked by default.
   * ⚠️ **This is a breaking API change**: ``anchorView`` property has been removed if you want to change the position of the prompts use the ``promptsStyling`` property.
   * Added new property ``context``. It must be provided in the constructor.
   * Do not save new site permissions in private sessions.


### PR DESCRIPTION
Please read #2988 and make diagonal-check solution in this PR. Is this a way-to-go solution?
Or should we go with breaking change instead (I suppose that it'll be nice to have ability to configure default behavior)?

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
