### PR TITLE
Use GeckoResult in coroutines seamlessly

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -8,7 +8,6 @@ import android.annotation.SuppressLint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
@@ -442,12 +441,10 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(false)
             }
 
-            val result = GeckoResult<Boolean>()
-            launch {
+            return launchGeckoResult {
                 delegate.onVisited(url, visitType)
-                result.complete(true)
+                true
             }
-            return result
         }
 
         override fun getVisited(
@@ -460,12 +457,10 @@ class GeckoEngineSession(
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(null)
 
-            val result = GeckoResult<BooleanArray>()
-            launch {
-                val visits: List<Boolean>? = delegate.getVisited(urls.toList())
-                result.complete(visits?.toBooleanArray())
+            return launchGeckoResult {
+                val visits = delegate.getVisited(urls.toList())
+                visits.toBooleanArray()
             }
-            return result
         }
     }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import org.mozilla.geckoview.GeckoResult
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Wait for a GeckoResult to be complete in a co-routine.
+ */
+suspend fun <T> GeckoResult<T>.await() = suspendCoroutine<T?> { continuation ->
+    then({
+        continuation.resume(it)
+        GeckoResult<Void>()
+    }, {
+        continuation.resumeWithException(it)
+        GeckoResult<Void>()
+    })
+}
+
+/**
+ * Create a GeckoResult from a co-routine.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun <T> CoroutineScope.launchGeckoResult(
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> T
+) = GeckoResult<T>().apply {
+    launch(context, start) {
+        try {
+            val value = block()
+            complete(value)
+        } catch (exception: Throwable) {
+            completeExceptionally(exception)
+        }
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoResult
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoResultTest {
+
+    @Test
+    fun awaitWithResult() {
+        val result = runBlocking {
+            GeckoResult.fromValue(42).await()
+        }
+        assertEquals(42, result)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun awaitWithException() {
+        runBlocking {
+            GeckoResult.fromException<Unit>(IllegalStateException()).await()
+        }
+    }
+
+    @Test
+    fun fromResult() {
+        runBlocking {
+            val result = launchGeckoResult { 42 }
+
+            result.then {
+                assertEquals(42, it)
+                GeckoResult.fromValue(null)
+            }.await()
+        }
+    }
+
+    @Test
+    fun fromException() {
+        runBlocking {
+            val result = launchGeckoResult { throw IllegalStateException() }
+
+            result.then({
+                assertTrue("Invalid branch", false)
+                GeckoResult.fromValue(null)
+            }, {
+                assertTrue(it is IllegalStateException)
+                GeckoResult.fromValue(null)
+            }).await()
+        }
+    }
+}


### PR DESCRIPTION
Added an extension function to go from `GeckoResult` to a suspend function.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
