### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `feature-contextmenu` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -17,7 +17,6 @@ object KotlinCompiler {
         "browser-engine-servo",
         "browser-storage-sync",
         "feature-accounts",
-        "feature-contextmenu",
         "feature-downloads",
         "feature-prompts",
         "feature-search",

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -6,8 +6,8 @@ package mozilla.components.feature.contextmenu
 
 import android.content.ClipboardManager
 import android.content.Context
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -16,6 +16,7 @@ import mozilla.components.concept.engine.HitResult
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -28,11 +29,10 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ContextMenuCandidateTest {
-    private val context: Context get() = RuntimeEnvironment.application
+
     private lateinit var snackbarDelegate: TestSnackbarDelegate
 
     @Before
@@ -42,7 +42,7 @@ class ContextMenuCandidateTest {
 
     @Test
     fun `Default candidates sanity check`() {
-        val candidates = ContextMenuCandidate.defaultCandidates(context, mock(), mock())
+        val candidates = ContextMenuCandidate.defaultCandidates(testContext, mock(), mock())
         // Just a sanity check: When changing the list of default candidates be aware that this will affect all
         // consumers of this component using the default list.
         assertEquals(7, candidates.size)
@@ -54,10 +54,10 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any())
         val session = Session("https://www.mozilla.org").apply { sessionManager.add(this) }
         val tabsUseCases = TabsUseCases(sessionManager)
-        val parentView = CoordinatorLayout(context)
+        val parentView = CoordinatorLayout(testContext)
 
         val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
-            context, tabsUseCases, parentView, snackbarDelegate)
+            testContext, tabsUseCases, parentView, snackbarDelegate)
 
         // showFor
 
@@ -108,10 +108,10 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any())
         val session = Session("https://www.mozilla.org").apply { sessionManager.add(this) }
         val tabsUseCases = TabsUseCases(sessionManager)
-        val parentView = CoordinatorLayout(context)
+        val parentView = CoordinatorLayout(testContext)
 
         val openInPrivateTab = ContextMenuCandidate.createOpenInPrivateTabCandidate(
-            context, tabsUseCases, parentView, snackbarDelegate)
+            testContext, tabsUseCases, parentView, snackbarDelegate)
 
         // showFor
 
@@ -163,10 +163,10 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any())
         val session = Session("https://www.mozilla.org").apply { sessionManager.add(this) }
         val tabsUseCases = TabsUseCases(sessionManager)
-        val parentView = CoordinatorLayout(context)
+        val parentView = CoordinatorLayout(testContext)
 
         val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(
-            context, tabsUseCases, parentView, snackbarDelegate)
+            testContext, tabsUseCases, parentView, snackbarDelegate)
 
         // showFor
 
@@ -222,10 +222,10 @@ class ContextMenuCandidateTest {
         ).apply { sessionManager.add(this) }
 
         val tabsUseCases = TabsUseCases(sessionManager)
-        val parentView = CoordinatorLayout(context)
+        val parentView = CoordinatorLayout(testContext)
 
         val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(
-            context, tabsUseCases, parentView, snackbarDelegate)
+            testContext, tabsUseCases, parentView, snackbarDelegate)
 
         assertEquals(1, sessionManager.size)
 
@@ -238,7 +238,7 @@ class ContextMenuCandidateTest {
 
     @Test
     fun `Candidate "Save image"`() {
-        val saveImage = ContextMenuCandidate.createSaveImageCandidate(context)
+        val saveImage = ContextMenuCandidate.createSaveImageCandidate(testContext)
 
         // showFor
 
@@ -287,7 +287,7 @@ class ContextMenuCandidateTest {
 
     @Test
     fun `Candidate "Share Link"`() {
-        val context = spy(context)
+        val context = spy(testContext)
 
         val shareLink = ContextMenuCandidate.createShareLinkCandidate(context)
 
@@ -324,10 +324,10 @@ class ContextMenuCandidateTest {
 
     @Test
     fun `Candidate "Copy Link"`() {
-        val parentView = CoordinatorLayout(context)
+        val parentView = CoordinatorLayout(testContext)
 
         val copyLink = ContextMenuCandidate.createCopyLinkCandidate(
-            context, parentView, snackbarDelegate)
+            testContext, parentView, snackbarDelegate)
 
         // showFor
 
@@ -359,7 +359,7 @@ class ContextMenuCandidateTest {
 
         assertTrue(snackbarDelegate.hasShownSnackbar)
 
-        val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipboardManager = testContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         assertEquals(
             "https://getpocket.com",
             clipboardManager.primaryClip!!.getItemAt(0).text
@@ -368,10 +368,10 @@ class ContextMenuCandidateTest {
 
     @Test
     fun `Candidate "Copy Image Location"`() {
-        val parentView = CoordinatorLayout(context)
+        val parentView = CoordinatorLayout(testContext)
 
         val copyImageLocation = ContextMenuCandidate.createCopyImageLocationCandidate(
-            context, parentView, snackbarDelegate)
+            testContext, parentView, snackbarDelegate)
 
         // showFor
 
@@ -403,7 +403,7 @@ class ContextMenuCandidateTest {
 
         assertTrue(snackbarDelegate.hasShownSnackbar)
 
-        val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipboardManager = testContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         assertEquals(
             "https://firefox.com",
             clipboardManager.primaryClip!!.getItemAt(0).text

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
@@ -4,15 +4,14 @@
 
 package mozilla.components.feature.contextmenu
 
-import android.content.Context
-import androidx.recyclerview.widget.RecyclerView
-import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.browser.session.Session
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -22,13 +21,9 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ContextMenuFragmentTest {
-    private val context: Context get() = ContextThemeWrapper(
-        RuntimeEnvironment.application,
-        R.style.Theme_AppCompat)
 
     @Test
     fun `Build dialog`() {
@@ -38,7 +33,7 @@ class ContextMenuFragmentTest {
         val session = Session("https://www.mozilla.org")
 
         val fragment = spy(ContextMenuFragment.create(session, title, ids, labels))
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(testContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -57,7 +52,7 @@ class ContextMenuFragmentTest {
 
         val fragment = spy(ContextMenuFragment.create(session, title, ids, labels))
 
-        val inflater = LayoutInflater.from(context)
+        val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogTitleView(inflater)
 
         assertEquals(
@@ -75,14 +70,14 @@ class ContextMenuFragmentTest {
 
         val fragment = ContextMenuFragment.create(session, title, ids, labels)
 
-        val inflater = LayoutInflater.from(context)
+        val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogContentView(inflater)
 
         val adapter = view.findViewById<RecyclerView>(R.id.recyclerView).adapter as ContextMenuAdapter
 
         assertEquals(3, adapter.itemCount)
 
-        val parent = LinearLayout(context)
+        val parent = LinearLayout(testContext)
 
         val holder = adapter.onCreateViewHolder(parent, 0)
 
@@ -106,11 +101,11 @@ class ContextMenuFragmentTest {
         val fragment = spy(ContextMenuFragment.create(session, title, ids, labels))
         doNothing().`when`(fragment).dismiss()
 
-        val inflater = LayoutInflater.from(context)
+        val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogContentView(inflater)
 
         val adapter = view.findViewById<RecyclerView>(R.id.recyclerView).adapter as ContextMenuAdapter
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), 0)
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), 0)
         adapter.bindViewHolder(holder, 0)
 
         holder.labelView.performClick()


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~