### PR TITLE
Add Sync Photon icons to component [ci skip]

### DIFF
--- a/components/ui/icons/src/main/res/drawable/mozac_ic_device_mobile.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_device_mobile.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:pathData="M12,0L4,0a2,2 0,0 0,-2 2v12a2,2 0,0 0,2 2h8a2,2 0,0 0,2 -2L14,2a2,2 0,0 0,-2 -2zM9,15L7,15v-1h2zM12,12.5a0.5,0.5 0,0 1,-0.5 0.5h-7a0.5,0.5 0,0 1,-0.5 -0.5v-10a0.5,0.5 0,0 1,0.5 -0.5h7a0.5,0.5 0,0 1,0.5 0.5z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/components/ui/icons/src/main/res/drawable/mozac_ic_new.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_new.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M14,7H9V2a1,1 0,0 0,-2 0v5H2a1,1 0,1 0,0 2h5v5a1,1 0,0 0,2 0V9h5a1,1 0,0 0,0 -2z"
+      android:fillColor="context-fill"/>
+</vector>

--- a/components/ui/icons/src/main/res/drawable/mozac_ic_select_all.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_select_all.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M15.222,22L5.778,22A3.778,3.778 0,0 1,2 18.222L2,8.778A3.778,3.778 0,0 1,5.778 5h9.444A3.778,3.778 0,0 1,19 8.778v9.444A3.778,3.778 0,0 1,15.222 22zM5.857,7A1.857,1.857 0,0 0,4 8.857v9.286C4,19.169 4.831,20 5.857,20h9.286A1.857,1.857 0,0 0,17 18.143L17,8.857A1.857,1.857 0,0 0,15.143 7L5.857,7zM6,4a2,2 0,0 1,2 -2h7.987a6,6 0,0 1,6 6v0.016l-0.024,7.987a2,2 0,0 1,-2.006 1.994l0.03,-9.986L19.987,8a4,4 0,0 0,-4 -4L6,4zM14.284,9.752a1,1 0,0 1,1.432 1.396l-5.95,6.1a1,1 0,0 1,-1.429 0.003l-3.05,-3.1a1,1 0,0 1,1.426 -1.402l2.334,2.372 5.237,-5.37z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/components/ui/icons/src/main/res/drawable/mozac_ic_sync.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_sync.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:pathData="M14,1a1,1 0,0 0,-1 1v1.146A6.948,6.948 0,0 0,1.227 6.307a1,1 0,1 0,1.94 0.484A4.983,4.983 0,0 1,8 3a4.919,4.919 0,0 1,3.967 2L10,5a1,1 0,0 0,0 2h4a1,1 0,0 0,1 -1L15,2a1,1 0,0 0,-1 -1zM14.046,8.481a1,1 0,0 0,-1.213 0.728A4.983,4.983 0,0 1,8 13a4.919,4.919 0,0 1,-3.967 -2L6,11a1,1 0,0 0,0 -2L2,9a1,1 0,0 0,-1 1v4a1,1 0,0 0,2 0v-1.146a6.948,6.948 0,0 0,11.773 -3.161,1 1,0 0,0 -0.727,-1.212z"
+        android:fillColor="#FFFFFF" />
+</vector>


### PR DESCRIPTION
Icons:
 - New: https://design.firefox.com/icons/viewer/#add
 - Sync: https://design.firefox.com/icons/viewer/#sync
 - Device mobile: https://design.firefox.com/icons/viewer/#mobile
 - Select All: (no link)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
