### PR TITLE
Make sure to always initialize the GleanDebugActivity.kt

### DIFF
--- a/components/service/glean/src/main/AndroidManifest.xml
+++ b/components/service/glean/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     package="mozilla.components.service.glean" >
     <application>
         <activity android:name=".debug.GleanDebugActivity"
-            android:exported="true" />
+            android:exported="true"
+            android:launchMode="singleTask" />
     </application>
 </manifest>

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.glean.debug
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import mozilla.components.service.glean.Glean
 import mozilla.components.support.base.log.logger.Logger
@@ -40,20 +41,30 @@ class GleanDebugActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        logger.debug("Calling onCreate")
+        handleExecution(intent)
+    }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        logger.debug("Calling onNewIntent")
+        handleExecution(intent)
+    }
+
+    private fun handleExecution(passedIntent: Intent) {
         if (!Glean.isInitialized()) {
             logger.error(
                 "Glean is not initialized. " +
-                "It may be disabled by the application."
+                    "It may be disabled by the application."
             )
             return
         }
 
         // Enable debugging options and start the application.
-        intent.extras?.let {
+        passedIntent.extras?.let {
             // Check for ping debug view tag to apply to the X-Debug-ID header when uploading the
             // ping to the endpoint
-            var pingTag: String? = intent.getStringExtra(TAG_DEBUG_VIEW_EXTRA_KEY)
+            var pingTag: String? = passedIntent.getStringExtra(TAG_DEBUG_VIEW_EXTRA_KEY)
 
             // Validate the ping tag against the regex pattern
             pingTag?.let {
@@ -64,7 +75,7 @@ class GleanDebugActivity : Activity() {
             }
 
             val debugConfig = Glean.configuration.copy(
-                logPings = intent.getBooleanExtra(LOG_PINGS_EXTRA_KEY, Glean.configuration.logPings),
+                logPings = passedIntent.getBooleanExtra(LOG_PINGS_EXTRA_KEY, Glean.configuration.logPings),
                 pingTag = pingTag
             )
 
@@ -73,13 +84,13 @@ class GleanDebugActivity : Activity() {
             logger.info("Setting debug config $debugConfig")
             Glean.configuration = debugConfig
 
-            intent.getStringExtra(SEND_PING_EXTRA_KEY)?.let {
+            passedIntent.getStringExtra(SEND_PING_EXTRA_KEY)?.let {
                 Glean.sendPingsByName(listOf(it))
             }
         }
 
-        val intent = packageManager.getLaunchIntentForPackage(packageName)
-        startActivity(intent)
+        val launchMainIntent = packageManager.getLaunchIntentForPackage(packageName)
+        startActivity(launchMainIntent)
 
         finish()
     }


### PR DESCRIPTION
This changes the `launchMode` of the activity to `"singleTask"`, which according to the [docs here](https://developer.android.com/guide/topics/manifest/activity-element),
goes through `onNewIntent` if the activity was already there, rather than reporting `"Warning: Activity not started, intent has been delivered to currently running top-most instance.".`

**What was the problem**: sometimes, while launching the activity from `adb` and the app was already started, we would not go through [`onCreate`](https://github.com/mozilla-mobile/android-components/blob/89ac9428b55cd628afd6e559fde3ce54bd4cee05/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt#L42), and nothing would happen. Other times, the above warning would be printed. Most of the times, it would go through the onCreate even if the app was open.

**Note**: I'm not entirely sure why the problem was there in the first place. I only happen to be randomly reproducing it *sometimes*. Now I can't randomly reproduce it anymore, but I'm not really confident this is the right fix. If anyone could shed more light on this, it would be great. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
