### PR TITLE
#1292: Disable release build types for sample apps

### DIFF
--- a/samples/crash/build.gradle
+++ b/samples/crash/build.gradle
@@ -25,6 +25,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 

--- a/samples/dataprotect/build.gradle
+++ b/samples/dataprotect/build.gradle
@@ -21,6 +21,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 dependencies {

--- a/samples/firefox-accounts/build.gradle
+++ b/samples/firefox-accounts/build.gradle
@@ -33,6 +33,14 @@ android {
             include 'x86', 'arm64-v8a', 'armeabi-v7a'
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 dependencies {

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -32,6 +32,14 @@ android {
             applicationIdSuffix ".debug"
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 dependencies {

--- a/samples/sync-logins/build.gradle
+++ b/samples/sync-logins/build.gradle
@@ -33,6 +33,14 @@ android {
             include 'x86', 'arm64-v8a', 'armeabi-v7a'
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 dependencies {

--- a/samples/sync/build.gradle
+++ b/samples/sync/build.gradle
@@ -33,6 +33,14 @@ android {
             include 'x86', 'arm64-v8a', 'armeabi-v7a'
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 dependencies {

--- a/samples/toolbar/build.gradle
+++ b/samples/toolbar/build.gradle
@@ -25,6 +25,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == "release") {
+            // This is a sample app that we are not releasing. Save some time and do not build
+            // release versions.
+            setIgnore(true)
+        }
+    }
 }
 
 


### PR DESCRIPTION
Modified the following files to disable release builds for various sample apps:
1. /samples/crash/build.gradle
2. /samples/dataprotect/build.gradle
3. /samples/firefox-accounts/build.gradle
4./samples/sync-logins/build.gradle
5. /samples/sync/build.gradle
6./samples/toolbar/build.gradle