### PR TITLE
Use hex value for fillColor in icons [ci skip]

### DIFF
--- a/components/ui/icons/src/main/res/drawable/mozac_ic_new.xml
+++ b/components/ui/icons/src/main/res/drawable/mozac_ic_new.xml
@@ -1,15 +1,13 @@
-<!--
-  ~ This Source Code Form is subject to the terms of the Mozilla Public
-  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
-  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  -->
-
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="16dp"
     android:height="16dp"
     android:viewportWidth="16"
     android:viewportHeight="16">
-  <path
-      android:pathData="M14,7H9V2a1,1 0,0 0,-2 0v5H2a1,1 0,1 0,0 2h5v5a1,1 0,0 0,2 0V9h5a1,1 0,0 0,0 -2z"
-      android:fillColor="context-fill"/>
+    <path
+        android:pathData="M14,7H9V2a1,1 0,0 0,-2 0v5H2a1,1 0,1 0,0 2h5v5a1,1 0,0 0,2 0V9h5a1,1 0,0 0,0 -2z"
+        android:fillColor="#FFFFFF" />
 </vector>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
