### PR TITLE
Closes #2957: Bump a-s version to 0.28.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val jna = "5.2.0"
     const val disklrucache = "2.0.2"
 
-    const val mozilla_appservices = "0.27.1"
+    const val mozilla_appservices = "0.28.1"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
@@ -36,11 +36,14 @@ interface DeviceConstellation : Observable<DeviceEventsObserver> {
     fun destroyCurrentDeviceAsync(): Deferred<Boolean>
 
     /**
-     * Ensure that all initialized [DeviceCapability], such as [DeviceCapability.SEND_TAB], are configured.
+     * Ensure that all passed in [capabilities] are configured.
      * This may involve backend service registration, or other work involving network/disc access.
+     * @param capabilities A list of capabilities to configure. This is expected to be the same or
+     * longer list than what was passed into [initDeviceAsync]. Removing capabilities is currently
+     * not supported.
      * @return A [Deferred] that will be resolved once operation is complete.
      */
-    fun ensureCapabilitiesAsync(): Deferred<Unit>
+    fun ensureCapabilitiesAsync(capabilities: List<DeviceCapability>): Deferred<Unit>
 
     /**
      * Current state of the constellation. May be missing if state was never queried.

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -83,9 +83,9 @@ class FxaDeviceConstellation(
         return CompletableDeferred(false)
     }
 
-    override fun ensureCapabilitiesAsync(): Deferred<Unit> {
+    override fun ensureCapabilitiesAsync(capabilities: List<DeviceCapability>): Deferred<Unit> {
         return scope.async {
-            account.ensureCapabilities()
+            account.ensureCapabilities(capabilities.map { it.into() }.toSet())
         }
     }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -384,7 +384,7 @@ open class FxaAccountManager(
                         account.registerPersistenceCallback(statePersistenceCallback)
                         account.deviceConstellation().register(deviceEventsIntegration)
 
-                        account.deviceConstellation().ensureCapabilitiesAsync().await()
+                        account.deviceConstellation().ensureCapabilitiesAsync(deviceTuple.capabilities).await()
                         account.deviceConstellation().startPeriodicRefresh()
 
                         notifyObservers { onAuthenticated(account) }


### PR DESCRIPTION
As part of the upgrade, behaviour of `ensureCapabilities` changed
to support upgrade use-cases. For example, a device that was initially
registered without SEND_TAB support will now be able to "upgrade" to
support it.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
