### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `browser-awesomebar`.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -12,7 +12,6 @@ object KotlinCompiler {
     // Maybe this is easier in Gradle 5+.
     @JvmStatic
     val projectsWithWarningsAsErrorsDisabled = setOf(
-        "browser-awesomebar",
         "browser-domains",
         "browser-engine-gecko",
         "browser-engine-servo",

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
@@ -6,43 +6,54 @@ package mozilla.components.browser.awesomebar
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.awesomebar.transform.SuggestionTransformer
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.support.test.mock
+import mozilla.utils.setupTestCoroutinesDispatcher
+import mozilla.utils.unsetTestCoroutinesDispatcher
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.never
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
-import java.lang.IllegalStateException
 import java.util.UUID
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class BrowserAwesomeBarTest {
-    private val testMainScope = CoroutineScope(newSingleThreadContext("Test"))
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    @Before
+    fun setUp() {
+        setupTestCoroutinesDispatcher()
+    }
+
+    @After
+    fun tearDown() {
+        unsetTestCoroutinesDispatcher()
+    }
+
     @Test
     fun `BrowserAwesomeBar forwards input to providers`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             val provider1 = mockProvider()
             val provider2 = mockProvider()
             val provider3 = mockProvider()
 
             val awesomeBar = BrowserAwesomeBar(context)
-            awesomeBar.scope = testMainScope
             awesomeBar.addProviders(provider1, provider2)
             awesomeBar.addProviders(provider3)
 
@@ -96,7 +107,7 @@ class BrowserAwesomeBarTest {
 
     @Test
     fun `onInputCancelled stops jobs`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             var providerTriggered = false
             var providerCancelled = false
 
@@ -118,7 +129,6 @@ class BrowserAwesomeBarTest {
             }
 
             val awesomeBar = BrowserAwesomeBar(context)
-            awesomeBar.scope = testMainScope
             awesomeBar.addProviders(blockingProvider)
 
             awesomeBar.onInputChanged("Hello!")
@@ -138,7 +148,7 @@ class BrowserAwesomeBarTest {
 
     @Test
     fun `removeProvider removes the provider`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             val provider1 = mockProvider()
             val provider2 = mockProvider()
             val provider3 = mockProvider()
@@ -170,7 +180,7 @@ class BrowserAwesomeBarTest {
 
     @Test
     fun `removeAllProviders removes all providers`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             val provider1 = mockProvider()
             val provider2 = mockProvider()
 
@@ -193,7 +203,7 @@ class BrowserAwesomeBarTest {
 
     @Test
     fun `BrowserAwesomeBar stops jobs when getting detached`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             var providerTriggered = false
             var providerCancelled = false
 
@@ -215,7 +225,6 @@ class BrowserAwesomeBarTest {
             }
 
             val awesomeBar = BrowserAwesomeBar(context)
-            awesomeBar.scope = testMainScope
             awesomeBar.addProviders(blockingProvider)
 
             awesomeBar.onInputChanged("Hello!")
@@ -235,7 +244,7 @@ class BrowserAwesomeBarTest {
 
     @Test
     fun `BrowserAwesomeBar cancels previous jobs if onInputStarted gets called again`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             var firstProviderCallCancelled = false
             var timesProviderCalled = 0
 
@@ -270,7 +279,6 @@ class BrowserAwesomeBarTest {
             }
 
             val awesomeBar = BrowserAwesomeBar(context)
-            awesomeBar.scope = testMainScope
             awesomeBar.addProviders(provider)
 
             awesomeBar.onInputChanged("Hello!")
@@ -289,9 +297,8 @@ class BrowserAwesomeBarTest {
 
     @Test
     fun `BrowserAwesomeBar will use optional transformer before passing suggestions to adapter`() {
-        runBlocking(testMainScope.coroutineContext) {
+        runBlocking {
             val awesomeBar = BrowserAwesomeBar(context)
-            awesomeBar.scope = testMainScope
 
             val inputSuggestions = listOf(AwesomeBar.Suggestion(mock(), title = "Tetst"))
             val provider = object : AwesomeBar.SuggestionProvider {

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/IconLoaderTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/IconLoaderTest.kt
@@ -6,15 +6,14 @@ package mozilla.components.browser.awesomebar.layout
 
 import android.graphics.Bitmap
 import android.widget.ImageView
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.support.test.mock
+import mozilla.utils.setupTestCoroutinesDispatcher
+import mozilla.utils.unsetTestCoroutinesDispatcher
 import org.junit.After
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -23,18 +22,19 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.Executors
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class IconLoaderTest {
+
     @Before
     fun setUp() {
-        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+        setupTestCoroutinesDispatcher()
     }
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
+        unsetTestCoroutinesDispatcher()
     }
 
     @Test
@@ -60,6 +60,7 @@ class IconLoaderTest {
     @Test
     fun `Load task is cancelled`() {
         runBlocking {
+            @Suppress("UNREACHABLE_CODE")
             val suggestion = AwesomeBar.Suggestion(
                 provider = mock(),
                 icon = { _, _ ->

--- a/components/browser/awesomebar/src/test/java/mozilla/utils/coroutines.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/utils/coroutines.kt
@@ -1,0 +1,31 @@
+package mozilla.utils
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import java.util.concurrent.Executors
+
+/**
+ * Create single threaded dispatcher for test environment.
+ */
+fun createTestCoroutinesDispatcher(): CoroutineDispatcher =
+    Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
+/**
+ * Call `@Before` test to setup test coroutines dispatcher as `Main`.
+ */
+@ExperimentalCoroutinesApi
+fun setupTestCoroutinesDispatcher() {
+    Dispatchers.setMain(createTestCoroutinesDispatcher())
+}
+
+/**
+ * Call `@After` test to reset `Main` coroutines dispatcher.
+ */
+@ExperimentalCoroutinesApi
+fun unsetTestCoroutinesDispatcher() {
+    Dispatchers.resetMain()
+}


### PR DESCRIPTION
**Issue**: #2346.

Made few changes in tests to enable `kotlinOptions.allWarningsAsErrors` for `browser-awesomebar`.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
