### PR TITLE
Revert "1504677: Handle default stores at build-time in glean_parser"

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -20,7 +20,7 @@ import groovy.json.JsonOutput
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "0.25.0"
+String GLEAN_PARSER_VERSION = "0.24.1"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
@@ -53,7 +53,7 @@ object ErrorRecording {
         val identifier = metricData.identifier.split("/", limit = 2)[0]
 
         // Record errors in the pings the metric is in, as well as the metrics ping.
-        var sendInPings = metricData.sendInPings
+        var sendInPings = metricData.getStorageNames()
         if (!sendInPings.contains("metrics")) {
             sendInPings = sendInPings + listOf("metrics")
         }
@@ -92,7 +92,7 @@ object ErrorRecording {
     * @param metricData The metric the errors were reported about
     * @param errorType The type of error
     * @param pingName The name of the ping (optional).  If null, will use
-    *     metricData.sendInPings.first()
+    *     metricData.getStorageNames().first()
     * @return The number of errors reported
     */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -107,7 +107,7 @@ object ErrorRecording {
         val usePingName = pingName?.let {
             pingName
         } ?: run {
-            metricData.sendInPings.first()
+            metricData.getStorageNames().first()
         }
 
         val errorName = GLEAN_ERROR_NAMES[errorType]!!

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/BooleanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/BooleanMetricType.kt
@@ -25,6 +25,8 @@ data class BooleanMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/BooleanMetricType")
 
     /**
@@ -58,7 +60,7 @@ data class BooleanMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -76,7 +78,7 @@ data class BooleanMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): Boolean {
+    fun testGetValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/CommonMetricData.kt
@@ -38,6 +38,10 @@ interface CommonMetricData {
 
     val identifier: String get() = if (category.isEmpty()) { name } else { "$category.$name" }
 
+    companion object {
+        internal const val DEFAULT_STORAGE_NAME = "default"
+    }
+
     fun shouldRecord(logger: Logger): Boolean {
         // Don't record metrics if we aren't initialized
         if (!Glean.isInitialized()) {
@@ -51,5 +55,26 @@ interface CommonMetricData {
         }
 
         return true
+    }
+
+    /**
+     * Defines the names of the storages the metric defaults to when
+     * "default" is used as the destination storage.
+     * Note that every metric type will need to override this.
+     */
+    val defaultStorageDestinations: List<String>
+
+    /**
+     * Get the list of storage names the metric will record to. This
+     * automatically expands [DEFAULT_STORAGE_NAME] to the list of default
+     * storages for the metric.
+     */
+    fun getStorageNames(): List<String> {
+        if (DEFAULT_STORAGE_NAME !in sendInPings) {
+            return sendInPings
+        }
+
+        val filteredNames = sendInPings.filter { it != DEFAULT_STORAGE_NAME }
+        return filteredNames + defaultStorageDestinations
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/CounterMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/CounterMetricType.kt
@@ -26,6 +26,8 @@ data class CounterMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/CounterMetricType")
 
     /**
@@ -60,7 +62,7 @@ data class CounterMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -78,7 +80,7 @@ data class CounterMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): Int {
+    fun testGetValue(pingName: String = getStorageNames().first()): Int {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/DatetimeMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/DatetimeMetricType.kt
@@ -27,6 +27,8 @@ data class DatetimeMetricType(
     val timeUnit: TimeUnit = TimeUnit.Minute
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/DatetimeMetricType")
 
     /**
@@ -85,7 +87,7 @@ data class DatetimeMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -104,7 +106,7 @@ data class DatetimeMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValueAsString(pingName: String = sendInPings.first()): String {
+    fun testGetValueAsString(pingName: String = getStorageNames().first()): String {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -126,7 +128,7 @@ data class DatetimeMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): Date {
+    fun testGetValue(pingName: String = getStorageNames().first()): Date {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/EventMetricType.kt
@@ -38,6 +38,8 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
     val allowedExtraKeys: List<String> = listOf()
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("events")
+
     private val logger = Logger("glean/EventMetricType")
 
     /**
@@ -100,7 +102,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -121,7 +123,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): List<RecordedEventData> {
+    fun testGetValue(pingName: String = getStorageNames().first()): List<RecordedEventData> {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
@@ -32,6 +32,9 @@ data class LabeledMetricType<T>(
     val labels: Set<String>? = null
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = (
+        subMetric as CommonMetricData).defaultStorageDestinations
+
     private val logger = Logger("glean/LabeledMetricType")
 
     companion object {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringListMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringListMetricType.kt
@@ -26,6 +26,8 @@ data class StringListMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/StringListMetricType")
 
     /**
@@ -82,7 +84,7 @@ data class StringListMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -100,7 +102,7 @@ data class StringListMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): List<String> {
+    fun testGetValue(pingName: String = getStorageNames().first()): List<String> {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringMetricType.kt
@@ -26,6 +26,8 @@ data class StringMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/StringMetricType")
 
     /**
@@ -60,7 +62,7 @@ data class StringMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -78,7 +80,7 @@ data class StringMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): String {
+    fun testGetValue(pingName: String = getStorageNames().first()): String {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
@@ -27,6 +27,8 @@ data class TimespanMetricType(
     val timeUnit: TimeUnit
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/TimespanMetricType")
 
     /**
@@ -93,7 +95,7 @@ data class TimespanMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         return TimespansStorageEngine.getSnapshot(pingName, false)?.get(identifier) != null
     }
 
@@ -107,7 +109,7 @@ data class TimespanMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): Long {
+    fun testGetValue(pingName: String = getStorageNames().first()): Long {
         return TimespansStorageEngine.getSnapshot(pingName, false)!![identifier]!!
     }
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
@@ -29,6 +29,8 @@ data class TimingDistributionMetricType(
     val timeUnit: TimeUnit
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/TimingDistributionMetricType")
 
     /**
@@ -102,7 +104,7 @@ data class TimingDistributionMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -120,7 +122,7 @@ data class TimingDistributionMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): TimingDistributionData {
+    fun testGetValue(pingName: String = getStorageNames().first()): TimingDistributionData {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/UuidMetricType.kt
@@ -27,6 +27,8 @@ data class UuidMetricType(
     override val sendInPings: List<String>
 ) : CommonMetricData {
 
+    override val defaultStorageDestinations: List<String> = listOf("metrics")
+
     private val logger = Logger("glean/UuidMetricType")
 
     /**
@@ -78,7 +80,7 @@ data class UuidMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testHasValue(pingName: String = sendInPings.first()): Boolean {
+    fun testHasValue(pingName: String = getStorageNames().first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 
@@ -96,7 +98,7 @@ data class UuidMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun testGetValue(pingName: String = sendInPings.first()): UUID {
+    fun testGetValue(pingName: String = getStorageNames().first()): UUID {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/EventsStorageEngine.kt
@@ -183,7 +183,7 @@ internal object EventsStorageEngine : StorageEngine {
         // Record a copy of the event in all the needed stores.
         synchronized(this) {
             val eventStoresToUpload: MutableList<String> = mutableListOf()
-            for (storeName in metricData.sendInPings) {
+            for (storeName in metricData.getStorageNames()) {
                 val storeData = eventStores.getOrPut(storeName) { mutableListOf() }
                 storeData.add(event.copy())
                 writeEventToDisk(storeName, jsonEvent)

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/GenericStorageEngine.kt
@@ -268,7 +268,7 @@ internal abstract class GenericStorageEngine<MetricType> : StorageEngine {
             Lifetime.Ping -> pingLifetimeStorage.edit()
             else -> null
         }
-        metricData.sendInPings.forEach { store ->
+        metricData.getStorageNames().forEach { store ->
             val storeData = dataStores[metricData.lifetime.ordinal].getOrPut(store) { mutableMapOf() }
             // We support empty categories for enabling the internal use of metrics
             // when assembling pings in [PingMaker].

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -138,7 +138,7 @@ class GleanTest {
             category = "ui",
             lifetime = Lifetime.Ping,
             name = "click",
-            sendInPings = listOf("events")
+            sendInPings = listOf("default")
         )
 
         resetGlean(getContextWithMockedInfo(), Glean.configuration.copy(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/BooleanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/BooleanMetricTypeTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean.private
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -23,6 +24,19 @@ class BooleanMetricTypeTest {
     @Before
     fun setUp() {
         resetGlean()
+    }
+
+    @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'booleanMetric' boolean metric, which will be stored in "store1"
+        val booleanMetric = BooleanMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "boolean_metric",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("metrics"), booleanMetric.defaultStorageDestinations)
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/CommonMetricDataTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/CommonMetricDataTest.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.private
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The following is a test-only specific metric type used
+ * to test the "default" data storage translation.
+ */
+data class TestOnlyMetricType(
+    override val disabled: Boolean,
+    override val category: String,
+    override val lifetime: Lifetime,
+    override val name: String,
+    override val sendInPings: List<String>
+) : CommonMetricData {
+
+    override val defaultStorageDestinations: List<String> = listOf("translated_default")
+}
+
+@RunWith(RobolectricTestRunner::class)
+class CommonMetricDataTest {
+    @Test
+    fun `getStorageNames() should correctly translate "default"`() {
+        val testData = TestOnlyMetricType(
+            disabled = false,
+            category = "glean_test",
+            lifetime = Lifetime.Ping,
+            name = "test",
+            sendInPings = listOf(CommonMetricData.DEFAULT_STORAGE_NAME, "other_test_ping"))
+
+        assertEquals(testData.getStorageNames(), listOf("other_test_ping", "translated_default"))
+    }
+
+    @Test
+    fun `getStorageNames() should pass-through if no "default" is present`() {
+        val testData = TestOnlyMetricType(
+            disabled = false,
+            category = "glean_test",
+            lifetime = Lifetime.Ping,
+            name = "test",
+            sendInPings = listOf("other_test_ping", "additional_storage"))
+
+        assertEquals(testData.getStorageNames(), listOf("other_test_ping", "additional_storage"))
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/CounterMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/CounterMetricTypeTest.kt
@@ -27,6 +27,19 @@ class CounterMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'counterMetric' counter metric, which will be stored in "store1"
+        val counterMetric = CounterMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "counter_metric",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("metrics"), counterMetric.defaultStorageDestinations)
+    }
+
+    @Test
     fun `The API saves to its storage engine`() {
         // Define a 'counterMetric' counter metric, which will be stored in "store1"
         val counterMetric = CounterMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/DatetimeMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/DatetimeMetricTypeTest.kt
@@ -28,6 +28,19 @@ class DatetimeMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'datetimeMetric' datetime metric, which will be stored in "store1"
+        val datetimeMetric = DatetimeMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "datetime_metric",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("metrics"), datetimeMetric.defaultStorageDestinations)
+    }
+
+    @Test
     fun `The API saves to its storage engine`() {
         // Define a 'datetimeMetric' datetime metric, which will be stored in "store1"
         val datetimeMetric = DatetimeMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
@@ -38,6 +38,19 @@ class EventMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'click' event, which will be stored in "store1"
+        val click = EventMetricType<NoExtraKeys>(
+            disabled = false,
+            category = "ui",
+            lifetime = Lifetime.Ping,
+            name = "click",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("events"), click.defaultStorageDestinations)
+    }
+
+    @Test
     fun `The API records to its storage engine`() {
 
         // Define a 'click' event, which will be stored in "store1"

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -44,7 +44,9 @@ class LabeledMetricTypeTest {
         override val lifetime: Lifetime,
         override val name: String,
         override val sendInPings: List<String>
-    ) : CommonMetricData
+    ) : CommonMetricData {
+        override val defaultStorageDestinations: List<String> = listOf("metrics")
+    }
 
     @Before
     fun setup() {
@@ -65,7 +67,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
@@ -73,7 +75,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = counterMetric
         )
 
@@ -122,7 +124,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
@@ -130,7 +132,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = counterMetric,
             labels = setOf("foo", "bar", "baz")
         )
@@ -181,7 +183,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
@@ -189,7 +191,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = counterMetric
         )
 
@@ -241,7 +243,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
@@ -249,7 +251,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_counter_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = counterMetric
         )
 
@@ -283,7 +285,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_timespan_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             timeUnit = TimeUnit.Nanosecond
         )
 
@@ -292,7 +294,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_timespan_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = timespanMetric
         )
 
@@ -313,7 +315,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_uuid_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledUuidMetric = LabeledMetricType<UuidMetricType>(
@@ -321,7 +323,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_uuid_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = uuidMetric
         )
 
@@ -340,7 +342,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_string_list_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledStringListMetric = LabeledMetricType<StringListMetricType>(
@@ -348,7 +350,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_string_list_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = stringListMetric
         )
 
@@ -365,7 +367,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_string_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledStringMetric = LabeledMetricType<StringMetricType>(
@@ -373,7 +375,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_string_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = stringMetric
         )
 
@@ -392,7 +394,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_string_list_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledBooleanMetric = LabeledMetricType<BooleanMetricType>(
@@ -400,7 +402,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_string_list_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = booleanMetric
         )
 
@@ -417,7 +419,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_event_metric",
-            sendInPings = listOf("metrics")
+            sendInPings = listOf("default")
         )
 
         val labeledEventMetric = LabeledMetricType<EventMetricType<NoExtraKeys>>(
@@ -425,7 +427,7 @@ class LabeledMetricTypeTest {
             category = "telemetry",
             lifetime = Lifetime.Application,
             name = "labeled_event_metric",
-            sendInPings = listOf("metrics"),
+            sendInPings = listOf("default"),
             subMetric = eventMetric
         )
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringListMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringListMetricTypeTest.kt
@@ -27,6 +27,19 @@ class StringListMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'stringMetric' string metric, which will be stored in "store1"
+        val stringListMetric = StringListMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "string_list_metric",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("metrics"), stringListMetric.defaultStorageDestinations)
+    }
+
+    @Test
     fun `The API saves to its storage engine by first adding then setting`() {
         // Define a 'stringMetric' string metric, which will be stored in "store1"
         val stringListMetric = StringListMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringMetricTypeTest.kt
@@ -27,6 +27,19 @@ class StringMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a 'stringMetric' string metric, which will be stored in "store1"
+        val stringMetric = StringMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "string_metric",
+            sendInPings = listOf("store1")
+        )
+        assertEquals(listOf("metrics"), stringMetric.defaultStorageDestinations)
+    }
+
+    @Test
     fun `The API saves to its storage engine`() {
         // Define a 'stringMetric' string metric, which will be stored in "store1"
         val stringMetric = StringMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -34,6 +34,20 @@ class TimingDistributionMetricTypeTest {
     }
 
     @Test
+    fun `The API must define the expected "default" storage`() {
+        // Define a timing distribution metric which will be stored in "store1"
+        val metric = TimingDistributionMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "timing_distribution",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Millisecond
+        )
+        assertEquals(listOf("metrics"), metric.defaultStorageDestinations)
+    }
+
+    @Test
     fun `The API saves to its storage engine`() {
         // Define a timing distribution metric which will be stored in "store1"
         val metric = TimingDistributionMetricType(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -235,7 +235,7 @@ class MetricsPingSchedulerTest {
                 category = "telemetry",
                 lifetime = Lifetime.Application,
                 name = "string_metric",
-                sendInPings = listOf("metrics")
+                sendInPings = listOf("default")
             )
 
             val expectedValue = "test-only metric"
@@ -388,7 +388,7 @@ class MetricsPingSchedulerTest {
     //         category = "telemetry",
     //         lifetime = Lifetime.Ping,
     //         name = "string_metric",
-    //         sendInPings = listOf("metrics")
+    //         sendInPings = listOf("default")
     //     )
 
     //     // Start Glean in the current thread, clean the local storage.

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -268,7 +268,7 @@ class EventsStorageEngineTest {
             category = "ui",
             lifetime = Lifetime.Ping,
             name = "click",
-            sendInPings = listOf("events"),
+            sendInPings = listOf("default"),
             allowedExtraKeys = listOf("test_event_number")
         )
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
@@ -29,7 +29,9 @@ class GenericStorageEngineTest {
         override val lifetime: Lifetime,
         override val name: String,
         override val sendInPings: List<String>
-    ) : CommonMetricData
+    ) : CommonMetricData {
+        override val defaultStorageDestinations: List<String> = listOf("metrics")
+    }
 
     @Test
     fun `metrics with 'user' lifetime must not be cleared when snapshotting`() {


### PR DESCRIPTION
This reverts commit 1e257c6ddea0a96636634dd4894759fc9e80a0dc.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
