### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `ui-tabcounter` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -44,7 +44,6 @@ object KotlinCompiler {
         "support-utils",
         "tooling-lint",
         "ui-autocomplete",
-        "ui-progress",
-        "ui-tabcounter"
+        "ui-progress"
     )
 }

--- a/components/ui/tabcounter/build.gradle
+++ b/components/ui/tabcounter/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
 
+    testImplementation project(":support-test")
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/ui/tabcounter/src/test/java/mozilla/components/ui/tabcounter/TabCounterTest.kt
+++ b/components/ui/tabcounter/src/test/java/mozilla/components/ui/tabcounter/TabCounterTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.ui.tabcounter
 
+import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.ui.tabcounter.TabCounter.Companion.DEFAULT_TABS_COUNTER_TEXT
 import mozilla.components.ui.tabcounter.TabCounter.Companion.ONE_DIGIT_SIZE_RATIO
 import mozilla.components.ui.tabcounter.TabCounter.Companion.SO_MANY_TABS_OPEN
@@ -12,14 +13,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class TabCounterTest {
 
     @Test
     fun `Default tab count is a smiley face`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(testContext)
 
         assertEquals(DEFAULT_TABS_COUNTER_TEXT, tabCounter.getText())
 
@@ -28,7 +28,7 @@ class TabCounterTest {
 
     @Test
     fun `Set tab count as 1`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(testContext)
 
         tabCounter.setCount(1)
 
@@ -39,7 +39,7 @@ class TabCounterTest {
 
     @Test
     fun `Set tab count as 99`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(testContext)
 
         tabCounter.setCount(99)
 
@@ -50,7 +50,7 @@ class TabCounterTest {
 
     @Test
     fun `Set tab count as 100`() {
-        val tabCounter = TabCounter(RuntimeEnvironment.application)
+        val tabCounter = TabCounter(testContext)
 
         tabCounter.setCount(100)
 


### PR DESCRIPTION
### Issue #2346

This one with trivial changes as well.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~