### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `feature-prompts` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -12,7 +12,6 @@ object KotlinCompiler {
     // Maybe this is easier in Gradle 5+.
     @JvmStatic
     val projectsWithWarningsAsErrorsDisabled = setOf(
-        "browser-domains",
-        "feature-prompts"
+        "browser-domains"
     )
 }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -153,6 +153,7 @@ class PromptFeature(
      * @param grantResults The grant results for the corresponding permissions
      * @see [onNeedToRequestPermissions].
      */
+    @Suppress("UNUSED_PARAMETER")
     fun onPermissionsResult(permissions: Array<String>, grantResults: IntArray) {
         if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
             onPermissionsGranted()

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TimePickerDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TimePickerDialogFragment.kt
@@ -27,7 +27,7 @@ private const val KEY_SELECTED_DATE = "KEY_SELECTED_DATE"
 private const val KEY_SELECTION_TYPE = "KEY_SELECTION_TYPE"
 
 /**
- * [android.support.v4.app.DialogFragment] implementation to display date picker with a native dialog.
+ * [DialogFragment][androidx.fragment.app.DialogFragment] implementation to display date picker with a native dialog.
  */
 @Suppress("TooManyFunctions")
 internal class TimePickerDialogFragment : PromptDialogFragment(), DatePicker.OnDateChangedListener,
@@ -110,7 +110,7 @@ internal class TimePickerDialogFragment : PromptDialogFragment(), DatePicker.OnD
         return view
     }
 
-    @SuppressWarnings("deprecation")
+    @Suppress("DEPRECATION")
     private fun bind(picker: TimePicker, cal: Calendar) {
         if (Build.VERSION.SDK_INT >= M) {
             picker.hour = cal.get(Calendar.HOUR_OF_DAY)

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TimePickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TimePickerDialogFragmentTest.kt
@@ -54,7 +54,7 @@ class TimePickerDialogFragmentTest {
         dialog.show()
 
         val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
-        val datePicker = dialog.findViewById<DatePicker>(mozilla.components.feature.prompts.R.id.date_picker)
+        val datePicker = dialog.findViewById<DatePicker>(R.id.date_picker)
 
         assertEquals(titleTextView.text, "title")
         assertEquals(2019, datePicker.year)
@@ -147,7 +147,7 @@ class TimePickerDialogFragmentTest {
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
 
-        val datePicker = dialog.findViewById<DatePicker>(mozilla.components.feature.prompts.R.id.date_picker)
+        val datePicker = dialog.findViewById<DatePicker>(R.id.date_picker)
 
         assertEquals(2018, datePicker.year)
         assertEquals(6, datePicker.month + 1)
@@ -156,14 +156,15 @@ class TimePickerDialogFragmentTest {
         assertEquals(minDate, Date(datePicker.minDate))
         assertEquals(maxDate, Date(datePicker.maxDate))
 
-        val timePicker = dialog.findViewById<TimePicker>(mozilla.components.feature.prompts.R.id.datetime_picker)
+        val timePicker = dialog.findViewById<TimePicker>(R.id.datetime_picker)
 
         assertEquals(19, timePicker.hour)
         assertEquals(30, timePicker.minute)
     }
 
-    @Config(sdk = [LOLLIPOP])
     @Test
+    @Config(sdk = [LOLLIPOP])
+    @Suppress("DEPRECATION")
     fun `building a time picker`() {
         val initialDate = "2018-06-12T19:30".toDate("yyyy-MM-dd'T'HH:mm")
         val minDate = "2018-06-07T00:00".toDate("yyyy-MM-dd'T'HH:mm")
@@ -184,7 +185,7 @@ class TimePickerDialogFragmentTest {
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
 
-        val timePicker = dialog.findViewById<TimePicker>(mozilla.components.feature.prompts.R.id.time_picker)
+        val timePicker = dialog.findViewById<TimePicker>(R.id.time_picker)
 
         assertEquals(19, timePicker.currentHour)
         assertEquals(30, timePicker.currentMinute)


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~