### PR TITLE
Always terminate the GleanDebugActivity when early returning

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
@@ -50,8 +50,24 @@ class GleanDebugActivity : Activity() {
             return
         }
 
+        if (intent.extras == null) {
+            logger.error("No debugging option was provided, doing nothing.")
+            finish()
+            return
+        }
+
+        // Make sure that at least one of the supported commands was used.
+        val supportedCommands =
+            listOf(SEND_PING_EXTRA_KEY, LOG_PINGS_EXTRA_KEY, TAG_DEBUG_VIEW_EXTRA_KEY)
+
         // Enable debugging options and start the application.
         intent.extras?.let {
+            it.keySet().forEach { cmd ->
+                if (!supportedCommands.contains(cmd)) {
+                    logger.error("Unknown command '$cmd'.")
+                }
+            }
+
             // Check for ping debug view tag to apply to the X-Debug-ID header when uploading the
             // ping to the endpoint
             var pingTag: String? = intent.getStringExtra(TAG_DEBUG_VIEW_EXTRA_KEY)

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/debug/GleanDebugActivity.kt
@@ -46,6 +46,7 @@ class GleanDebugActivity : Activity() {
                 "Glean is not initialized. " +
                 "It may be disabled by the application."
             )
+            finish()
             return
         }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -94,6 +94,8 @@ class GleanDebugActivityTest {
         // Build the intent that will call our debug activity, with no extra.
         val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
             GleanDebugActivity::class.java)
+        // Add at least an option, otherwise the activity will be removed.
+        intent.putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
         // Start the activity through our intent.
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()


### PR DESCRIPTION
Otherwise the product might be left in an unusable state
with an activity that's never terminated at the top of the
current stack.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
