### PR TITLE
Fixes #2976 - Implement feature-app-links

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -40,6 +40,10 @@ projects:
     path: components/feature/accounts
     description: 'Component for tying an account manager with the tabs feature to facilitate auth flows.'
     publish: true
+  feature-app-links:
+    path: components/feature/app-links
+    description: 'Component opening URLs in other non-browser apps.'
+    publish: true
   feature-contextmenu:
     path: components/feature/contextmenu
     description: 'Component for displaying context menus for web content.'

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -316,7 +316,7 @@ class GeckoEngineSession(
                     // Unlike the name LoadRequest.isRedirect may imply this flag is not about http redirects. The flag
                     // is "true if and only if the request was triggered by user interaction."
                     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1545170
-                    onLoadRequest(triggeredByUserInteraction = request.isRedirect)
+                    onLoadRequest(triggeredByRedirect = request.isRedirect, triggeredByWebContent = true)
                 }
 
                 GeckoResult.fromValue(AllowOrDeny.ALLOW)

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1676,24 +1676,24 @@ class GeckoEngineSessionTest {
 
         captureDelegates()
 
-        var triggeredByUser: Boolean? = null
+        var observedTriggeredByRedirect: Boolean? = null
 
         engineSession.register(object : EngineSession.Observer {
-            override fun onLoadRequest(triggeredByUserInteraction: Boolean) {
-                triggeredByUser = triggeredByUserInteraction
+            override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+                observedTriggeredByRedirect = triggeredByRedirect
             }
         })
 
         navigationDelegate.value.onLoadRequest(
-            mock(), mockLoadRequest("sample:about", triggeredByUserInteraction = true))
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
 
-        assertNotNull(triggeredByUser)
-        assertTrue(triggeredByUser!!)
+        assertNotNull(observedTriggeredByRedirect)
+        assertTrue(observedTriggeredByRedirect!!)
 
         navigationDelegate.value.onLoadRequest(
-            mock(), mockLoadRequest("sample:about", triggeredByUserInteraction = false))
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
-        assertFalse(triggeredByUser!!)
+        assertFalse(observedTriggeredByRedirect!!)
     }
 
     @Test
@@ -1713,9 +1713,9 @@ class GeckoEngineSessionTest {
         engineSession.register(observer)
 
         navigationDelegate.value.onLoadRequest(
-            mock(), mockLoadRequest("sample:about", triggeredByUserInteraction = true))
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
 
-        verify(observer, never()).onLoadRequest(anyBoolean())
+        verify(observer, never()).onLoadRequest(anyBoolean(), anyBoolean())
     }
 
     private fun mockGeckoSession(): GeckoSession {
@@ -1728,10 +1728,10 @@ class GeckoEngineSessionTest {
     private fun mockLoadRequest(
         uri: String,
         target: Int = 0,
-        triggeredByUserInteraction: Boolean = false
+        triggeredByRedirect: Boolean = false
     ): GeckoSession.NavigationDelegate.LoadRequest {
         var flags = 0
-        if (triggeredByUserInteraction) {
+        if (triggeredByRedirect) {
             flags = flags or 0x800000
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1701,24 +1701,24 @@ class GeckoEngineSessionTest {
 
         captureDelegates()
 
-        var triggeredByUser: Boolean? = null
+        var observedTriggeredByRedirect: Boolean? = null
 
         engineSession.register(object : EngineSession.Observer {
-            override fun onLoadRequest(triggeredByUserInteraction: Boolean) {
-                triggeredByUser = triggeredByUserInteraction
+            override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+                observedTriggeredByRedirect = triggeredByRedirect
             }
         })
 
         navigationDelegate.value.onLoadRequest(
-            mock(), mockLoadRequest("sample:about", triggeredByUserInteraction = true))
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
 
-        assertNotNull(triggeredByUser)
-        assertTrue(triggeredByUser!!)
+        assertNotNull(observedTriggeredByRedirect)
+        assertTrue(observedTriggeredByRedirect!!)
 
         navigationDelegate.value.onLoadRequest(
-            mock(), mockLoadRequest("sample:about", triggeredByUserInteraction = false))
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
-        assertFalse(triggeredByUser!!)
+        assertFalse(observedTriggeredByRedirect!!)
     }
 
     @Test
@@ -1738,9 +1738,9 @@ class GeckoEngineSessionTest {
         engineSession.register(observer)
 
         navigationDelegate.value.onLoadRequest(
-            mock(), mockLoadRequest("sample:about", triggeredByUserInteraction = true))
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
 
-        verify(observer, never()).onLoadRequest(anyBoolean())
+        verify(observer, never()).onLoadRequest(anyBoolean(), anyBoolean())
     }
 
     private fun mockGeckoSession(): GeckoSession {
@@ -1753,10 +1753,10 @@ class GeckoEngineSessionTest {
     private fun mockLoadRequest(
         uri: String,
         target: Int = 0,
-        triggeredByUserInteraction: Boolean = false
+        triggeredByRedirect: Boolean = false
     ): GeckoSession.NavigationDelegate.LoadRequest {
         var flags = 0
-        if (triggeredByUserInteraction) {
+        if (triggeredByRedirect) {
             flags = flags or 0x800000
         }
 

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -226,7 +226,7 @@ class SystemEngineView @JvmOverloads constructor(
             }
 
             if (request.isForMainFrame) {
-                session?.let { it.notifyObservers { onLoadRequest(request.hasGesture()) } }
+                session?.let { it.notifyObservers { onLoadRequest(request.hasGesture(), true) } }
             }
 
             return super.shouldInterceptRequest(view, request)

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -463,7 +463,7 @@ class SystemEngineSessionTest {
 
         engineSession.webView.webViewClient.shouldInterceptRequest(engineSession.webView, request)
 
-        verify(observer).onLoadRequest(true)
+        verify(observer).onLoadRequest(true, true)
 
         val redirect: WebResourceRequest = mock()
         doReturn(true).`when`(redirect).isForMainFrame
@@ -472,7 +472,7 @@ class SystemEngineSessionTest {
 
         engineSession.webView.webViewClient.shouldInterceptRequest(engineSession.webView, redirect)
 
-        verify(observer).onLoadRequest(false)
+        verify(observer).onLoadRequest(false, true)
     }
 
     @Test
@@ -502,7 +502,7 @@ class SystemEngineSessionTest {
             engineSession.webView,
             request)
 
-        verify(observer, never()).onLoadRequest(anyBoolean())
+        verify(observer, never()).onLoadRequest(anyBoolean(), anyBoolean())
     }
 
     @Test

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -6,6 +6,8 @@ package mozilla.components.browser.session
 
 import android.graphics.Bitmap
 import mozilla.components.browser.session.engine.EngineSessionHolder
+import mozilla.components.browser.session.engine.request.LoadRequestOption
+import mozilla.components.browser.session.engine.request.isSet
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -52,6 +54,7 @@ class Session(
         fun onProgress(session: Session, progress: Int) = Unit
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
         fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) = Unit
+        fun onLoadRequest(session: Session, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) = Unit
         fun onSearch(session: Session, searchTerms: String) = Unit
         fun onSecurityChanged(session: Session, securityInfo: SecurityInfo) = Unit
         fun onCustomTabConfigChanged(session: Session, customTabConfig: CustomTabConfig?) = Unit
@@ -195,6 +198,19 @@ class Session(
     var searchTerms: String by Delegates.observable("") {
         _, _, new -> notifyObservers {
             onSearch(this@Session, new)
+        }
+    }
+
+    /**
+     * Set when a load request is received, indicating if the user was involved in the interaction.
+     */
+    var loadRequestTriggers: Int by Delegates.observable(0) {
+        _, _, new -> notifyObservers {
+            onLoadRequest(
+                this@Session,
+                new.isSet(LoadRequestOption.REDIRECT),
+                new.isSet(LoadRequestOption.WEB_CONTENT)
+            )
         }
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -8,6 +8,8 @@ import android.graphics.Bitmap
 import android.os.Environment
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.engine.request.LoadRequestOption
+import mozilla.components.browser.session.engine.request.plus
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -41,10 +43,20 @@ internal class EngineObserver(
         }
     }
 
-    override fun onLoadRequest(triggeredByUserInteraction: Boolean) {
-        if (triggeredByUserInteraction) {
+    override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+        if (triggeredByWebContent) {
             session.searchTerms = ""
         }
+        var triggers = LoadRequestOption.NONE.toMask()
+        if (triggeredByRedirect) {
+            triggers += LoadRequestOption.REDIRECT
+        }
+
+        if (triggeredByWebContent) {
+            triggers += LoadRequestOption.WEB_CONTENT
+        }
+
+        session.loadRequestTriggers = triggers
     }
 
     override fun onTitleChange(title: String) {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/request/LoadRequestOption.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/request/LoadRequestOption.kt
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.session.engine.request
+
+/**
+ * Simple enum class for defining the set of characteristics of a [LoadRequest].
+ *
+ * Facilities for combining these and testing the resulting bit mask also exist as operators.
+ *
+ * This should be generalized, but it's not clear if it will be useful enough to go into [kotlin.support].
+ */
+enum class LoadRequestOption constructor(val mask: Int) {
+    NONE(0),
+    REDIRECT(1 shl 0),
+    WEB_CONTENT(1 shl 1);
+
+    fun toMask() = mask
+}
+
+infix operator fun LoadRequestOption.plus(other: LoadRequestOption) = this.mask or other.mask
+infix operator fun Int.plus(other: LoadRequestOption) = this or other.mask
+infix fun Int.isSet(option: LoadRequestOption) = this and option.mask > 0

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session.Source
+import mozilla.components.browser.session.engine.request.LoadRequestOption
+import mozilla.components.browser.session.engine.request.isSet
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -159,6 +161,20 @@ class SessionTest {
 
         assertEquals("mozilla android", session.searchTerms)
         verify(observer, times(1)).onSearch(eq(session), eq("mozilla android"))
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is notified when load request is triggered`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        session.loadRequestTriggers = LoadRequestOption.REDIRECT.toMask()
+
+        assertTrue(session.loadRequestTriggers.isSet(LoadRequestOption.REDIRECT))
+        verify(observer, times(1)).onLoadRequest(eq(session), eq(true), eq(false))
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -6,6 +6,8 @@ package mozilla.components.browser.session.engine
 
 import android.graphics.Bitmap
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.engine.request.LoadRequestOption
+import mozilla.components.browser.session.engine.request.isSet
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
@@ -445,19 +447,30 @@ class EngineObserverTest {
         session.searchTerms = "Mozilla Foundation"
 
         val observer = EngineObserver(session)
-        observer.onLoadRequest(triggeredByUserInteraction = true)
+        observer.onLoadRequest(triggeredByRedirect = true, triggeredByWebContent = true)
 
         assertEquals("", session.searchTerms)
+        val triggeredByRedirect = session.loadRequestTriggers.isSet(LoadRequestOption.REDIRECT)
+        val triggeredByWebContent = session.loadRequestTriggers.isSet(LoadRequestOption.WEB_CONTENT)
+
+        assertTrue(triggeredByRedirect)
+        assertTrue(triggeredByWebContent)
     }
 
     @Test
-    fun `onLoadRequest does not clear search terms for requests not triggered by user interaction`() {
+    fun `onLoadRequest does not clear search terms for requests not triggered by user interacting with web content`() {
         val session = Session("https://www.mozilla.org")
         session.searchTerms = "Mozilla Foundation"
 
         val observer = EngineObserver(session)
-        observer.onLoadRequest(triggeredByUserInteraction = false)
+        observer.onLoadRequest(triggeredByRedirect = true, triggeredByWebContent = false)
 
         assertEquals("Mozilla Foundation", session.searchTerms)
+
+        val triggeredByRedirect = session.loadRequestTriggers.isSet(LoadRequestOption.REDIRECT)
+        val triggeredByWebContent = session.loadRequestTriggers.isSet(LoadRequestOption.WEB_CONTENT)
+
+        assertTrue(triggeredByRedirect)
+        assertFalse(triggeredByWebContent)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -58,10 +58,11 @@ abstract class EngineSession(
         /**
          * The engine received a request to load a request.
          *
-         * @param triggeredByUserInteraction True if and only if the request was triggered by user interaction (e.g.
-         * clicking on a link on a website).
+         * @param triggeredByRedirect True if and only if the request was triggered by an HTTP redirect.
+         * @param triggeredByWebContent True if and only if the request was triggered from within
+         * web content (as opposed to via the browser chrome).
          */
-        fun onLoadRequest(triggeredByUserInteraction: Boolean) = Unit
+        fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) = Unit
 
         @Suppress("LongParameterList")
         fun onExternalResource(

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -60,7 +60,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaAdded(mediaAdded) }
         session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
         session.notifyInternalObservers { onCrashStateChange(true) }
-        session.notifyInternalObservers { onLoadRequest(true) }
+        session.notifyInternalObservers { onLoadRequest(true, true) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
@@ -84,7 +84,7 @@ class EngineSessionTest {
         verify(observer).onMediaAdded(mediaAdded)
         verify(observer).onMediaRemoved(mediaRemoved)
         verify(observer).onCrashStateChange(true)
-        verify(observer).onLoadRequest(true)
+        verify(observer).onLoadRequest(true, true)
         verifyNoMoreInteractions(observer)
     }
 
@@ -118,7 +118,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
         session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
         session.notifyInternalObservers { onCrashStateChange(false) }
-        session.notifyInternalObservers { onLoadRequest(true) }
+        session.notifyInternalObservers { onLoadRequest(true, true) }
         session.unregister(observer)
 
         val mediaAdded: Media = mock()
@@ -144,7 +144,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaAdded(mediaAdded) }
         session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
         session.notifyInternalObservers { onCrashStateChange(true) }
-        session.notifyInternalObservers { onLoadRequest(false) }
+        session.notifyInternalObservers { onLoadRequest(false, true) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -164,7 +164,7 @@ class EngineSessionTest {
         verify(observer).onOpenWindowRequest(windowRequest)
         verify(observer).onCloseWindowRequest(windowRequest)
         verify(observer).onCrashStateChange(false)
-        verify(observer).onLoadRequest(true)
+        verify(observer).onLoadRequest(true, true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -185,7 +185,7 @@ class EngineSessionTest {
         verify(observer, never()).onMediaAdded(mediaAdded)
         verify(observer, never()).onMediaRemoved(mediaRemoved)
         verify(observer, never()).onCrashStateChange(true)
-        verify(observer, never()).onLoadRequest(false)
+        verify(observer, never()).onLoadRequest(false, true)
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/feature/app-links/README.md
+++ b/components/feature/app-links/README.md
@@ -1,0 +1,40 @@
+# [Android Components](../../../README.md) > Feature > App-Links
+
+A session component to support opening non-browser apps and `intent://` style URLs.
+
+## Usage
+
+From a `BrowserFragment`:
+```kotlin
+// Start listening to the intercepted and offer to open app banners
+AppLinksFeature(
+    context = context,
+    sessionManager = sessionManager,
+    sessionId = customSessionId,
+    fragmentManager = fragmentManager
+)
+```
+
+From elsewhere in the app:
+```kotlin
+val redirect = AppLinksUseCases.appLinkRedirect.invoke(redirect)
+
+if (redirect.isExternalApp()) {
+    AppLinkUseCases.openAppLink(redirect)
+}
+```
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/)
+ ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-app-links:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/app-links/build.gradle
+++ b/components/feature/app-links/build.gradle
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/proguard/androidx-annotations.pro'
+    }
+}
+
+dependencies {
+    implementation project(':browser-session')
+    implementation project(':concept-engine')
+    implementation project(':support-base')
+    implementation project(':support-ktx')
+
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_robolectric
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/feature/app-links/proguard-rules.pro
+++ b/components/feature/app-links/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/app-links/src/main/AndroidManifest.xml
+++ b/components/feature/app-links/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.app.links" />

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinkRedirect.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinkRedirect.kt
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.content.Intent
+
+/**
+ * Data class for the external Intent or fallback URL a given URL encodes for.
+ */
+data class AppLinkRedirect(
+    val appIntent: Intent?,
+    val webUrl: String?,
+    val isFallback: Boolean
+) {
+    fun hasExternalApp() = appIntent != null
+
+    fun hasFallback() = webUrl != null && isFallback
+
+    fun isRedirect() = hasExternalApp() || hasFallback()
+}

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -1,0 +1,133 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.VisibleForTesting
+import androidx.fragment.app.FragmentManager
+import mozilla.components.browser.session.SelectionAwareSessionObserver
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.feature.app.links.RedirectDialogFragment.Companion.FRAGMENT_TAG
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+
+/**
+ * This feature implements use cases for detecting and handling redirects to external apps. The user
+ * is asked to confirm her intention before leaving the app. These include the Android Intents,
+ * custom schemes and support for [Intent.CATEGORY_BROWSABLE] `http(s)` URLs.
+ *
+ * In the case of Android Intents that are not installed, and with no fallback, the user is prompted
+ * to search the installed market place.
+ *
+ * It provides use cases to detect and open links openable in third party non-browser apps.
+ *
+ * It provides a [RequestInterceptor] to do the detection and asking of consent.
+ *
+ * It requires: a [Context], and a [FragmentManager].
+ *
+ * A [Boolean] flag is provided at construction to allow the feature and use cases to be landed without
+ * adjoining UI. The UI will be activated in https://github.com/mozilla-mobile/android-components/issues/2974
+ * and https://github.com/mozilla-mobile/android-components/issues/2975.
+ */
+class AppLinksFeature(
+    private val context: Context,
+    private val sessionManager: SessionManager,
+    private val sessionId: String? = null,
+    private val interceptLinkClicks: Boolean = true,
+    private val fragmentManager: FragmentManager? = null,
+    private var dialog: RedirectDialogFragment = SimpleRedirectDialogFragment.newInstance(),
+    private val useCases: AppLinksUseCases = AppLinksUseCases(context)
+) : LifecycleAwareFeature {
+
+    @VisibleForTesting
+    internal val observer: SelectionAwareSessionObserver = object : SelectionAwareSessionObserver(sessionManager) {
+        override fun onLoadRequest(session: Session, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+            handleLoadRequest(session, triggeredByWebContent)
+        }
+    }
+
+    /**
+     * Starts observing app links on the selected session.
+     */
+    override fun start() {
+        if (interceptLinkClicks) {
+            observer.observeIdOrSelected(sessionId)
+        }
+        findPreviousDialogFragment()?.let {
+            reAttachOnConfirmRedirectListener(it)
+        }
+    }
+
+    override fun stop() {
+        if (interceptLinkClicks) {
+            observer.stop()
+        }
+    }
+
+    @VisibleForTesting
+    internal fun handleLoadRequest(session: Session, triggeredByWebContent: Boolean) {
+        if (!triggeredByWebContent) {
+            return
+        }
+
+        val url = session.url
+        val redirect = useCases.interceptedAppLinkRedirect.invoke(url)
+
+        if (redirect.isRedirect()) {
+            handleRedirect(redirect, session)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    @VisibleForTesting
+    internal fun handleRedirect(redirect: AppLinkRedirect, session: Session) {
+        if (!redirect.hasExternalApp()) {
+            handleFallback(redirect, session)
+            return
+        }
+
+        val doOpenApp = {
+            useCases.openAppLink.invoke(redirect)
+        }
+
+        if (!session.private || fragmentManager == null) {
+            doOpenApp()
+            return
+        }
+
+        dialog.setAppLinkRedirect(redirect)
+        dialog.onConfirmRedirect = doOpenApp
+
+        if (!isAlreadyADialogCreated()) {
+            dialog.show(fragmentManager, FRAGMENT_TAG)
+        }
+    }
+
+    private fun handleFallback(redirect: AppLinkRedirect, session: Session) {
+        redirect.webUrl?.let {
+            sessionManager.getOrCreateEngineSession(session).loadUrl(it)
+        }
+    }
+
+    private fun isAlreadyADialogCreated(): Boolean {
+        return findPreviousDialogFragment() != null
+    }
+
+    @VisibleForTesting
+    internal fun reAttachOnConfirmRedirectListener(previousDialog: RedirectDialogFragment?) {
+        previousDialog?.apply {
+            this@AppLinksFeature.dialog = this
+        }
+    }
+
+    private fun findPreviousDialogFragment(): RedirectDialogFragment? {
+        return fragmentManager?.findFragmentByTag(FRAGMENT_TAG) as? RedirectDialogFragment
+    }
+}

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -1,0 +1,158 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import androidx.annotation.VisibleForTesting
+import mozilla.components.support.ktx.android.net.isHttpOrHttps
+import java.util.UUID
+
+private const val EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url"
+private const val MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id="
+
+/**
+ * These use cases allow for the detection of, and opening of links that other apps have registered
+ * an [IntentFilter]s to open.
+ *
+ * Care is taken to:
+ *  * resolve [intent://] links, including [S.browser_fallback_url]
+ *  * provide a fallback to the installed marketplace app (e.g. on Google Android, the Play Store).
+ *  * open HTTP(S) links with an external app.
+ *
+ * Since browsers are able to open HTTPS pages, existing browser apps are excluded from the list of
+ * apps that trigger a redirect to an external app.
+ */
+class AppLinksUseCases(
+    private val context: Context,
+    browserPackageNames: Set<String>? = null,
+    unguessableWebUrl: String = "https://${UUID.randomUUID()}.net"
+) {
+    @VisibleForTesting
+    val browserPackageNames: Set<String>
+
+    init {
+        this.browserPackageNames = browserPackageNames ?: findExcludedPackages(unguessableWebUrl)
+    }
+
+    private fun findActivities(intent: Intent): List<ResolveInfo> {
+        return context.packageManager
+            .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY) ?: emptyList()
+    }
+
+    private fun findExcludedPackages(randomWebURLString: String): Set<String> {
+        // We generate a URL is not likely to be opened by a native app
+        // but will fallback to a browser.
+        // In this way, we're looking for only the browsers — including us.
+        return findActivities(Intent.parseUri(randomWebURLString, 0).addCategory(Intent.CATEGORY_BROWSABLE))
+            .map { it.activityInfo.packageName }
+            .toHashSet()
+    }
+
+    /**
+     * Parse a URL and check if it can be handled by an app elsewhere on the Android device.
+     * If that app is not available, then a market place intent is also provided.
+     *
+     * It will also provide a fallback.
+     */
+    inner class GetAppLinkRedirect internal constructor(
+        private val includeHttpAppLinks: Boolean = false,
+        private val includeInstallAppFallback: Boolean = false
+    ) {
+        fun invoke(url: String): AppLinkRedirect {
+            val intents = createBrowsableIntents(url)
+            val appIntent = if (includeHttpAppLinks) {
+                intents.firstOrNull {
+                    getNonBrowserActivities(it).isNotEmpty()
+                }
+            } else {
+                intents.filter { it.data?.isHttpOrHttps != true }.firstOrNull {
+                    getNonBrowserActivities(it).isNotEmpty()
+                }
+            }
+
+            val webUrls = intents.mapNotNull {
+                if (it.data?.isHttpOrHttps == true) it.dataString else null
+            }
+
+            val webUrl = webUrls.firstOrNull { it != url } ?: webUrls.firstOrNull()
+
+            return AppLinkRedirect(appIntent, webUrl, webUrl != url)
+        }
+
+        private fun getNonBrowserActivities(intent: Intent): List<ResolveInfo> {
+            return findActivities(intent)
+                .filter { !browserPackageNames.contains(it.activityInfo.packageName) }
+        }
+
+        private fun createBrowsableIntents(url: String): List<Intent> {
+            val intent = Intent.parseUri(url, 0)
+
+            if (intent.action == Intent.ACTION_VIEW) {
+                intent.addCategory(Intent.CATEGORY_BROWSABLE)
+            }
+
+            return when (intent.data?.isHttpOrHttps) {
+                null -> emptyList()
+                true -> listOf(intent)
+                false -> {
+                    // Non http[s] schemes:
+
+                    val fallback = intent.getStringExtra(EXTRA_BROWSER_FALLBACK_URL)?.let {
+                        Intent.parseUri(it, 0)
+                    }
+
+                    val marketplaceIntent = intent.`package`?.let {
+                        if (includeInstallAppFallback) {
+                            Intent.parseUri(MARKET_INTENT_URI_PACKAGE_PREFIX + it, 0)
+                        } else {
+                            null
+                        }
+                    }
+
+                    return listOfNotNull(intent, fallback, marketplaceIntent)
+                }
+            }
+        }
+    }
+
+    /**
+     * Open an external app with the redirect created by the [GetAppLinkRedirect].
+     *
+     * This does not do any additional UI other than the chooser that Android may provide the user.
+     */
+    class OpenAppLinkRedirect internal constructor(
+        private val context: Context
+    ) {
+        fun invoke(redirect: AppLinkRedirect) {
+            val intent = redirect.appIntent ?: return
+
+            val openInIntent = Intent.createChooser(
+                intent,
+                context.getString(R.string.mozac_feature_applinks_open_in)
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+            context.startActivity(openInIntent)
+        }
+    }
+
+    val openAppLink: OpenAppLinkRedirect by lazy { OpenAppLinkRedirect(context) }
+    val interceptedAppLinkRedirect: GetAppLinkRedirect by lazy {
+        GetAppLinkRedirect(
+            includeHttpAppLinks = true,
+            includeInstallAppFallback = false
+        )
+    }
+    val appLinkRedirect: GetAppLinkRedirect by lazy {
+        GetAppLinkRedirect(
+            includeHttpAppLinks = true,
+            includeInstallAppFallback = false
+        )
+    }
+}

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/RedirectDialogFragment.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/RedirectDialogFragment.kt
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+
+/**
+ * This is a general representation of a dialog meant to be used in collaboration with [AppLinksFeature]
+ * to show a dialog before an external link is opened.
+ * If [SimpleRedirectDialogFragment] is not flexible enough for your use case you should inherit for this class.
+ * Be mindful to call [onConfirmRedirect] when you want to open the linked app.
+ */
+abstract class RedirectDialogFragment : DialogFragment() {
+
+    /**
+     * A callback to trigger a download, call it when you are ready to open the linked app. For instance,
+     * a valid use case can be in confirmation dialog, after the positive button is clicked,
+     * this callback must be called.
+     */
+    var onConfirmRedirect: () -> Unit = {}
+
+    /**
+     * add the metadata of this download object to the arguments of this fragment.
+     */
+    fun setAppLinkRedirect(redirect: AppLinkRedirect) {
+        val args = arguments ?: Bundle()
+        with(args) {
+            putString(KEY_INTENT_URL, redirect.appIntent?.dataString)
+        }
+        arguments = args
+    }
+
+    companion object {
+        /**
+         * Key for finding the app link.
+         */
+        const val KEY_INTENT_URL = "KEY_INTENT_URL"
+
+        const val FRAGMENT_TAG = "SHOULD_OPEN_APP_LINK_PROMPT_DIALOG"
+    }
+}

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragment.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragment.kt
@@ -1,0 +1,103 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import androidx.annotation.StringRes
+import androidx.annotation.StyleRes
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+
+/**
+ * This is the default implementation of the [RedirectDialogFragment].
+ *
+ * It provides an [AlertDialog] giving the user the choice to allow or deny the opening of a
+ * third party app.
+ *
+ * Intents passed are guaranteed to be openable by a non-browser app.
+ */
+class SimpleRedirectDialogFragment : RedirectDialogFragment() {
+
+    @VisibleForTesting
+    internal var testingContext: Context? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        fun getBuilder(themeID: Int): AlertDialog.Builder {
+            val context = testingContext ?: requireContext()
+            return if (themeID == 0) AlertDialog.Builder(context) else AlertDialog.Builder(context, themeID)
+        }
+
+        return with(requireBundle()) {
+            val fileName = getString(KEY_INTENT_URL, "")
+            val dialogTitleText = getInt(KEY_TITLE_TEXT, R.string.mozac_feature_applinks_confirm_dialog_title)
+            val positiveButtonText = getInt(KEY_POSITIVE_TEXT, R.string.mozac_feature_applinks_confirm_dialog_confirm)
+            val negativeButtonText = getInt(KEY_NEGATIVE_TEXT, R.string.mozac_feature_applinks_confirm_dialog_deny)
+            val themeResId = getInt(KEY_THEME_ID, 0)
+            val cancelable = getBoolean(KEY_CANCELABLE, false)
+
+            getBuilder(themeResId)
+                .setTitle(dialogTitleText)
+                .setMessage(fileName)
+                .setPositiveButton(positiveButtonText) { _, _ ->
+                    onConfirmRedirect()
+                }
+                .setNegativeButton(negativeButtonText) { _, _ ->
+                    dismiss()
+                }
+                .setCancelable(cancelable)
+                .create()
+        }
+    }
+
+    companion object {
+        /**
+         * A builder method for creating a [SimpleRedirectDialogFragment]
+         */
+        fun newInstance(
+            @StringRes dialogTitleText: Int = R.string.mozac_feature_applinks_confirm_dialog_title,
+            @StringRes positiveButtonText: Int = R.string.mozac_feature_applinks_confirm_dialog_confirm,
+            @StringRes negativeButtonText: Int = R.string.mozac_feature_applinks_confirm_dialog_deny,
+            @StyleRes themeResId: Int = 0,
+            cancelable: Boolean = false
+        ): RedirectDialogFragment {
+            val fragment = SimpleRedirectDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putInt(KEY_TITLE_TEXT, dialogTitleText)
+
+                putInt(KEY_POSITIVE_TEXT, positiveButtonText)
+
+                putInt(KEY_NEGATIVE_TEXT, negativeButtonText)
+
+                putInt(KEY_THEME_ID, themeResId)
+
+                putBoolean(KEY_CANCELABLE, cancelable)
+            }
+
+            fragment.arguments = arguments
+
+            return fragment
+        }
+
+        const val KEY_POSITIVE_TEXT = "KEY_POSITIVE_TEXT"
+
+        const val KEY_NEGATIVE_TEXT = "KEY_NEGATIVE_TEXT"
+
+        const val KEY_TITLE_TEXT = "KEY_TITLE_TEXT"
+
+        const val KEY_THEME_ID = "KEY_THEME_ID"
+
+        const val KEY_CANCELABLE = "KEY_CANCELABLE"
+    }
+
+    private fun requireBundle(): Bundle {
+        return arguments ?: throw IllegalStateException("Fragment $this arguments is not set.")
+    }
+}

--- a/components/feature/app-links/src/main/res/values/strings.xml
+++ b/components/feature/app-links/src/main/res/values/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<resources>
+    <string name="mozac_feature_applinks_open_in">Open in…</string>
+    <string name="mozac_feature_applinks_confirm_dialog_title">Open in external app?</string>
+    <string name="mozac_feature_applinks_confirm_dialog_confirm">Open</string>
+    <string name="mozac_feature_applinks_confirm_dialog_deny">Cancel</string>
+</resources>

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -1,0 +1,234 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.content.Context
+import android.content.Intent
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.support.test.any
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.verifyZeroInteractions
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AppLinksFeatureTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockSessionManager: SessionManager
+    private lateinit var mockFragmentManager: FragmentManager
+    private lateinit var mockUseCases: AppLinksUseCases
+    private lateinit var mockGetRedirect: AppLinksUseCases.GetAppLinkRedirect
+    private lateinit var mockOpenRedirect: AppLinksUseCases.OpenAppLinkRedirect
+
+    private lateinit var feature: AppLinksFeature
+
+    private val webUrl = "https://example.com"
+    private val webUrlWithAppLink = "https://soundcloud.com"
+    private val intentUrl = "zxing://scan"
+
+    @Before
+    fun setup() {
+        mockContext = mock(Context::class.java)
+
+        val engine = mock(Engine::class.java)
+        mockSessionManager = Mockito.spy(SessionManager(engine))
+        mockFragmentManager = mock(FragmentManager::class.java)
+        mockUseCases = mock(AppLinksUseCases::class.java)
+
+        mockGetRedirect = mock(AppLinksUseCases.GetAppLinkRedirect::class.java)
+        mockOpenRedirect = mock(AppLinksUseCases.OpenAppLinkRedirect::class.java)
+        `when`(mockUseCases.interceptedAppLinkRedirect).thenReturn(mockGetRedirect)
+        `when`(mockUseCases.openAppLink).thenReturn(mockOpenRedirect)
+
+        val webRedirect = AppLinkRedirect(null, webUrl, false)
+        val appRedirect = AppLinkRedirect(Intent.parseUri(intentUrl, 0), null, false)
+        val appRedirectFromWebUrl = AppLinkRedirect(Intent.parseUri(webUrlWithAppLink, 0), null, false)
+
+        `when`(mockGetRedirect.invoke(webUrl)).thenReturn(webRedirect)
+        `when`(mockGetRedirect.invoke(intentUrl)).thenReturn(appRedirect)
+        `when`(mockGetRedirect.invoke(webUrlWithAppLink)).thenReturn(appRedirectFromWebUrl)
+
+        feature = AppLinksFeature(
+            context = mockContext,
+            sessionManager = mockSessionManager,
+            fragmentManager = mockFragmentManager,
+            interceptLinkClicks = true,
+            useCases = mockUseCases
+        )
+    }
+
+    private fun createSession(url: String, isPrivate: Boolean): Session {
+        val session = mock(Session::class.java)
+        `when`(session.private).thenReturn(isPrivate)
+        `when`(session.url).thenReturn(url)
+        return session
+    }
+
+    private fun userTapsOnSession(url: String, private: Boolean) {
+        feature.observer.onLoadRequest(
+            createSession(url, private),
+            triggeredByRedirect = false,
+            triggeredByWebContent = true
+        )
+    }
+
+    @Test
+    fun `it does not listen for URL changes when it is configured not to`() {
+        val subject = AppLinksFeature(
+            mockContext,
+            mockSessionManager,
+            useCases = mockUseCases,
+            interceptLinkClicks = false
+        )
+
+        subject.start()
+        verifyZeroInteractions(mockSessionManager)
+
+        subject.stop()
+        verifyZeroInteractions(mockSessionManager)
+    }
+
+    @Test
+    fun `it tests for app links when triggered by user clicking on a link`() {
+        val session = createSession(webUrl, false)
+        val subject = AppLinksFeature(
+            mockContext,
+            mockSessionManager,
+            useCases = mockUseCases
+        )
+
+        subject.handleLoadRequest(session, true)
+
+        verify(mockGetRedirect).invoke(webUrl)
+        verifyNoMoreInteractions(mockOpenRedirect)
+    }
+
+    @Test
+    fun `when valid sessionId is provided, observe its session`() {
+        feature = AppLinksFeature(
+            mockContext,
+            sessionManager = mockSessionManager,
+            sessionId = "123",
+            useCases = mockUseCases
+        )
+        val mockSession = createSession(webUrl, false)
+        `when`(mockSessionManager.findSessionById(ArgumentMatchers.anyString())).thenReturn(mockSession)
+
+        feature.start()
+
+        verify(mockSession).register(feature.observer)
+    }
+
+    @Test
+    fun `when sessionId is NOT provided, observe selected session`() {
+        feature = AppLinksFeature(
+            mockContext,
+            sessionManager = mockSessionManager,
+            useCases = mockUseCases
+        )
+
+        feature.start()
+
+        verify(mockSessionManager).register(feature.observer)
+    }
+
+    @Test
+    fun `when start is called must register SessionManager observers`() {
+        feature.start()
+        verify(mockSessionManager).register(feature.observer)
+    }
+
+    @Test
+    fun `when stop is called must unregister SessionManager observers `() {
+        feature.stop()
+        verify(mockSessionManager).unregister(feature.observer)
+    }
+
+    @Test
+    fun `an external app is not opened if it does not match`() {
+        val mockDialog = spy(RedirectDialogFragment::class.java)
+
+        val featureWithDialog =
+            AppLinksFeature(
+                context = mockContext,
+                sessionManager = mockSessionManager,
+                useCases = mockUseCases,
+                fragmentManager = mockFragmentManager,
+                dialog = mockDialog
+            )
+
+        featureWithDialog.start()
+
+        userTapsOnSession(webUrl, true)
+
+        verifyNoMoreInteractions(mockDialog)
+        verifyNoMoreInteractions(mockOpenRedirect)
+    }
+
+    @Test
+    fun `an external app is not opened if it is typed in to the URL bar`() {
+        val mockDialog = spy(RedirectDialogFragment::class.java)
+
+        `when`(mockFragmentManager.beginTransaction()).thenReturn(mozilla.components.support.test.mock())
+
+        val featureWithDialog =
+            AppLinksFeature(
+                context = mockContext,
+                sessionManager = mockSessionManager,
+                useCases = mockUseCases,
+                fragmentManager = mockFragmentManager,
+                dialog = mockDialog
+            )
+
+        featureWithDialog.start()
+
+        feature.observer.onLoadRequest(
+            createSession(webUrl, true),
+            triggeredByRedirect = false,
+            triggeredByWebContent = false
+        )
+
+        verifyNoMoreInteractions(mockDialog)
+        verifyNoMoreInteractions(mockOpenRedirect)
+    }
+
+    @Test
+    fun `in non-private mode an external app is opened without a dialog`() {
+        val mockDialog = Mockito.spy(RedirectDialogFragment::class.java)
+        val mockFragmentManager = mock(FragmentManager::class.java)
+
+        `when`(mockFragmentManager.beginTransaction()).thenReturn(mock(FragmentTransaction::class.java))
+
+        val featureWithDialog =
+            AppLinksFeature(
+                context = mockContext,
+                sessionManager = mockSessionManager,
+                useCases = mockUseCases,
+                fragmentManager = mockFragmentManager,
+                dialog = mockDialog
+            )
+
+        featureWithDialog.start()
+
+        userTapsOnSession(intentUrl, false)
+
+        verifyNoMoreInteractions(mockDialog)
+        verify(mockOpenRedirect).invoke(any())
+    }
+}

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -1,0 +1,157 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class AppLinksUseCasesTest {
+    private val appUrl = "https://example.com"
+    private val appPackage = "com.example.app"
+    private val browserPackage = "com.browser"
+
+    private fun createContext(vararg urlToPackages: Pair<String, String>): Context {
+        val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+        val packageManager = shadowOf(pm)
+
+        urlToPackages.forEach { (urlString, packageName) ->
+            val intent = Intent.parseUri(urlString, 0).addCategory(Intent.CATEGORY_BROWSABLE)
+
+            val activityInfo = ActivityInfo()
+            activityInfo.packageName = packageName
+
+            val resolveInfo = ResolveInfo()
+            resolveInfo.activityInfo = activityInfo
+
+            packageManager.addResolveInfoForIntentNoDefaults(intent, resolveInfo)
+        }
+
+        val context = mock(Context::class.java)
+        `when`(context.packageManager).thenReturn(pm)
+
+        return context
+    }
+
+    @Test
+    fun `A URL that matches zero apps is not an app link`() {
+        val context = createContext()
+        val subject = AppLinksUseCases(context, emptySet())
+
+        val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
+        assertFalse(redirect.isRedirect())
+    }
+
+    @Test
+    fun `A web URL that matches more than zero apps is an app link`() {
+        val context = createContext(appUrl to appPackage)
+        val subject = AppLinksUseCases(context, emptySet())
+
+        // We will redirect to it when we click on it.
+        val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
+        assertTrue(redirect.isRedirect())
+
+        // But we do from a context menu.
+        val menuRedirect = subject.appLinkRedirect.invoke(appUrl)
+        assertTrue(menuRedirect.isRedirect())
+    }
+
+    @Test
+    fun `A URL that matches only excluded packages is not an app link`() {
+        val context = createContext(appUrl to browserPackage)
+        val subject = AppLinksUseCases(context, setOf(browserPackage))
+
+        val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
+        assertFalse(redirect.isRedirect())
+    }
+
+    @Test
+    fun `A URL that also matches excluded packages is an app link`() {
+        val context = createContext(appUrl to appPackage, appUrl to browserPackage)
+        val subject = AppLinksUseCases(context, setOf(browserPackage))
+
+        val redirect = subject.appLinkRedirect.invoke(appUrl)
+        assertTrue(redirect.isRedirect())
+    }
+
+    @Test
+    fun `A list of browser package names can be generated if not supplied`() {
+        val unguessable = "https://unguessable-test-url.com"
+        val context = createContext(unguessable to browserPackage)
+        val subject = AppLinksUseCases(context, unguessableWebUrl = unguessable)
+
+        assertEquals(subject.browserPackageNames, setOf(browserPackage))
+    }
+
+    @Test
+    fun `A intent scheme uri with an installed app`() {
+        val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
+        val context = createContext(uri to appPackage, appUrl to browserPackage)
+        val subject = AppLinksUseCases(context, setOf(browserPackage))
+
+        val redirect = subject.interceptedAppLinkRedirect.invoke(uri)
+        assertTrue(redirect.hasExternalApp())
+        assertNotNull(redirect.appIntent)
+
+        assertEquals("zxing://scan/", redirect.appIntent!!.dataString)
+    }
+
+    @Test
+    fun `A intent scheme uri without an installed app`() {
+        val context = createContext(appUrl to browserPackage)
+        val subject = AppLinksUseCases(context, setOf(browserPackage))
+
+        val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
+
+        val redirect = subject.interceptedAppLinkRedirect.invoke(uri)
+        assertFalse(redirect.hasExternalApp())
+        assertFalse(redirect.hasFallback())
+        assertNull(redirect.webUrl)
+    }
+
+    @Test
+    fun `A intent scheme uri with a fallback, but without an installed app`() {
+        val context = createContext(appUrl to browserPackage)
+        val subject = AppLinksUseCases(context, setOf(browserPackage))
+
+        val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;S.browser_fallback_url=http%3A%2F%2Fzxing.org;end"
+
+        val redirect = subject.interceptedAppLinkRedirect.invoke(uri)
+        assertFalse(redirect.hasExternalApp())
+        assertTrue(redirect.hasFallback())
+
+        assertEquals("http://zxing.org", redirect.webUrl)
+    }
+
+    @Test
+    fun `An openAppLink use case starts an activity`() {
+        val context = createContext()
+        val appIntent = Intent()
+        val redirect = AppLinkRedirect(appIntent, appUrl, false)
+        val subject = AppLinksUseCases(context, setOf(browserPackage))
+
+        subject.openAppLink.invoke(redirect)
+
+        verify(context).startActivity(any())
+    }
+}

--- a/components/feature/app-links/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/app-links/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/docs/api/package-list
+++ b/docs/api/package-list
@@ -150,6 +150,7 @@ mozilla.components.concept.sync
 mozilla.components.concept.tabstray
 mozilla.components.concept.toolbar
 mozilla.components.feature.accounts
+mozilla.components.feature.app.links
 mozilla.components.feature.awesomebar
 mozilla.components.feature.awesomebar.provider
 mozilla.components.feature.contextmenu

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -162,6 +162,10 @@ permalink: /changelog/
   * Added ability for `SuggestionProvider` to return an initial list of suggestions from `onInputStarted()`.
   * Modified `ClipboardSuggestionProvider` to already return a suggestions from `onInputStarted()` if the clipboard contains a URL.
 
+* **feature-app-links**
+  *  🆕 New component: to detect and open links in other non-browser apps.
+  * Use cases to parse intent:// URLs, query the package manager for activities and generate Play store URLs.
+
 * **browser-engine-gecko-nightly**, **concept-engine**:
   * Added `EngineSession.Observer.onRecordingStateChanged()` to get list of recording devices currently used by web content.
 

--- a/l10n.toml
+++ b/l10n.toml
@@ -35,6 +35,10 @@ branches = [
   l10n = "components/browser/toolbar/src/main/res/values-{android_locale}/strings.xml"
 
 [[paths]]
+  reference = "components/feature/app-links/src/main/res/values/strings.xml"
+  l10n = "components/feature/app-links/src/main/res/values-{android_locale}/strings.xml"
+
+[[paths]]
   reference = "components/feature/contextmenu/src/main/res/values/strings.xml"
   l10n = "components/feature/contextmenu/src/main/res/values-{android_locale}/strings.xml"
 

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     implementation project(':lib-fetch-httpurlconnection')
 
     implementation project(':feature-awesomebar')
+    implementation project(':feature-app-links')
     implementation project(':feature-contextmenu')
     implementation project(':feature-customtabs')
     implementation project(':feature-intent')

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
+import mozilla.components.feature.app.links.AppLinksFeature
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
@@ -48,6 +49,7 @@ class BrowserFragment : Fragment(), BackHandler {
     private val thumbnailsFeature = ViewBoundFeatureWrapper<ThumbnailsFeature>()
     private val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewIntegration>()
     private val swipeRefreshFeature = ViewBoundFeatureWrapper<SwipeRefreshFeature>()
+    private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
 
     @Suppress("LongMethod")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -200,6 +202,17 @@ class BrowserFragment : Fragment(), BackHandler {
 
         thumbnailsFeature.set(
             feature = ThumbnailsFeature(requireContext(), layout.engineView, components.sessionManager),
+            owner = this,
+            view = layout
+        )
+
+        appLinksFeature.set(
+            feature = AppLinksFeature(
+                context = requireContext(),
+                sessionManager = components.sessionManager,
+                sessionId = sessionId,
+                fragmentManager = requireFragmentManager()
+            ),
             owner = this,
             view = layout
         )


### PR DESCRIPTION
Fixes #2976.

This PR introduces a new feature component: `feature-app-links`.

It provides use cases for testing and opening a link in an external/non-browser app. 

Some of the UI for #2975 and the link interception in #2974 is also here, but turned off by a boolean flag.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
