### PR TITLE
Closes #3176: Support limiting clipboard suggestions to empty text

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -26,7 +26,8 @@ class ClipboardSuggestionProvider(
     private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
     private val icon: Bitmap? = null,
     private val title: String? = null,
-    private val icons: BrowserIcons? = null
+    private val icons: BrowserIcons? = null,
+    private val requireEmptyText: Boolean = true
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
 
@@ -34,7 +35,8 @@ class ClipboardSuggestionProvider(
 
     override fun onInputStarted(): List<AwesomeBar.Suggestion> = createClipboardSuggestion()
 
-    override suspend fun onInputChanged(text: String) = createClipboardSuggestion()
+    override suspend fun onInputChanged(text: String) =
+            if ((requireEmptyText && text.isEmpty()) || !requireEmptyText) createClipboardSuggestion() else emptyList()
 
     private fun createClipboardSuggestion(): List<AwesomeBar.Suggestion> {
         val url = getTextFromClipboard(clipboardManager)?.let {


### PR DESCRIPTION
This seems to be the right compromise. With this default behaviour we can remove the workaround in Fenix (https://github.com/mozilla-mobile/fenix/commit/11918d45f4ce97f9c64273fcbe6f7df1d6fd4365#diff-e68bc3f7a2e6f8d0a48238b79105867a) which is expensive and likely to cause problems.

For apps using the `AwesomeBarFeature` (r-b, sample browser), the default is still reasonable. When switching to edit mode (onInputStarted) we see the clipboard suggestion and also when the text changes to empty. We no longer see it (by default) if the user starts typing but I think that makes sense, as the suggestion wouldn't "match". Before it was kind of hidden too (listed below the matching suggestions from other providers).

