### PR TITLE
Closes #2699: Fix menu actions not working in all Custom Tabs

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -58,20 +58,30 @@ class CustomTabsToolbarFeature(
         session.customTabConfig?.let { config ->
             // Don't allow clickable toolbar so a custom tab can't switch to edit mode.
             toolbar.onUrlClicked = { false }
+
             // If it's available, hold on to the readable colour for other assets.
             config.toolbarColor?.let {
                 readableColor = getReadableTextColor(it)
             }
+
             // Change the toolbar colour
             updateToolbarColor(config.toolbarColor)
+
             // Add navigation close action
             addCloseButton(session, config.closeButtonIcon)
+
             // Add action button
             addActionButton(session, config.actionButtonConfig)
+
             // Show share button
-            if (config.showShareMenuItem) addShareButton(session)
+            if (config.showShareMenuItem) {
+                addShareButton(session)
+            }
+
             // Add menu items
-            if (config.menuItems.isNotEmpty()) addMenuItems(session, config.menuItems, menuItemIndex)
+            if (config.menuItems.isNotEmpty() || menuBuilder?.items?.isNotEmpty() == true) {
+                addMenuItems(session, config.menuItems, menuItemIndex)
+            }
 
             return true
         }

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -279,7 +279,7 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
-    fun `initialize calls addMenuItems`() {
+    fun `initialize calls addMenuItems when config has items`() {
         val session: Session = mock()
         val toolbar = BrowserToolbar(RuntimeEnvironment.application)
         val customTabConfig: CustomTabConfig = mock()
@@ -297,6 +297,58 @@ class CustomTabsToolbarFeatureTest {
         feature.initialize(session)
 
         verify(feature).addMenuItems(any(), anyList(), anyInt())
+    }
+
+    @Test
+    fun `initialize calls addMenuItems when menuBuilder has items`() {
+        val session: Session = mock()
+        val menuBuilder: BrowserMenuBuilder = mock()
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        val customTabConfig: CustomTabConfig = mock()
+        `when`(session.customTabConfig).thenReturn(customTabConfig)
+        `when`(customTabConfig.menuItems).thenReturn(emptyList())
+        `when`(menuBuilder.items).thenReturn(listOf(mock(), mock()))
+
+        val feature = spy(CustomTabsToolbarFeature(mock(), toolbar, "", menuBuilder) {})
+
+        feature.initialize(session)
+
+        verify(feature).addMenuItems(any(), anyList(), anyInt())
+    }
+
+    @Test
+    fun `initialize never calls addMenuItems when no config or builder items available`() {
+        val session: Session = mock()
+        val menuBuilder: BrowserMenuBuilder = mock()
+        val toolbar = BrowserToolbar(RuntimeEnvironment.application)
+        val customTabConfig: CustomTabConfig = mock()
+        `when`(session.customTabConfig).thenReturn(customTabConfig)
+
+        // With NO config or builder.
+        var feature = spy(CustomTabsToolbarFeature(mock(), toolbar, "") {})
+
+        feature.initialize(session)
+
+        verify(feature, never()).addMenuItems(any(), anyList(), anyInt())
+
+        // With only builder but NO items.
+        feature = spy(CustomTabsToolbarFeature(mock(), toolbar, "", menuBuilder) {})
+
+        feature.initialize(session)
+
+        // With only builder and items.
+        `when`(menuBuilder.items).thenReturn(listOf())
+
+        feature.initialize(session)
+
+        verify(feature, never()).addMenuItems(any(), anyList(), anyInt())
+
+        // With config with NO items and builder with items.
+        `when`(customTabConfig.menuItems).thenReturn(emptyList())
+
+        feature.initialize(session)
+
+        verify(feature, never()).addMenuItems(any(), anyList(), anyInt())
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-findinpage**
   * Find in Page Bar now displays 0/0 for no matches found with new attr findInPageNoMatchesTextColor
 
+* **feature-customtabs**
+  * Fixed a bug where menu actions would not work for all Custom Tab sessions.
+
 * **support-test**
   * Added `testContext` property for retrieving application context from tests.
 
@@ -61,7 +64,7 @@ permalink: /changelog/
 
 * ℹ️ **Upgraded Gradle to 5.3.1**
   * ⚠️ This requires using the 1.3.30 Kotlin gradle plugin or higher.
-  
+
 * **feature-tab-collections**
   * 🆕 New component: Feature implementation for saving, restoring and organizing collections of tabs.
 
@@ -184,10 +187,10 @@ permalink: /changelog/
   accountManager.register(accountObserver, owner = this, autoPause = true)
   accountManager.registerForDeviceEvents(deviceEventsObserver, owner = this, autoPause = true)
   ```
-  
+
 * **feature-prompts**
   * ⚠️ **This is a breaking API change**:
-  * `PromptFeature` constructor adds an optional `sessionId`. This should use the custom tab session id if available. 
+  * `PromptFeature` constructor adds an optional `sessionId`. This should use the custom tab session id if available.
 
 
 * **browser-session**


### PR DESCRIPTION
Checks if menuBuilder also has items when adding it to the toolbar menu options.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
