### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `support-utils` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -41,7 +41,6 @@ object KotlinCompiler {
         "service-fretboard",
         "service-glean",
         "support-test",
-        "support-utils",
         "tooling-lint",
         "ui-autocomplete",
         "ui-progress",

--- a/components/support/utils/build.gradle
+++ b/components/support/utils/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     // We expose the app-compat as API so that consumers get access to the Lifecycle classes automatically
     api Dependencies.androidx_appcompat
 
+    testImplementation project(":support-test")
+
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_mockito

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
@@ -1,22 +1,26 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 @file:Suppress("MatchingDeclarationName")
 
 package mozilla.components.support.utils
 
 import android.net.Uri
 import java.net.MalformedURLException
+import java.util.Locale
 
 data class DomainMatch(val url: String, val matchedSegment: String)
 
 // FIXME implement Fennec-style segment matching logic
 // See https://github.com/mozilla-mobile/android-components/issues/1279
 fun segmentAwareDomainMatch(query: String, urls: Iterable<String>): DomainMatch? {
-    val caseInsensitiveQuery = query.toLowerCase()
+    val locale = Locale.US
+
+    val caseInsensitiveQuery = query.toLowerCase(locale)
     // Process input 'urls' lazily, as the list could be very large and likely we'll find a match
     // by going through just a small subset.
-    val caseInsensitiveUrls = urls.asSequence().map { it.toLowerCase() }
+    val caseInsensitiveUrls = urls.asSequence().map { it.toLowerCase(locale) }
 
     return basicMatch(caseInsensitiveQuery, caseInsensitiveUrls)?.let { matchedUrl ->
         matchSegment(caseInsensitiveQuery, matchedUrl)?.let { DomainMatch(matchedUrl, it) }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -108,14 +108,14 @@ object DownloadUtils {
                 }
             }
             if (extension == null) {
-                if (mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("text/")) {
+                extension = if (mimeType?.toLowerCase(Locale.ROOT)?.startsWith("text/") == true) {
                     if (mimeType.equals("text/html", ignoreCase = true)) {
-                        extension = ".html"
+                        ".html"
                     } else {
-                        extension = ".txt"
+                        ".txt"
                     }
                 } else {
-                    extension = ".bin"
+                    ".bin"
                 }
             }
         } else {
@@ -128,7 +128,7 @@ object DownloadUtils {
                 if (typeFromExt == null || !typeFromExt.equals(mimeType, ignoreCase = true)) {
                     extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
                     if (extension != null) {
-                        extension = "." + extension
+                        extension = ".$extension"
                     }
                 }
             }
@@ -157,9 +157,8 @@ object DownloadUtils {
                 // Return quoted string if available and replace escaped characters.
                 val quotedFileName = m.group(QUOTED_FILE_NAME_GROUP)
 
-                return if (quotedFileName != null) {
-                    quotedFileName.replace("\\\\(.)".toRegex(), "$1")
-                } else m.group(UNQUOTED_FILE_NAME)
+                return quotedFileName?.replace("\\\\(.)".toRegex(), "$1")
+                    ?: m.group(UNQUOTED_FILE_NAME)
 
                 // Otherwise try to extract the unquoted file name
             }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/StatusBarUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/StatusBarUtils.kt
@@ -12,6 +12,7 @@ object StatusBarUtils {
     /**
      * Determine the height of the status bar asynchronously.
      */
+    @Suppress("unused")
     fun getStatusBarHeight(view: View, block: (Int) -> Unit) {
         if (statusBarSize > 0) {
             block(statusBarSize)

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/StorageUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/StorageUtils.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.utils
 
 object StorageUtils {
+
     // Borrowed from https://gist.github.com/ademar111190/34d3de41308389a0d0d8
     fun levenshteinDistance(a: String, b: String): Int {
         val lhsLength = a.length
@@ -22,10 +23,10 @@ object StorageUtils {
         var cost = Array(lhsLength) { it }
         var newCost = Array(lhsLength) { 0 }
 
-        for (i in 1..rhsLength - 1) {
+        for (i in 1 until rhsLength) {
             newCost[0] = i
 
-            for (j in 1..lhsLength - 1) {
+            for (j in 1 until lhsLength) {
                 val match = if (a[j - 1] == b[i - 1]) 0 else 1
 
                 val costReplace = cost[j - 1] + match

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/ThreadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/ThreadUtils.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
 
+@Suppress("unused")
 object ThreadUtils {
     private val looperBackgroundThread by lazy {
         HandlerThread("BackgroundThread")

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
@@ -12,6 +12,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class DomainMatcherTest {
+
     @Test
     fun `should perform basic domain matching for a given query`() {
         assertNull(segmentAwareDomainMatch("moz", listOf()))
@@ -21,6 +22,7 @@ class DomainMatcherTest {
                 "https://mobile.twitter.com", "https://m.youtube.com",
                 "https://en.Wikipedia.org/Wiki/Mozilla",
                 "http://192.168.254.254:8000", "http://192.168.254.254:8000/admin",
+                "http://иННая.локаль", // TODO add more test data for non-english locales
                 "about:config", "about:crashes"
         )
         // Full url matching.
@@ -81,6 +83,12 @@ class DomainMatcherTest {
         assertEquals(
                 DomainMatch("about:crashes", "about:crashes"),
                 segmentAwareDomainMatch("about:cr", urls)
+        )
+
+        // Non-english locale.
+        assertEquals(
+            DomainMatch("http://инная.локаль", "инная.локаль"),
+            segmentAwareDomainMatch("ин", urls)
         )
 
         assertNull(segmentAwareDomainMatch("nomatch", urls))

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -29,32 +29,32 @@ class DownloadUtilsTest {
         CONTENT_DISPOSITION_TYPES.forEach { contentDisposition ->
             // continuing with default filenames
             assertContentDisposition("downloadfile.bin", contentDisposition)
-            assertContentDisposition("downloadfile.bin", contentDisposition + ";")
-            assertContentDisposition("downloadfile.bin", contentDisposition + "; filename")
-            assertContentDisposition(".bin", contentDisposition + "; filename=")
-            assertContentDisposition(".bin", contentDisposition + "; filename=\"\"")
+            assertContentDisposition("downloadfile.bin", "$contentDisposition;")
+            assertContentDisposition("downloadfile.bin", "$contentDisposition; filename")
+            assertContentDisposition(".bin", "$contentDisposition; filename=")
+            assertContentDisposition(".bin", "$contentDisposition; filename=\"\"")
 
             // Provided filename field
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=\"filename.jpg\"")
-            assertContentDisposition("file\"name.jpg", contentDisposition + "; filename=\"file\\\"name.jpg\"")
-            assertContentDisposition("file\\name.jpg", contentDisposition + "; filename=\"file\\\\name.jpg\"")
-            assertContentDisposition("file\\\"name.jpg", contentDisposition + "; filename=\"file\\\\\\\"name.jpg\"")
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=filename.jpg")
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=filename.jpg; foo")
-            assertContentDisposition("filename.jpg", contentDisposition + "; filename=\"filename.jpg\"; foo")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=\"filename.jpg\"")
+            assertContentDisposition("file\"name.jpg", "$contentDisposition; filename=\"file\\\"name.jpg\"")
+            assertContentDisposition("file\\name.jpg", "$contentDisposition; filename=\"file\\\\name.jpg\"")
+            assertContentDisposition("file\\\"name.jpg", "$contentDisposition; filename=\"file\\\\\\\"name.jpg\"")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=filename.jpg")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=filename.jpg; foo")
+            assertContentDisposition("filename.jpg", "$contentDisposition; filename=\"filename.jpg\"; foo")
 
             // UTF-8 encoded filename* field
             assertContentDisposition("\uD83E\uDD8A + x.jpg",
-                    contentDisposition + "; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg")
+                "$contentDisposition; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg")
             assertContentDisposition("filename 的副本.jpg",
                     contentDisposition + ";filename=\"_.jpg\";" +
                             "filename*=UTF-8''filename%20%E7%9A%84%E5%89%AF%E6%9C%AC.jpg")
             assertContentDisposition("filename.jpg",
-                    contentDisposition + "; filename=_.jpg; filename*=utf-8'en'filename.jpg")
+                "$contentDisposition; filename=_.jpg; filename*=utf-8'en'filename.jpg")
 
             // ISO-8859-1 encoded filename* field
             assertContentDisposition("file' 'name.jpg",
-                    contentDisposition + "; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg")
+                "$contentDisposition; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg")
         }
     }
 

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/StorageUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/StorageUtilsTest.kt
@@ -1,0 +1,53 @@
+package mozilla.components.support.utils
+
+import mozilla.components.support.utils.StorageUtils.levenshteinDistance
+import org.junit.Assert.assertEquals
+import org.junit.Ignore
+import org.junit.Test
+
+class StorageUtilsTest {
+
+    @Test
+    @Ignore("Some assertions failed. Should we fix implementation?")
+    fun checkLevenshteinDistance() {
+        // Test data <s>stealed</s> borrowed from
+        // https://oldfashionedsoftware.com/tag/levenshtein-distance/
+
+        // Empty strings
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("", ""))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("a", ""))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("", "a"))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("abc", ""))
+        assertEquals(Int.MAX_VALUE, levenshteinDistance("", "abc"))
+
+        // Equal strings
+        assertEquals(0, levenshteinDistance("a", "a"))
+        assertEquals(0, levenshteinDistance("abc", "abc"))
+
+        // Only inserts are needed
+        assertEquals(1, levenshteinDistance("a", "ab"))
+        assertEquals(1, levenshteinDistance("b", "ab"))
+        assertEquals(1, levenshteinDistance("ac", "abc"))
+        assertEquals(6, levenshteinDistance("abcdefg", "xabxcdxxefxgx"))
+
+        // Only deletes are needed
+        assertEquals(1, levenshteinDistance("ab", "a"))
+        assertEquals(1, levenshteinDistance("ab", "b"))
+        assertEquals(1, levenshteinDistance("abc", "ac"))
+        assertEquals(6, levenshteinDistance("xabxcdxxefxgx", "abcdefg"))
+
+        // Only substitutions are needed
+        assertEquals(1, levenshteinDistance("a", "b"))
+        assertEquals(1, levenshteinDistance("ab", "ac"))
+        assertEquals(1, levenshteinDistance("ac", "bc"))
+        assertEquals(1, levenshteinDistance("abc", "axc"))
+        assertEquals(6, levenshteinDistance("xabxcdxxefxgx", "1ab2cd34ef5g6"))
+
+        // Many operations are needed
+        assertEquals(3, levenshteinDistance("example", "samples"))
+        assertEquals(6, levenshteinDistance("sturgeon", "urgently"))
+        assertEquals(6, levenshteinDistance("levenshtein", "frankenstein"))
+        assertEquals(5, levenshteinDistance("distance", "difference"))
+        assertEquals(10, levenshteinDistance("java was neat", "kotlin is great"))
+    }
+}


### PR DESCRIPTION
### Issue #2346

  - Trivial changes in tests.
  - Few more tests.
  - Minor code style improvements.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~