### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `concept-toolbar` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -20,7 +20,6 @@ object KotlinCompiler {
         "browser-search",
         "browser-storage-sync",
         "browser-toolbar",
-        "concept-toolbar",
         "feature-accounts",
         "feature-awesomebar",
         "feature-contextmenu",

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -404,6 +404,18 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `cast to view`() {
+        // Given
+        val toolbar = BrowserToolbar(context)
+
+        // When
+        val view = toolbar.asView()
+
+        // Then
+        assertNotNull(view)
+    }
+
+    @Test
     fun `URL update does not override search terms in edit mode`() {
         val toolbar = BrowserToolbar(context)
         val displayToolbar = mock(DisplayToolbar::class.java)

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -29,7 +29,7 @@ interface AwesomeBar {
     fun removeProviders(vararg providers: SuggestionProvider)
 
     /**
-     * Removes all [SuggestionProviders]
+     * Removes all [SuggestionProvider]s
      */
     fun removeAllProviders()
 

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionButtonTest.kt
@@ -7,12 +7,12 @@ package mozilla.components.concept.toolbar
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ActionButtonTest {
@@ -20,7 +20,7 @@ class ActionButtonTest {
     @Test
     fun `set padding`() {
         var button = Toolbar.ActionButton(mock(), "imageResource") {}
-        val linearLayout = LinearLayout(RuntimeEnvironment.application)
+        val linearLayout = LinearLayout(testContext)
         var view = button.createView(linearLayout)
 
         assertEquals(view.paddingLeft, 0)

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionImageTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionImageTest.kt
@@ -11,13 +11,13 @@ import android.view.View
 import android.view.ViewGroup
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ActionImageTest {
@@ -29,7 +29,7 @@ class ActionImageTest {
         val emptyImage = Toolbar.ActionImage(mock())
 
         val viewGroup: ViewGroup = mock()
-        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(viewGroup.context).thenReturn(testContext)
         `when`(drawable.intrinsicWidth).thenReturn(5)
 
         val emptyImageView = emptyImage.createView(viewGroup)
@@ -44,7 +44,7 @@ class ActionImageTest {
         val image = Toolbar.ActionImage(mock())
         var imageAccessible = Toolbar.ActionImage(mock(), "image")
         val viewGroup: ViewGroup = mock()
-        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(viewGroup.context).thenReturn(testContext)
 
         val imageView = image.createView(viewGroup)
         assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_NO, imageView.importantForAccessibility)
@@ -67,7 +67,7 @@ class ActionImageTest {
     fun `padding is set`() {
         var image = Toolbar.ActionImage(mock())
         val viewGroup: ViewGroup = mock()
-        `when`(viewGroup.context).thenReturn(RuntimeEnvironment.application)
+        `when`(viewGroup.context).thenReturn(testContext)
         var view = image.createView(viewGroup)
 
         assertEquals(view.paddingLeft, 0)

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionSpaceTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionSpaceTest.kt
@@ -7,11 +7,11 @@ package mozilla.components.concept.toolbar
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ActionSpaceTest {
@@ -19,7 +19,7 @@ class ActionSpaceTest {
     @Test
     fun `Toolbar ActionSpace must set padding`() {
         var space = Toolbar.ActionSpace(0)
-        val linearLayout = LinearLayout(RuntimeEnvironment.application)
+        val linearLayout = LinearLayout(testContext)
         var view = space.createView(linearLayout)
 
         assertEquals(view.paddingLeft, 0)

--- a/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionToggleButtonTest.kt
+++ b/components/concept/toolbar/src/test/java/mozilla/components/concept/toolbar/ActionToggleButtonTest.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -15,16 +16,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class ActionToggleButtonTest {
+
     @Test
     fun `clicking view will toggle state`() {
         val button =
             Toolbar.ActionToggleButton(mock(), mock(), UUID.randomUUID().toString(), UUID.randomUUID().toString()) {}
-        val view = button.createView(FrameLayout(RuntimeEnvironment.application))
+        val view = button.createView(FrameLayout(testContext))
 
         assertFalse(button.isSelected())
 
@@ -46,7 +47,7 @@ class ActionToggleButtonTest {
                 listenerInvoked = true
             }
 
-        val view = button.createView(FrameLayout(RuntimeEnvironment.application))
+        val view = button.createView(FrameLayout(testContext))
 
         assertFalse(listenerInvoked)
 
@@ -159,7 +160,7 @@ class ActionToggleButtonTest {
         button.toggle(notifyListener = false)
         assertFalse(button.isSelected())
 
-        val view = button.createView(FrameLayout(RuntimeEnvironment.application))
+        val view = button.createView(FrameLayout(testContext))
         view.performClick()
         assertTrue(button.isSelected())
     }
@@ -167,7 +168,7 @@ class ActionToggleButtonTest {
     @Test
     fun `Toolbar ActionToggleButton must set padding`() {
         var button = Toolbar.ActionToggleButton(mock(), mock(), "imageResource", "") {}
-        val linearLayout = LinearLayout(RuntimeEnvironment.application)
+        val linearLayout = LinearLayout(testContext)
         var view = button.createView(linearLayout)
         val padding = Padding(16, 20, 24, 28)
 


### PR DESCRIPTION
### Issue #2346

Trivial changes: using `testContext`.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~