### PR TITLE
Closes #1628. Hide built-in WebView zoom controls in `engine-system`.

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -227,7 +227,7 @@ class SystemEngineSession(
         operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) = set(value)
     }
 
-    internal fun initSettings() {
+    private fun initSettings() {
         webView.settings?.let { webSettings ->
             // Explicitly set global defaults.
             webSettings.setAppCacheEnabled(false)
@@ -238,8 +238,10 @@ class SystemEngineSession(
             // We currently don't implement the callback to support turning this on.
             webSettings.setGeolocationEnabled(false)
 
-            // webViewSettings built-in zoom controls are the only supported ones, so they should be turned on.
+            // webViewSettings built-in zoom controls are the only supported ones,
+            // so they should be turned on but hidden.
             webSettings.builtInZoomControls = true
+            webSettings.displayZoomControls = false
 
             initSettings(webView, webSettings)
         }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -21,7 +21,6 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.support.test.mock
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -352,10 +351,11 @@ class SystemEngineSessionTest {
         verify(webViewSettings).savePassword = false
         verify(webViewSettings).saveFormData = false
         verify(webViewSettings).builtInZoomControls = true
+        verify(webViewSettings).displayZoomControls = false
     }
 
     @Test
-    fun defaultSettings() {
+    fun withProvidedDefaultSettings() {
         val defaultSettings = DefaultSettings(
                 javascriptEnabled = false,
                 domStorageEnabled = false,
@@ -364,24 +364,25 @@ class SystemEngineSessionTest {
                 userAgentString = "userAgent",
                 mediaPlaybackRequiresUserGesture = false,
                 javaScriptCanOpenWindowsAutomatically = true,
-                displayZoomControls = false,
+                displayZoomControls = true,
                 loadWithOverviewMode = true,
                 supportMultipleWindows = true)
         val engineSession = spy(SystemEngineSession(getApplicationContext(), defaultSettings))
+
         val webView = mock(WebView::class.java)
         `when`(webView.context).thenReturn(getApplicationContext())
-        engineSession.webView = webView
 
         val webViewSettings = mock(WebSettings::class.java)
         `when`(webView.settings).thenReturn(webViewSettings)
 
-        engineSession.initSettings()
+        engineSession.webView = webView
+
         verify(webViewSettings).domStorageEnabled = false
         verify(webViewSettings).javaScriptEnabled = false
         verify(webViewSettings).userAgentString = "userAgent"
         verify(webViewSettings).mediaPlaybackRequiresUserGesture = false
         verify(webViewSettings).javaScriptCanOpenWindowsAutomatically = true
-        verify(webViewSettings).displayZoomControls = false
+        verify(webViewSettings).displayZoomControls = true
         verify(webViewSettings).loadWithOverviewMode = true
         verify(webViewSettings).setSupportMultipleWindows(true)
         verify(engineSession).enableTrackingProtection(EngineSession.TrackingProtectionPolicy.all())
@@ -580,47 +581,47 @@ class SystemEngineSessionTest {
 
     @Test
     fun webViewErrorMappingToErrorType() {
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNKNOWN_HOST,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_HOST_LOOKUP)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_CONNECTION_REFUSED,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_CONNECT)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_CONNECTION_REFUSED,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_IO)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_NET_TIMEOUT,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_TIMEOUT)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_REDIRECT_LOOP,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_REDIRECT_LOOP)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNKNOWN_PROTOCOL,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_UNSUPPORTED_SCHEME)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SECURITY_SSL,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_FAILED_SSL_HANDSHAKE)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_MALFORMED_URI,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_BAD_URL)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.UNKNOWN,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_TOO_MANY_REQUESTS)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_FILE_NOT_FOUND,
             SystemEngineSession.webViewErrorToErrorType(WebViewClient.ERROR_FILE_NOT_FOUND)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.UNKNOWN,
             SystemEngineSession.webViewErrorToErrorType(-500)
         )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-engine-system**
+  * ⚠️ **This is a breaking behavior change**: built-in `WebView`'s on-screen zoom controls are hidden by default.
+
 * **browser-icons**
   * Added disk cache for icons.
 


### PR DESCRIPTION
I suppose that [previous PR](https://github.com/mozilla-mobile/android-components/pull/2308) is not active anymore. So.

### Issue #1628

### Changes
  - `WebView`'s built-in zoom controls are hidden by default.
  - Verifying this in test when settings are not provided.
  - Renamed `defaultSettings` to more clear `withProvidedDefaultSettings`.
  - Calling `SystemEngineSession.initSettings()` from outside is not needed because settings are initialized when `WebView` is set.
  - Mentioning breaking behavior change in changelog.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features