### PR TITLE
Closes #2675: Add EngineViewBottomBehavior to dynamically update vertical clipping when toolbar scrolls away.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -21,7 +21,6 @@ class GeckoEngineView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
-
     internal var currentGeckoView = object : NestedGeckoView(context) {
         override fun onDetachedFromWindow() {
             // We are releasing the session before GeckoView gets detached from the window. Otherwise
@@ -71,5 +70,9 @@ class GeckoEngineView @JvmOverloads constructor(
             onFinish(null)
             GeckoResult<Void>()
         })
+    }
+
+    override fun setVerticalClipping(clippingHeight: Int) {
+        // no-op: requires GeckoView 68.0
     }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
@@ -71,5 +72,14 @@ class GeckoEngineViewTest {
 
         geckoResult.completeExceptionally(mock())
         assertNull(thumbnail)
+    }
+
+    @Test
+    fun `setVerticalClipping is a no-op`() {
+        val engineView = GeckoEngineView(context)
+        engineView.currentGeckoView = mock()
+
+        engineView.setVerticalClipping(42)
+        Mockito.verifyNoMoreInteractions(engineView.currentGeckoView)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -93,6 +93,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
+    override fun setVerticalClipping(clippingHeight: Int) {
+        currentGeckoView.setVerticalClipping(clippingHeight)
+    }
+
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         val geckoResult = currentGeckoView.capturePixels()
         geckoResult.then({ bitmap ->

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -72,4 +72,14 @@ class GeckoEngineViewTest {
         geckoResult.completeExceptionally(mock())
         assertNull(thumbnail)
     }
+
+    @Test
+    fun `setVerticalClipping is forwarded to GeckoView instance`() {
+        val engineView = GeckoEngineView(context)
+        engineView.currentGeckoView = mock()
+
+        engineView.setVerticalClipping(42)
+
+        verify(engineView.currentGeckoView).setVerticalClipping(42)
+    }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -20,7 +20,6 @@ class GeckoEngineView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
-
     internal var currentGeckoView = object : NestedGeckoView(context) {
         override fun onDetachedFromWindow() {
             // We are releasing the session before GeckoView gets detached from the window. Otherwise
@@ -62,4 +61,8 @@ class GeckoEngineView @JvmOverloads constructor(
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
+
+    override fun setVerticalClipping(clippingHeight: Int) {
+        // no-op: requires GeckoView 68.0
+    }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -4,22 +4,27 @@
 
 package mozilla.components.browser.engine.gecko
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.support.test.mock
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mozilla.geckoview.GeckoSession
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class GeckoEngineViewTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun render() {
-        val engineView = GeckoEngineView(RuntimeEnvironment.application)
+        val engineView = GeckoEngineView(context)
         val engineSession = mock(GeckoEngineSession::class.java)
         val geckoSession = mock(GeckoSession::class.java)
         val geckoView = mock(NestedGeckoView::class.java)
@@ -33,5 +38,14 @@ class GeckoEngineViewTest {
         `when`(geckoView.session).thenReturn(geckoSession)
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
+    }
+
+    @Test
+    fun `setVerticalClipping is a no-op`() {
+        val engineView = GeckoEngineView(context)
+        engineView.currentGeckoView = mock()
+
+        engineView.setVerticalClipping(42)
+        verifyNoMoreInteractions(engineView.currentGeckoView)
     }
 }

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineView.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineView.kt
@@ -46,4 +46,8 @@ class ServoEngineView @JvmOverloads constructor(
     }
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
+
+    override fun setVerticalClipping(clippingHeight: Int) {
+        // no-op
+    }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -63,7 +63,6 @@ class SystemEngineView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView, View.OnLongClickListener {
-
     @VisibleForTesting(otherwise = PRIVATE)
     internal var session: SystemEngineSession? = null
     internal var jsAlertCount = 0
@@ -635,6 +634,10 @@ class SystemEngineView @JvmOverloads constructor(
 
             session?.internalNotifyObservers { onLongPress(HitResult.IMAGE_SRC(src, url)) }
         }
+    }
+
+    override fun setVerticalClipping(clippingHeight: Int) {
+        // no-op
     }
 
     override fun canScrollVerticallyDown() = session?.webView?.canScrollVertically(1) ?: false

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.OnLifecycleEvent
 /**
  * View component that renders web content.
  */
+@Suppress("TooManyFunctions")
 interface EngineView {
 
     /**
@@ -71,6 +72,14 @@ interface EngineView {
      * @param onFinish A callback to inform that process of capturing a thumbnail has finished.
      */
     fun captureThumbnail(onFinish: (Bitmap?) -> Unit)
+
+    /**
+     * Updates the amount of vertical space that is clipped or visibly obscured in the bottom portion of the view.
+     * Tells the [EngineView] where to put bottom fixed elements so they are fully visible.
+     *
+     * @param clippingHeight The height of the bottom clipped space in screen pixels.
+     */
+    fun setVerticalClipping(clippingHeight: Int)
 }
 
 /**

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
@@ -63,12 +63,14 @@ class EngineViewTest {
     private fun createDummyEngineView(context: Context): EngineView = DummyEngineView(context)
 
     open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
+        override fun setVerticalClipping(clippingHeight: Int) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
     }
 
     // Class it not actually a View!
     open class BrokenEngineView : EngineView {
+        override fun setVerticalClipping(clippingHeight: Int) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
     }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/behavior/EngineViewBottomBehavior.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/behavior/EngineViewBottomBehavior.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.behavior
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import mozilla.components.concept.engine.EngineView
+
+/**
+ * A [CoordinatorLayout.Behavior] implementation to be used with [EngineView] when placing a toolbar at the
+ * bottom of the screen.
+ *
+ * Using this behavior requires the toolbar to use the BrowserToolbarBottomBehavior.
+ *
+ * This implementation will update the vertical clipping of the [EngineView] so that bottom-aligned web content will
+ * be drawn above the native toolbar.
+ */
+class EngineViewBottomBehavior(
+    context: Context?,
+    attrs: AttributeSet?
+) : CoordinatorLayout.Behavior<View>(context, attrs) {
+    @SuppressLint("LogUsage")
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: View, dependency: View): Boolean {
+        // This package does not have access to "BrowserToolbar" ... so we are just checking the class name here since
+        // we actually do not need anything from that class - we only need to identify the instance.
+        // Right now we do not have a component that has access to (concept/browser-toolbar and concept-engine).
+        // Creating one just for this behavior is too excessive.
+        if (dependency::class.java.simpleName == "BrowserToolbar") {
+            return true
+        }
+
+        return super.layoutDependsOn(parent, child, dependency)
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout, child: View, dependency: View): Boolean {
+        (child as EngineView).setVerticalClipping(dependency.height - dependency.translationY.toInt())
+        return true
+    }
+}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.session.behavior
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.view.View
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineView
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EngineViewBottomBehaviorTest {
+    val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `EngineView clipping and toolbar offset are kept in sync`() {
+        val behavior = EngineViewBottomBehavior(mock(), null)
+
+        val engineView: EngineView = spy(FakeEngineView(context))
+        val toolbar: View = mock()
+        doReturn(100).`when`(toolbar).height
+
+        doReturn(42f).`when`(toolbar).translationY
+        behavior.onDependentViewChanged(mock(), engineView.asView(), toolbar)
+        verify(engineView).setVerticalClipping(58)
+    }
+
+    @Test
+    fun `Behavior does not depend on normal views`() {
+        val behavior = EngineViewBottomBehavior(mock(), null)
+
+        assertFalse(behavior.layoutDependsOn(mock(), mock(), TextView(context)))
+        assertFalse(behavior.layoutDependsOn(mock(), mock(), EditText(context)))
+        assertFalse(behavior.layoutDependsOn(mock(), mock(), ImageView(context)))
+    }
+
+    @Test
+    fun `Behavior depends on BrowserToolbar`() {
+        val behavior = EngineViewBottomBehavior(mock(), null)
+
+        assertTrue(behavior.layoutDependsOn(mock(), mock(), BrowserToolbar(context)))
+    }
+}
+
+class FakeEngineView(context: Context) : TextView(context), EngineView {
+    override fun render(session: EngineSession) {}
+
+    override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {}
+
+    override fun setVerticalClipping(clippingHeight: Int) {}
+}
+
+class BrowserToolbar(context: Context) : TextView(context)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-icons**
   * Added disk cache for icons.
 
+* **feature-session**:
+  * Added `EngineViewBottomBehavior`: A `CoordinatorLayout.Behavior` implementation to be used with [EngineView] when placing a toolbar at the bottom of the screen. This implementation will update the vertical clipping of the `EngineView` so that bottom-aligned web content will be drawn above the browser toolbar.
+
 # 0.52.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.51.0...v0.52.0)


### PR DESCRIPTION
This patch fixes issues with bottom-aligned web content that is drawn behind the toolbar, as described in:
- https://github.com/mozilla-mobile/fenix/issues/552
- https://github.com/mozilla-mobile/reference-browser/issues/464

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
