### PR TITLE
Issue #3026: Don't set unchanged values of fontSizeFactor/fontInflation

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -173,11 +173,25 @@ class GeckoEngine(
 
         override var fontInflationEnabled: Boolean
             get() = runtime.settings.fontInflationEnabled
-            set(value) { runtime.settings.fontInflationEnabled = value }
+            set(value) {
+                // Setting, even to the default value, causes an Exception if
+                // automaticFontSizeAdjustment is set to true (its default).
+                // So, let's only set if the value has changed.
+                if (value != runtime.settings.fontInflationEnabled) {
+                    runtime.settings.fontInflationEnabled = value
+                }
+            }
 
         override var fontSizeFactor: Float
             get() = runtime.settings.fontSizeFactor
-            set(value) { runtime.settings.fontSizeFactor = value }
+            set(value) {
+                // Setting, even to the default value, causes an Exception if
+                // automaticFontSizeAdjustment is set to true (its default).
+                // So, let's only set if the value has changed.
+                if (value != runtime.settings.fontSizeFactor) {
+                    runtime.settings.fontSizeFactor = value
+                }
+            }
     }.apply {
         defaultSettings?.let {
             this.javascriptEnabled = it.javascriptEnabled

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoResult
@@ -68,7 +69,7 @@ class GeckoEngineTest {
         `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
         `when`(runtimeSettings.webFontsEnabled).thenReturn(true)
         `when`(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
-        `when`(runtimeSettings.fontInflationEnabled).thenReturn(false)
+        `when`(runtimeSettings.fontInflationEnabled).thenReturn(true)
         `when`(runtimeSettings.fontSizeFactor).thenReturn(1.0F)
         `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
         `when`(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
@@ -88,11 +89,15 @@ class GeckoEngineTest {
         engine.settings.automaticFontSizeAdjustment = false
         verify(runtimeSettings).automaticFontSizeAdjustment = false
 
-        assertFalse(engine.settings.fontInflationEnabled)
+        assertTrue(engine.settings.fontInflationEnabled)
         engine.settings.fontInflationEnabled = true
-        verify(runtimeSettings).fontInflationEnabled = true
+        verify(runtimeSettings, never()).fontInflationEnabled = true
+        engine.settings.fontInflationEnabled = false
+        verify(runtimeSettings).fontInflationEnabled = false
 
         assertEquals(1.0F, engine.settings.fontSizeFactor)
+        engine.settings.fontSizeFactor = 1.0F
+        verify(runtimeSettings, never()).fontSizeFactor = 1.0F
         engine.settings.fontSizeFactor = 2.0F
         verify(runtimeSettings).fontSizeFactor = 2.0F
 
@@ -160,6 +165,7 @@ class GeckoEngineTest {
         `when`(runtime.settings).thenReturn(runtimeSettings)
         `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
         `when`(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
+        `when`(runtimeSettings.fontInflationEnabled).thenReturn(true)
 
         val engine = GeckoEngine(context,
             DefaultSettings(
@@ -167,7 +173,7 @@ class GeckoEngineTest {
                 javascriptEnabled = false,
                 webFontsEnabled = false,
                 automaticFontSizeAdjustment = false,
-                fontInflationEnabled = true,
+                fontInflationEnabled = false,
                 fontSizeFactor = 2.0F,
                 remoteDebuggingEnabled = true,
                 testingModeEnabled = true,
@@ -180,7 +186,7 @@ class GeckoEngineTest {
         verify(runtimeSettings).javaScriptEnabled = false
         verify(runtimeSettings).webFontsEnabled = false
         verify(runtimeSettings).automaticFontSizeAdjustment = false
-        verify(runtimeSettings).fontInflationEnabled = true
+        verify(runtimeSettings).fontInflationEnabled = false
         verify(runtimeSettings).fontSizeFactor = 2.0F
         verify(runtimeSettings).remoteDebuggingEnabled = true
         verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -187,7 +187,7 @@ data class DefaultSettings(
     override var testingModeEnabled: Boolean = false,
     override var allowAutoplayMedia: Boolean = true,
     override var suspendMediaWhenInactive: Boolean = false,
-    override var fontInflationEnabled: Boolean = false,
+    override var fontInflationEnabled: Boolean = true,
     override var fontSizeFactor: Float = 1.0F
 ) : Settings()
 

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -113,7 +113,7 @@ class SettingsTest {
         assertFalse(settings.testingModeEnabled)
         assertTrue(settings.allowAutoplayMedia)
         assertFalse(settings.suspendMediaWhenInactive)
-        assertFalse(settings.fontInflationEnabled)
+        assertTrue(settings.fontInflationEnabled)
         assertEquals(1.0F, settings.fontSizeFactor)
 
         val interceptor: RequestInterceptor = mock()
@@ -145,7 +145,7 @@ class SettingsTest {
             testingModeEnabled = true,
             allowAutoplayMedia = false,
             suspendMediaWhenInactive = true,
-            fontInflationEnabled = true,
+            fontInflationEnabled = false,
             fontSizeFactor = 2.0F)
 
         assertFalse(defaultSettings.domStorageEnabled)
@@ -173,7 +173,7 @@ class SettingsTest {
         assertTrue(defaultSettings.testingModeEnabled)
         assertFalse(defaultSettings.allowAutoplayMedia)
         assertTrue(defaultSettings.suspendMediaWhenInactive)
-        assertTrue(defaultSettings.fontInflationEnabled)
+        assertFalse(defaultSettings.fontInflationEnabled)
         assertEquals(2.0F, defaultSettings.fontSizeFactor)
     }
 }


### PR DESCRIPTION
Setting these (even to their defaults when intializing) will cause an exception (crash) if `automaticFontSizeAdjustment` is set to true as well (its default).

In addition, the default of `fontInflationEnabled` was incorrect.