### PR TITLE
Use public LifecycleObserver instead of internal

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -4,11 +4,15 @@
 
 package mozilla.components.support.base.observer
 
-import android.annotation.SuppressLint
 import android.view.View
-import androidx.lifecycle.GenericLifecycleObserver
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
+import androidx.lifecycle.Lifecycle.Event.ON_PAUSE
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.Lifecycle.State.DESTROYED
+import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
 import java.util.Collections
 import java.util.WeakHashMap
 
@@ -35,17 +39,18 @@ class ObserverRegistry<T> : Observable<T> {
     }
 
     override fun register(observer: T, owner: LifecycleOwner, autoPause: Boolean) {
-        if (owner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+        // Don't register if the owner is already destroyed
+        if (owner.lifecycle.currentState == DESTROYED) {
             return
         }
 
         register(observer)
 
-        val lifecycleObserver = LifecycleBoundObserver(
-                owner,
-                registry = this,
-                observer = observer,
-                autoPause = autoPause)
+        val lifecycleObserver = if (autoPause) {
+            AutoPauseLifecycleBoundObserver(owner, registry = this, observer = observer)
+        } else {
+            LifecycleBoundObserver(owner, registry = this, observer = observer)
+        }
 
         lifecycleObservers[observer] = lifecycleObserver
 
@@ -128,32 +133,39 @@ class ObserverRegistry<T> : Observable<T> {
     }
 
     /**
-     * GenericLifecycleObserver implementation to bind an observer to a Lifecycle.
+     * LifecycleObserver implementation to bind an observer to a Lifecycle.
      */
-    @SuppressLint("RestrictedApi")
-    private class LifecycleBoundObserver<T>(
+    private open class LifecycleBoundObserver<T>(
         private val owner: LifecycleOwner,
-        private val registry: ObserverRegistry<T>,
-        private val observer: T,
-        private val autoPause: Boolean
-    ) : GenericLifecycleObserver {
-        override fun onStateChanged(source: LifecycleOwner?, event: Lifecycle.Event?) {
-            if (autoPause) {
-                if (event == Lifecycle.Event.ON_PAUSE) {
-                    registry.pauseObserver(observer)
-                } else if (event == Lifecycle.Event.ON_RESUME) {
-                    registry.resumeObserver(observer)
-                }
-            }
+        protected val registry: ObserverRegistry<T>,
+        protected val observer: T
+    ) : LifecycleObserver {
+        @OnLifecycleEvent(ON_DESTROY)
+        fun onDestroy() = registry.unregister(observer)
 
-            if (owner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
-                registry.unregister(observer)
+        fun remove() = owner.lifecycle.removeObserver(this)
+    }
+
+    /**
+     * LifecycleObserver implementation to bind an observer to a Lifecycle and pause observing
+     * automatically for the pause and resume events.
+     */
+    private class AutoPauseLifecycleBoundObserver<T>(
+        owner: LifecycleOwner,
+        registry: ObserverRegistry<T>,
+        observer: T
+    ) : LifecycleBoundObserver<T>(owner, registry, observer) {
+        init {
+            if (!owner.lifecycle.currentState.isAtLeast(RESUMED)) {
+                registry.pauseObserver(observer)
             }
         }
 
-        fun remove() {
-            owner.lifecycle.removeObserver(this)
-        }
+        @OnLifecycleEvent(ON_PAUSE)
+        fun onPause() = registry.pauseObserver(observer)
+
+        @OnLifecycleEvent(ON_RESUME)
+        fun onResume() = registry.resumeObserver(observer)
     }
 
     /**


### PR DESCRIPTION
Removed used of [internal GenericLifecycleObserver](https://github.com/mozilla-mobile/android-components/pull/3122#discussion_r287835670)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
