### PR TITLE
BrowserAwesomeBar: Only call onInputChanged() after onInputStarted() and allow provider to return suggestions from onInputStarted()

### DIFF
--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
@@ -167,6 +167,8 @@ class BrowserAwesomeBarTest {
 
             awesomeBar.onInputStarted()
 
+            awesomeBar.job!!.join()
+
             // Confirm that only provider2's suggestions were removed
             verify(adapter, never()).removeSuggestions(provider1)
             verify(adapter).removeSuggestions(provider2)

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -138,8 +138,11 @@ interface AwesomeBar {
 
         /**
          * Fired when the user starts interacting with the awesome bar by entering text in the toolbar.
+         *
+         * The provider has the option to return an initial list of suggestions that will be displayed before the
+         * user has entered/modified any of the text.
          */
-        fun onInputStarted() = Unit
+        fun onInputStarted(): List<Suggestion> = emptyList()
 
         /**
          * Fired whenever the user changes their input, after they have started interacting with the awesome bar.

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -32,7 +32,11 @@ class ClipboardSuggestionProvider(
 
     private val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
-    override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
+    override fun onInputStarted(): List<AwesomeBar.Suggestion> = createClipboardSuggestion()
+
+    override suspend fun onInputChanged(text: String) = createClipboardSuggestion()
+
+    private fun createClipboardSuggestion(): List<AwesomeBar.Suggestion> {
         val url = getTextFromClipboard(clipboardManager)?.let {
             findUrl(it)
         } ?: return emptyList()

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
@@ -90,16 +90,19 @@ class ClipboardSuggestionProviderTest {
         assertClipboardYieldsUrl("My IP is 192.168.0.1.", "192.168.0.1")
     }
 
-    private fun getInt() = 1
-
-    internal var foo = {
-        val someInteger = getInt()
-        someInteger / 5
-    }()
-
     @Test
-    fun `print foo`() {
-        println(foo)
+    fun `provider return suggestion on input start`() {
+        clipboardManager.primaryClip = ClipData.newPlainText("Test label", "https://www.mozilla.org")
+
+        val provider = ClipboardSuggestionProvider(context, mock())
+        val suggestions = runBlocking { provider.onInputStarted() }
+
+        assertEquals(1, suggestions.size)
+
+        val suggestion = suggestions.firstOrNull()
+        assertNotNull(suggestion!!)
+
+        assertEquals("https://www.mozilla.org", suggestion.description)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,11 @@ permalink: /changelog/
 * **lib-crash**
   * Crash reports sent to Sentry now contain additional tags about the used Android Components version and setup (prefixed with "ac.").
 
+* **browser-awesomebar**, **feature-awesomebar**
+  * Fixed an issue where `SuggestionProvider.onInputChanged()` was called before `SuggestionProvider.onInputStarted()`.
+  * Added ability for `SuggestionProvider` to return an initial list of suggestions from `onInputStarted()`.
+  * Modified `ClipboardSuggestionProvider` to already return a suggestions from `onInputStarted()` if the clipboard contains a URL.
+
 # 0.53.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.52.0...v0.53.0)


### PR DESCRIPTION
For: https://github.com/mozilla-mobile/fenix/issues/2406

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
