### PR TITLE
 For #2346. Enable kotlin warningsAsErrors for `ui-progress` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -43,7 +43,6 @@ object KotlinCompiler {
         "support-utils",
         "tooling-lint",
         "ui-autocomplete",
-        "ui-progress",
         "ui-tabcounter"
     )
 }

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -12,7 +12,6 @@ object KotlinCompiler {
     // Maybe this is easier in Gradle 5+.
     @JvmStatic
     val projectsWithWarningsAsErrorsDisabled = setOf(
-        "browser-domains",
         "browser-engine-gecko",
         "browser-engine-servo",
         "browser-errorpages",

--- a/components/browser/domains/build.gradle
+++ b/components/browser/domains/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 
+    testImplementation project(':support-test')
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/DomainAutoCompleteProvider.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/DomainAutoCompleteProvider.kt
@@ -17,8 +17,12 @@ import java.util.Locale
  * [CustomDomains].
  */
 // FIXME delete this https://github.com/mozilla-mobile/android-components/issues/1358
-@Deprecated("Use [Providers.ShippedDomainsProvider] or [Providers.CustomDomainsProvider]")
+@Deprecated("Use `ShippedDomainsProvider` or `CustomDomainsProvider`",
+    ReplaceWith("ShippedDomainsProvider()/CustomDomainsProvider()",
+        "mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider",
+        "mozilla.components.browser.domains.autocomplete.CustomDomainsProvider"))
 class DomainAutoCompleteProvider {
+
     object AutocompleteSource {
         const val DEFAULT_LIST = "default"
         const val CUSTOM_LIST = "custom"

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/autocomplete/Providers.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/autocomplete/Providers.kt
@@ -23,40 +23,40 @@ enum class DomainList(val listName: String) {
 /**
  * Provides autocomplete functionality for domains based on provided list of assets (see [Domains]).
  */
-class ShippedDomainsProvider : BaseDomainAutocompleteProvider(DomainList.DEFAULT) {
-    override fun initialize(context: Context) {
-        scope.launch {
-            domains = async { Domains.load(context).into() }.await()
-        }
-    }
-}
+class ShippedDomainsProvider : BaseDomainAutocompleteProvider(DomainList.DEFAULT, Domains.asLoader())
 
 /**
  * Provides autocomplete functionality for domains based on a list managed by [CustomDomains].
  */
-class CustomDomainsProvider : BaseDomainAutocompleteProvider(DomainList.CUSTOM) {
-    override fun initialize(context: Context) {
-        scope.launch {
-            domains = async { CustomDomains.load(context).into() }.await()
-        }
-    }
-}
+class CustomDomainsProvider : BaseDomainAutocompleteProvider(DomainList.CUSTOM, CustomDomains.asLoader())
 
 interface DomainAutocompleteProvider {
     fun getAutocompleteSuggestion(query: String): DomainAutocompleteResult?
 }
 
+typealias DomainsLoader = (Context) -> List<Domain>
+
+private fun Domains.asLoader(): DomainsLoader = { context: Context -> load(context).into() }
+private fun CustomDomains.asLoader(): DomainsLoader = { context: Context -> load(context).into() }
+
 /**
  * Provides common autocomplete functionality powered by domain lists.
+ *
+ * @param list source of domains
+ * @param domainsLoader provider for all available domains
  */
-abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
-    DomainAutocompleteProvider {
-    internal val scope = CoroutineScope(Dispatchers.IO)
-    // We compute 'domains' on the worker thread; make sure it's immediately visible on the UI thread.
-    @Volatile
+open class BaseDomainAutocompleteProvider(
+    private val list: DomainList,
+    private val domainsLoader: DomainsLoader
+) : DomainAutocompleteProvider, CoroutineScope by CoroutineScope(Dispatchers.IO) {
+
     var domains: List<Domain> = emptyList()
 
-    abstract fun initialize(context: Context)
+    fun initialize(context: Context) {
+        launch {
+            domains = async { domainsLoader(context) }.await()
+        }
+    }
 
     /**
      * Computes an autocomplete suggestion for the given text, and invokes the
@@ -103,12 +103,12 @@ abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
      * that exactly matches the search text - which is what this method is for:
      */
     private fun getResultText(rawSearchText: String, autocomplete: String) =
-            rawSearchText + autocomplete.substring(rawSearchText.length)
+        rawSearchText + autocomplete.substring(rawSearchText.length)
 }
 
 /**
  * Describes an autocompletion result against a list of domains.
-* @property input Input for which this result is being provided.
+ * @property input Input for which this result is being provided.
  * @property text Result of autocompletion, text to be displayed.
  * @property url Result of autocompletion, full matching url.
  * @property source Name of the autocompletion source.

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt
@@ -1,0 +1,140 @@
+package mozilla.components.browser.domains
+
+import android.content.Context
+import android.preference.PreferenceManager
+import kotlinx.coroutines.Dispatchers
+import mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider
+import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvider
+import mozilla.components.browser.domains.autocomplete.DomainList
+import mozilla.components.browser.domains.autocomplete.DomainsLoader
+import mozilla.components.support.test.robolectric.applicationContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BaseDomainAutocompleteProviderTest {
+
+    private val context by applicationContext()
+
+    @After
+    fun tearDown() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .apply()
+    }
+
+    @Test
+    fun `empty provider with DEFAULT list returns nothing`() {
+        val provider = createAndInitProvider(context, DomainList.DEFAULT) {
+            emptyList()
+        }
+
+        assertNoCompletion(provider, "m")
+        assertNoCompletion(provider, "mo")
+        assertNoCompletion(provider, "moz")
+        assertNoCompletion(provider, "g")
+        assertNoCompletion(provider, "go")
+        assertNoCompletion(provider, "goo")
+        assertNoCompletion(provider, "w")
+        assertNoCompletion(provider, "www")
+    }
+
+    @Test
+    fun `empty provider with CUSTOM list returns nothing`() {
+        val provider = createAndInitProvider(context, DomainList.CUSTOM) {
+            emptyList()
+        }
+
+        assertNoCompletion(provider, "m")
+        assertNoCompletion(provider, "mo")
+        assertNoCompletion(provider, "moz")
+        assertNoCompletion(provider, "g")
+        assertNoCompletion(provider, "go")
+        assertNoCompletion(provider, "goo")
+        assertNoCompletion(provider, "w")
+        assertNoCompletion(provider, "www")
+    }
+
+    @Test
+    fun `non-empty provider with DEFAULT list returns completion`() {
+        val domains = listOf("mozilla.org", "google.com", "facebook.com").into()
+        val list = DomainList.DEFAULT
+        val domainsCount = domains.size
+
+        val provider = createAndInitProvider(context, list) { domains }
+
+        assertCompletion(provider, list, domainsCount, "m", "m", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "moz", "moz", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www", "www", "www.mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.face", "www.face", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "M", "m", "Mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "MOZ", "moz", "MOZilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.GOO", "www.goo", "www.GOOgle.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "WWW.GOOGLE.", "www.google.", "WWW.GOOGLE.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "www.facebook.com", "www.facebook.com", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "facebook.com", "facebook.com", "facebook.com", "http://facebook.com")
+
+        assertNoCompletion(provider, "wwww")
+        assertNoCompletion(provider, "yahoo")
+    }
+
+    @Test
+    fun `non-empty provider with CUSTOM list returns completion`() {
+        val domains = listOf("mozilla.org", "google.com", "facebook.com").into()
+        val list = DomainList.CUSTOM
+        val domainsCount = domains.size
+
+        val provider = createAndInitProvider(context, list) { domains }
+
+        assertCompletion(provider, list, domainsCount, "m", "m", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "moz", "moz", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www", "www", "www.mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.face", "www.face", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "M", "m", "Mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "MOZ", "moz", "MOZilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.GOO", "www.goo", "www.GOOgle.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "WWW.GOOGLE.", "www.google.", "WWW.GOOGLE.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "www.facebook.com", "www.facebook.com", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "facebook.com", "facebook.com", "facebook.com", "http://facebook.com")
+
+        assertNoCompletion(provider, "wwww")
+        assertNoCompletion(provider, "yahoo")
+    }
+}
+
+private fun assertCompletion(
+    provider: DomainAutocompleteProvider,
+    domainSource: DomainList,
+    sourceSize: Int,
+    input: String,
+    expectedInput: String,
+    completion: String,
+    expectedUrl: String
+) {
+    val result = provider.getAutocompleteSuggestion(input)!!
+
+    assertTrue("Autocompletion shouldn't be empty", result.text.isNotEmpty())
+
+    assertEquals("Autocompletion input", expectedInput, result.input)
+    assertEquals("Autocompletion completion", completion, result.text)
+    assertEquals("Autocompletion source list", domainSource.listName, result.source)
+    assertEquals("Autocompletion url", expectedUrl, result.url)
+    assertEquals("Autocompletion source list size", sourceSize, result.totalItems)
+}
+
+private fun assertNoCompletion(provider: DomainAutocompleteProvider, input: String) {
+    val result = provider.getAutocompleteSuggestion(input)
+
+    assertNull("Result should be null", result)
+}
+
+private fun createAndInitProvider(context: Context, list: DomainList, loader: DomainsLoader): DomainAutocompleteProvider =
+    object : BaseDomainAutocompleteProvider(list, loader) {
+        override val coroutineContext = super.coroutineContext + Dispatchers.Main
+    }.apply { initialize(context) }

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
@@ -6,28 +6,30 @@ package mozilla.components.browser.domains
 
 import android.content.Context
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class CustomDomainsTest {
+
+    private val context by applicationContext()
+
     @Before
     fun setUp() {
-        RuntimeEnvironment.application
-                .getSharedPreferences("custom_autocomplete", Context.MODE_PRIVATE)
-                .edit()
-                .clear()
-                .apply()
+        context.getSharedPreferences("custom_autocomplete", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
     }
 
     @Test
     fun customListIsEmptyByDefault() {
         val domains = runBlocking {
-            CustomDomains.load(RuntimeEnvironment.application)
+            CustomDomains.load(context)
         }
 
         assertEquals(0, domains.size)
@@ -35,38 +37,38 @@ class CustomDomainsTest {
 
     @Test
     fun saveAndRemoveDomains() {
-        CustomDomains.save(RuntimeEnvironment.application, listOf(
-                "mozilla.org",
-                "example.org",
-                "example.com"
+        CustomDomains.save(context, listOf(
+            "mozilla.org",
+            "example.org",
+            "example.com"
         ))
 
-        var domains = CustomDomains.load(RuntimeEnvironment.application)
+        var domains = CustomDomains.load(context)
         assertEquals(3, domains.size)
 
-        CustomDomains.remove(RuntimeEnvironment.application, listOf("example.org", "example.com"))
-        domains = CustomDomains.load(RuntimeEnvironment.application)
+        CustomDomains.remove(context, listOf("example.org", "example.com"))
+        domains = CustomDomains.load(context)
         assertEquals(1, domains.size)
         assertEquals("mozilla.org", domains.elementAt(0))
     }
 
     @Test
     fun addAndLoadDomains() {
-        CustomDomains.add(RuntimeEnvironment.application, "mozilla.org")
-        val domains = CustomDomains.load(RuntimeEnvironment.application)
+        CustomDomains.add(context, "mozilla.org")
+        val domains = CustomDomains.load(context)
         assertEquals(1, domains.size)
         assertEquals("mozilla.org", domains.elementAt(0))
     }
 
     @Test
     fun saveAndLoadDomains() {
-        CustomDomains.save(RuntimeEnvironment.application, listOf(
-                "mozilla.org",
-                "example.org",
-                "example.com"
+        CustomDomains.save(context, listOf(
+            "mozilla.org",
+            "example.org",
+            "example.com"
         ))
 
-        val domains = CustomDomains.load(RuntimeEnvironment.application)
+        val domains = CustomDomains.load(context)
 
         assertEquals(3, domains.size)
         assertEquals("mozilla.org", domains.elementAt(0))

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.components.browser.domains
 
 import android.preference.PreferenceManager
 import mozilla.components.browser.domains.DomainAutoCompleteProvider.AutocompleteSource.CUSTOM_LIST
 import mozilla.components.browser.domains.DomainAutoCompleteProvider.AutocompleteSource.DEFAULT_LIST
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -14,26 +17,33 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
+/**
+ * While [DomainAutoCompleteProvider] exists (even if it's deprecated) we need to test it.
+ */
 @RunWith(RobolectricTestRunner::class)
 class DomainAutoCompleteProviderTest {
 
+    private val context by applicationContext()
+
     @After
     fun tearDown() {
-        PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
-                .edit()
-                .clear()
-                .apply()
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .apply()
     }
 
     @Test
     fun autocompletionWithShippedDomains() {
-        val provider = DomainAutoCompleteProvider()
-        provider.initialize(RuntimeEnvironment.application, true, false, false)
+        val provider = DomainAutoCompleteProvider().also {
+            it.initialize(context,
+                useShippedDomains = true, useCustomDomains = false,
+                loadDomainsFromDisk = false)
 
-        provider.shippedDomains = listOf("mozilla.org", "google.com", "facebook.com").into()
-        provider.customDomains = emptyList()
+            it.shippedDomains = listOf("mozilla.org", "google.com", "facebook.com").into()
+            it.customDomains = emptyList()
+        }
 
         val size = provider.shippedDomains.size
 
@@ -55,10 +65,13 @@ class DomainAutoCompleteProviderTest {
         val domains = listOf("facebook.com", "google.com", "mozilla.org")
         val customDomains = listOf("gap.com", "www.fanfiction.com", "https://mobile.de")
 
-        val provider = DomainAutoCompleteProvider()
-        provider.initialize(RuntimeEnvironment.application, true, true, false)
-        provider.shippedDomains = domains.into()
-        provider.customDomains = customDomains.into()
+        val provider = DomainAutoCompleteProvider().also {
+            it.initialize(context,
+                useShippedDomains = true, useCustomDomains = true,
+                loadDomainsFromDisk = false)
+            it.shippedDomains = domains.into()
+            it.customDomains = customDomains.into()
+        }
 
         assertCompletion(provider, "f", CUSTOM_LIST, customDomains.size, "fanfiction.com", "http://www.fanfiction.com")
         assertCompletion(provider, "fa", CUSTOM_LIST, customDomains.size, "fanfiction.com", "http://www.fanfiction.com")
@@ -89,6 +102,7 @@ class DomainAutoCompleteProviderTest {
         expectedUrl: String
     ) {
         val result = provider.autocomplete(text)
+
         assertFalse(result.text.isEmpty())
 
         assertEquals(completion, result.text)
@@ -99,6 +113,7 @@ class DomainAutoCompleteProviderTest {
 
     private fun assertNoCompletion(provider: DomainAutoCompleteProvider, text: String) {
         val result = provider.autocomplete(text)
+
         assertTrue(result.text.isEmpty())
         assertTrue(result.url.isEmpty())
         assertTrue(result.source.isEmpty())

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
@@ -4,25 +4,27 @@
 
 package mozilla.components.browser.domains
 
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class DomainsTest {
 
+    val context by applicationContext()
+
     @Test
     fun loadDomains() {
-        val domains = Domains.load(RuntimeEnvironment.application, setOf("us"))
+        val domains = Domains.load(context, setOf("us"))
         Assert.assertFalse(domains.isEmpty())
         Assert.assertTrue(domains.contains("reddit.com"))
     }
 
     @Test
     fun loadDomainsWithDefaultCountries() {
-        val domains = Domains.load(RuntimeEnvironment.application)
+        val domains = Domains.load(context)
         Assert.assertFalse(domains.isEmpty())
         // From the global list
         Assert.assertTrue(domains.contains("mozilla.org"))

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.toolbar
 
-import android.content.Context
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.Toolbar
@@ -110,8 +109,7 @@ class ToolbarAutocompleteFeatureTest {
         val autocompleteDelegate: AutocompleteDelegate = mock()
 
         var history: HistoryStorage = InMemoryHistoryStorage()
-        val domains = object : BaseDomainAutocompleteProvider(DomainList.CUSTOM) {
-            override fun initialize(context: Context) {}
+        val domains = object : BaseDomainAutocompleteProvider(DomainList.CUSTOM, { emptyList() }) {
             fun testDomains(list: List<Domain>) {
                 domains = list
             }

--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation Dependencies.testing_mockito
     implementation Dependencies.testing_robolectric
 
+    implementation Dependencies.androidx_test_core
+
     testImplementation Dependencies.androidx_core
     testImplementation project(':support-ktx')
 }

--- a/components/support/test/src/main/java/mozilla/components/support/test/robolectric/delegates.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/robolectric/delegates.kt
@@ -1,0 +1,17 @@
+package mozilla.components.support.test.robolectric
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+internal class ApplicationContextProvider<T : Context> : ReadOnlyProperty<Any?, T> {
+
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T =
+        ApplicationProvider.getApplicationContext()
+}
+
+/**
+ * Delegate for providing application context
+ */
+fun applicationContext(): ReadOnlyProperty<Any?, Context> = ApplicationContextProvider()

--- a/components/ui/progress/build.gradle
+++ b/components/ui/progress/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation Dependencies.androidx_appcompat
 
+    testImplementation project(":support-test")
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/ui/progress/src/main/java/mozilla/components/ui/progress/DrawableWrapper.kt
+++ b/components/ui/progress/src/main/java/mozilla/components/ui/progress/DrawableWrapper.kt
@@ -36,7 +36,7 @@ internal open class DrawableWrapper(val wrappedDrawable: Drawable) : Drawable() 
         return wrappedDrawable.changingConfigurations
     }
 
-    override fun getConstantState(): Drawable.ConstantState? {
+    override fun getConstantState(): ConstantState? {
         return wrappedDrawable.constantState
     }
 
@@ -93,8 +93,7 @@ internal open class DrawableWrapper(val wrappedDrawable: Drawable) : Drawable() 
         return wrappedDrawable.mutate()
     }
 
-    @Suppress("MagicNumber")
-    override fun setAlpha(@IntRange(from = 0, to = 255) i: Int) {
+    override fun setAlpha(@IntRange(from = MIN_ALPHA_VALUE, to = MAX_ALPHA_VALUE) i: Int) {
         wrappedDrawable.alpha = i
     }
 
@@ -138,3 +137,6 @@ internal open class DrawableWrapper(val wrappedDrawable: Drawable) : Drawable() 
         return wrappedDrawable.setState(state)
     }
 }
+
+private const val MIN_ALPHA_VALUE = 0L
+private const val MAX_ALPHA_VALUE = 255L

--- a/components/ui/progress/src/test/java/mozilla/components/ui/progress/AnimatedProgressBarTest.kt
+++ b/components/ui/progress/src/test/java/mozilla/components/ui/progress/AnimatedProgressBarTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.ui.progress
 
 import android.view.View
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,14 +13,15 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AnimatedProgressBarTest {
 
+    private val context by applicationContext()
+
     @Test
     fun setProgress() {
-        val progressBar = AnimatedProgressBar(RuntimeEnvironment.application)
+        val progressBar = AnimatedProgressBar(context)
 
         progressBar.progress = -1
         assertEquals(0, progressBar.progress)
@@ -36,7 +38,7 @@ class AnimatedProgressBarTest {
 
     @Test
     fun setVisibility() {
-        val progressBar = spy(AnimatedProgressBar(RuntimeEnvironment.application))
+        val progressBar = spy(AnimatedProgressBar(context))
 
         progressBar.visibility = View.GONE
         verify(progressBar, never()).animateClosing()

--- a/docs/api/alltypes/index.md
+++ b/docs/api/alltypes/index.md
@@ -43,7 +43,7 @@
 | [mozilla.components.support.base.feature.BackHandler](../mozilla.components.support.base.feature/-back-handler/index.md) | Generic interface for fragments, features and other components that want to handle 'back' button presses. |
 | [mozilla.components.feature.sync.BackgroundSyncManager](../mozilla.components.feature.sync/-background-sync-manager/index.md) | A SyncManager implementation which uses WorkManager APIs to schedule sync tasks. |
 | [mozilla.components.support.ktx.android.util.Base64](../mozilla.components.support.ktx.android.util/-base64/index.md) |  |
-| [mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider](../mozilla.components.browser.domains.autocomplete/-base-domain-autocomplete-provider/index.md) | Provides common autocomplete functionality powered by domain lists. |
+| [mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider](../mozilla.components.browser.domains.autocomplete/-base-domain-autocomplete-provider/index.md) | Provides common autocomplete functionality powered by domain lists. **(Deprecated. Use `ShippedDomainsProvider` or `CustomDomainsProvider` instead)** |
 | [android.graphics.Bitmap](../mozilla.components.support.ktx.android.graphics/android.graphics.-bitmap/index.md) (extensions in package mozilla.components.support.ktx.android.graphics) |  |
 | [mozilla.components.concept.storage.BookmarkInfo](../mozilla.components.concept.storage/-bookmark-info/index.md) | Class for making alterations to any bookmark node |
 | [mozilla.components.concept.storage.BookmarkNode](../mozilla.components.concept.storage/-bookmark-node/index.md) | Class for holding metadata about any bookmark node |


### PR DESCRIPTION
### Issue #2346 

### Depends on #3017.

Uses `applicationContext()` delegate, introduced in previous PR. Will be rebased once dependency will be merged / denied.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
