### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `service-experiments` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -32,7 +32,6 @@ object KotlinCompiler {
         "lib-fetch-okhttp",
         "lib-jexl",
         "samples-toolbar",
-        "service-experiments",
         "service-firefox-accounts",
         "service-fretboard",
         "service-glean",

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentEvaluatorTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentEvaluatorTest.kt
@@ -9,13 +9,13 @@ import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
@@ -23,7 +23,6 @@ import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import kotlin.reflect.full.functions
 import kotlin.reflect.jvm.isAccessible
 
@@ -46,7 +45,7 @@ class ExperimentEvaluatorTest {
 
         `when`(context.packageName).thenReturn(appId)
 
-        packageInfo.versionName = "test.version"
+        packageInfo.versionName = versionName
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -70,6 +69,7 @@ class ExperimentEvaluatorTest {
         `when`(sharedPrefsOverrideBranch.edit()).thenReturn(branchEditor)
     }
 
+    @Suppress("SameParameterValue")
     private fun setOverride(experimentName: String, isActive: Boolean, branchName: String) {
         `when`(sharedPrefsOverrideEnabled.getBoolean(eq(experimentName), anyBoolean())).thenReturn(isActive)
         `when`(sharedPrefsOverrideBranch.getString(eq(experimentName), eq(null))).thenReturn(branchName)
@@ -453,13 +453,13 @@ class ExperimentEvaluatorTest {
             override fun getClientId(context: Context): String = "c641eacf-c30c-4171-b403-f077724e848a"
         })
 
-        assertEquals(79, evaluator1.getUserBucket(RuntimeEnvironment.application))
+        assertEquals(79, evaluator1.getUserBucket(testContext))
 
         val evaluator2 = ExperimentEvaluator(object : ValuesProvider() {
             override fun getClientId(context: Context): String = "01a15650-9a5d-4383-a7ba-2f047b25c620"
         })
 
-        assertEquals(55, evaluator2.getUserBucket(RuntimeEnvironment.application))
+        assertEquals(55, evaluator2.getUserBucket(testContext))
     }
 
     @Test
@@ -469,9 +469,9 @@ class ExperimentEvaluatorTest {
         val sharedPrefs: SharedPreferences = mock()
         val prefsEditor: SharedPreferences.Editor = mock()
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
-        `when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)
-        `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
-        `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
+        `when`(prefsEditor.putBoolean(anyString(), anyBoolean())).thenReturn(prefsEditor)
+        `when`(prefsEditor.putString(anyString(), anyString())).thenReturn(prefsEditor)
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPrefs)
 
         val distribution = (1..1000).map {
             val experimentEvaluator = ExperimentEvaluator()
@@ -656,7 +656,7 @@ class ExperimentEvaluatorTest {
     fun `evaluate debug tags`() {
         testReset()
 
-        var experiments = listOf(
+        val experiments = listOf(
             createDefaultExperiment(
                 id = "id-1",
                 match = createDefaultMatcher(

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/FlatFileExperimentStorageTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/FlatFileExperimentStorageTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.experiments
 
 import mozilla.components.support.ktx.android.org.json.toList
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -13,7 +14,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -69,7 +69,7 @@ class FlatFileExperimentStorageTest {
                 lastModified = 1526991669
             )
         )
-        val file = File(RuntimeEnvironment.application.filesDir, "experiments.json")
+        val file = File(testContext.filesDir, "experiments.json")
         assertFalse(file.exists())
         FlatFileExperimentStorage(file).save(ExperimentsSnapshot(experiments, 1526991669))
         assertTrue(file.exists())
@@ -80,7 +80,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun replacingContent() {
-        val file = File(RuntimeEnvironment.application.filesDir, "experiments.json")
+        val file = File(testContext.filesDir, "experiments.json")
 
         FlatFileExperimentStorage(file).save(ExperimentsSnapshot(listOf(
             createDefaultExperiment(
@@ -126,7 +126,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun retrieve() {
-        val file = File(RuntimeEnvironment.application.filesDir, "experiments.json")
+        val file = File(testContext.filesDir, "experiments.json")
         val json = """
             {
               "experiments": [
@@ -183,7 +183,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun retrieveFileNotFound() {
-        val file = File(RuntimeEnvironment.application.filesDir, "missingFile.json")
+        val file = File(testContext.filesDir, "missingFile.json")
         val experimentsResult = FlatFileExperimentStorage(file).retrieve()
         assertEquals(0, experimentsResult.experiments.size)
         assertNull(experimentsResult.lastModified)
@@ -191,7 +191,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun readingCorruptJSON() {
-        val file = File(RuntimeEnvironment.application.filesDir, "corrupt-experiments.json")
+        val file = File(testContext.filesDir, "corrupt-experiments.json")
         file.writer().use {
             it.write("""{"experiment":[""")
         }


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~