### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `browser-errorpages`.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -15,7 +15,6 @@ object KotlinCompiler {
         "browser-domains",
         "browser-engine-gecko",
         "browser-engine-servo",
-        "browser-errorpages",
         "browser-menu",
         "browser-search",
         "browser-storage-sync",

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -6,7 +6,9 @@
 
 package mozilla.components.browser.errorpages
 
-import org.junit.Assert
+import mozilla.components.browser.errorpages.ErrorPages.createErrorPage
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.nullable
@@ -15,21 +17,52 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ErrorPagesTest {
 
     @Test
     fun `createErrorPage should replace default HTML placeholders`() {
-        val context = spy(RuntimeEnvironment.application)
-        val errorPage = ErrorPages.createErrorPage(context, ErrorType.UNKNOWN)
-        Assert.assertFalse(errorPage.contains("%pageTitle%"))
-        Assert.assertFalse(errorPage.contains("%backButton%"))
-        Assert.assertFalse(errorPage.contains("%button%"))
-        Assert.assertFalse(errorPage.contains("%messageShort%"))
-        Assert.assertFalse(errorPage.contains("%messageLong%"))
-        Assert.assertFalse(errorPage.contains("%css%"))
+        assertTemplateIsValid(ErrorType.UNKNOWN)
+        assertTemplateIsValid(ErrorType.ERROR_SECURITY_SSL)
+        assertTemplateIsValid(ErrorType.ERROR_SECURITY_BAD_CERT)
+        assertTemplateIsValid(ErrorType.ERROR_NET_INTERRUPT)
+        assertTemplateIsValid(ErrorType.ERROR_NET_TIMEOUT)
+        assertTemplateIsValid(ErrorType.ERROR_CONNECTION_REFUSED)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_SOCKET_TYPE)
+        assertTemplateIsValid(ErrorType.ERROR_REDIRECT_LOOP)
+        assertTemplateIsValid(ErrorType.ERROR_OFFLINE)
+        assertTemplateIsValid(ErrorType.ERROR_PORT_BLOCKED)
+        assertTemplateIsValid(ErrorType.ERROR_NET_RESET)
+        assertTemplateIsValid(ErrorType.ERROR_UNSAFE_CONTENT_TYPE)
+        assertTemplateIsValid(ErrorType.ERROR_CORRUPTED_CONTENT)
+        assertTemplateIsValid(ErrorType.ERROR_CONTENT_CRASHED)
+        assertTemplateIsValid(ErrorType.ERROR_INVALID_CONTENT_ENCODING)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_HOST)
+        assertTemplateIsValid(ErrorType.ERROR_MALFORMED_URI)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_PROTOCOL)
+        assertTemplateIsValid(ErrorType.ERROR_FILE_NOT_FOUND)
+        assertTemplateIsValid(ErrorType.ERROR_FILE_ACCESS_DENIED)
+        assertTemplateIsValid(ErrorType.ERROR_PROXY_CONNECTION_REFUSED)
+        assertTemplateIsValid(ErrorType.ERROR_UNKNOWN_PROXY_HOST)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_MALWARE_URI)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_UNWANTED_URI)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_HARMFUL_URI)
+        assertTemplateIsValid(ErrorType.ERROR_SAFEBROWSING_PHISHING_URI)
+    }
+
+    private fun assertTemplateIsValid(errorType: ErrorType) {
+        val context = spy(testContext)
+
+        val errorPage = createErrorPage(context, errorType)
+
+        assertFalse(errorPage.contains("%pageTitle%"))
+        assertFalse(errorPage.contains("%backButton%"))
+        assertFalse(errorPage.contains("%button%"))
+        assertFalse(errorPage.contains("%messageShort%"))
+        assertFalse(errorPage.contains("%messageLong%"))
+        assertFalse(errorPage.contains("%css%"))
+
         verify(context, times(4)).getString(anyInt())
         verify(context, times(1)).getString(anyInt(), nullable(String::class.java))
     }


### PR DESCRIPTION
### Issue #2346

   - Trivial changes: using `testContext`.
   - Added few more test-cases.

### Complexity
Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~