### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `browser-menu` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -15,7 +15,6 @@ object KotlinCompiler {
         "browser-domains",
         "browser-engine-gecko",
         "browser-engine-servo",
-        "browser-menu",
         "browser-search",
         "browser-storage-sync",
         "browser-toolbar",

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -74,16 +74,16 @@ class BrowserMenu internal constructor(
         /**
          * Determines the orientation to be used for a menu based on the positioning of the [parent] in the layout.
          */
-        fun determineMenuOrientation(parent: View): BrowserMenu.Orientation {
+        fun determineMenuOrientation(parent: View): Orientation {
             val params = parent.layoutParams
             return if (params is CoordinatorLayout.LayoutParams) {
                 if ((params.gravity and Gravity.BOTTOM) == Gravity.BOTTOM) {
-                    BrowserMenu.Orientation.UP
+                    Orientation.UP
                 } else {
-                    BrowserMenu.Orientation.DOWN
+                    Orientation.DOWN
                 }
             } else {
-                BrowserMenu.Orientation.DOWN
+                Orientation.DOWN
             }
         }
     }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.menu
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Test
@@ -17,10 +18,10 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuAdapterTest {
+
     @Test
     fun `items that return false from the visible lambda will be filtered out`() {
         val items = listOf(
@@ -30,7 +31,7 @@ class BrowserMenuAdapterTest {
             createMenuItem(4) { false },
             createMenuItem(5) { true })
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(testContext, items)
 
         assertEquals(3, adapter.visibleItems.size)
 
@@ -49,7 +50,7 @@ class BrowserMenuAdapterTest {
                 createMenuItem(23),
                 createMenuItem(42))
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, items)
+        val adapter = BrowserMenuAdapter(testContext, items)
 
         assertEquals(2, adapter.itemCount)
 
@@ -64,7 +65,7 @@ class BrowserMenuAdapterTest {
 
         val menu = mock(BrowserMenu::class.java)
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, listOf(item1, item2))
+        val adapter = BrowserMenuAdapter(testContext, listOf(item1, item2))
         adapter.menu = menu
 
         val view = mock(View::class.java)
@@ -91,7 +92,7 @@ class BrowserMenuAdapterTest {
 
         val menu = mock(BrowserMenu::class.java)
 
-        val adapter = BrowserMenuAdapter(RuntimeEnvironment.application, listOf(item1, item2))
+        val adapter = BrowserMenuAdapter(testContext, listOf(item1, item2))
         adapter.menu = menu
         val recyclerView = mock(RecyclerView::class.java)
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
@@ -7,22 +7,23 @@ package mozilla.components.browser.menu
 import android.view.View
 import android.widget.ImageButton
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuBuilderTest {
+
     @Test
     fun `items are forwarded from builder to menu`() {
         val builder = BrowserMenuBuilder(listOf(mockMenuItem(), mockMenuItem()))
 
-        val menu = builder.build(RuntimeEnvironment.application)
+        val menu = builder.build(testContext)
 
-        val anchor = ImageButton(RuntimeEnvironment.application)
+        val anchor = ImageButton(testContext)
         val popup = menu.show(anchor)
 
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.widget.CheckBox
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -13,7 +14,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuCompoundButtonTest {
@@ -33,9 +33,8 @@ class BrowserMenuCompoundButtonTest {
             // do nothing
         }
 
-        val view = LayoutInflater.from(
-            RuntimeEnvironment.application
-        ).inflate(item.getLayoutResource(), null)
+        val view = LayoutInflater.from(testContext)
+            .inflate(item.getLayoutResource(), null)
 
         assertNotNull(view)
     }
@@ -49,7 +48,7 @@ class BrowserMenuCompoundButtonTest {
         }
 
         val menu = mock(BrowserMenu::class.java)
-        val view = CheckBox(RuntimeEnvironment.application)
+        val view = CheckBox(testContext)
 
         item.bind(menu, view)
 
@@ -65,7 +64,7 @@ class BrowserMenuCompoundButtonTest {
         val item = SimpleTestBrowserCompoundButton("Hello", initialState) {}
 
         val menu = mock(BrowserMenu::class.java)
-        val view = spy(CheckBox(RuntimeEnvironment.application))
+        val view = spy(CheckBox(testContext))
         item.bind(menu, view)
 
         verify(view).isChecked = true

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -11,6 +11,7 @@ import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -22,10 +23,10 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserMenuItemToolbarTest {
+
     @Test
     fun `toolbar is visible by default`() {
         val toolbar = BrowserMenuItemToolbar(emptyList())
@@ -37,16 +38,15 @@ class BrowserMenuItemToolbarTest {
     fun `layout resource can be inflated`() {
         val toolbar = BrowserMenuItemToolbar(emptyList())
 
-        val view = LayoutInflater.from(
-            RuntimeEnvironment.application
-        ).inflate(toolbar.getLayoutResource(), null)
+        val view = LayoutInflater.from(testContext)
+            .inflate(toolbar.getLayoutResource(), null)
 
         assertNotNull(view)
     }
 
     @Test
     fun `empty toolbar does not add anything to view group`() {
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val menu = mock(BrowserMenu::class.java)
 
@@ -58,9 +58,9 @@ class BrowserMenuItemToolbarTest {
 
     @Test
     fun `toolbar removes previously existing child views from view group`() {
-        val layout = LinearLayout(RuntimeEnvironment.application)
-        layout.addView(TextView(RuntimeEnvironment.application))
-        layout.addView(TextView(RuntimeEnvironment.application))
+        val layout = LinearLayout(testContext)
+        layout.addView(TextView(testContext))
+        layout.addView(TextView(testContext))
 
         assertEquals(2, layout.childCount)
 
@@ -92,7 +92,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -124,7 +124,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -146,7 +146,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -174,7 +174,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -225,7 +225,7 @@ class BrowserMenuItemToolbarTest {
         )
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val toolbar = BrowserMenuItemToolbar(buttons)
         toolbar.bind(menu, layout)
@@ -274,7 +274,7 @@ class BrowserMenuItemToolbarTest {
         assertFalse(callbackInvoked)
 
         val menu = mock(BrowserMenu::class.java)
-        val layout = LinearLayout(RuntimeEnvironment.application)
+        val layout = LinearLayout(testContext)
 
         val toolbar = BrowserMenuItemToolbar(listOf(button))
         toolbar.bind(menu, layout)

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
@@ -4,13 +4,12 @@
 
 package mozilla.components.browser.menu.item
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -19,11 +18,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class SimpleBrowserMenuItemTest {
-    private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `simple menu items are always visible by default`() {
@@ -40,9 +37,8 @@ class SimpleBrowserMenuItemTest {
             // do nothing
         }
 
-        val view = LayoutInflater.from(
-            RuntimeEnvironment.application
-        ).inflate(item.getLayoutResource(), null)
+        val view = LayoutInflater.from(testContext)
+            .inflate(item.getLayoutResource(), null)
 
         assertNotNull(view)
     }
@@ -56,7 +52,7 @@ class SimpleBrowserMenuItemTest {
         }
 
         val menu = mock(BrowserMenu::class.java)
-        val view = TextView(RuntimeEnvironment.application)
+        val view = TextView(testContext)
 
         item.bind(menu, view)
 
@@ -79,11 +75,11 @@ class SimpleBrowserMenuItemTest {
         val textView = view.findViewById<TextView>(R.id.simple_text)
         assertEquals(textView.text, "Powered by Mozilla")
         assertEquals(textView.textSize, 10f)
-        assertEquals(textView.currentTextColor, context.getColor(android.R.color.holo_green_dark))
+        assertEquals(textView.currentTextColor, testContext.getColor(android.R.color.holo_green_dark))
     }
 
     private fun inflate(item: SimpleBrowserMenuItem): View {
-        val view = LayoutInflater.from(context).inflate(item.getLayoutResource(), null)
+        val view = LayoutInflater.from(testContext).inflate(item.getLayoutResource(), null)
         val mockMenu = mock(BrowserMenu::class.java)
         item.bind(mockMenu, view)
         return view


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~