### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `lib-jexl` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -30,7 +30,6 @@ object KotlinCompiler {
         "feature-tabs",
         "feature-toolbar",
         "lib-fetch-okhttp",
-        "lib-jexl",
         "samples-toolbar",
         "service-experiments",
         "service-firefox-accounts",

--- a/components/lib/jexl/src/test/java/mozilla/components/lib/jexl/lexer/LexerTest.kt
+++ b/components/lib/jexl/src/test/java/mozilla/components/lib/jexl/lexer/LexerTest.kt
@@ -371,12 +371,38 @@ class LexerTest {
 
     @Test
     fun `should tokenize a full expression`() {
-        val expression = "6+x -  -17.55*y<= !foo.bar[\"baz\\\\\"foz\"]"
+        val expression = """6+x -  -17.55*y<= !foo.bar["baz\\"foz"]"""
+
+        assertExpressionYieldsTokens(expression, listOf(
+            Token(Token.Type.LITERAL, "6", 6),
+            Token(Token.Type.BINARY_OP, "+", "+"),
+            Token(Token.Type.IDENTIFIER, "x", "x"),
+            Token(Token.Type.BINARY_OP, "-", "-"),
+            Token(Token.Type.LITERAL, "-17.55", -17.55),
+            Token(Token.Type.BINARY_OP, "*", "*"),
+            Token(Token.Type.IDENTIFIER, "y", "y"),
+            Token(Token.Type.BINARY_OP, "<=", "<="),
+            Token(Token.Type.UNARY_OP, "!", "!"),
+            Token(Token.Type.IDENTIFIER, "foo", "foo"),
+            Token(Token.Type.DOT, ".", "."),
+            Token(Token.Type.IDENTIFIER, "bar", "bar"),
+            Token(Token.Type.OPEN_BRACKET, "[", "["),
+            Token(Token.Type.LITERAL, """"baz\\"foz"""", """baz\"foz"""),
+            Token(Token.Type.CLOSE_BRACKET, "]", "]")
+        ))
     }
 
     @Test
     fun `should consider minus to be negative appropriately`() {
         val expression = "-1?-2:-3"
+
+        assertExpressionYieldsTokens(expression, listOf(
+            Token(Token.Type.LITERAL, "-1", -1),
+            Token(Token.Type.QUESTION, "?", "?"),
+            Token(Token.Type.LITERAL, "-2", -2),
+            Token(Token.Type.COLON, ":", ":"),
+            Token(Token.Type.LITERAL, "-3", -3)
+        ))
     }
 
     private fun assertExpressionYieldsTokens(expression: String, tokens: List<Token>) {


### PR DESCRIPTION
### Issue #2346

Completed empty tests

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~