### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `feature-session` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -23,7 +23,6 @@ object KotlinCompiler {
         "feature-downloads",
         "feature-prompts",
         "feature-search",
-        "feature-session",
         "feature-sitepermissions",
         "feature-tabs",
         "lib-fetch-okhttp",

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/PictureInPictureFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/PictureInPictureFeature.kt
@@ -6,11 +6,11 @@
 
 package mozilla.components.feature.session
 
-import android.annotation.TargetApi
 import android.app.Activity
 import android.app.PictureInPictureParams
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.annotation.RequiresApi
 import mozilla.components.browser.session.SessionManager
 
 /**
@@ -38,16 +38,24 @@ class PictureInPictureFeature(
         return fullScreenMode && enterPipModeCompat()
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
     fun enterPipModeCompat() = when {
         !hasSystemFeature -> false
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ->
-            activity.enterPictureInPictureMode(PictureInPictureParams.Builder().build())
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> {
-            activity.enterPictureInPictureMode()
-            true
-        }
+            enterPipModeForO()
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ->
+            enterPipModeForN()
         else -> false
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun enterPipModeForO() =
+        activity.enterPictureInPictureMode(PictureInPictureParams.Builder().build())
+
+    @Suppress("DEPRECATION")
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun enterPipModeForN() = run {
+        activity.enterPictureInPictureMode()
+        true
     }
 
     fun onPictureInPictureModeChanged(enabled: Boolean) = pipChanged?.invoke(enabled)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/CoordinateScrollingFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/CoordinateScrollingFeatureTest.kt
@@ -14,15 +14,16 @@ import mozilla.components.feature.session.CoordinateScrollingFeature.Companion.D
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.any
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class CoordinateScrollingFeatureTest {
+
     private lateinit var scrollFeature: CoordinateScrollingFeature
     private lateinit var mockSessionManager: SessionManager
     private lateinit var mockEngineView: EngineView

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/EngineViewPresenterTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/EngineViewPresenterTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 class EngineViewPresenterTest {
+
     private val sessionManager = mock(SessionManager::class.java)
     private val engineView = mock(EngineView::class.java)
     private val session = mock(Session::class.java)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
@@ -20,6 +20,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 class FullScreenFeatureTest {
+
     private val sessionManager: SessionManager = mock()
     private val selectedSession: Session = mock()
     private val useCases = spy(SessionUseCases(sessionManager))

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -13,8 +13,8 @@ import mozilla.components.concept.storage.VisitInfo
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,6 +24,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class HistoryDelegateTest {
+
     @Test
     fun `history delegate passes through onVisited calls`() = runBlocking {
         val storage: HistoryStorage = mock()

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/PictureInPictureFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/PictureInPictureFeatureTest.kt
@@ -23,9 +23,11 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.verifyZeroInteractions
+import org.mockito.verification.VerificationMode
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -33,6 +35,7 @@ private interface PipChangedCallback : (Boolean) -> Unit
 
 @RunWith(RobolectricTestRunner::class)
 class PictureInPictureFeatureTest {
+
     private val sessionManager: SessionManager = mock()
     private val selectedSession: Session = mock()
     private val activity: Activity = Mockito.mock(Activity::class.java, Mockito.RETURNS_DEEP_STUBS)
@@ -140,7 +143,7 @@ class PictureInPictureFeatureTest {
 
         assertFalse(pictureInPictureFeature.enterPipModeCompat())
         verify(activity, never()).enterPictureInPictureMode(any())
-        verify(activity, never()).enterPictureInPictureMode()
+        verifyDeprecatedPictureInPictureMode(activity, never())
     }
 
     @Test
@@ -160,7 +163,7 @@ class PictureInPictureFeatureTest {
         val pictureInPictureFeature = PictureInPictureFeature(sessionManager, activity)
 
         assertTrue(pictureInPictureFeature.enterPipModeCompat())
-        verify(activity).enterPictureInPictureMode()
+        verifyDeprecatedPictureInPictureMode(activity)
     }
 
     @Test
@@ -176,6 +179,11 @@ class PictureInPictureFeatureTest {
 
         verifyNoMoreInteractions(sessionManager)
         verify(activity, never()).enterPictureInPictureMode(any())
-        verify(activity, never()).enterPictureInPictureMode()
+        verifyDeprecatedPictureInPictureMode(activity, never())
     }
+}
+
+@Suppress("DEPRECATION")
+private fun verifyDeprecatedPictureInPictureMode(activity: Activity, mode: VerificationMode = times(1)) {
+    verify(activity, mode).enterPictureInPictureMode()
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class SessionFeatureTest {
+
     private val sessionManager = mock(SessionManager::class.java)
     private val engineView = mock(EngineView::class.java)
     private val sessionUseCases = SessionUseCases(sessionManager)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -21,6 +21,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class SessionUseCasesTest {
+
     private val sessionManager = mock(SessionManager::class.java)
     private val selectedEngineSession = mock(EngineSession::class.java)
     private val selectedSession = mock(Session::class.java)
@@ -127,11 +128,11 @@ class SessionUseCasesTest {
         `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.requestDesktopSite.invoke(true, session)
-        verify(engineSession).toggleDesktopMode(true, true)
+        verify(engineSession).toggleDesktopMode(true, reload = true)
 
         `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.requestDesktopSite.invoke(true)
-        verify(selectedEngineSession).toggleDesktopMode(true, true)
+        verify(selectedEngineSession).toggleDesktopMode(true, reload = true)
     }
 
     @Test

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 class SettingsUseCasesTest {
+
     private val settings = mock(Settings::class.java)
     private val sessionManager = mock(SessionManager::class.java)
     private val sessionA = mock(Session::class.java)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -10,10 +10,10 @@ import android.view.View
 import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,14 +25,12 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class EngineViewBottomBehaviorTest {
-    val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `EngineView clipping and toolbar offset are kept in sync`() {
         val behavior = EngineViewBottomBehavior(mock(), null)
 
-        val engineView: EngineView = spy(FakeEngineView(context))
+        val engineView: EngineView = spy(FakeEngineView(testContext))
         val toolbar: View = mock()
         doReturn(100).`when`(toolbar).height
 
@@ -45,16 +43,16 @@ class EngineViewBottomBehaviorTest {
     fun `Behavior does not depend on normal views`() {
         val behavior = EngineViewBottomBehavior(mock(), null)
 
-        assertFalse(behavior.layoutDependsOn(mock(), mock(), TextView(context)))
-        assertFalse(behavior.layoutDependsOn(mock(), mock(), EditText(context)))
-        assertFalse(behavior.layoutDependsOn(mock(), mock(), ImageView(context)))
+        assertFalse(behavior.layoutDependsOn(mock(), mock(), TextView(testContext)))
+        assertFalse(behavior.layoutDependsOn(mock(), mock(), EditText(testContext)))
+        assertFalse(behavior.layoutDependsOn(mock(), mock(), ImageView(testContext)))
     }
 
     @Test
     fun `Behavior depends on BrowserToolbar`() {
         val behavior = EngineViewBottomBehavior(mock(), null)
 
-        assertTrue(behavior.layoutDependsOn(mock(), mock(), BrowserToolbar(context)))
+        assertTrue(behavior.layoutDependsOn(mock(), mock(), BrowserToolbar(testContext)))
     }
 }
 


### PR DESCRIPTION
### Issue #2346

  - Trivial changes in tests.
  - Extracted different implementations for `PictureInPictureFeature.enterPipModeCompat` into separate methods marked with `@RequiresApi`.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~