### PR TITLE
Add applink strings to error pages [ci skip]

### DIFF
--- a/components/browser/errorpages/src/main/res/values/strings.xml
+++ b/components/browser/errorpages/src/main/res/values/strings.xml
@@ -262,4 +262,13 @@
     <string name="mozac_browser_errorpages_safe_phishing_uri_message"><![CDATA[
       <p>This web page at %1$s has been reported as a deceptive site and has been blocked based on your security preferences.</p>
     ]]></string>
+
+    <!-- The tile for the list of external apps to open the link in -->
+    <string name="mozac_feature_applinks_open_in">Open in…</string>
+    <!-- The description to warn users that their private browsing session changes  -->
+    <string name="mozac_feature_applinks_confirm_dialog_title">Open in app? Your activity may no longer be private.</string>
+    <!-- Opens the selected time -->
+    <string name="mozac_feature_applinks_confirm_dialog_confirm">Open</string>
+    <!-- Cancels the prompt -->
+    <string name="mozac_feature_applinks_confirm_dialog_deny">Cancel</string>
 </resources>


### PR DESCRIPTION
Follow up issue: https://github.com/mozilla-mobile/android-components/issues/3113