### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `browser-engine-servo` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -13,7 +13,6 @@ object KotlinCompiler {
     @JvmStatic
     val projectsWithWarningsAsErrorsDisabled = setOf(
         "browser-domains",
-        "browser-engine-servo",
         "browser-storage-sync",
         "feature-accounts",
         "feature-downloads",

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSessionState.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSessionState.kt
@@ -13,7 +13,13 @@ import org.json.JSONObject
 class ServoEngineSessionState : EngineSessionState {
     override fun toJSON() = JSONObject()
 
+    override fun equals(other: Any?) =
+        other != null && this::class == other::class
+
+    override fun hashCode() = this::class.hashCode()
+
     companion object {
+        @Suppress("UNUSED_PARAMETER")
         fun fromJSON(json: JSONObject) = ServoEngineSessionState()
     }
 }

--- a/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionStateTest.kt
+++ b/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionStateTest.kt
@@ -1,0 +1,43 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.engine.servo
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ServoEngineSessionStateTest {
+
+    @Test
+    fun `toJson() returns empty object`() {
+        // Given
+        val state = ServoEngineSessionState()
+
+        // When
+        val json = state.toJSON()
+
+        // Then
+        assertEquals("Json object is empty", 0, json.length())
+    }
+
+    @Test
+    fun `fromJson() returns default state`() {
+        // Given
+        val json = JSONObject().apply {
+            put("some-key", "some-value")
+        }
+
+        // When
+        val state = ServoEngineSessionState.fromJSON(json)
+
+        // Then
+        assertEquals(state, ServoEngineSessionState())
+    }
+}

--- a/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionTest.kt
+++ b/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionTest.kt
@@ -1,0 +1,161 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.engine.servo
+
+import android.net.Uri
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.mozilla.servoview.ServoView
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ServoEngineSessionTest {
+
+    @Test
+    fun `loadUrl() with absent view not crashed`() {
+        // Given
+        val session = ServoEngineSession()
+
+        // When
+        session.loadUrl("http://mozilla.org")
+
+        // Then
+        assertTrue("Not crashed", true)
+    }
+
+    @Test
+    fun `loadUrl() with predefined view loads url`() {
+        // Given
+        val view = mock<ServoView>()
+        val engineView = mock<ServoEngineView>().apply {
+            whenever(this.servoView).then { view }
+        }
+        val session = ServoEngineSession().apply {
+            attachView(engineView)
+        }
+        val uri = Uri.parse("http://mozilla.org")
+
+        // When
+        session.loadUrl(uri.toString())
+
+        // Then
+        verify(view).loadUri(uri)
+    }
+
+    @Test
+    fun `loadUrl() with unset view loads url later`() {
+        // Given
+        val session = ServoEngineSession()
+        val uri = Uri.parse("http://mozilla.org")
+
+        // When
+        session.loadUrl(uri.toString())
+
+        // Then
+        assertTrue("Not crashed", true)
+
+        // When
+        val view = mock<ServoView>()
+        val engineView = mock<ServoEngineView>().apply {
+            whenever(this.servoView).then { view }
+        }
+        session.attachView(engineView)
+
+        // Then
+        verify(view).loadUri(uri)
+    }
+
+    @Test
+    fun `stopLoading() forwarded to view`() {
+        // Given
+        val view = mock<ServoView>()
+        val session = ServoEngineSession().apply {
+            val engineView = mock<ServoEngineView>().apply {
+                whenever(this.servoView).then { view }
+            }
+            attachView(engineView)
+        }
+
+        // When
+        session.stopLoading()
+
+        // Then
+        verify(view).stop()
+    }
+
+    @Test
+    fun `reload() forwarded to view`() {
+        // Given
+        val view = mock<ServoView>()
+        val session = ServoEngineSession().apply {
+            val engineView = mock<ServoEngineView>().apply {
+                whenever(this.servoView).then { view }
+            }
+            attachView(engineView)
+        }
+
+        // When
+        session.reload()
+
+        // Then
+        verify(view).reload()
+    }
+
+    @Test
+    fun `goBack() forwarded to view`() {
+        // Given
+        val view = mock<ServoView>()
+        val session = ServoEngineSession().apply {
+            val engineView = mock<ServoEngineView>().apply {
+                whenever(this.servoView).then { view }
+            }
+            attachView(engineView)
+        }
+
+        // When
+        session.goBack()
+
+        // Then
+        verify(view).goBack()
+    }
+
+    @Test
+    fun `goForward() forwarded to view`() {
+        // Given
+        val view = mock<ServoView>()
+        val session = ServoEngineSession().apply {
+            val engineView = mock<ServoEngineView>().apply {
+                whenever(this.servoView).then { view }
+            }
+            attachView(engineView)
+        }
+
+        // When
+        session.goForward()
+
+        // Then
+        verify(view).goForward()
+    }
+
+    @Test
+    fun `saveState() returns emptyState`() {
+        // Given
+        val session = ServoEngineSession()
+
+        // When
+        val state = session.saveState()
+
+        // Then
+        assertEquals("Saved state is empty",
+            ServoEngineSessionState(), state)
+    }
+}

--- a/components/support/test/src/main/java/mozilla/components/support/test/Mock.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/Mock.kt
@@ -20,6 +20,16 @@ import org.mockito.Mockito
 inline fun <reified T : Any> mock(): T = Mockito.mock(T::class.java)!!
 
 /**
+ * Enables stubbing methods. Use it when you want the mock to return particular value when particular method is called.
+ *
+ * Alias for [Mockito.when ].
+ *
+ * Taken from [mockito-kotlin](https://github.com/nhaarman/mockito-kotlin/).
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T> whenever(methodCall: T) = Mockito.`when`(methodCall)!!
+
+/**
  * Creates a custom [MotionEvent] for testing. As of SDK 28 [MotionEvent]s can't be mocked anymore and need to be created
  * through [MotionEvent.obtain].
  */


### PR DESCRIPTION
### Issue #2346

Added few tests.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~