### PR TITLE
Closes #3151 - Init clearView as gone

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -91,6 +91,7 @@ internal class EditToolbar(
     }
 
     private val clearView = ImageView(context).apply {
+        visibility = View.GONE
         id = R.id.mozac_browser_toolbar_clear_view
         val padding = resources.pxToDp(CANCEL_PADDING_DP)
         setPadding(padding, padding, padding, padding)

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
@@ -166,6 +166,14 @@ class EditToolbarTest {
     }
 
     @Test
+    fun `clearView gone on init`() {
+        val toolbar = mock(BrowserToolbar::class.java)
+        val editToolbar = EditToolbar(context, toolbar)
+        val clearView = extractClearView(editToolbar)
+        assertTrue(clearView.visibility == View.GONE)
+    }
+
+    @Test
     fun `clearView clears text in urlView`() {
         val toolbar = mock(BrowserToolbar::class.java)
         val editToolbar = EditToolbar(context, toolbar)


### PR DESCRIPTION
This takes care of the flash I mentioned in #3151 before the text is updated (and checked so that we show clearView if the text isn't blank). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
