### PR TITLE
Update GleanDebugActivity docs regarding `sendPing` flag [ci skip]

### DIFF
--- a/components/service/glean/README.md
+++ b/components/service/glean/README.md
@@ -180,9 +180,13 @@ adb shell am start -n org.mozilla.samples.glean/mozilla.components.service.glean
   --es tagPings test-metrics-ping
 ```
 
-### Important GleanDebugActivity note!
+### Important GleanDebugActivity notes!
 
-Options that are set using the adb flags are not immediately reset and will persist until the application is closed or manually reset.
+- Options that are set using the adb flags are not immediately reset and will persist until the application is closed or manually reset.
+
+- There are a couple different ways in which to send pings through the GleanDebugActivity.
+    1. You can use the `GleanDebugActivity` in order to tag pings and trigger them manually using the UI.  This should always produce a ping with all required fields.
+    2. You can use the `GleanDebugActivity` to tag _and_ send pings.  This has the side effect of potentially sending a ping which does not include all fields because `sendPings` triggers pings to be sent before certain application behaviors can occur which would record that information.  For example, `duration` is not calculated or included in a baseline ping sent with `sendPing` because it forces the ping to be sent before the `duration` metric has been recorded.
 
 ## Data documentation
 


### PR DESCRIPTION
Since the `sendPing` flag does not allow for things like `duration` to be calculated and added to the ping since the ping is sent before application dependent things like `duration` are started, the documentation needed to be updated to explicitly indicate this was the actual behavior of the `GleanDebugActivity`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
