### PR TITLE
 Closes #1798: Add clear data functionality to Gecko engine 

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -11,7 +11,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Beta Version.
      */
-    const val beta_version = "68.0.20190520141152"
+    const val beta_version = "68.0.20190527103257"
 
     /**
      * GeckoView Release Version.

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -103,6 +103,29 @@ class GeckoEngine(
         }
     }
 
+    /**
+     * See [Engine.clearData].
+     */
+    override fun clearData(
+        data: Engine.BrowsingData,
+        host: String?,
+        onSuccess: () -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        val flags = data.types.toLong()
+        if (host != null) {
+            runtime.storageController.clearDataFromHost(host, flags)
+        } else {
+            runtime.storageController.clearData(flags)
+        }.then({
+            onSuccess()
+            GeckoResult<Void>()
+        }, {
+            throwable -> onError(throwable)
+            GeckoResult<Void>()
+        })
+    }
+
     override fun name(): String = "Gecko"
 
     /**

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -202,13 +202,6 @@ class GeckoEngineSession(
     }
 
     /**
-     * See [EngineSession.clearData]
-     */
-    override fun clearData() {
-        // API not available yet.
-    }
-
-    /**
      * See [EngineSession.findAll]
      */
     override fun findAll(text: String) {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -103,6 +103,29 @@ class GeckoEngine(
         }
     }
 
+    /**
+     * See [Engine.clearData].
+     */
+    override fun clearData(
+        data: Engine.BrowsingData,
+        host: String?,
+        onSuccess: () -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        val flags = data.types.toLong()
+        if (host != null) {
+            runtime.storageController.clearDataFromHost(host, flags)
+        } else {
+            runtime.storageController.clearData(flags)
+        }.then({
+            onSuccess()
+            GeckoResult<Void>()
+        }, {
+            throwable -> onError(throwable)
+            GeckoResult<Void>()
+        })
+    }
+
     override fun name(): String = "Gecko"
 
     /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -201,13 +201,6 @@ class GeckoEngineSession(
     }
 
     /**
-     * See [EngineSession.clearData]
-     */
-    override fun clearData() {
-        // API not available yet.
-    }
-
-    /**
      * See [EngineSession.findAll]
      */
     override fun findAll(text: String) {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -218,13 +218,6 @@ class GeckoEngineSession(
     }
 
     /**
-     * See [EngineSession.clearData]
-     */
-    override fun clearData() {
-        // API not available yet.
-    }
-
-    /**
      * See [EngineSession.findAll]
      */
     override fun findAll(text: String) {

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSession.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSession.kt
@@ -123,10 +123,6 @@ class ServoEngineSession(
         // not implemented yet
     }
 
-    override fun clearData() {
-        // not implemented yet
-    }
-
     override fun findAll(text: String) {
         // not implemented yet
     }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -49,7 +49,6 @@ class EngineObserverTest {
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
                 notifyObservers { onDesktopModeChange(enable) }
             }
-            override fun clearData() {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -98,7 +97,6 @@ class EngineObserverTest {
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
-            override fun clearData() {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -146,7 +144,6 @@ class EngineObserverTest {
             override fun saveState(): EngineSessionState = mock()
             override fun loadUrl(url: String) {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
-            override fun clearData() {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -118,18 +118,19 @@ interface Engine {
     /**
      * Clears browsing data stored by the engine.
      *
-     * @param data the type of data that should be cleared.
+     * @param data the type of data that should be cleared, defaults to all.
      * @param host (optional) name of the host for which data should be cleared. If
      * omitted data will be cleared for all hosts.
      * @param onSuccess (optional) callback invoked if the data was cleared successfully.
      * @param onError (optional) callback invoked if clearing the data caused an exception.
      */
     fun clearData(
-        data: BrowsingData,
+        data: BrowsingData = BrowsingData.all(),
         host: String? = null,
         onSuccess: (() -> Unit) = { },
         onError: ((Throwable) -> Unit) = { }
-    ): Unit = onSuccess()
+    ): Unit = onError(UnsupportedOperationException("Clearing browsing data is not supported by this engine. " +
+            "Check both the engine and engine session implementation."))
 
     /**
      * Provides access to the settings of this engine.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
+import java.lang.UnsupportedOperationException
 
 /**
  * Class representing a single engine session.
@@ -150,12 +151,14 @@ abstract class EngineSession(
              * This is the strictest setting and may cause issues on some web sites.
              */
             fun all() = TrackingProtectionPolicyForSessionTypes(ALL)
+
             /**
              * Recommended policy.
              * Combining the [AD], [ANALYTICS], [SOCIAL], [TEST] categories plus [SAFE_BROWSING_ALL].
              * This is the recommended setting.
              */
             fun recommended() = TrackingProtectionPolicyForSessionTypes(RECOMMENDED)
+
             fun select(vararg categories: Int) = TrackingProtectionPolicyForSessionTypes(categories.sum())
         }
 
@@ -278,9 +281,21 @@ abstract class EngineSession(
     abstract fun toggleDesktopMode(enable: Boolean, reload: Boolean = false)
 
     /**
-     * Clears all user data sources available.
+     * Clears browsing data stored by the engine.
+     *
+     * @param data the type of data that should be cleared.
+     * @param host (optional) name of the host for which data should be cleared. If
+     * omitted data will be cleared for all hosts.
+     * @param onSuccess (optional) callback invoked if the data was cleared successfully.
+     * @param onError (optional) callback invoked if clearing the data caused an exception.
      */
-    abstract fun clearData()
+    open fun clearData(
+        data: Engine.BrowsingData = Engine.BrowsingData.all(),
+        host: String? = null,
+        onSuccess: (() -> Unit) = { },
+        onError: ((Throwable) -> Unit) = { }
+    ): Unit = onError(UnsupportedOperationException("Clearing browsing data is not supported by this engine. " +
+            "Check both the engine and engine session implementation."))
 
     /**
      * Finds and highlights all occurrences of the provided String and highlights them asynchronously.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -648,8 +648,6 @@ open class DummyEngineSession : EngineSession() {
 
     override fun disableTrackingProtection() {}
 
-    override fun clearData() {}
-
     override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
 
     override fun findAll(text: String) {}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
@@ -50,14 +50,12 @@ class EngineTest {
         assertTrue(exception is UnsupportedOperationException)
     }
 
-    // TODO change this behaviour to invoke error callback once
-    // https://github.com/mozilla-mobile/android-components/issues/1798
-    // is fully implemented.
     @Test
-    fun `invokes success callback if clear data not supported`() {
-        var callbackInvoked = false
-        testEngine.clearData(Engine.BrowsingData.all(), onSuccess = { callbackInvoked = true })
-        assertTrue(callbackInvoked)
+    fun `invokes error callback if clear data not supported`() {
+        var exception: Throwable? = null
+        testEngine.clearData(Engine.BrowsingData.all(), onError = { exception = it })
+        assertNotNull(exception)
+        assertTrue(exception is UnsupportedOperationException)
     }
 
     @Test

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.session
 
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine.BrowsingData
 
 /**
  * Contains use cases related to the session feature.
@@ -167,9 +168,10 @@ class SessionUseCases(
         /**
          * Clears all user data sources available.
          */
-        fun invoke(session: Session? = sessionManager.selectedSession) {
+        fun invoke(session: Session? = sessionManager.selectedSession, data: BrowsingData = BrowsingData.all()) {
+            sessionManager.engine.clearData(data)
             if (session != null) {
-                sessionManager.getOrCreateEngineSession(session).clearData()
+                sessionManager.getOrCreateEngineSession(session).clearData(data)
             }
         }
     }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -6,8 +6,11 @@ package mozilla.components.feature.session
 
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -153,10 +156,19 @@ class SessionUseCasesTest {
     fun clearData() {
         val engineSession = mock(EngineSession::class.java)
         val session = mock(Session::class.java)
+        val engine = mock(Engine::class.java)
+        `when`(sessionManager.engine).thenReturn(engine)
         `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.clearData.invoke(session)
+        verify(engine).clearData()
         verify(engineSession).clearData()
+
+        useCases.clearData.invoke(data = BrowsingData.select(BrowsingData.COOKIES))
+        verify(engine).clearData(eq(BrowsingData.select(BrowsingData.COOKIES)), eq(null), any(), any())
+
+        useCases.clearData.invoke(session, data = BrowsingData.select(BrowsingData.COOKIES))
+        verify(engineSession).clearData(eq(BrowsingData.select(BrowsingData.COOKIES)), eq(null), any(), any())
 
         `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.clearData.invoke()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,19 @@ permalink: /changelog/
   * `OAuthAccount` and `DeviceConstellation` methods that returned `Deferred<T>` (for some T) now return `Deferred<T?>`, where `null` means failure.
   * `FirefoxAccount`, `FirefoxDeviceConstellation` and `FirefoxDeviceManager` now handle all expected `FxAException`.
 
+* **engine-gecko-nightly**, **engine-gecko-beta**, **concept-engine**
+  * Added engine API to clear browsing data.
+  ```kotlin
+  // Clear all browsing data
+  engine.clearData(BrowsingData.all())
+
+  // Clear all caches
+  engine.clearData(BrowsingData.allCaches())
+
+  // Clear cookies only for the provided host
+  engine.clearData(BrowsingData.select(BrowsingData.COOKIES), host = "mozilla.org")
+  ```
+
 # 0.54.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.53.0...v0.54.0)


### PR DESCRIPTION
Includes upgrade to latest GV beta and implementation for engine-gecko-beta and nightly.

Updated engine-system as well and kept it backward-compatible. There we already had `clearData` API on the engine session (not the engine). We had cases like this before for settings, where some settings are on the engine in gecko but session in system. I followed the same approach to make the API symmetric and throw an exception, if unsupported.
