### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `service-firefox-accounts` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -33,7 +33,6 @@ object KotlinCompiler {
         "lib-jexl",
         "samples-toolbar",
         "service-experiments",
-        "service-firefox-accounts",
         "service-fretboard",
         "service-glean",
         "support-test",

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/PollingDeviceManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/PollingDeviceManagerTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.fxa.manager
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.setMain
@@ -29,6 +30,7 @@ import org.mockito.Mockito.verify
 import java.util.concurrent.Executors
 
 class PollingDeviceManagerTest {
+
     internal class TestableDeviceManager(
         constellation: DeviceConstellation,
         scope: CoroutineScope,
@@ -140,6 +142,7 @@ class PollingDeviceManagerTest {
     }
 
     @Test
+    @ExperimentalCoroutinesApi
     fun `refreshing devices triggers observers`() {
         val testDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
         val testScope = CoroutineScope(testDispatcher)


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Extremely Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~