### PR TITLE
Closes #3026: Add fontSizeFactor and fontInflationEnabled settings

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -170,6 +170,14 @@ class GeckoEngine(
         override var suspendMediaWhenInactive: Boolean
             get() = defaultSettings?.suspendMediaWhenInactive ?: false
             set(value) { defaultSettings?.suspendMediaWhenInactive = value }
+
+        override var fontInflationEnabled: Boolean
+            get() = runtime.settings.fontInflationEnabled
+            set(value) { runtime.settings.fontInflationEnabled = value }
+
+        override var fontSizeFactor: Float
+            get() = runtime.settings.fontSizeFactor
+            set(value) { runtime.settings.fontSizeFactor = value }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled
@@ -183,6 +191,8 @@ class GeckoEngine(
             this.preferredColorScheme = it.preferredColorScheme
             this.allowAutoplayMedia = it.allowAutoplayMedia
             this.suspendMediaWhenInactive = it.suspendMediaWhenInactive
+            this.fontInflationEnabled = it.fontInflationEnabled
+            this.fontSizeFactor = it.fontSizeFactor
         }
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -68,6 +68,8 @@ class GeckoEngineTest {
         `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
         `when`(runtimeSettings.webFontsEnabled).thenReturn(true)
         `when`(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
+        `when`(runtimeSettings.fontInflationEnabled).thenReturn(false)
+        `when`(runtimeSettings.fontSizeFactor).thenReturn(1.0F)
         `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
         `when`(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
         `when`(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
@@ -85,6 +87,14 @@ class GeckoEngineTest {
         assertTrue(engine.settings.automaticFontSizeAdjustment)
         engine.settings.automaticFontSizeAdjustment = false
         verify(runtimeSettings).automaticFontSizeAdjustment = false
+
+        assertFalse(engine.settings.fontInflationEnabled)
+        engine.settings.fontInflationEnabled = true
+        verify(runtimeSettings).fontInflationEnabled = true
+
+        assertEquals(1.0F, engine.settings.fontSizeFactor)
+        engine.settings.fontSizeFactor = 2.0F
+        verify(runtimeSettings).fontSizeFactor = 2.0F
 
         assertFalse(engine.settings.remoteDebuggingEnabled)
         engine.settings.remoteDebuggingEnabled = true
@@ -157,6 +167,8 @@ class GeckoEngineTest {
                 javascriptEnabled = false,
                 webFontsEnabled = false,
                 automaticFontSizeAdjustment = false,
+                fontInflationEnabled = true,
+                fontSizeFactor = 2.0F,
                 remoteDebuggingEnabled = true,
                 testingModeEnabled = true,
                 userAgentString = "test-ua",
@@ -168,6 +180,8 @@ class GeckoEngineTest {
         verify(runtimeSettings).javaScriptEnabled = false
         verify(runtimeSettings).webFontsEnabled = false
         verify(runtimeSettings).automaticFontSizeAdjustment = false
+        verify(runtimeSettings).fontInflationEnabled = true
+        verify(runtimeSettings).fontSizeFactor = 2.0F
         verify(runtimeSettings).remoteDebuggingEnabled = true
         verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -146,6 +146,16 @@ abstract class Settings {
      * Setting to control whether media should be suspended when the session is inactive.
      */
     open var suspendMediaWhenInactive: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control whether font inflation is enabled.
+     */
+    open var fontInflationEnabled: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control the font size factor. All font sizes will be multiplied by this factor.
+     */
+    open var fontSizeFactor: Float by UnsupportedSetting()
 }
 
 /**
@@ -176,7 +186,9 @@ data class DefaultSettings(
     override var preferredColorScheme: PreferredColorScheme = PreferredColorScheme.System,
     override var testingModeEnabled: Boolean = false,
     override var allowAutoplayMedia: Boolean = true,
-    override var suspendMediaWhenInactive: Boolean = false
+    override var suspendMediaWhenInactive: Boolean = false,
+    override var fontInflationEnabled: Boolean = false,
+    override var fontSizeFactor: Float = 1.0F
 ) : Settings()
 
 class UnsupportedSetting<T> {

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -72,7 +72,11 @@ class SettingsTest {
             { settings.allowAutoplayMedia },
             { settings.allowAutoplayMedia = false },
             { settings.suspendMediaWhenInactive },
-            { settings.suspendMediaWhenInactive = false }
+            { settings.suspendMediaWhenInactive = false },
+            { settings.fontInflationEnabled },
+            { settings.fontInflationEnabled = false },
+            { settings.fontSizeFactor },
+            { settings.fontSizeFactor = 1.0F }
         )
     }
 
@@ -109,6 +113,8 @@ class SettingsTest {
         assertFalse(settings.testingModeEnabled)
         assertTrue(settings.allowAutoplayMedia)
         assertFalse(settings.suspendMediaWhenInactive)
+        assertFalse(settings.fontInflationEnabled)
+        assertEquals(1.0F, settings.fontSizeFactor)
 
         val interceptor: RequestInterceptor = mock()
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
@@ -138,7 +144,9 @@ class SettingsTest {
             preferredColorScheme = PreferredColorScheme.Dark,
             testingModeEnabled = true,
             allowAutoplayMedia = false,
-            suspendMediaWhenInactive = true)
+            suspendMediaWhenInactive = true,
+            fontInflationEnabled = true,
+            fontSizeFactor = 2.0F)
 
         assertFalse(defaultSettings.domStorageEnabled)
         assertFalse(defaultSettings.javascriptEnabled)
@@ -165,5 +173,7 @@ class SettingsTest {
         assertTrue(defaultSettings.testingModeEnabled)
         assertFalse(defaultSettings.allowAutoplayMedia)
         assertTrue(defaultSettings.suspendMediaWhenInactive)
+        assertTrue(defaultSettings.fontInflationEnabled)
+        assertEquals(2.0F, defaultSettings.fontSizeFactor)
     }
 }


### PR DESCRIPTION
/cc @ekager, just a heads-up that `automaticFontSizeAdjustment` needs to be set to false to use `fontSizeFactor` (we already expose that setting with default=true).