### PR TITLE
Make TrackingProtectionPolicy immutable

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -82,8 +82,8 @@ abstract class EngineSession(
      */
     open class TrackingProtectionPolicy internal constructor(
         val categories: Int,
-        var useForPrivateSessions: Boolean = true,
-        var useForRegularSessions: Boolean = true
+        val useForPrivateSessions: Boolean = true,
+        val useForRegularSessions: Boolean = true
     ) {
         companion object {
             internal const val NONE: Int = 0
@@ -97,7 +97,7 @@ abstract class EngineSession(
             const val FINGERPRINTING = 1 shl 7
             internal const val ALL: Int = AD + ANALYTICS + SOCIAL + CONTENT + TEST + CRYPTOMINING + FINGERPRINTING
 
-            fun none(): TrackingProtectionPolicy = TrackingProtectionPolicy(NONE)
+            fun none() = TrackingProtectionPolicy(NONE)
             fun all() = TrackingProtectionPolicyForSessionTypes(ALL)
             fun select(vararg categories: Int) = TrackingProtectionPolicyForSessionTypes(categories.sum())
         }
@@ -113,9 +113,7 @@ abstract class EngineSession(
             return true
         }
 
-        override fun hashCode(): Int {
-            return categories
-        }
+        override fun hashCode() = categories
     }
 
     /**
@@ -128,20 +126,20 @@ abstract class EngineSession(
         /**
          * Marks this policy to be used for private sessions only.
          */
-        fun forPrivateSessionsOnly(): TrackingProtectionPolicy {
-            useForPrivateSessions = true
+        fun forPrivateSessionsOnly() = TrackingProtectionPolicy(
+            categories,
+            useForPrivateSessions = true,
             useForRegularSessions = false
-            return this
-        }
+        )
 
         /**
          * Marks this policy to be used for regular (non-private) sessions only.
          */
-        fun forRegularSessionsOnly(): TrackingProtectionPolicy {
+        fun forRegularSessionsOnly() = TrackingProtectionPolicy(
+            categories,
+            useForPrivateSessions = false,
             useForRegularSessions = true
-            useForPrivateSessions = false
-            return this
-        }
+        )
     }
 
     /**


### PR DESCRIPTION
It was a little confusing that `useForPrivateSessions` and `useForRegularSessions` were mutable, and code that consumes a policy only reads these flags once. This PR changes `var` to `val`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
