### PR TITLE
Bug 1555334 - Change InvalidValue to InvalidLabel in LabeledMetricType

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
@@ -90,7 +90,7 @@ data class LabeledMetricType<T>(
                 if (label.length > MAX_LABEL_LENGTH) {
                     recordError(
                         this,
-                        ErrorType.InvalidValue,
+                        ErrorType.InvalidLabel,
                         "label length ${label.length} exceeds maximum of $MAX_LABEL_LENGTH",
                         logger
                     )
@@ -101,7 +101,7 @@ data class LabeledMetricType<T>(
                 if (!labelRegex.matches(label)) {
                     recordError(
                         this,
-                        ErrorType.InvalidValue,
+                        ErrorType.InvalidLabel,
                         "label must be snake_case, got '$label'",
                         logger
                     )

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -258,7 +258,7 @@ class LabeledMetricTypeTest {
             4,
             ErrorRecording.testGetNumRecordedErrors(
                 labeledCounterMetric,
-                ErrorRecording.ErrorType.InvalidValue
+                ErrorRecording.ErrorType.InvalidLabel
             )
         )
         assertEquals(


### PR DESCRIPTION
Fixes the error recording in LabeledMetricType to point to the correct error type.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
