### PR TITLE
Remove overscroll effect in menu

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
@@ -14,6 +14,7 @@
             android:id="@+id/mozac_browser_menu_recyclerView"
             android:paddingTop="@dimen/mozac_browser_menu_padding_vertical"
             android:paddingBottom="@dimen/mozac_browser_menu_padding_vertical"
+            android:overScrollMode="never"
             android:layout_width="@dimen/mozac_browser_menu_width"
             android:layout_height="wrap_content" />
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-menu**
+  * Fixed a bug where overscroll effects would appear on the overflow menu.
+
 # 0.54.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.53.0...v0.54.0)
@@ -19,7 +22,7 @@ permalink: /changelog/
 * [Dependencies](https://github.com/mozilla-mobile/android-components/blob/v0.54.0/buildSrc/src/main/java/Dependencies.kt)
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/v0.54.0/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v0.54.0/buildSrc/src/main/java/Config.kt)
-  
+
 * **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
   * **Merge day!**
     * `browser-engine-gecko-release`: GeckoView 67.0
@@ -3058,4 +3061,3 @@ _Due to a packaging bug this release is not usable. Please use 0.5.1 instead._
   * Kotlin Standard library 1.2.30
 
 * First release with synchronized version numbers.
-


### PR DESCRIPTION
Fixes mozilla-mobile/fenix#1634

Normal overflow menus have no overscroll effect, and the effect here didn't align with the edges of the menu anyways.

![Screenshot_20190528-095028](https://user-images.githubusercontent.com/1782266/58484085-6c2f5c80-812f-11e9-88a1-914b10b78b39.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
