### PR TITLE
Fixes #3032 - Add animation for browser-menu

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -44,6 +44,10 @@ class BrowserMenu internal constructor(
                 WindowManager.LayoutParams.WRAP_CONTENT
         ).apply {
             setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            animationStyle = when (orientation) {
+                Orientation.DOWN -> R.style.Mozac_Browser_Menu_Animation_OverflowMenuTop
+                Orientation.UP -> R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom
+            }
             isFocusable = true
             elevation = view.resources.pxToDp(MENU_ELEVATION_DP).toFloat()
 

--- a/components/browser/menu/src/main/res/anim/menu_enter_bottom.xml
+++ b/components/browser/menu/src/main/res/anim/menu_enter_bottom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromXScale="0"
+        android:toXScale="1"
+        android:fromYScale="0"
+        android:toYScale="1"
+        android:pivotX="95%"
+        android:pivotY="100%"
+        android:duration="@android:integer/config_shortAnimTime" />
+    <alpha android:interpolator="@android:anim/linear_interpolator"
+        android:fromAlpha="0"
+        android:toAlpha="1"
+        android:duration="@android:integer/config_shortAnimTime" />
+    <translate android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromYDelta="0"
+        android:toYDelta="0"
+        android:duration="@android:integer/config_shortAnimTime" />
+</set>

--- a/components/browser/menu/src/main/res/anim/menu_enter_top.xml
+++ b/components/browser/menu/src/main/res/anim/menu_enter_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromXScale="0"
+        android:toXScale="1"
+        android:fromYScale="0"
+        android:toYScale="1"
+        android:pivotX="95%"
+        android:pivotY="5%"
+        android:duration="@android:integer/config_shortAnimTime" />
+    <alpha android:interpolator="@android:anim/linear_interpolator"
+        android:fromAlpha="0"
+        android:toAlpha="1"
+        android:duration="@android:integer/config_shortAnimTime" />
+    <translate android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromYDelta="0"
+        android:toYDelta="0"
+        android:duration="@android:integer/config_shortAnimTime" />
+</set>

--- a/components/browser/menu/src/main/res/anim/menu_exit.xml
+++ b/components/browser/menu/src/main/res/anim/menu_exit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha android:interpolator="@android:anim/linear_interpolator"
+        android:fromAlpha="1"
+        android:toAlpha="0"
+        android:duration="@android:integer/config_shortAnimTime" />
+</set>

--- a/components/browser/menu/src/main/res/values/style.xml
+++ b/components/browser/menu/src/main/res/values/style.xml
@@ -47,4 +47,16 @@
         <item name="android:paddingStart">@dimen/mozac_browser_menu_item_image_text_label_padding_start</item>
     </style>
     <!-- BrowserMenuImageText -->
+
+    <!-- Animation -->
+    <style name="Mozac.Browser.Menu.Animation.OverflowMenuTop" parent="">
+        <item name="android:windowEnterAnimation">@anim/menu_enter_top</item>
+        <item name="android:windowExitAnimation">@anim/menu_exit</item>
+    </style>
+
+    <style name="Mozac.Browser.Menu.Animation.OverflowMenuBottom" parent="">
+        <item name="android:windowEnterAnimation">@anim/menu_enter_bottom</item>
+        <item name="android:windowExitAnimation">@anim/menu_exit</item>
+    </style>
+    <!-- Animation -->
 </resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,7 @@ permalink: /changelog/
 
 * **browser-menu**
   * Fixed a bug where overscroll effects would appear on the overflow menu.
+  * Added enter and exit animations.
 
 * **browser-session**
   * Added handler for `onWebAppManifestLoaded` to update `session.webAppManifest`.


### PR DESCRIPTION
[**Video**](https://drive.google.com/file/d/1HR3FyX8levtddR-76N4ggLNJgQy6rh75/view?usp=sharing)

Adds enter and exit animations for browser-menu designed to match the existing overflow menu animations built into Android.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
