### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `service-fretboard` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -34,7 +34,6 @@ object KotlinCompiler {
         "samples-toolbar",
         "service-experiments",
         "service-firefox-accounts",
-        "service-fretboard",
         "service-glean",
         "support-test",
         "tooling-lint",

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -21,10 +22,10 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ExperimentEvaluatorTest {
+
     @Test
     fun evaluateEmtpyMatchers() {
         val experiment = Experiment(
@@ -591,12 +592,12 @@ class ExperimentEvaluatorTest {
             override fun getClientId(context: Context): String = "c641eacf-c30c-4171-b403-f077724e848a"
         })
 
-        assertEquals(79, evaluator1.getUserBucket(RuntimeEnvironment.application))
+        assertEquals(79, evaluator1.getUserBucket(testContext))
 
         val evaluator2 = ExperimentEvaluator(object : ValuesProvider() {
             override fun getClientId(context: Context): String = "01a15650-9a5d-4383-a7ba-2f047b25c620"
         })
 
-        assertEquals(55, evaluator2.getUserBucket(RuntimeEnvironment.application))
+        assertEquals(55, evaluator2.getUserBucket(testContext))
     }
 }

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import mozilla.components.service.fretboard.storage.flatfile.FlatFileExperimentStorage
 import mozilla.components.support.test.any
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -25,13 +26,13 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.io.File
 import kotlin.reflect.full.functions
 import kotlin.reflect.jvm.isAccessible
 
 @RunWith(RobolectricTestRunner::class)
 class FretboardTest {
+
     @Test
     fun loadExperiments() {
         val experimentSource = mock(ExperimentSource::class.java)
@@ -516,13 +517,13 @@ class FretboardTest {
             override fun getClientId(context: Context): String = "c641eacf-c30c-4171-b403-f077724e848a"
         })
 
-        assertEquals(79, fretboard1.getUserBucket(RuntimeEnvironment.application))
+        assertEquals(79, fretboard1.getUserBucket(testContext))
 
         val fretboard2 = Fretboard(experimentSource, experimentStorage, object : ValuesProvider() {
             override fun getClientId(context: Context): String = "01a15650-9a5d-4383-a7ba-2f047b25c620"
         })
 
-        assertEquals(55, fretboard2.getUserBucket(RuntimeEnvironment.application))
+        assertEquals(55, fretboard2.getUserBucket(testContext))
     }
 
     @Test
@@ -568,7 +569,7 @@ class FretboardTest {
     fun loadingCorruptJSON() {
         val experimentSource = mock(ExperimentSource::class.java)
 
-        val file = File(RuntimeEnvironment.application.filesDir, "corrupt-experiments.json")
+        val file = File(testContext.filesDir, "corrupt-experiments.json")
         file.writer().use {
             it.write("""{"experiment":[""")
         }

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorageTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorageTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.fretboard.storage.flatfile
 
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentsSnapshot
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -14,13 +15,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
 @RunWith(RobolectricTestRunner::class)
 class FlatFileExperimentStorageTest {
+
     @Test
     fun save() {
         val experiments = listOf(
@@ -31,7 +32,7 @@ class FlatFileExperimentStorageTest {
                 Experiment.Bucket(20, 0),
                 1526991669)
         )
-        val file = File(RuntimeEnvironment.application.filesDir, "experiments.json")
+        val file = File(testContext.filesDir, "experiments.json")
         assertFalse(file.exists())
         FlatFileExperimentStorage(file).save(ExperimentsSnapshot(experiments, 1526991669))
         assertTrue(file.exists())
@@ -42,7 +43,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun replacingContent() {
-        val file = File(RuntimeEnvironment.application.filesDir, "experiments.json")
+        val file = File(testContext.filesDir, "experiments.json")
 
         FlatFileExperimentStorage(file).save(ExperimentsSnapshot(listOf(
             Experiment("sample-id",
@@ -98,7 +99,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun retrieve() {
-        val file = File(RuntimeEnvironment.application.filesDir, "experiments.json")
+        val file = File(testContext.filesDir, "experiments.json")
         file.writer().use {
             it.write("""{"experiments":[{"name":"sample-name","match":{"lang":"es|en","appId":"sample-appId","regions":["US"]},"buckets":{"max":20,"min":0},"description":"sample-description","id":"sample-id","last_modified":1526991669}],"last_modified":1526991669}""")
         }
@@ -120,7 +121,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun retrieveFileNotFound() {
-        val file = File(RuntimeEnvironment.application.filesDir, "missingFile.json")
+        val file = File(testContext.filesDir, "missingFile.json")
         val experimentsResult = FlatFileExperimentStorage(file).retrieve()
         assertEquals(0, experimentsResult.experiments.size)
         assertNull(experimentsResult.lastModified)
@@ -128,7 +129,7 @@ class FlatFileExperimentStorageTest {
 
     @Test
     fun readingCorruptJSON() {
-        val file = File(RuntimeEnvironment.application.filesDir, "corrupt-experiments.json")
+        val file = File(testContext.filesDir, "corrupt-experiments.json")
         file.writer().use {
             it.write("""{"experiment":[""")
         }


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~