### PR TITLE
Add MediaStateMachine to create aggregated MediaState..

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
@@ -20,13 +20,11 @@ internal class GeckoMediaDelegate(
     private val mediaMap: MutableMap<MediaElement, Media> = mutableMapOf()
 
     override fun onMediaAdd(session: GeckoSession, element: MediaElement) {
-        engineSession.notifyObservers {
-            val media = GeckoMedia(element)
-
-            mediaMap[element] = media
-
-            onMediaAdded(media)
+        val media = GeckoMedia(element).also {
+            mediaMap[element] = it
         }
+
+        engineSession.notifyObservers { onMediaAdded(media) }
     }
 
     override fun onMediaRemove(session: GeckoSession, element: MediaElement) {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
@@ -67,4 +67,21 @@ class GeckoMediaTest {
 
         assertTrue(media.controller is GeckoMediaController)
     }
+
+    @Test
+    fun `GeckoMedia observer is notified when its playback state changes`() {
+        val mediaElement: MediaElement = mock()
+
+        val media = GeckoMedia(mediaElement)
+
+        val captor = argumentCaptor<MediaElement.Delegate>()
+        verify(mediaElement).delegate = captor.capture()
+        val delegate = captor.value
+
+        val observer: Media.Observer = mock()
+        media.register(observer)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PLAYING)
+        verify(observer).onPlaybackStateChanged(media, Media.PlaybackState.PLAYING)
+    }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/IconSessionObserver.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/IconSessionObserver.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.icons.extension
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.utils.AllSessionsObserver
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.WebExtension
 
@@ -23,7 +24,7 @@ internal class IconSessionObserver(
     private val icons: BrowserIcons,
     private val sessionManager: SessionManager,
     private val extension: WebExtension
-) : Session.Observer {
+) : AllSessionsObserver.Observer {
     override fun onLoadingStateChanged(session: Session, loading: Boolean) {
         if (loading) {
             registerMessageHandler(session)

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/utils/AllSessionsObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/utils/AllSessionsObserver.kt
@@ -15,7 +15,7 @@ import mozilla.components.browser.session.SessionManager
  */
 class AllSessionsObserver(
     private val sessionManager: SessionManager,
-    private val sessionObserver: Session.Observer
+    private val sessionObserver: Observer
 ) {
     private val observer = Observer(this)
     private val registeredSessions: MutableSet<Session> = mutableSetOf()
@@ -38,18 +38,25 @@ class AllSessionsObserver(
         if (session !in registeredSessions) {
             session.register(sessionObserver)
             registeredSessions.add(session)
+            sessionObserver.onRegisteredToSession(session)
         }
     }
 
     internal fun unregisterSession(session: Session) {
         registeredSessions.remove(session)
         session.unregister(sessionObserver)
+        sessionObserver.onUnregisteredFromSession(session)
     }
 
     internal fun unregisterAllSessions() {
         registeredSessions.toList().forEach { session ->
             unregisterSession(session)
         }
+    }
+
+    interface Observer : Session.Observer {
+        fun onRegisteredToSession(session: Session) = Unit
+        fun onUnregisteredFromSession(session: Session) = Unit
     }
 }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/utils/AllSessionsObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/utils/AllSessionsObserverTest.kt
@@ -25,7 +25,7 @@ class AllSessionsObserverTest {
             add(session2)
         }
 
-        val observer: Session.Observer = mock()
+        val observer: AllSessionsObserver.Observer = mock()
 
         AllSessionsObserver(sessionManager, observer)
             .start()
@@ -38,7 +38,7 @@ class AllSessionsObserverTest {
     fun `Observer will be registered on added Sessions`() {
         val sessionManager = SessionManager(engine = mock())
 
-        val observer: Session.Observer = mock()
+        val observer: AllSessionsObserver.Observer = mock()
 
         AllSessionsObserver(sessionManager, observer)
             .start()
@@ -63,7 +63,7 @@ class AllSessionsObserverTest {
             add(session2)
         }
 
-        val observer: Session.Observer = mock()
+        val observer: AllSessionsObserver.Observer = mock()
 
         AllSessionsObserver(sessionManager, observer)
             .start()
@@ -81,7 +81,7 @@ class AllSessionsObserverTest {
     fun `Observer gets registered when Sessions get restored`() {
         val sessionManager = SessionManager(engine = mock())
 
-        val observer: Session.Observer = mock()
+        val observer: AllSessionsObserver.Observer = mock()
         AllSessionsObserver(sessionManager, observer)
             .start()
 
@@ -110,7 +110,7 @@ class AllSessionsObserverTest {
             add(session2)
         }
 
-        val observer: Session.Observer = mock()
+        val observer: AllSessionsObserver.Observer = mock()
         AllSessionsObserver(sessionManager, observer)
             .start()
 
@@ -131,7 +131,7 @@ class AllSessionsObserverTest {
             add(session1)
         }
 
-        val observer: Session.Observer = mock()
+        val observer: AllSessionsObserver.Observer = mock()
 
         val allObserver = AllSessionsObserver(sessionManager, observer).apply {
             start()

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/media/Media.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/media/Media.kt
@@ -137,4 +137,6 @@ abstract class Media(
             notifyObservers(block)
         }
     }
+
+    override fun toString(): String = "Media($playbackState)"
 }

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/Placeholder.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/Placeholder.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package mozilla.components.feature.media
-
-class Placeholder

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaMap.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaMap.kt
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.state
+
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.engine.media.Media
+import java.util.WeakHashMap
+
+/**
+ * Internal helper to keep a list from [Session] instances to its [Media] and make it searchable.
+ */
+internal class MediaMap {
+    private val map = WeakHashMap<Session, List<Media>>()
+
+    /**
+     * Update the list of [Media] for the given [Session].
+     */
+    fun updateSessionMedia(session: Session, media: List<Media>) {
+        if (media.isEmpty()) {
+            map.remove(session)
+        } else {
+            map[session] = media
+        }
+    }
+
+    /**
+     * Find a [Session] with playing [Media] and return this [Pair] or `null` if no such [Session] could be found.
+     */
+    fun findPlayingSession(): Pair<Session, List<Media>>? {
+        map.forEach { (session, media) ->
+            val playingMedia = media.filter { it.playbackState in playStates }
+            if (playingMedia.isNotEmpty()) {
+                return Pair(session, playingMedia)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Get the list of playing [Media] for the provided [Session].
+     */
+    fun getPlayingMedia(session: Session): List<Media> {
+        val media = map[session] ?: emptyList()
+        return media.filter { it.playbackState in activePlayStates }
+    }
+
+    /**
+     * Get the list of paused [Media] for the provided [Session].
+     */
+    fun getPausedMedia(session: Session): List<Media> {
+        val media = map[session] ?: emptyList()
+        return media.filter { it.playbackState in pauseStates }
+    }
+
+    /**
+     * Get all media for the provided [Session].
+     */
+    fun getAllMedia(session: Session): List<Media> {
+        return map[session] ?: emptyList()
+    }
+}
+
+private val playStates = listOf(
+    Media.PlaybackState.PLAY,
+    Media.PlaybackState.PLAYING
+)
+
+private val activePlayStates = playStates + listOf(
+    // If media was playing or started to play and is now waiting then we consider this media to be still in
+    // playing state until it switches to a different state.
+    Media.PlaybackState.WAITING
+)
+
+private val pauseStates = listOf(
+    Media.PlaybackState.PAUSE
+)

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaState.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaState.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.state
+
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.engine.media.Media
+
+/**
+ * Accumulated state of all [Media] of all [Session]s.
+ */
+sealed class MediaState {
+    /**
+     * None: No media state.
+     */
+    object None : MediaState() {
+        override fun toString(): String = "MediaState.None"
+    }
+
+    /**
+     * Playing: [media] of [session] is currently playing.
+     */
+    data class Playing(
+        val session: Session,
+        val media: List<Media>
+    ) : MediaState()
+
+    /**
+     * Paused: [media] of [session] is currently paused.
+     */
+    data class Paused(
+        val session: Session,
+        val media: List<Media>
+    ) : MediaState()
+}

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaStateMachine.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaStateMachine.kt
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.state
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.utils.AllSessionsObserver
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+
+/**
+ * A state machine that subscribes to all [Session] instances and watches changes to their [Media] to create an
+ * aggregated [MediaState].
+ *
+ * Other components can subscribe to the state machine to get notified about [MediaState] changes.
+ */
+class MediaStateMachine(
+    sessionManager: SessionManager,
+    delegate: Observable<Observer> = ObserverRegistry()
+) : Observable<MediaStateMachine.Observer> by delegate {
+    private val logger = Logger("MediaStateMachine")
+    private val observer = AllSessionsObserver(sessionManager,
+        MediaSessionObserver(this)
+    )
+    private var state: MediaState =
+        MediaState.None
+
+    /**
+     * Start observing [Session] and their [Media] and create an aggregated [MediaState] that can be observed.
+     */
+    fun start() {
+        observer.start()
+    }
+
+    /**
+     * Stop observing [Session] and their [Media].
+     *
+     * The [MediaState] will be reset to [MediaState.None]
+     */
+    fun stop() {
+        observer.stop()
+    }
+
+    /**
+     * Get the current [MediaState].
+     */
+    fun getState() = state
+
+    @Synchronized
+    internal fun transitionTo(state: MediaState) {
+        if (this.state == state) {
+            // We are already in this state. Nothing to do.
+            return
+        }
+
+        logger.info("Transitioning from ${this.state} to $state")
+
+        this.state = state
+
+        notifyObservers { onStateChanged(state) }
+    }
+
+    /**
+     * Interface for observers that are interested in [MediaState] changes.
+     */
+    interface Observer {
+        /**
+         * The [MediaState] has changed.
+         */
+        fun onStateChanged(state: MediaState)
+    }
+}
+
+private class MediaSessionObserver(
+    private val stateMachine: MediaStateMachine
+) : AllSessionsObserver.Observer, Media.Observer {
+    private val mediaMap = MediaMap()
+
+    override fun onMediaAdded(session: Session, media: List<Media>, added: Media) {
+        added.register(this)
+
+        mediaMap.updateSessionMedia(session, media)
+
+        updateState()
+    }
+
+    override fun onMediaRemoved(session: Session, media: List<Media>, removed: Media) {
+        removed.unregister(this)
+
+        mediaMap.updateSessionMedia(session, media)
+
+        updateState()
+    }
+
+    override fun onPlaybackStateChanged(media: Media, playbackState: Media.PlaybackState) {
+        updateState()
+    }
+
+    override fun onRegisteredToSession(session: Session) {
+        session.media.forEach { media -> media.register(this) }
+        mediaMap.updateSessionMedia(session, session.media)
+
+        updateState()
+    }
+
+    override fun onUnregisteredFromSession(session: Session) {
+        mediaMap.getAllMedia(session).forEach { media ->
+            media.unregister(this)
+        }
+
+        mediaMap.updateSessionMedia(session, emptyList())
+
+        updateState()
+    }
+
+    private fun updateState() {
+        val state = determineNewState()
+        stateMachine.transitionTo(state)
+    }
+
+    @Suppress("ReturnCount")
+    private fun determineNewState(): MediaState {
+        val currentState = stateMachine.getState()
+
+        // If we are in "playing" state and there's still media playing for this session then stay in this state and
+        // just update the list of media.
+        if (currentState is MediaState.Playing) {
+            val media = mediaMap.getPlayingMedia(currentState.session)
+            if (media.isNotEmpty()) {
+                return MediaState.Playing(currentState.session, media)
+            }
+        }
+
+        // Check if there's a session that has playing media and emit a "playing" state for it.
+        val playingSession = mediaMap.findPlayingSession()
+        if (playingSession != null) {
+            return MediaState.Playing(
+                playingSession.first,
+                playingSession.second
+            )
+        }
+
+        // If we were in "playing" state and the media for this session is now paused then emit a "paused" state.
+        if (currentState is MediaState.Playing) {
+            val media = mediaMap.getPausedMedia(currentState.session)
+            if (media.isNotEmpty()) {
+                return MediaState.Paused(currentState.session, media)
+            }
+        }
+
+        // If we are in "paused" state and the media for this session is still paused then stay in this state and just
+        // update the list of media
+        if (currentState is MediaState.Paused) {
+            val media = mediaMap.getPausedMedia(currentState.session)
+            if (media.isNotEmpty()) {
+                return MediaState.Paused(currentState.session, media)
+            }
+        }
+
+        return MediaState.None
+    }
+}

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/PlaceholderTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/PlaceholderTest.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package mozilla.components.feature.media
-
-class PlaceholderTest

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/state/MediaStateMachineTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/state/MediaStateMachineTest.kt
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.state
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MediaStateMachineTest {
+    @Test
+    fun `default state is None`() {
+        val stateMachine = MediaStateMachine(SessionManager(mock()))
+        assertEquals(MediaState.None, stateMachine.getState())
+    }
+
+    @Test
+    fun `State changes when existing media session pauses and new media session starts playing`() {
+        val sessionManager = SessionManager(mock())
+
+        val initialMedia = MockMedia(Media.PlaybackState.PLAY)
+        val initialSession = Session("https://www.mozilla.org").apply {
+            sessionManager.add(this)
+            media = listOf(initialMedia)
+        }
+
+        val stateMachine = MediaStateMachine(sessionManager)
+        stateMachine.start()
+
+        assertEquals(MediaState.Playing(initialSession, listOf(initialMedia)), stateMachine.getState())
+
+        initialMedia.playbackState = Media.PlaybackState.PAUSE
+        assertEquals(MediaState.Paused(initialSession, listOf(initialMedia)), stateMachine.getState())
+
+        val newMedia = MockMedia(Media.PlaybackState.UNKNOWN)
+        val newSession = Session("https://www.firefox.com").apply {
+            sessionManager.add(this)
+            media = listOf(newMedia)
+        }
+
+        assertEquals(MediaState.Paused(initialSession, listOf(initialMedia)), stateMachine.getState())
+
+        newMedia.playbackState = Media.PlaybackState.WAITING
+        assertEquals(MediaState.Paused(initialSession, listOf(initialMedia)), stateMachine.getState())
+
+        newMedia.playbackState = Media.PlaybackState.PLAYING
+        assertEquals(MediaState.Playing(newSession, listOf(newMedia)), stateMachine.getState())
+    }
+
+    @Test
+    fun `State is updated after media is removed`() {
+        val sessionManager = SessionManager(mock())
+
+        val stateMachine = MediaStateMachine(sessionManager)
+        stateMachine.start()
+
+        val session = Session("https://www.mozilla.org").also {
+            sessionManager.add(it)
+        }
+
+        assertEquals(MediaState.None, stateMachine.getState())
+
+        val media = MockMedia(Media.PlaybackState.PLAY)
+        session.media = listOf(media)
+        assertEquals(MediaState.Playing(session, listOf(media)), stateMachine.getState())
+
+        session.media = emptyList()
+        assertEquals(MediaState.None, stateMachine.getState())
+    }
+
+    @Test
+    fun `State is updated after session is removed`() {
+        val sessionManager = SessionManager(mock())
+
+        val stateMachine = MediaStateMachine(sessionManager)
+        stateMachine.start()
+
+        assertEquals(MediaState.None, stateMachine.getState())
+
+        val media = MockMedia(Media.PlaybackState.PLAYING)
+        val session = Session("https://www.mozilla.org").also {
+            sessionManager.add(it)
+
+            it.media = listOf(media)
+        }
+
+        assertEquals(MediaState.Playing(session, listOf(media)), stateMachine.getState())
+
+        sessionManager.remove(session)
+        assertEquals(MediaState.None, stateMachine.getState())
+    }
+
+    @Test
+    fun `Multiple media of session start playing and stop`() {
+        val sessionManager = SessionManager(mock())
+
+        val stateMachine = MediaStateMachine(sessionManager)
+        stateMachine.start()
+
+        assertEquals(MediaState.None, stateMachine.getState())
+
+        val media1 = MockMedia(Media.PlaybackState.PLAYING)
+        val media2 = MockMedia(Media.PlaybackState.PAUSE)
+        val session = Session("https://www.mozilla.org").also {
+            sessionManager.add(it)
+
+            it.media = listOf(media1)
+            it.media = listOf(media1, media2)
+        }
+
+        assertEquals(MediaState.Playing(session, listOf(media1)), stateMachine.getState())
+
+        media2.playbackState = Media.PlaybackState.PLAYING
+
+        assertEquals(MediaState.Playing(session, listOf(media1, media2)), stateMachine.getState())
+
+        media1.playbackState = Media.PlaybackState.ENDED
+
+        assertEquals(MediaState.Playing(session, listOf(media2)), stateMachine.getState())
+
+        media2.playbackState = Media.PlaybackState.ENDED
+
+        assertEquals(MediaState.None, stateMachine.getState())
+    }
+
+    @Test
+    fun `Falls back to state NONE after stopping`() {
+        val sessionManager = SessionManager(mock())
+
+        val stateMachine = MediaStateMachine(sessionManager)
+        stateMachine.start()
+
+        val media = MockMedia(Media.PlaybackState.PLAYING)
+        val session = Session("https://www.mozilla.org").also {
+            sessionManager.add(it)
+
+            it.media = listOf(media)
+        }
+
+        assertEquals(MediaState.Playing(session, listOf(media)), stateMachine.getState())
+
+        media.playbackState = Media.PlaybackState.PAUSE
+        assertEquals(MediaState.Paused(session, listOf(media)), stateMachine.getState())
+
+        stateMachine.stop()
+        assertEquals(MediaState.None, stateMachine.getState())
+
+        // Does not change state since state machine is stopped
+        media.playbackState = Media.PlaybackState.PLAYING
+        assertEquals(MediaState.None, stateMachine.getState())
+    }
+}
+
+class MockMedia(
+    initialState: PlaybackState
+) : Media() {
+    init {
+        playbackState = initialState
+    }
+
+    override val controller: Controller = mock()
+}


### PR DESCRIPTION
Those are the humble beginnings of a `MediaStateMachine` that tries to generate an aggregate `MediaState` from all the `Session`s and their `Media` and makes that state observable.

This will be needed to show a media notification and later on support the MediaSession API. For now I mostly tried to support the media notification use case. For MediaSession this may need to get a bit more complex.

Closes #2460

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
