### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `lib-fetch-okhttp` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -29,7 +29,6 @@ object KotlinCompiler {
         "feature-sitepermissions",
         "feature-tabs",
         "feature-toolbar",
-        "lib-fetch-okhttp",
         "lib-jexl",
         "samples-toolbar",
         "service-experiments",

--- a/components/lib/fetch-okhttp/build.gradle
+++ b/components/lib/fetch-okhttp/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
     implementation project(':concept-fetch')
 
+    testImplementation project(':support-test')
+
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito

--- a/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
+++ b/components/lib/fetch-okhttp/src/main/java/mozilla/components/lib/fetch/okhttp/OkHttpClient.kt
@@ -58,7 +58,7 @@ class OkHttpClient(
     }
 }
 
-private fun okhttp3.OkHttpClient.rebuildFor(request: Request, context: Context?): okhttp3.OkHttpClient {
+private fun OkHttpClient.rebuildFor(request: Request, context: Context?): OkHttpClient {
     @Suppress("ComplexCondition")
     if (request.connectTimeout != null ||
         request.readTimeout != null ||
@@ -105,11 +105,9 @@ private fun createRequestBuilderWithBody(request: Request): RequestBuilder {
         RequestBody.create(null, body.useStream { it.readBytes() })
     }
 
-    val requestBuilder = RequestBuilder()
+    return RequestBuilder()
         .url(request.url)
         .method(request.method.name, requestBody)
-
-    return requestBuilder
 }
 
 private fun RequestBuilder.addHeadersFrom(request: Request, defaultHeaders: Headers) {

--- a/components/lib/fetch-okhttp/src/test/java/mozilla/components/lib/fetch/okhttp/OkHttpFetchTestCases.kt
+++ b/components/lib/fetch-okhttp/src/test/java/mozilla/components/lib/fetch/okhttp/OkHttpFetchTestCases.kt
@@ -5,15 +5,16 @@
 package mozilla.components.lib.fetch.okhttp
 
 import mozilla.components.concept.fetch.Client
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class OkHttpFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
-    override fun createNewClient(): Client = OkHttpClient(okhttp3.OkHttpClient(), RuntimeEnvironment.application)
+
+    override fun createNewClient(): Client = OkHttpClient(okhttp3.OkHttpClient(), testContext)
 
     // Inherits test methods from generic test suite base class
 


### PR DESCRIPTION
### Issue #2346

Trivial changes.

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~