### PR TITLE
[SKIP, has dependencies]  For #2346. Enable kotlin warningsAsErrors for few more modules.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -43,7 +43,6 @@ object KotlinCompiler {
         "support-utils",
         "tooling-lint",
         "ui-autocomplete",
-        "ui-progress",
         "ui-tabcounter"
     )
 }

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -39,7 +39,6 @@ object KotlinCompiler {
         "service-firefox-accounts",
         "service-fretboard",
         "service-glean",
-        "support-test",
-        "support-utils"
+        "support-test"
     )
 }

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -14,7 +14,6 @@ object KotlinCompiler {
     val projectsWithWarningsAsErrorsDisabled = setOf(
         "browser-engine-gecko",
         "browser-engine-servo",
-        "browser-errorpages",
         "browser-menu",
         "browser-search",
         "browser-storage-sync",

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -12,7 +12,6 @@ object KotlinCompiler {
     // Maybe this is easier in Gradle 5+.
     @JvmStatic
     val projectsWithWarningsAsErrorsDisabled = setOf(
-        "browser-domains",
         "browser-engine-gecko",
         "browser-engine-servo",
         "browser-errorpages",

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -18,7 +18,6 @@ object KotlinCompiler {
         "browser-menu",
         "browser-search",
         "browser-storage-sync",
-        "browser-toolbar",
         "feature-accounts",
         "feature-awesomebar",
         "feature-contextmenu",

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -19,7 +19,6 @@ object KotlinCompiler {
         "browser-search",
         "browser-storage-sync",
         "browser-toolbar",
-        "concept-toolbar",
         "feature-accounts",
         "feature-awesomebar",
         "feature-contextmenu",

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -14,7 +14,6 @@ object KotlinCompiler {
     val projectsWithWarningsAsErrorsDisabled = setOf(
         "browser-engine-gecko",
         "browser-engine-servo",
-        "browser-menu",
         "browser-search",
         "browser-storage-sync",
         "feature-accounts",

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -41,7 +41,6 @@ object KotlinCompiler {
         "service-glean",
         "support-test",
         "support-utils",
-        "tooling-lint",
-        "ui-autocomplete"
+        "tooling-lint"
     )
 }

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -42,7 +42,6 @@ object KotlinCompiler {
         "support-test",
         "support-utils",
         "tooling-lint",
-        "ui-autocomplete",
-        "ui-tabcounter"
+        "ui-autocomplete"
     )
 }

--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -40,7 +40,6 @@ object KotlinCompiler {
         "service-fretboard",
         "service-glean",
         "support-test",
-        "support-utils",
-        "tooling-lint"
+        "support-utils"
     )
 }

--- a/components/browser/domains/build.gradle
+++ b/components/browser/domains/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 
+    testImplementation project(':support-test')
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/DomainAutoCompleteProvider.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/DomainAutoCompleteProvider.kt
@@ -17,8 +17,12 @@ import java.util.Locale
  * [CustomDomains].
  */
 // FIXME delete this https://github.com/mozilla-mobile/android-components/issues/1358
-@Deprecated("Use [Providers.ShippedDomainsProvider] or [Providers.CustomDomainsProvider]")
+@Deprecated("Use `ShippedDomainsProvider` or `CustomDomainsProvider`",
+    ReplaceWith("ShippedDomainsProvider()/CustomDomainsProvider()",
+        "mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider",
+        "mozilla.components.browser.domains.autocomplete.CustomDomainsProvider"))
 class DomainAutoCompleteProvider {
+
     object AutocompleteSource {
         const val DEFAULT_LIST = "default"
         const val CUSTOM_LIST = "custom"

--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/autocomplete/Providers.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/autocomplete/Providers.kt
@@ -23,40 +23,40 @@ enum class DomainList(val listName: String) {
 /**
  * Provides autocomplete functionality for domains based on provided list of assets (see [Domains]).
  */
-class ShippedDomainsProvider : BaseDomainAutocompleteProvider(DomainList.DEFAULT) {
-    override fun initialize(context: Context) {
-        scope.launch {
-            domains = async { Domains.load(context).into() }.await()
-        }
-    }
-}
+class ShippedDomainsProvider : BaseDomainAutocompleteProvider(DomainList.DEFAULT, Domains.asLoader())
 
 /**
  * Provides autocomplete functionality for domains based on a list managed by [CustomDomains].
  */
-class CustomDomainsProvider : BaseDomainAutocompleteProvider(DomainList.CUSTOM) {
-    override fun initialize(context: Context) {
-        scope.launch {
-            domains = async { CustomDomains.load(context).into() }.await()
-        }
-    }
-}
+class CustomDomainsProvider : BaseDomainAutocompleteProvider(DomainList.CUSTOM, CustomDomains.asLoader())
 
 interface DomainAutocompleteProvider {
     fun getAutocompleteSuggestion(query: String): DomainAutocompleteResult?
 }
 
+typealias DomainsLoader = (Context) -> List<Domain>
+
+private fun Domains.asLoader(): DomainsLoader = { context: Context -> load(context).into() }
+private fun CustomDomains.asLoader(): DomainsLoader = { context: Context -> load(context).into() }
+
 /**
  * Provides common autocomplete functionality powered by domain lists.
+ *
+ * @param list source of domains
+ * @param domainsLoader provider for all available domains
  */
-abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
-    DomainAutocompleteProvider {
-    internal val scope = CoroutineScope(Dispatchers.IO)
-    // We compute 'domains' on the worker thread; make sure it's immediately visible on the UI thread.
-    @Volatile
+open class BaseDomainAutocompleteProvider(
+    private val list: DomainList,
+    private val domainsLoader: DomainsLoader
+) : DomainAutocompleteProvider, CoroutineScope by CoroutineScope(Dispatchers.IO) {
+
     var domains: List<Domain> = emptyList()
 
-    abstract fun initialize(context: Context)
+    fun initialize(context: Context) {
+        launch {
+            domains = async { domainsLoader(context) }.await()
+        }
+    }
 
     /**
      * Computes an autocomplete suggestion for the given text, and invokes the
@@ -103,12 +103,12 @@ abstract class BaseDomainAutocompleteProvider(private val list: DomainList) :
      * that exactly matches the search text - which is what this method is for:
      */
     private fun getResultText(rawSearchText: String, autocomplete: String) =
-            rawSearchText + autocomplete.substring(rawSearchText.length)
+        rawSearchText + autocomplete.substring(rawSearchText.length)
 }
 
 /**
  * Describes an autocompletion result against a list of domains.
-* @property input Input for which this result is being provided.
+ * @property input Input for which this result is being provided.
  * @property text Result of autocompletion, text to be displayed.
  * @property url Result of autocompletion, full matching url.
  * @property source Name of the autocompletion source.

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt
@@ -1,0 +1,140 @@
+package mozilla.components.browser.domains
+
+import android.content.Context
+import android.preference.PreferenceManager
+import kotlinx.coroutines.Dispatchers
+import mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider
+import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvider
+import mozilla.components.browser.domains.autocomplete.DomainList
+import mozilla.components.browser.domains.autocomplete.DomainsLoader
+import mozilla.components.support.test.robolectric.applicationContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BaseDomainAutocompleteProviderTest {
+
+    private val context by applicationContext()
+
+    @After
+    fun tearDown() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .apply()
+    }
+
+    @Test
+    fun `empty provider with DEFAULT list returns nothing`() {
+        val provider = createAndInitProvider(context, DomainList.DEFAULT) {
+            emptyList()
+        }
+
+        assertNoCompletion(provider, "m")
+        assertNoCompletion(provider, "mo")
+        assertNoCompletion(provider, "moz")
+        assertNoCompletion(provider, "g")
+        assertNoCompletion(provider, "go")
+        assertNoCompletion(provider, "goo")
+        assertNoCompletion(provider, "w")
+        assertNoCompletion(provider, "www")
+    }
+
+    @Test
+    fun `empty provider with CUSTOM list returns nothing`() {
+        val provider = createAndInitProvider(context, DomainList.CUSTOM) {
+            emptyList()
+        }
+
+        assertNoCompletion(provider, "m")
+        assertNoCompletion(provider, "mo")
+        assertNoCompletion(provider, "moz")
+        assertNoCompletion(provider, "g")
+        assertNoCompletion(provider, "go")
+        assertNoCompletion(provider, "goo")
+        assertNoCompletion(provider, "w")
+        assertNoCompletion(provider, "www")
+    }
+
+    @Test
+    fun `non-empty provider with DEFAULT list returns completion`() {
+        val domains = listOf("mozilla.org", "google.com", "facebook.com").into()
+        val list = DomainList.DEFAULT
+        val domainsCount = domains.size
+
+        val provider = createAndInitProvider(context, list) { domains }
+
+        assertCompletion(provider, list, domainsCount, "m", "m", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "moz", "moz", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www", "www", "www.mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.face", "www.face", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "M", "m", "Mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "MOZ", "moz", "MOZilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.GOO", "www.goo", "www.GOOgle.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "WWW.GOOGLE.", "www.google.", "WWW.GOOGLE.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "www.facebook.com", "www.facebook.com", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "facebook.com", "facebook.com", "facebook.com", "http://facebook.com")
+
+        assertNoCompletion(provider, "wwww")
+        assertNoCompletion(provider, "yahoo")
+    }
+
+    @Test
+    fun `non-empty provider with CUSTOM list returns completion`() {
+        val domains = listOf("mozilla.org", "google.com", "facebook.com").into()
+        val list = DomainList.CUSTOM
+        val domainsCount = domains.size
+
+        val provider = createAndInitProvider(context, list) { domains }
+
+        assertCompletion(provider, list, domainsCount, "m", "m", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "moz", "moz", "mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www", "www", "www.mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.face", "www.face", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "M", "m", "Mozilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "MOZ", "moz", "MOZilla.org", "http://mozilla.org")
+        assertCompletion(provider, list, domainsCount, "www.GOO", "www.goo", "www.GOOgle.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "WWW.GOOGLE.", "www.google.", "WWW.GOOGLE.com", "http://google.com")
+        assertCompletion(provider, list, domainsCount, "www.facebook.com", "www.facebook.com", "www.facebook.com", "http://facebook.com")
+        assertCompletion(provider, list, domainsCount, "facebook.com", "facebook.com", "facebook.com", "http://facebook.com")
+
+        assertNoCompletion(provider, "wwww")
+        assertNoCompletion(provider, "yahoo")
+    }
+}
+
+private fun assertCompletion(
+    provider: DomainAutocompleteProvider,
+    domainSource: DomainList,
+    sourceSize: Int,
+    input: String,
+    expectedInput: String,
+    completion: String,
+    expectedUrl: String
+) {
+    val result = provider.getAutocompleteSuggestion(input)!!
+
+    assertTrue("Autocompletion shouldn't be empty", result.text.isNotEmpty())
+
+    assertEquals("Autocompletion input", expectedInput, result.input)
+    assertEquals("Autocompletion completion", completion, result.text)
+    assertEquals("Autocompletion source list", domainSource.listName, result.source)
+    assertEquals("Autocompletion url", expectedUrl, result.url)
+    assertEquals("Autocompletion source list size", sourceSize, result.totalItems)
+}
+
+private fun assertNoCompletion(provider: DomainAutocompleteProvider, input: String) {
+    val result = provider.getAutocompleteSuggestion(input)
+
+    assertNull("Result should be null", result)
+}
+
+private fun createAndInitProvider(context: Context, list: DomainList, loader: DomainsLoader): DomainAutocompleteProvider =
+    object : BaseDomainAutocompleteProvider(list, loader) {
+        override val coroutineContext = super.coroutineContext + Dispatchers.Main
+    }.apply { initialize(context) }

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/CustomDomainsTest.kt
@@ -6,28 +6,30 @@ package mozilla.components.browser.domains
 
 import android.content.Context
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class CustomDomainsTest {
+
+    private val context by applicationContext()
+
     @Before
     fun setUp() {
-        RuntimeEnvironment.application
-                .getSharedPreferences("custom_autocomplete", Context.MODE_PRIVATE)
-                .edit()
-                .clear()
-                .apply()
+        context.getSharedPreferences("custom_autocomplete", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
     }
 
     @Test
     fun customListIsEmptyByDefault() {
         val domains = runBlocking {
-            CustomDomains.load(RuntimeEnvironment.application)
+            CustomDomains.load(context)
         }
 
         assertEquals(0, domains.size)
@@ -35,38 +37,38 @@ class CustomDomainsTest {
 
     @Test
     fun saveAndRemoveDomains() {
-        CustomDomains.save(RuntimeEnvironment.application, listOf(
-                "mozilla.org",
-                "example.org",
-                "example.com"
+        CustomDomains.save(context, listOf(
+            "mozilla.org",
+            "example.org",
+            "example.com"
         ))
 
-        var domains = CustomDomains.load(RuntimeEnvironment.application)
+        var domains = CustomDomains.load(context)
         assertEquals(3, domains.size)
 
-        CustomDomains.remove(RuntimeEnvironment.application, listOf("example.org", "example.com"))
-        domains = CustomDomains.load(RuntimeEnvironment.application)
+        CustomDomains.remove(context, listOf("example.org", "example.com"))
+        domains = CustomDomains.load(context)
         assertEquals(1, domains.size)
         assertEquals("mozilla.org", domains.elementAt(0))
     }
 
     @Test
     fun addAndLoadDomains() {
-        CustomDomains.add(RuntimeEnvironment.application, "mozilla.org")
-        val domains = CustomDomains.load(RuntimeEnvironment.application)
+        CustomDomains.add(context, "mozilla.org")
+        val domains = CustomDomains.load(context)
         assertEquals(1, domains.size)
         assertEquals("mozilla.org", domains.elementAt(0))
     }
 
     @Test
     fun saveAndLoadDomains() {
-        CustomDomains.save(RuntimeEnvironment.application, listOf(
-                "mozilla.org",
-                "example.org",
-                "example.com"
+        CustomDomains.save(context, listOf(
+            "mozilla.org",
+            "example.org",
+            "example.com"
         ))
 
-        val domains = CustomDomains.load(RuntimeEnvironment.application)
+        val domains = CustomDomains.load(context)
 
         assertEquals(3, domains.size)
         assertEquals("mozilla.org", domains.elementAt(0))

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.components.browser.domains
 
 import android.preference.PreferenceManager
 import mozilla.components.browser.domains.DomainAutoCompleteProvider.AutocompleteSource.CUSTOM_LIST
 import mozilla.components.browser.domains.DomainAutoCompleteProvider.AutocompleteSource.DEFAULT_LIST
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -14,26 +17,33 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
+/**
+ * While [DomainAutoCompleteProvider] exists (even if it's deprecated) we need to test it.
+ */
 @RunWith(RobolectricTestRunner::class)
 class DomainAutoCompleteProviderTest {
 
+    private val context by applicationContext()
+
     @After
     fun tearDown() {
-        PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
-                .edit()
-                .clear()
-                .apply()
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .apply()
     }
 
     @Test
     fun autocompletionWithShippedDomains() {
-        val provider = DomainAutoCompleteProvider()
-        provider.initialize(RuntimeEnvironment.application, true, false, false)
+        val provider = DomainAutoCompleteProvider().also {
+            it.initialize(context,
+                useShippedDomains = true, useCustomDomains = false,
+                loadDomainsFromDisk = false)
 
-        provider.shippedDomains = listOf("mozilla.org", "google.com", "facebook.com").into()
-        provider.customDomains = emptyList()
+            it.shippedDomains = listOf("mozilla.org", "google.com", "facebook.com").into()
+            it.customDomains = emptyList()
+        }
 
         val size = provider.shippedDomains.size
 
@@ -55,10 +65,13 @@ class DomainAutoCompleteProviderTest {
         val domains = listOf("facebook.com", "google.com", "mozilla.org")
         val customDomains = listOf("gap.com", "www.fanfiction.com", "https://mobile.de")
 
-        val provider = DomainAutoCompleteProvider()
-        provider.initialize(RuntimeEnvironment.application, true, true, false)
-        provider.shippedDomains = domains.into()
-        provider.customDomains = customDomains.into()
+        val provider = DomainAutoCompleteProvider().also {
+            it.initialize(context,
+                useShippedDomains = true, useCustomDomains = true,
+                loadDomainsFromDisk = false)
+            it.shippedDomains = domains.into()
+            it.customDomains = customDomains.into()
+        }
 
         assertCompletion(provider, "f", CUSTOM_LIST, customDomains.size, "fanfiction.com", "http://www.fanfiction.com")
         assertCompletion(provider, "fa", CUSTOM_LIST, customDomains.size, "fanfiction.com", "http://www.fanfiction.com")
@@ -89,6 +102,7 @@ class DomainAutoCompleteProviderTest {
         expectedUrl: String
     ) {
         val result = provider.autocomplete(text)
+
         assertFalse(result.text.isEmpty())
 
         assertEquals(completion, result.text)
@@ -99,6 +113,7 @@ class DomainAutoCompleteProviderTest {
 
     private fun assertNoCompletion(provider: DomainAutoCompleteProvider, text: String) {
         val result = provider.autocomplete(text)
+
         assertTrue(result.text.isEmpty())
         assertTrue(result.url.isEmpty())
         assertTrue(result.source.isEmpty())

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainsTest.kt
@@ -4,25 +4,27 @@
 
 package mozilla.components.browser.domains
 
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class DomainsTest {
 
+    val context by applicationContext()
+
     @Test
     fun loadDomains() {
-        val domains = Domains.load(RuntimeEnvironment.application, setOf("us"))
+        val domains = Domains.load(context, setOf("us"))
         Assert.assertFalse(domains.isEmpty())
         Assert.assertTrue(domains.contains("reddit.com"))
     }
 
     @Test
     fun loadDomainsWithDefaultCountries() {
-        val domains = Domains.load(RuntimeEnvironment.application)
+        val domains = Domains.load(context)
         Assert.assertFalse(domains.isEmpty())
         // From the global list
         Assert.assertTrue(domains.contains("mozilla.org"))

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -6,7 +6,9 @@
 
 package mozilla.components.browser.errorpages
 
-import org.junit.Assert
+import mozilla.components.browser.errorpages.ErrorPages.createErrorPage
+import mozilla.components.support.test.robolectric.applicationContext
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.nullable
@@ -15,21 +17,52 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ErrorPagesTest {
 
     @Test
     fun `createErrorPage should replace default HTML placeholders`() {
-        val context = spy(RuntimeEnvironment.application)
-        val errorPage = ErrorPages.createErrorPage(context, ErrorType.UNKNOWN)
-        Assert.assertFalse(errorPage.contains("%pageTitle%"))
-        Assert.assertFalse(errorPage.contains("%backButton%"))
-        Assert.assertFalse(errorPage.contains("%button%"))
-        Assert.assertFalse(errorPage.contains("%messageShort%"))
-        Assert.assertFalse(errorPage.contains("%messageLong%"))
-        Assert.assertFalse(errorPage.contains("%css%"))
+        assertTemplateIsValid(ErrorType.UNKNOWN)
+        assertTemplateIsValid(ErrorType.ERROR_SECURITY_SSL)
+        assertTemplateIsValid(ErrorType.ERROR_SECURITY_BAD_CERT)
+        assertTemplateIsValid(ErrorType.ERROR_NET_INTERRUPT)
+        assertTemplateIsValid(ErrorType.ERROR_NET_TIMEOUT)
+        assertTemplateIsValid(ErrorType.ERROR_CONNECTION_REFUSED)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_SOCKET_TYPE)
+        assertTemplateIsValid(ErrorType.ERROR_REDIRECT_LOOP)
+        assertTemplateIsValid(ErrorType.ERROR_OFFLINE)
+        assertTemplateIsValid(ErrorType.ERROR_PORT_BLOCKED)
+        assertTemplateIsValid(ErrorType.ERROR_NET_RESET)
+        assertTemplateIsValid(ErrorType.ERROR_UNSAFE_CONTENT_TYPE)
+        assertTemplateIsValid(ErrorType.ERROR_CORRUPTED_CONTENT)
+        assertTemplateIsValid(ErrorType.ERROR_CONTENT_CRASHED)
+        assertTemplateIsValid(ErrorType.ERROR_INVALID_CONTENT_ENCODING)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_HOST)
+        assertTemplateIsValid(ErrorType.ERROR_MALFORMED_URI)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_PROTOCOL)
+        assertTemplateIsValid(ErrorType.ERROR_FILE_NOT_FOUND)
+        assertTemplateIsValid(ErrorType.ERROR_FILE_ACCESS_DENIED)
+        assertTemplateIsValid(ErrorType.ERROR_PROXY_CONNECTION_REFUSED)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_PROXY_HOST)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_MALWARE_URI)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_UNWANTED_URI)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_HARMFUL_URI)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_PHISHING_URI)
+    }
+
+    private fun assertTemplateIsValid(errorType: ErrorType) {
+        val context = spy(applicationContext().get())
+
+        val errorPage = createErrorPage(context, errorType)
+
+        assertFalse(errorPage.contains("%pageTitle%"))
+        assertFalse(errorPage.contains("%backButton%"))
+        assertFalse(errorPage.contains("%button%"))
+        assertFalse(errorPage.contains("%messageShort%"))
+        assertFalse(errorPage.contains("%messageLong%"))
+        assertFalse(errorPage.contains("%css%"))
+
         verify(context, times(4)).getString(anyInt())
         verify(context, times(1)).getString(anyInt(), nullable(String::class.java))
     }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -68,16 +68,16 @@ class BrowserMenu internal constructor(
         /**
          * Determines the orientation to be used for a menu based on the positioning of the [parent] in the layout.
          */
-        fun determineMenuOrientation(parent: View): BrowserMenu.Orientation {
+        fun determineMenuOrientation(parent: View): Orientation {
             val params = parent.layoutParams
             return if (params is CoordinatorLayout.LayoutParams) {
                 if ((params.gravity and Gravity.BOTTOM) == Gravity.BOTTOM) {
-                    BrowserMenu.Orientation.UP
+                    Orientation.UP
                 } else {
-                    BrowserMenu.Orientation.DOWN
+                    Orientation.DOWN
                 }
             } else {
-                BrowserMenu.Orientation.DOWN
+                Orientation.DOWN
             }
         }
     }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.menu
 
 import android.view.View
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Test
@@ -15,10 +16,12 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuAdapterTest {
+
+    private val context by applicationContext()
+
     @Test
     fun `items that return false from the visible lambda will be filtered out`() {
         val items = listOf(
@@ -28,7 +31,7 @@ class BrowserMenuAdapterTest {
             createMenuItem(4) { false },
             createMenuItem(5) { true })
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(context, items)
 
         assertEquals(3, adapter.visibleItems.size)
 
@@ -47,7 +50,7 @@ class BrowserMenuAdapterTest {
                 createMenuItem(23),
                 createMenuItem(42))
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(context, items)
 
         assertEquals(2, adapter.itemCount)
 
@@ -62,7 +65,7 @@ class BrowserMenuAdapterTest {
 
         val menu = mock(BrowserMenu::class.java)
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, listOf(item1, item2))
+        val adapter = BrowserMenuAdapter(context, listOf(item1, item2))
         adapter.menu = menu
 
         val view = mock(View::class.java)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
@@ -7,22 +7,25 @@ package mozilla.components.browser.menu
 import android.view.View
 import android.widget.ImageButton
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuBuilderTest {
+
+    private val context by applicationContext()
+
     @Test
     fun `items are forwarded from builder to menu`() {
         val builder = BrowserMenuBuilder(listOf(mockMenuItem(), mockMenuItem()))
 
-        val menu = builder.build(RuntimeEnvironment.application)
+        val menu = builder.build(context)
 
-        val anchor = ImageButton(RuntimeEnvironment.application)
+        val anchor = ImageButton(context)
         val popup = menu.show(anchor)
 
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.widget.CheckBox
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -12,10 +13,11 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuCompoundButtonTest {
+
+    private val context by applicationContext()
 
     @Test
     fun `simple menu items are always visible by default`() {
@@ -32,9 +34,8 @@ class BrowserMenuCompoundButtonTest {
             // do nothing
         }
 
-        val view = LayoutInflater.from(
-            RuntimeEnvironment.application
-        ).inflate(item.getLayoutResource(), null)
+        val view = LayoutInflater.from(context)
+            .inflate(item.getLayoutResource(), null)
 
         assertNotNull(view)
     }
@@ -48,7 +49,7 @@ class BrowserMenuCompoundButtonTest {
         }
 
         val menu = mock(BrowserMenu::class.java)
-        val view = CheckBox(RuntimeEnvironment.application)
+        val view = CheckBox(context)
 
         item.bind(menu, view)
 
@@ -64,7 +65,7 @@ class BrowserMenuCompoundButtonTest {
         val item = SimpleTestBrowserCompoundButton("Hello", initialState) {}
 
         val menu = mock(BrowserMenu::class.java)
-        val view = spy(CheckBox(RuntimeEnvironment.application))
+        val view = spy(CheckBox(context))
         item.bind(menu, view)
 
         verify(view).isChecked = true

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -10,6 +10,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -20,10 +21,12 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuItemToolbarTest {
+
+    private val context by applicationContext()
+
     @Test
     fun `toolbar is visible by default`() {
         val toolbar = BrowserMenuItemToolbar(emptyList())
@@ -35,16 +38,15 @@ class BrowserMenuItemToolbarTest {
     fun `layout resource can be inflated`() {
         val toolbar = BrowserMenuItemToolbar(emptyList())
 
-        val view = LayoutInflater.from(
-            RuntimeEnvironment.application
-        ).inflate(toolbar.getLayoutResource(), null)
+        val view = LayoutInflater.from(context)
+            .inflate(toolbar.getLayoutResource(), null)
 
         assertNotNull(view)
     }
 
     @Test
     fun `empty toolbar does not add anything to view group`() {
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(context)
 
         val menu = mock(BrowserMenu::class.java)
 
@@ -56,9 +58,9 @@ class BrowserMenuItemToolbarTest {
 
     @Test
     fun `toolbar removes previously existing child views from view group`() {
-        val layout = LinearLayout(RuntimeEnvironment.application)
-        layout.addView(TextView(RuntimeEnvironment.application))
-        layout.addView(TextView(RuntimeEnvironment.application))
+        val layout = LinearLayout(context)
+        layout.addView(TextView(context))
+        layout.addView(TextView(context))
 
         assertEquals(2, layout.childCount)
 
@@ -90,7 +92,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(context)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -124,7 +126,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(context)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -170,7 +172,7 @@ class BrowserMenuItemToolbarTest {
         assertFalse(callbackInvoked)
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(context)
 
         val toolbar = BrowserMenuItemToolbar(listOf(button))
         toolbar.bind(menu, layout)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
@@ -4,13 +4,12 @@
 
 package mozilla.components.browser.menu.item
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -19,11 +18,11 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class SimpleBrowserMenuItemTest {
-    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private val context by applicationContext()
 
     @Test
     fun `simple menu items are always visible by default`() {
@@ -40,9 +39,8 @@ class SimpleBrowserMenuItemTest {
             // do nothing
         }
 
-        val view = LayoutInflater.from(
-            RuntimeEnvironment.application
-        ).inflate(item.getLayoutResource(), null)
+        val view = LayoutInflater.from(context)
+            .inflate(item.getLayoutResource(), null)
 
         assertNotNull(view)
     }
@@ -56,7 +54,7 @@ class SimpleBrowserMenuItemTest {
         }
 
         val menu = mock(BrowserMenu::class.java)
-        val view = TextView(RuntimeEnvironment.application)
+        val view = TextView(context)
 
         item.bind(menu, view)
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -404,6 +404,18 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `cast to view`() {
+        // Given
+        val toolbar = BrowserToolbar(context)
+
+        // When
+        val view = toolbar.asView()
+
+        // Then
+        assertNotNull(view)
+    }
+
+    @Test
     fun `URL update does not override search terms in edit mode`() {
         val toolbar = BrowserToolbar(context)
         val displayToolbar = mock(DisplayToolbar::class.java)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.browser.toolbar.display
 
-import android.content.Context
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
@@ -12,7 +11,6 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
@@ -24,6 +22,7 @@ import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.processor.CollectionProcessor
 import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -38,13 +37,12 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class DisplayToolbarTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
+
+    private val context by applicationContext()
 
     @Test
     fun `clicking on the URL switches the toolbar to editing mode`() {
@@ -767,7 +765,7 @@ class DisplayToolbarTest {
     @Test
     fun `iconView changes image resource when site security changes`() {
         val toolbar = mock(BrowserToolbar::class.java)
-        val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
+        val displayToolbar = DisplayToolbar(context, toolbar)
         var shadowDrawable = shadowOf(displayToolbar.siteSecurityIconView.drawable)
         assertEquals(R.drawable.mozac_ic_globe, shadowDrawable.createdFromResId)
 
@@ -785,7 +783,7 @@ class DisplayToolbarTest {
     @Test
     fun `securityIconColor is set when securityIconColor changes`() {
         val toolbar = mock(BrowserToolbar::class.java)
-        val displayToolbar = DisplayToolbar(RuntimeEnvironment.application, toolbar)
+        val displayToolbar = DisplayToolbar(context, toolbar)
 
         displayToolbar.securityIconColor = Pair(R.color.photonBlue40, R.color.photonBlue40)
 

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -29,7 +29,7 @@ interface AwesomeBar {
     fun removeProviders(vararg providers: SuggestionProvider)
 
     /**
-     * Removes all [SuggestionProviders]
+     * Removes all [SuggestionProvider]s
      */
     fun removeAllProviders()
 

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
@@ -7,20 +7,22 @@ package mozilla.components.concept.toolbar
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ActionButtonTest {
 
+    private val context by applicationContext()
+
     @Test
     fun `set padding`() {
         var button = Toolbar.ActionButton(mock(), "imageResource") {}
-        val linearLayout = LinearLayout(RuntimeEnvironment.application)
+        val linearLayout = LinearLayout(context)
         var view = button.createView(linearLayout)
 
         assertEquals(view.paddingLeft, 0)

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionImageTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionImageTest.kt
@@ -11,16 +11,18 @@ import android.view.View
 import android.view.ViewGroup
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ActionImageTest {
+
+    private val context by applicationContext()
 
     @Test
     fun `setting minimumWidth`() {
@@ -29,7 +31,7 @@ class ActionImageTest {
         val emptyImage = Toolbar.ActionImage(mock())
 
         val viewGroup: ViewGroup = mock()
-        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(viewGroup.context).thenReturn(context)
         `when`(drawable.intrinsicWidth).thenReturn(5)
 
         val emptyImageView = emptyImage.createView(viewGroup)
@@ -44,7 +46,7 @@ class ActionImageTest {
         val image = Toolbar.ActionImage(mock())
         var imageAccessible = Toolbar.ActionImage(mock(), "image")
         val viewGroup: ViewGroup = mock()
-        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(viewGroup.context).thenReturn(context)
 
         val imageView = image.createView(viewGroup)
         assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_NO, imageView.importantForAccessibility)
@@ -67,7 +69,7 @@ class ActionImageTest {
     fun `padding is set`() {
         var image = Toolbar.ActionImage(mock())
         val viewGroup: ViewGroup = mock()
-        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(viewGroup.context).thenReturn(context)
         var view = image.createView(viewGroup)
 
         assertEquals(view.paddingLeft, 0)

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionSpaceTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionSpaceTest.kt
@@ -7,19 +7,21 @@ package mozilla.components.concept.toolbar
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ActionSpaceTest {
 
+    private val context by applicationContext()
+
     @Test
     fun `Toolbar ActionSpace must set padding`() {
         var space = Toolbar.ActionSpace(0)
-        val linearLayout = LinearLayout(RuntimeEnvironment.application)
+        val linearLayout = LinearLayout(context)
         var view = space.createView(linearLayout)
 
         assertEquals(view.paddingLeft, 0)

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionToggleButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionToggleButtonTest.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -15,16 +16,18 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class ActionToggleButtonTest {
+
+    private val context by applicationContext()
+
     @Test
     fun `clicking view will toggle state`() {
         val button =
             Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {}
-        val view = button.createView(FrameLayout(RuntimeEnvironment.application))
+        val view = button.createView(FrameLayout(context))
 
         assertFalse(button.isSelected())
 
@@ -46,7 +49,7 @@ class ActionToggleButtonTest {
                 listenerInvoked = true
             }
 
-        val view = button.createView(FrameLayout(RuntimeEnvironment.application))
+        val view = button.createView(FrameLayout(context))
 
         assertFalse(listenerInvoked)
 
@@ -159,7 +162,7 @@ class ActionToggleButtonTest {
         button.toggle(notifyListener = false)
         assertFalse(button.isSelected())
 
-        val view = button.createView(FrameLayout(RuntimeEnvironment.application))
+        val view = button.createView(FrameLayout(context))
         view.performClick()
         assertTrue(button.isSelected())
     }
@@ -167,7 +170,7 @@ class ActionToggleButtonTest {
     @Test
     fun `Toolbar ActionToggleButton must set padding`() {
         var button = Toolbar.ActionToggleButton(mock(), mock(), "imageResource", "") {}
-        val linearLayout = LinearLayout(RuntimeEnvironment.application)
+        val linearLayout = LinearLayout(context)
         var view = button.createView(linearLayout)
         val padding = Padding(16, 20, 24, 28)
 

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.toolbar
 
-import android.content.Context
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.Toolbar
@@ -110,8 +109,7 @@ class ToolbarAutocompleteFeatureTest {
         val autocompleteDelegate: AutocompleteDelegate = mock()
 
         var history: HistoryStorage = InMemoryHistoryStorage()
-        val domains = object : BaseDomainAutocompleteProvider(DomainList.CUSTOM) {
-            override fun initialize(context: Context) {}
+        val domains = object : BaseDomainAutocompleteProvider(DomainList.CUSTOM, { emptyList() }) {
             fun testDomains(list: List<Domain>) {
                 domains = list
             }

--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation Dependencies.testing_mockito
     implementation Dependencies.testing_robolectric
 
+    implementation Dependencies.androidx_test_core
+
     testImplementation Dependencies.androidx_core
     testImplementation project(':support-ktx')
 }

--- a/components/support/test/src/main/java/mozilla/components/support/test/robolectric/delegates.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/robolectric/delegates.kt
@@ -5,13 +5,20 @@ import androidx.test.core.app.ApplicationProvider
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
-internal class ApplicationContextProvider<T : Context> : ReadOnlyProperty<Any?, T> {
+interface DelegatedReadOnlyProperty<T> : ReadOnlyProperty<Any?, T> {
+
+    fun get(): T
+}
+
+internal class ApplicationContextProvider<T : Context> : DelegatedReadOnlyProperty<T> {
 
     override operator fun getValue(thisRef: Any?, property: KProperty<*>): T =
-        ApplicationProvider.getApplicationContext()
+        get()
+
+    override fun get(): T = ApplicationProvider.getApplicationContext()
 }
 
 /**
  * Delegate for providing application context
  */
-fun applicationContext(): ReadOnlyProperty<Any?, Context> = ApplicationContextProvider()
+fun applicationContext(): DelegatedReadOnlyProperty<Context> = ApplicationContextProvider()

--- a/components/support/test/src/main/java/mozilla/components/support/test/robolectric/delegates.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/robolectric/delegates.kt
@@ -1,0 +1,17 @@
+package mozilla.components.support.test.robolectric
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+internal class ApplicationContextProvider<T : Context> : ReadOnlyProperty<Any?, T> {
+
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T =
+        ApplicationProvider.getApplicationContext()
+}
+
+/**
+ * Delegate for providing application context
+ */
+fun applicationContext(): ReadOnlyProperty<Any?, Context> = ApplicationContextProvider()

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
@@ -1,22 +1,26 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 @file:Suppress("MatchingDeclarationName")
 
 package mozilla.components.support.utils
 
 import android.net.Uri
 import java.net.MalformedURLException
+import java.util.Locale
 
 data class DomainMatch(val url: String, val matchedSegment: String)
 
 // FIXME implement Fennec-style segment matching logic
 // See https://github.com/mozilla-mobile/android-components/issues/1279
 fun segmentAwareDomainMatch(query: String, urls: Iterable<String>): DomainMatch? {
-    val caseInsensitiveQuery = query.toLowerCase()
+    val locale = Locale.ROOT
+
+    val caseInsensitiveQuery = query.toLowerCase(locale)
     // Process input 'urls' lazily, as the list could be very large and likely we'll find a match
     // by going through just a small subset.
-    val caseInsensitiveUrls = urls.asSequence().map { it.toLowerCase() }
+    val caseInsensitiveUrls = urls.asSequence().map { it.toLowerCase(locale) }
 
     return basicMatch(caseInsensitiveQuery, caseInsensitiveUrls)?.let { matchedUrl ->
         matchSegment(caseInsensitiveQuery, matchedUrl)?.let { DomainMatch(matchedUrl, it) }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -108,14 +108,14 @@ object DownloadUtils {
                 }
             }
             if (extension == null) {
-                if (mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("text/")) {
+                extension = if (mimeType?.toLowerCase(Locale.ROOT)?.startsWith("text/") == true) {
                     if (mimeType.equals("text/html", ignoreCase = true)) {
-                        extension = ".html"
+                        ".html"
                     } else {
-                        extension = ".txt"
+                        ".txt"
                     }
                 } else {
-                    extension = ".bin"
+                    ".bin"
                 }
             }
         } else {
@@ -128,7 +128,7 @@ object DownloadUtils {
                 if (typeFromExt == null || !typeFromExt.equals(mimeType, ignoreCase = true)) {
                     extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
                     if (extension != null) {
-                        extension = "." + extension
+                        extension = ".$extension"
                     }
                 }
             }
@@ -157,9 +157,8 @@ object DownloadUtils {
                 // Return quoted string if available and replace escaped characters.
                 val quotedFileName = m.group(QUOTED_FILE_NAME_GROUP)
 
-                return if (quotedFileName != null) {
-                    quotedFileName.replace("\\\\(.)".toRegex(), "$1")
-                } else m.group(UNQUOTED_FILE_NAME)
+                return quotedFileName?.replace("\\\\(.)".toRegex(), "$1")
+                    ?: m.group(UNQUOTED_FILE_NAME)
 
                 // Otherwise try to extract the unquoted file name
             }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/StatusBarUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/StatusBarUtils.kt
@@ -12,6 +12,7 @@ object StatusBarUtils {
     /**
      * Determine the height of the status bar asynchronously.
      */
+    @Suppress("unused")
     fun getStatusBarHeight(view: View, block: (Int) -> Unit) {
         if (statusBarSize > 0) {
             block(statusBarSize)

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/StorageUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/StorageUtils.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.utils
 
 object StorageUtils {
+
     // Borrowed from https://gist.github.com/ademar111190/34d3de41308389a0d0d8
     fun levenshteinDistance(a: String, b: String): Int {
         val lhsLength = a.length
@@ -22,10 +23,10 @@ object StorageUtils {
         var cost = Array(lhsLength) { it }
         var newCost = Array(lhsLength) { 0 }
 
-        for (i in 1..rhsLength - 1) {
+        for (i in 1 until rhsLength) {
             newCost[0] = i
 
-            for (j in 1..lhsLength - 1) {
+            for (j in 1 until lhsLength) {
                 val match = if (a[j - 1] == b[i - 1]) 0 else 1
 
                 val costReplace = cost[j - 1] + match

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/ThreadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/ThreadUtils.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
 
+@Suppress("unused")
 object ThreadUtils {
     private val looperBackgroundThread by lazy {
         HandlerThread("BackgroundThread")

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
@@ -12,6 +12,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class DomainMatcherTest {
+
     @Test
     fun `should perform basic domain matching for a given query`() {
         assertNull(segmentAwareDomainMatch("moz", listOf()))
@@ -21,6 +22,7 @@ class DomainMatcherTest {
                 "https://mobile.twitter.com", "https://m.youtube.com",
                 "https://en.Wikipedia.org/Wiki/Mozilla",
                 "http://192.168.254.254:8000", "http://192.168.254.254:8000/admin",
+                "http://иННая.локаль", // TODO add more test data for non-english locales
                 "about:config", "about:crashes"
         )
         // Full url matching.
@@ -81,6 +83,12 @@ class DomainMatcherTest {
         assertEquals(
                 DomainMatch("about:crashes", "about:crashes"),
                 segmentAwareDomainMatch("about:cr", urls)
+        )
+
+        // Non-english locale.
+        assertEquals(
+            DomainMatch("http://инная.локаль", "инная.локаль"),
+            segmentAwareDomainMatch("ин", urls)
         )
 
         assertNull(segmentAwareDomainMatch("nomatch", urls))

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -29,32 +29,32 @@ class DownloadUtilsTest {
         CONTENT_DISPOSITION_TYPES.forEach { contentDisposition ->
             // continuing with default filenames
             assertContentDisposition("downloadfile.bin", contentDisposition)
-            assertContentDisposition("downloadfile.bin", contentDisposition + ";")
-            assertContentDisposition("downloadfile.bin", contentDisposition + "; filename")
-            assertContentDisposition(".bin", contentDisposition + "; filename=")
-            assertContentDisposition(".bin", contentDisposition + "; filename=\"\"")
+            assertContentDisposition("downloadfile.bin", "$contentDisposition;")
+            assertContentDisposition("downloadfile.bin", "$contentDisposition; filename")
+            assertContentDisposition(".bin", "$contentDisposition; filename=")
+            assertContentDisposition(".bin", "$contentDisposition; filename=\"\"")
 
             // Provided filename field
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=\"filename.jpg\"")
-            assertContentDisposition("file\"name.jpg", contentDisposition + "; filename=\"file\\\"name.jpg\"")
-            assertContentDisposition("file\\name.jpg", contentDisposition + "; filename=\"file\\\\name.jpg\"")
-            assertContentDisposition("file\\\"name.jpg", contentDisposition + "; filename=\"file\\\\\\\"name.jpg\"")
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=filename.jpg")
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=filename.jpg; foo")
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=\"filename.jpg\"; foo")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=\"filename.jpg\"")
+            assertContentDisposition("file\"name.jpg", "$contentDisposition; filename=\"file\\\"name.jpg\"")
+            assertContentDisposition("file\\name.jpg", "$contentDisposition; filename=\"file\\\\name.jpg\"")
+            assertContentDisposition("file\\\"name.jpg", "$contentDisposition; filename=\"file\\\\\\\"name.jpg\"")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=filename.jpg")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=filename.jpg; foo")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=\"filename.jpg\"; foo")
 
             // UTF-8 encoded filename* field
             assertContentDisposition("\uD83E\uDD8A + x.jpg",
-                    contentDisposition + "; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg")
+                "$contentDisposition; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg")
             assertContentDisposition("filename 的副本.jpg",
                     contentDisposition + ";filename=\"_.jpg\";" +
                             "filename*=UTF-8''filename%20%E7%9A%84%E5%89%AF%E6%9C%AC.jpg")
             assertContentDisposition("filename.jpg",
-                    contentDisposition + "; filename=_.jpg; filename*=utf-8'en'filename.jpg")
+                "$contentDisposition; filename=_.jpg; filename*=utf-8'en'filename.jpg")
 
             // ISO-8859-1 encoded filename* field
             assertContentDisposition("file' 'name.jpg",
-                    contentDisposition + "; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg")
+                "$contentDisposition; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg")
         }
     }
 

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/StorageUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/StorageUtilsTest.kt
@@ -1,0 +1,53 @@
+package mozilla.components.support.utils
+
+import mozilla.components.support.utils.StorageUtils.levenshteinDistance
+import org.junit.Assert.assertEquals
+import org.junit.Ignore
+import org.junit.Test
+
+class StorageUtilsTest {
+
+    @Test
+    @Ignore("Some assertions failed. Should we fix implementation?")
+    fun checkLevenshteinDistance() {
+        // Test data <s>stealed</s> borrowed from
+        // https://oldfashionedsoftware.com/tag/levenshtein-distance/
+
+        // Empty strings
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("", ""))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("a", ""))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("", "a"))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("abc", ""))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("", "abc"))
+
+        // Equal strings
+        assertEquals(0, levenshteinDistance("a", "a"))
+        assertEquals(0, levenshteinDistance("abc", "abc"))
+
+        // Only inserts are needed
+        assertEquals(1, levenshteinDistance("a", "ab"))
+        assertEquals(1, levenshteinDistance("b", "ab"))
+        assertEquals(1, levenshteinDistance("ac", "abc"))
+        assertEquals(6, levenshteinDistance("abcdefg", "xabxcdxxefxgx"))
+
+        // Only deletes are needed
+        assertEquals(1, levenshteinDistance("ab", "a"))
+        assertEquals(1, levenshteinDistance("ab", "b"))
+        assertEquals(1, levenshteinDistance("abc", "ac"))
+        assertEquals(6, levenshteinDistance("xabxcdxxefxgx", "abcdefg"))
+
+        // Only substitutions are needed
+        assertEquals(1, levenshteinDistance("a", "b"))
+        assertEquals(1, levenshteinDistance("ab", "ac"))
+        assertEquals(1, levenshteinDistance("ac", "bc"))
+        assertEquals(1, levenshteinDistance("abc", "axc"))
+        assertEquals(6, levenshteinDistance("xabxcdxxefxgx", "1ab2cd34ef5g6"))
+
+        // Many operations are needed
+        assertEquals(3, levenshteinDistance("example", "samples"))
+        assertEquals(6, levenshteinDistance("sturgeon", "urgently"))
+        assertEquals(6, levenshteinDistance("levenshtein", "frankenstein"))
+        assertEquals(5, levenshteinDistance("distance", "difference"))
+        assertEquals(10, levenshteinDistance("java was neat", "kotlin is great"))
+    }
+}

--- a/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/LintLogChecks.kt
+++ b/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/LintLogChecks.kt
@@ -27,7 +27,7 @@ class LintLogChecks : Detector(), Detector.UastScanner {
 
     override fun getApplicableMethodNames() = listOf("v", "d", "i", "w", "e")
 
-    override fun visitMethod(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         if (context.evaluator.isMemberInClass(method, ANDROID_LOG_CLASS)) {
             val inComponentPackage = componentPackages.any {
                 node.methodIdentifier?.getContainingUClass()?.qualifiedName?.startsWith(it) == true

--- a/components/tooling/lint/src/test/java/mozilla/components/tooling/lint/LintLogChecksTest.kt
+++ b/components/tooling/lint/src/test/java/mozilla/components/tooling/lint/LintLogChecksTest.kt
@@ -34,23 +34,23 @@ class LintLogChecksTest {
         `when`(context.evaluator).thenReturn(evaluator)
 
         val logCheck = LintLogChecks()
-        logCheck.visitMethod(context, node, method)
+        logCheck.visitMethodCall(context, node, method)
         verify(context, never()).report(ISSUE_LOG_USAGE, node, context.getLocation(node), ERROR_MESSAGE)
 
         `when`(node.methodIdentifier).thenReturn(methodIdentifier)
-        logCheck.visitMethod(context, node, method)
+        logCheck.visitMethodCall(context, node, method)
         verify(context, never()).report(ISSUE_LOG_USAGE, node, context.getLocation(node), ERROR_MESSAGE)
 
         `when`(methodIdentifier.getContainingUClass()).thenReturn(clazz)
-        logCheck.visitMethod(context, node, method)
+        logCheck.visitMethodCall(context, node, method)
         verify(context, never()).report(ISSUE_LOG_USAGE, node, context.getLocation(node), ERROR_MESSAGE)
 
         `when`(clazz.qualifiedName).thenReturn("com.some.app.Class")
-        logCheck.visitMethod(context, node, method)
+        logCheck.visitMethodCall(context, node, method)
         verify(context, never()).report(ISSUE_LOG_USAGE, node, context.getLocation(node), ERROR_MESSAGE)
 
         `when`(clazz.qualifiedName).thenReturn("mozilla.components.some.Class")
-        logCheck.visitMethod(context, node, method)
+        logCheck.visitMethodCall(context, node, method)
         verify(context, times(1)).report(ISSUE_LOG_USAGE, node, context.getLocation(node), ERROR_MESSAGE)
     }
 }

--- a/components/ui/autocomplete/build.gradle
+++ b/components/ui/autocomplete/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation Dependencies.androidx_appcompat
 
+    testImplementation project(":support-test")
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.ui.autocomplete
 
-import android.content.Context
-import android.text.Spanned
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.util.AttributeSet
 import android.view.KeyEvent
@@ -13,26 +11,26 @@ import android.view.ViewParent
 import android.view.accessibility.AccessibilityEvent
 import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
+import mozilla.components.support.test.robolectric.applicationContext
+import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
+import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.Companion.AUTOCOMPLETE_SPAN
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.spy
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-
-import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.Companion.AUTOCOMPLETE_SPAN
-import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
-import org.junit.Assert.assertNull
 
 @RunWith(RobolectricTestRunner::class)
 class InlineAutocompleteEditTextTest {
-    private val context: Context = RuntimeEnvironment.application
-    private val attributes: AttributeSet = mock(AttributeSet::class.java)
+
+    private val context by applicationContext()
+    private val attributes = mock(AttributeSet::class.java)
 
     @Test
     fun autoCompleteResult() {
@@ -157,7 +155,7 @@ class InlineAutocompleteEditTextTest {
 
         assertEquals(4, et.text.getSpanStart(AUTOCOMPLETE_SPAN))
         assertEquals(14, et.text.getSpanEnd(AUTOCOMPLETE_SPAN))
-        assertEquals(Spanned.SPAN_EXCLUSIVE_EXCLUSIVE, et.text.getSpanFlags(AUTOCOMPLETE_SPAN))
+        assertEquals(SPAN_EXCLUSIVE_EXCLUSIVE, et.text.getSpanFlags(AUTOCOMPLETE_SPAN))
     }
 
     @Test
@@ -211,7 +209,7 @@ class InlineAutocompleteEditTextTest {
     @Test
     fun onCommitListenerInvocation() {
         val et = InlineAutocompleteEditText(context, attributes)
-        var invoked: Boolean = false
+        var invoked = false
         et.setOnCommitListener { invoked = true }
         et.onAttachedToWindow()
 

--- a/components/ui/progress/build.gradle
+++ b/components/ui/progress/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation Dependencies.androidx_appcompat
 
+    testImplementation project(":support-test")
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/ui/progress/src/main/java/mozilla/components/ui/progress/DrawableWrapper.kt
+++ b/components/ui/progress/src/main/java/mozilla/components/ui/progress/DrawableWrapper.kt
@@ -36,7 +36,7 @@ internal open class DrawableWrapper(val wrappedDrawable: Drawable) : Drawable() 
         return wrappedDrawable.changingConfigurations
     }
 
-    override fun getConstantState(): Drawable.ConstantState? {
+    override fun getConstantState(): ConstantState? {
         return wrappedDrawable.constantState
     }
 
@@ -93,8 +93,7 @@ internal open class DrawableWrapper(val wrappedDrawable: Drawable) : Drawable() 
         return wrappedDrawable.mutate()
     }
 
-    @Suppress("MagicNumber")
-    override fun setAlpha(@IntRange(from = 0, to = 255) i: Int) {
+    override fun setAlpha(@IntRange(from = MIN_ALPHA_VALUE, to = MAX_ALPHA_VALUE) i: Int) {
         wrappedDrawable.alpha = i
     }
 
@@ -138,3 +137,6 @@ internal open class DrawableWrapper(val wrappedDrawable: Drawable) : Drawable() 
         return wrappedDrawable.setState(state)
     }
 }
+
+private const val MIN_ALPHA_VALUE = 0L
+private const val MAX_ALPHA_VALUE = 255L

--- a/components/ui/progress/src/test/java/mozilla/components/ui/progress/AnimatedProgressBarTest.kt
+++ b/components/ui/progress/src/test/java/mozilla/components/ui/progress/AnimatedProgressBarTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.ui.progress
 
 import android.view.View
+import mozilla.components.support.test.robolectric.applicationContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,14 +13,15 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AnimatedProgressBarTest {
 
+    private val context by applicationContext()
+
     @Test
     fun setProgress() {
-        val progressBar = AnimatedProgressBar(RuntimeEnvironment.application)
+        val progressBar = AnimatedProgressBar(context)
 
         progressBar.progress = -1
         assertEquals(0, progressBar.progress)
@@ -36,7 +38,7 @@ class AnimatedProgressBarTest {
 
     @Test
     fun setVisibility() {
-        val progressBar = spy(AnimatedProgressBar(RuntimeEnvironment.application))
+        val progressBar = spy(AnimatedProgressBar(context))
 
         progressBar.visibility = View.GONE
         verify(progressBar, never()).animateClosing()

--- a/components/ui/tabcounter/build.gradle
+++ b/components/ui/tabcounter/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
 
+    testImplementation project(":support-test")
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/ui/tabcounter/src/test/java/mozilla/components/ui/tabcounter/TabCounterTest.kt
+++ b/components/ui/tabcounter/src/test/java/mozilla/components/ui/tabcounter/TabCounterTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.ui.tabcounter
 
+import mozilla.components.support.test.robolectric.applicationContext
 import mozilla.components.ui.tabcounter.TabCounter.Companion.DEFAULT_TABS_COUNTER_TEXT
 import mozilla.components.ui.tabcounter.TabCounter.Companion.ONE_DIGIT_SIZE_RATIO
 import mozilla.components.ui.tabcounter.TabCounter.Companion.SO_MANY_TABS_OPEN
@@ -12,14 +13,15 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class TabCounterTest {
 
+    private val context by applicationContext()
+
     @Test
     fun `Default tab count is a smiley face`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(context)
 
         assertEquals(DEFAULT_TABS_COUNTER_TEXT, tabCounter.getText())
 
@@ -28,7 +30,7 @@ class TabCounterTest {
 
     @Test
     fun `Set tab count as 1`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(context)
 
         tabCounter.setCount(1)
 
@@ -39,7 +41,7 @@ class TabCounterTest {
 
     @Test
     fun `Set tab count as 99`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(context)
 
         tabCounter.setCount(99)
 
@@ -50,7 +52,7 @@ class TabCounterTest {
 
     @Test
     fun `Set tab count as 100`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(context)
 
         tabCounter.setCount(100)
 

--- a/docs/api/alltypes/index.md
+++ b/docs/api/alltypes/index.md
@@ -43,7 +43,7 @@
 | [mozilla.components.support.base.feature.BackHandler](../mozilla.components.support.base.feature/-back-handler/index.md) | Generic interface for fragments, features and other components that want to handle 'back' button presses. |
 | [mozilla.components.feature.sync.BackgroundSyncManager](../mozilla.components.feature.sync/-background-sync-manager/index.md) | A SyncManager implementation which uses WorkManager APIs to schedule sync tasks. |
 | [mozilla.components.support.ktx.android.util.Base64](../mozilla.components.support.ktx.android.util/-base64/index.md) |  |
-| [mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider](../mozilla.components.browser.domains.autocomplete/-base-domain-autocomplete-provider/index.md) | Provides common autocomplete functionality powered by domain lists. |
+| [mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider](../mozilla.components.browser.domains.autocomplete/-base-domain-autocomplete-provider/index.md) | Provides common autocomplete functionality powered by domain lists. **(Deprecated. Use `ShippedDomainsProvider` or `CustomDomainsProvider` instead)** |
 | [android.graphics.Bitmap](../mozilla.components.support.ktx.android.graphics/android.graphics.-bitmap/index.md) (extensions in package mozilla.components.support.ktx.android.graphics) |  |
 | [mozilla.components.concept.storage.BookmarkInfo](../mozilla.components.concept.storage/-bookmark-info/index.md) | Class for making alterations to any bookmark node |
 | [mozilla.components.concept.storage.BookmarkNode](../mozilla.components.concept.storage/-bookmark-node/index.md) | Class for holding metadata about any bookmark node |


### PR DESCRIPTION
:construction: **Will be rebased after dependency resolution** :construction:  

### Issue #2346 

### Depends on #3017.

Uses `applicationContext()` delegate, introduced in previous PR. Will be rebased once dependency will be merged / denied.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
