### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `browser-search` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -15,7 +15,6 @@ object KotlinCompiler {
         "browser-domains",
         "browser-engine-gecko",
         "browser-engine-servo",
-        "browser-search",
         "browser-storage-sync",
         "feature-accounts",
         "feature-contextmenu",

--- a/components/browser/search/build.gradle
+++ b/components/browser/search/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
+
+    testImplementation Dependencies.kotlin_coroutines_test
+
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/ParseSearchPluginsTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/ParseSearchPluginsTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import java.io.File
 import java.io.FileInputStream
-import java.util.ArrayList
 import java.util.UUID
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
@@ -45,18 +44,13 @@ class ParseSearchPluginsTest(private val searchEngineIdentifier: String) {
     companion object {
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
-        fun searchPlugins(): Collection<Array<Any>> {
-            val searchPlugins = ArrayList<Array<Any>>()
-            basePath.list().forEach {
-                searchPlugins.add(arrayOf(it))
-            }
-            return searchPlugins
-        }
+        fun searchPlugins(): Collection<Array<Any>> = basePath.list()
+            .mapNotNull { it as Any }
+            .map { arrayOf(it) }
 
         private val basePath: File
-            get() {
-                val classLoader = ParseSearchPluginsTest::class.java.classLoader
-                return File(classLoader.getResource("searchplugins").file)
-            }
+            get() = ParseSearchPluginsTest::class.java.classLoader!!
+                .getResource("searchplugins").file
+                .let { File(it) }
     }
 }

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineParserTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineParserTest.kt
@@ -4,13 +4,13 @@
 
 package mozilla.components.browser.search
 
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
@@ -18,7 +18,7 @@ class SearchEngineParserTest {
     @Test
     fun `SearchEngine can be parsed from assets`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "google", "searchplugins/google-b-m.xml")
 
         assertEquals("google", searchEngine.identifier)
@@ -35,7 +35,7 @@ class SearchEngineParserTest {
     @Test
     fun `SearchEngine without SuggestUri wont build suggestionURL`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "amazon", "searchplugins/amazon-au.xml")
 
         val suggestionURL = searchEngine.buildSuggestionsURL("Mozilla")
@@ -45,7 +45,7 @@ class SearchEngineParserTest {
     @Test(expected = IOException::class)
     fun `Parsing not existing file will throw exception`() {
         SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "google", "does/not/exist.xml")
     }
 }

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/provider/AssetsSearchEngineProviderTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/provider/AssetsSearchEngineProviderTest.kt
@@ -9,14 +9,15 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.provider.filter.SearchEngineFilter
 import mozilla.components.browser.search.provider.localization.SearchLocalizationProvider
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AssetsSearchEngineProviderTest {
+
     @Test
     fun `Load search engines for en-US from assets`() = runBlocking {
         val localizationProvider = object : SearchLocalizationProvider() {
@@ -27,7 +28,7 @@ class AssetsSearchEngineProviderTest {
 
         val searchEngineProvider = AssetsSearchEngineProvider(localizationProvider)
 
-        val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+        val engines = searchEngineProvider.loadSearchEngines(testContext)
         val searchEngines = engines.list
 
         assertEquals(6, searchEngines.size)
@@ -51,7 +52,7 @@ class AssetsSearchEngineProviderTest {
 
         val searchEngineProvider = AssetsSearchEngineProvider(localizationProvider, listOf(filter))
 
-        val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+        val engines = searchEngineProvider.loadSearchEngines(testContext)
         val searchEngines = engines.list
 
         assertEquals(4, searchEngines.size)
@@ -68,7 +69,7 @@ class AssetsSearchEngineProviderTest {
             }
 
             val searchEngineProvider = AssetsSearchEngineProvider(localizationProviderWithoutRegion)
-            val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+            val engines = searchEngineProvider.loadSearchEngines(testContext)
             val searchEngines = engines.list
 
             assertEquals(7, searchEngines.size)
@@ -84,7 +85,7 @@ class AssetsSearchEngineProviderTest {
             }
 
             val searchEngineProvider = AssetsSearchEngineProvider(localizationProviderWithRegion)
-            val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+            val engines = searchEngineProvider.loadSearchEngines(testContext)
             val searchEngines = engines.list
 
             assertEquals(7, searchEngines.size)
@@ -104,7 +105,7 @@ class AssetsSearchEngineProviderTest {
             }
 
             val searchEngineProvider = AssetsSearchEngineProvider(localizationProviderWithoutRegion)
-            val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+            val engines = searchEngineProvider.loadSearchEngines(testContext)
             val searchEngines = engines.list
 
             assertEquals(6, searchEngines.size)
@@ -119,7 +120,7 @@ class AssetsSearchEngineProviderTest {
             }
 
             val searchEngineProvider = AssetsSearchEngineProvider(localizationProviderWithRegion)
-            val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+            val engines = searchEngineProvider.loadSearchEngines(testContext)
             val searchEngines = engines.list
 
             assertEquals(7, searchEngines.size)
@@ -136,7 +137,7 @@ class AssetsSearchEngineProviderTest {
         }
 
         val searchEngineProvider = AssetsSearchEngineProvider(provider)
-        val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+        val engines = searchEngineProvider.loadSearchEngines(testContext)
         val searchEngines = engines.list
 
         // visibleDefaultEngines: ["google-b-m", "baidu", "bing", "taobao", "wikipedia-zh-CN"]
@@ -160,7 +161,7 @@ class AssetsSearchEngineProviderTest {
         }
 
         val searchEngineProvider = AssetsSearchEngineProvider(provider)
-        val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+        val engines = searchEngineProvider.loadSearchEngines(testContext)
         val searchEngines = engines.list
 
         // visibleDefaultEngines: ["google-b-m", "yandex-ru", "twitter", "wikipedia-ru"]
@@ -184,7 +185,7 @@ class AssetsSearchEngineProviderTest {
         }
 
         val searchEngineProvider = AssetsSearchEngineProvider(provider)
-        val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+        val engines = searchEngineProvider.loadSearchEngines(testContext)
         val searchEngines = engines.list
 
         // visibleDefaultEngines: ["amazondotcom", "bing", "google-b-m", "twitter", "wikipedia-es"]
@@ -208,7 +209,7 @@ class AssetsSearchEngineProviderTest {
         }
 
         val searchEngineProvider = AssetsSearchEngineProvider(provider)
-        val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+        val engines = searchEngineProvider.loadSearchEngines(testContext)
         val searchEngines = engines.list
 
         assertEquals(6, searchEngines.size)
@@ -225,7 +226,7 @@ class AssetsSearchEngineProviderTest {
         // Loading "en-US" without additional identifiers
         runBlocking {
             val searchEngineProvider = AssetsSearchEngineProvider(usProvider)
-            val engines = searchEngineProvider.loadSearchEngines(RuntimeEnvironment.application)
+            val engines = searchEngineProvider.loadSearchEngines(testContext)
             val searchEngines = engines.list
 
             assertEquals(6, searchEngines.size)
@@ -237,7 +238,7 @@ class AssetsSearchEngineProviderTest {
             val provider = AssetsSearchEngineProvider(
                     usProvider,
                     additionalIdentifiers = listOf("duckduckgo"))
-            val engines = provider.loadSearchEngines(RuntimeEnvironment.application)
+            val engines = provider.loadSearchEngines(testContext)
             val searchEngines = engines.list
 
             assertEquals(7, searchEngines.size)

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
@@ -6,15 +6,16 @@ package mozilla.components.browser.search.suggestions
 
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.SearchEngineParser
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.Assert.assertEquals
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 class SearchSuggestionClientTest {
+
     companion object {
         val GOOGLE_MOCK_RESPONSE: SearchSuggestionFetcher = { "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]" }
         val QWANT_MOCK_RESPONSE: SearchSuggestionFetcher = { "{\"status\":\"success\",\"data\":{\"items\":[{\"value\":\"firefox (video game)\",\"suggestType\":3},{\"value\":\"firefox addons\",\"suggestType\":12},{\"value\":\"firefox\",\"suggestType\":2},{\"value\":\"firefox quantum\",\"suggestType\":12},{\"value\":\"firefox focus\",\"suggestType\":12}],\"special\":[],\"availableQwick\":[]}}" }
@@ -24,7 +25,7 @@ class SearchSuggestionClientTest {
     @Test
     fun `Get a list of results based on the Google search engine`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "google", "searchplugins/google-b-m.xml")
 
         val client = SearchSuggestionClient(searchEngine, GOOGLE_MOCK_RESPONSE)
@@ -40,7 +41,7 @@ class SearchSuggestionClientTest {
     @Test
     fun `Get a list of results based on a non google search engine`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "google", "searchplugins/qwant.xml")
 
         val client = SearchSuggestionClient(searchEngine, QWANT_MOCK_RESPONSE)
@@ -56,7 +57,7 @@ class SearchSuggestionClientTest {
     @Test(expected = SearchSuggestionClient.ResponseParserException::class)
     fun `Check that a bad response will throw a parser exception`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "google", "searchplugins/google-b-m.xml")
 
         val client = SearchSuggestionClient(searchEngine, SERVER_ERROR_RESPONSE)
@@ -69,10 +70,10 @@ class SearchSuggestionClientTest {
     @Test(expected = SearchSuggestionClient.FetchException::class)
     fun `Check that an exception in the suggestionFetcher will re-throw an IOException`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "google", "searchplugins/google-b-m.xml")
 
-        val client = SearchSuggestionClient(searchEngine, { throw IOException() })
+        val client = SearchSuggestionClient(searchEngine) { throw IOException() }
 
         runBlocking {
             client.getSuggestions("firefox")
@@ -82,9 +83,9 @@ class SearchSuggestionClientTest {
     @Test(expected = IllegalArgumentException::class)
     fun `Check that a search engine without a suggestURI will throw an exception`() {
         val searchEngine = SearchEngineParser().load(
-                RuntimeEnvironment.application.assets,
+            testContext.assets,
                 "drae", "searchplugins/drae.xml")
 
-        val client = SearchSuggestionClient(searchEngine, { "no-op" })
+        SearchSuggestionClient(searchEngine) { "no-op" }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-search**
+  * `SearchEngineManager.load()` is deprecated. Use `SearchEngineManager.loadAsync()` instead.
+
 * **browser-menu**
   * Fixed a bug where overscroll effects would appear on the overflow menu.
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -84,7 +84,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     val searchEngineManager by lazy {
         SearchEngineManager().apply {
             CoroutineScope(Dispatchers.Default).launch {
-                load(applicationContext).await()
+                loadAsync(applicationContext).await()
             }
         }
     }


### PR DESCRIPTION
### Issue #2346

  - Used `runBlockingTest {}` in tests.
  - Added `@Test "manager returns engines from deffered"`.
  - Renamed `load()` in `SearchEngineManager` to `loadAsync()` because it returns named deffered result.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~