### PR TITLE
Ensure page reload is available after error pages are displayed

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -391,11 +391,9 @@ class GeckoEngineSession(
         }
 
         override fun onPageStop(session: GeckoSession, success: Boolean) {
-            if (success) {
-                notifyObservers {
-                    onProgress(PROGRESS_STOP)
-                    onLoadingStateChange(false)
-                }
+            notifyObservers {
+                onProgress(PROGRESS_STOP)
+                onLoadingStateChange(false)
             }
         }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -157,6 +157,16 @@ class GeckoEngineSessionTest {
         assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
         assertEquals(false, observedLoadingState)
 
+        // Stop will update the loading state and progress observers even when
+        // we haven't completed been successful.
+        progressDelegate.value.onPageStart(mock(), "http://mozilla.org")
+        assertEquals(GeckoEngineSession.PROGRESS_START, observedProgress)
+        assertEquals(true, observedLoadingState)
+
+        progressDelegate.value.onPageStop(mock(), false)
+        assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
+        assertEquals(false, observedLoadingState)
+
         val securityInfo = mock(GeckoSession.ProgressDelegate.SecurityInformation::class.java)
         progressDelegate.value.onSecurityChange(mock(), securityInfo)
         assertTrue(observedSecurityChange)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -391,11 +391,9 @@ class GeckoEngineSession(
         }
 
         override fun onPageStop(session: GeckoSession, success: Boolean) {
-            if (success) {
-                notifyObservers {
-                    onProgress(PROGRESS_STOP)
-                    onLoadingStateChange(false)
-                }
+            notifyObservers {
+                onProgress(PROGRESS_STOP)
+                onLoadingStateChange(false)
             }
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -157,6 +157,16 @@ class GeckoEngineSessionTest {
         assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
         assertEquals(false, observedLoadingState)
 
+        // Stop will update the loading state and progress observers even when
+        // we haven't completed been successful.
+        progressDelegate.value.onPageStart(mock(), "http://mozilla.org")
+        assertEquals(GeckoEngineSession.PROGRESS_START, observedProgress)
+        assertEquals(true, observedLoadingState)
+
+        progressDelegate.value.onPageStop(mock(), false)
+        assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
+        assertEquals(false, observedLoadingState)
+
         val securityInfo = mock(GeckoSession.ProgressDelegate.SecurityInformation::class.java)
         progressDelegate.value.onSecurityChange(mock(), securityInfo)
         assertTrue(observedSecurityChange)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -384,11 +384,9 @@ class GeckoEngineSession(
         }
 
         override fun onPageStop(session: GeckoSession, success: Boolean) {
-            if (success) {
-                notifyObservers {
-                    onProgress(PROGRESS_STOP)
-                    onLoadingStateChange(false)
-                }
+            notifyObservers {
+                onProgress(PROGRESS_STOP)
+                onLoadingStateChange(false)
             }
         }
     }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -156,6 +156,16 @@ class GeckoEngineSessionTest {
         assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
         assertEquals(false, observedLoadingState)
 
+        // Stop will update the loading state and progress observers even when
+        // we haven't completed been successful.
+        progressDelegate.value.onPageStart(mock(), "http://mozilla.org")
+        assertEquals(GeckoEngineSession.PROGRESS_START, observedProgress)
+        assertEquals(true, observedLoadingState)
+
+        progressDelegate.value.onPageStop(mock(), false)
+        assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
+        assertEquals(false, observedLoadingState)
+
         val securityInfo = mock(GeckoSession.ProgressDelegate.SecurityInformation::class.java)
         progressDelegate.value.onSecurityChange(mock(), securityInfo)
         assertTrue(observedSecurityChange)


### PR DESCRIPTION
Fixes [fenix#2058][1].

This PR ensures that the Observers are notified of page stop even when it stops in error.

[1]: https://github.com/mozilla-mobile/fenix/issues/2058 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
