### PR TITLE
For fenix/#1306. Add `isInUrlEditMode` property to Toolbar. 

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -64,7 +64,7 @@ private const val AUTOCOMPLETE_QUERY_THREADS = 3
  *  +----------------+ +----------------+
  * ```
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 class BrowserToolbar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -254,6 +254,9 @@ class BrowserToolbar @JvmOverloads constructor(
             editToolbar.urlView.typeface = value
         }
 
+    override val isInUrlEditMode: Boolean
+        get() = state == State.EDIT
+
     /**
      * Sets a listener to be invoked when focus of the URL input view (in edit mode) changed.
      */

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -946,4 +946,53 @@ class BrowserToolbarTest {
             EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING)
         assertEquals(false, toolbar.private)
     }
+
+    @Test
+    fun `toolbar is not in URL edit mode by default`() {
+        // Given
+        val toolbar = BrowserToolbar(testContext)
+
+        // When
+        // Then
+        assertFalse("Toolbar is not in URL edit mode",
+            toolbar.isInUrlEditMode)
+    }
+
+    @Test
+    fun `toolbar is in URL edit mode when changed`() {
+        // Given
+        val toolbar = BrowserToolbar(testContext)
+
+        // When
+        toolbar.editMode()
+
+        // Then
+        assertTrue(toolbar.isInUrlEditMode)
+    }
+
+    @Test
+    fun `toolbar is in URL edit mode when switched to displayMode`() {
+        // Given
+        val toolbar = BrowserToolbar(testContext)
+
+        // When
+        toolbar.editMode()
+        toolbar.displayMode()
+
+        // Then
+        assertFalse(toolbar.isInUrlEditMode)
+    }
+
+    @Test
+    fun `toolbar is in URL edit mode when back pressed`() {
+        // Given
+        val toolbar = BrowserToolbar(testContext)
+
+        // When
+        toolbar.editMode()
+        toolbar.onBackPressed()
+
+        // Then
+        assertFalse(toolbar.isInUrlEditMode)
+    }
 }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -16,7 +16,6 @@ import android.view.accessibility.AccessibilityManager
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import androidx.core.view.inputmethod.EditorInfoCompat
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar.Companion.ACTION_PADDING_DP
 import mozilla.components.browser.toolbar.display.DisplayToolbar
@@ -27,6 +26,7 @@ import mozilla.components.support.base.android.Padding
 import mozilla.components.support.ktx.android.view.isGone
 import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -50,19 +50,17 @@ import org.robolectric.Shadows
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserToolbarTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `display toolbar is visible by default`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertTrue(toolbar.displayToolbar.visibility == View.VISIBLE)
         assertTrue(toolbar.editToolbar.visibility == View.GONE)
     }
 
     @Test
     fun `calling editMode() makes edit toolbar visible`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertTrue(toolbar.displayToolbar.visibility == View.VISIBLE)
         assertTrue(toolbar.editToolbar.visibility == View.GONE)
 
@@ -74,7 +72,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `calling displayMode() makes display toolbar visible`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.editMode()
 
         assertTrue(toolbar.displayToolbar.visibility == View.GONE)
@@ -88,7 +86,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `back presses will not be handled in display mode`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.displayMode()
 
         assertFalse(toolbar.onBackPressed())
@@ -99,7 +97,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `back presses will switch from edit mode to display mode`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.editMode()
 
         assertTrue(toolbar.displayToolbar.visibility == View.GONE)
@@ -113,7 +111,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `displayUrl will be forwarded to display toolbar immediately`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
         val ediToolbar = mock(EditToolbar::class.java)
 
@@ -128,7 +126,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `last URL will be forwarded to edit toolbar when switching mode`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val ediToolbar = mock(EditToolbar::class.java)
         toolbar.editToolbar = ediToolbar
@@ -143,12 +141,12 @@ class BrowserToolbarTest {
 
     @Test
     fun `displayProgress will send accessibility events`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val root = mock(ViewParent::class.java)
         Shadows.shadowOf(toolbar).setMyParent(root)
         `when`(root.requestSendAccessibilityEvent(any(), any())).thenReturn(false)
 
-        Shadows.shadowOf(context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).setEnabled(true)
+        Shadows.shadowOf(testContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).setEnabled(true)
 
         toolbar.displayProgress(10)
         toolbar.displayProgress(50)
@@ -159,7 +157,7 @@ class BrowserToolbarTest {
         verify(root, times(4)).requestSendAccessibilityEvent(any(), captor.capture())
 
         assertEquals(AccessibilityEvent.TYPE_ANNOUNCEMENT, captor.allValues[0].eventType)
-        assertEquals(context.getString(R.string.mozac_browser_toolbar_progress_loading), captor.allValues[0].text[0])
+        assertEquals(testContext.getString(R.string.mozac_browser_toolbar_progress_loading), captor.allValues[0].text[0])
 
         assertEquals(AccessibilityEvent.TYPE_VIEW_SCROLLED, captor.allValues[1].eventType)
         assertEquals(10, captor.allValues[1].scrollY)
@@ -176,7 +174,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `displayProgress will be forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
 
         toolbar.displayToolbar = displayToolbar
@@ -196,7 +194,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `internal onUrlEntered callback will be forwarded to urlChangeListener`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val mockedListener = object {
             var called = false
@@ -218,7 +216,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `internal onEditCancelled callback will be forwarded to editListener`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val listener: Toolbar.OnEditListener = mock()
         toolbar.setOnEditListener(listener)
         assertEquals(toolbar.editToolbar.editListener, listener)
@@ -229,7 +227,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `toolbar measure will use full width and fixed 56dp height`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val widthSpec = View.MeasureSpec.makeMeasureSpec(1024, View.MeasureSpec.AT_MOST)
         val heightSpec = View.MeasureSpec.makeMeasureSpec(800, View.MeasureSpec.AT_MOST)
@@ -242,7 +240,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `toolbar will use provided height with EXACTLY measure spec`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val widthSpec = View.MeasureSpec.makeMeasureSpec(1024, View.MeasureSpec.AT_MOST)
         val heightSpec = View.MeasureSpec.makeMeasureSpec(800, View.MeasureSpec.EXACTLY)
@@ -255,7 +253,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `display and edit toolbar will use full size of browser toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertEquals(0, toolbar.displayToolbar.measuredWidth)
         assertEquals(0, toolbar.displayToolbar.measuredHeight)
@@ -275,7 +273,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `toolbar will switch back to display mode after an URL has been entered`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.editMode()
 
         assertTrue(toolbar.displayToolbar.visibility == View.GONE)
@@ -289,7 +287,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `toolbar will switch back to display mode if URL commit listener returns true`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.setOnUrlCommitListener { true }
         toolbar.editMode()
 
@@ -304,7 +302,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `toolbar will stay in edit mode if URL commit listener returns false`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.setOnUrlCommitListener { false }
         toolbar.editMode()
 
@@ -319,7 +317,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `display and edit toolbar will be laid out at the exact same position`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
         val editToolbar = mock(EditToolbar::class.java)
 
@@ -343,7 +341,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `menu builder will be forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertNull(toolbar.displayToolbar.menuBuilder)
 
@@ -356,7 +354,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `add browser action will be forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
 
         toolbar.displayToolbar = displayToolbar
@@ -372,7 +370,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `add page action will be forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val displayToolbar = mock(DisplayToolbar::class.java)
 
@@ -389,7 +387,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `add edit action will be forwarded to edit toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val editToolbar: EditToolbar = mock()
         toolbar.editToolbar = editToolbar
@@ -406,7 +404,7 @@ class BrowserToolbarTest {
     @Test
     fun `cast to view`() {
         // Given
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         // When
         val view = toolbar.asView()
@@ -417,7 +415,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `URL update does not override search terms in edit mode`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
         val editToolbar = mock(EditToolbar::class.java)
 
@@ -439,7 +437,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `add navigation action will be forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
         toolbar.displayToolbar = displayToolbar
 
@@ -454,7 +452,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `invalidate actions is forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
         toolbar.displayToolbar = displayToolbar
 
@@ -467,7 +465,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `search terms (if set) are forwarded to edit toolbar instead of URL`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val ediToolbar = mock(EditToolbar::class.java)
         toolbar.editToolbar = ediToolbar
@@ -486,7 +484,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `urlBoxBackgroundDrawable, browserActionMargin and urlBoxMargin are forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = toolbar.displayToolbar
 
         assertNull(displayToolbar.urlBoxView)
@@ -505,7 +503,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `onUrlClicked is forwarded to display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val displayToolbar = toolbar.displayToolbar
 
         assertTrue(displayToolbar.onUrlClicked())
@@ -517,7 +515,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `onUrlLongClick is forwarded to the display toolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         var hasBeenLongClicked = false
 
@@ -538,15 +536,15 @@ class BrowserToolbarTest {
 
     @Test
     fun `layout of children will factor in padding`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.setPadding(50, 20, 60, 15)
         toolbar.removeAllViews()
 
-        val displayToolbar = spy(DisplayToolbar(context, toolbar)).also {
+        val displayToolbar = spy(DisplayToolbar(testContext, toolbar)).also {
             toolbar.displayToolbar = it
         }
 
-        val editToolbar = spy(EditToolbar(context, toolbar)).also {
+        val editToolbar = spy(EditToolbar(testContext, toolbar)).also {
             toolbar.editToolbar = it
         }
 
@@ -573,7 +571,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `editListener is set on EditToolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertNull(toolbar.editToolbar.editListener)
 
         val listener: Toolbar.OnEditListener = mock()
@@ -584,7 +582,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `editListener is invoked when switching between modes`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val listener: Toolbar.OnEditListener = mock()
         toolbar.setOnEditListener(listener)
@@ -602,7 +600,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `editListener is invoked when text changes`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         val listener: Toolbar.OnEditListener = mock()
         toolbar.setOnEditListener(listener)
@@ -622,7 +620,7 @@ class BrowserToolbarTest {
     @Test
     fun `BrowserToolbar Button must set padding`() {
         var button = BrowserToolbar.Button(mock(), "imageResource", visible = { true }) {}
-        val linearLayout = LinearLayout(context)
+        val linearLayout = LinearLayout(testContext)
         var view = button.createView(linearLayout)
         val padding = Padding(0, 0, 0, 0)
         assertEquals(view.paddingLeft, ACTION_PADDING_DP)
@@ -664,7 +662,7 @@ class BrowserToolbarTest {
             selected = false,
             background = 0
         ) {}
-        val linearLayout = LinearLayout(context)
+        val linearLayout = LinearLayout(testContext)
         var view = button.createView(linearLayout)
         assertEquals(view.paddingLeft, ACTION_PADDING_DP)
         assertEquals(view.paddingTop, ACTION_PADDING_DP)
@@ -702,7 +700,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `hint changes edit and display urlView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertNull(toolbar.displayToolbar.urlView.hint)
         assertNull(toolbar.editToolbar.urlView.hint)
@@ -717,7 +715,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `hintColor changes edit and display urlView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertTrue(toolbar.displayToolbar.urlView.currentHintTextColor != Color.RED)
         assertTrue(toolbar.editToolbar.urlView.currentHintTextColor != Color.RED)
@@ -730,7 +728,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `textColor changes edit and display urlView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertTrue(toolbar.displayToolbar.urlView.currentTextColor != Color.RED)
         assertTrue(toolbar.editToolbar.urlView.currentTextColor != Color.RED)
@@ -743,7 +741,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `textSize changes edit and display urlView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertTrue(toolbar.displayToolbar.urlView.textSize != 12f)
         assertTrue(toolbar.editToolbar.urlView.textSize != 12f)
@@ -756,7 +754,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `titleTextSize changes display titleView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertTrue(toolbar.displayToolbar.titleView.textSize != 12f)
 
@@ -767,7 +765,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `titleTextColor changes display titleView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         toolbar.titleColor = R.color.photonBlue40
 
@@ -776,7 +774,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `titleView visibility is based on being set`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         assertEquals(toolbar.displayToolbar.titleView.visibility, View.GONE)
         toolbar.title = "Mozilla"
@@ -787,7 +785,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `titleView text is set properly`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
 
         toolbar.title = "Mozilla"
         assertEquals(toolbar.displayToolbar.titleView.text, "Mozilla")
@@ -795,7 +793,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `typeface changes edit and display urlView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val typeface: Typeface = mock()
 
         assertNotEquals(typeface, toolbar.editToolbar.urlView.typeface)
@@ -811,7 +809,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `obtainAttributes called when attributes provided`() {
-        val application = spy(context)
+        val application = spy(testContext)
         val attributeSet: AttributeSet = mock()
 
         BrowserToolbar(application)
@@ -823,7 +821,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `displaySiteSecurityIcon getter and setter`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertEquals(toolbar.displayToolbar.siteSecurityIconView.isVisible(), toolbar.displaySiteSecurityIcon)
 
         toolbar.displaySiteSecurityIcon = false
@@ -835,31 +833,31 @@ class BrowserToolbarTest {
 
     @Test
     fun `urlBoxView getter`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertEquals(toolbar.displayToolbar.urlBoxView, toolbar.urlBoxView)
     }
 
     @Test
     fun `browserActionMargin getter`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertEquals(toolbar.displayToolbar.browserActionMargin, toolbar.browserActionMargin)
     }
 
     @Test
     fun `urlBoxMargin getter`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertEquals(toolbar.displayToolbar.urlBoxMargin, toolbar.urlBoxMargin)
     }
 
     @Test
     fun `onUrlClicked getter`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         assertEquals(toolbar.displayToolbar.onUrlClicked, toolbar.onUrlClicked)
     }
 
     @Test
     fun `setUrlTextPadding applies padding to urlView`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.setUrlTextPadding(5, 5, 5, 5)
         assertEquals(5, toolbar.displayToolbar.urlView.paddingLeft)
         assertEquals(5, toolbar.displayToolbar.urlView.paddingTop)
@@ -917,7 +915,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `siteSecure updates the displayToolbar`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.displayToolbar = spy(toolbar.displayToolbar)
         assertEquals(SiteSecurity.INSECURE, toolbar.siteSecure)
 
@@ -928,7 +926,7 @@ class BrowserToolbarTest {
 
     @Test
     fun `private flag sets IME_FLAG_NO_PERSONALIZED_LEARNING on url edit view`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val editToolbar = toolbar.editToolbar
 
         // By default "private mode" is off.

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -45,6 +45,14 @@ interface Toolbar {
     var siteSecure: SiteSecurity
 
     /**
+     * Returns **true** if toolbar is currently in URL editing mode, **false** otherwise.
+     *
+     * @see editMode
+     * @see displayMode
+     */
+    val isInUrlEditMode: Boolean
+
+    /**
      * Displays the currently used search terms as part of this Toolbar.
      *
      * @param searchTerms the search terms used by the current session

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -36,6 +36,8 @@ class ToolbarAutocompleteFeatureTest {
         override var siteSecure: Toolbar.SiteSecurity = Toolbar.SiteSecurity.INSECURE
         override var private: Boolean = false
 
+        override val isInUrlEditMode: Boolean get() = fail()
+
         var autocompleteFilter: (suspend (String, AutocompleteDelegate) -> Unit)? = null
 
         override fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit) {

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -16,9 +16,9 @@ import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.AutocompleteResult
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.test.any
+import mozilla.components.support.test.fail
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -38,54 +38,31 @@ class ToolbarAutocompleteFeatureTest {
 
         var autocompleteFilter: (suspend (String, AutocompleteDelegate) -> Unit)? = null
 
-        override fun setSearchTerms(searchTerms: String) {
-            fail()
-        }
-
-        override fun displayProgress(progress: Int) {
-            fail()
-        }
-
-        override fun onBackPressed(): Boolean {
-            fail()
-            return false
-        }
-
-        override fun setOnUrlCommitListener(listener: (String) -> Boolean) {
-            fail()
-        }
-
         override fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit) {
             autocompleteFilter = filter
         }
 
-        override fun addBrowserAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun setSearchTerms(searchTerms: String) = fail()
 
-        override fun addPageAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun displayProgress(progress: Int) = fail()
 
-        override fun addNavigationAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun onBackPressed() = fail()
 
-        override fun setOnEditListener(listener: Toolbar.OnEditListener) {
-            fail()
-        }
+        override fun setOnUrlCommitListener(listener: (String) -> Boolean) = fail()
 
-        override fun displayMode() {
-            fail()
-        }
+        override fun addBrowserAction(action: Toolbar.Action) = fail()
 
-        override fun editMode() {
-            fail()
-        }
+        override fun addPageAction(action: Toolbar.Action) = fail()
 
-        override fun addEditAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun addNavigationAction(action: Toolbar.Action) = fail()
+
+        override fun setOnEditListener(listener: Toolbar.OnEditListener) = fail()
+
+        override fun displayMode() = fail()
+
+        override fun editMode() = fail()
+
+        override fun addEditAction(action: Toolbar.Action) = fail()
     }
 
     @Test

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -9,8 +9,8 @@ package mozilla.components.feature.toolbar
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.test.fail
 import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
@@ -25,54 +25,31 @@ class ToolbarInteractorTest {
         override var private: Boolean = false
         override var title: String = ""
 
-        override fun setSearchTerms(searchTerms: String) {
-            fail()
-        }
-
-        override fun displayProgress(progress: Int) {
-            fail()
-        }
-
-        override fun onBackPressed(): Boolean {
-            fail()
-            return false
-        }
-
         override fun setOnUrlCommitListener(listener: (String) -> Boolean) {
             listener("https://mozilla.org")
         }
 
-        override fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit) {
-            fail()
-        }
+        override fun setSearchTerms(searchTerms: String) = fail()
 
-        override fun addBrowserAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun displayProgress(progress: Int) = fail()
 
-        override fun addPageAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun onBackPressed() = fail()
 
-        override fun addNavigationAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit) = fail()
 
-        override fun setOnEditListener(listener: Toolbar.OnEditListener) {
-            fail()
-        }
+        override fun addBrowserAction(action: Toolbar.Action) = fail()
 
-        override fun displayMode() {
-            fail()
-        }
+        override fun addPageAction(action: Toolbar.Action) = fail()
 
-        override fun editMode() {
-            fail()
-        }
+        override fun addNavigationAction(action: Toolbar.Action) = fail()
 
-        override fun addEditAction(action: Toolbar.Action) {
-            fail()
-        }
+        override fun setOnEditListener(listener: Toolbar.OnEditListener) = fail()
+
+        override fun displayMode() = fail()
+
+        override fun editMode() = fail()
+
+        override fun addEditAction(action: Toolbar.Action) = fail()
     }
     @Test
     fun `provide custom use case for loading url`() {

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -29,6 +29,8 @@ class ToolbarInteractorTest {
             listener("https://mozilla.org")
         }
 
+        override val isInUrlEditMode: Boolean get() = fail()
+
         override fun setSearchTerms(searchTerms: String) = fail()
 
         override fun displayProgress(progress: Int) = fail()

--- a/components/support/test/src/main/java/mozilla/components/support/test/Assert.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/Assert.kt
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+@file:JvmName("AssertUtils")
+
+package mozilla.components.support.test
+
+/**
+ * Throw assertion error.
+ *
+ * @param message optional message for error
+ */
+@JvmOverloads
+fun fail(message: String? = null): Nothing {
+    message ?: throw AssertionError()
+
+    throw AssertionError(message)
+}

--- a/components/support/test/src/main/java/mozilla/components/support/test/Assert.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/Assert.kt
@@ -15,7 +15,9 @@ package mozilla.components.support.test
  */
 @JvmOverloads
 fun fail(message: String? = null): Nothing {
-    message ?: throw AssertionError()
-
-    throw AssertionError(message)
+    throw if (message != null) {
+        AssertionError(message)
+    } else {
+        AssertionError()
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,9 @@ permalink: /changelog/
   * Added `onWebAppManifestLoaded` to `EngineSession`, called when the engine finds a web app manifest.
   * Added `WebAppManifest` from browser-session.
 
+* **concept-toolbar**
+  * Added `isInEditMode()` to `Toolbar` and `BrowserToolbar`.
+
 * **concept-sync**, **service-accounts**
   * ⚠️ **This is a breaking behavior change**: API changes to facilitate error handling; new method on AccountObserver interface.
   * Added `onAuthenticationProblems` observer method, used for indicating that account needs to re-authenticate (e.g. after a password change).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,12 @@ permalink: /changelog/
 * **engine-system**:
   * Added `EngineView.canScrollVerticallyUp()` for pull to refresh.
 
+* **support-test**
+  * Added Kotlin-friendly `fail()` that returns `Nothing`. Usage:
+  ```kotlin
+  fun returnsSomething(): MyObject = fail("Optional message")
+  ```
+
 * **service-glean**
   * Disabling telemetry through `setUploadEnabled` now clears all metrics (except first_run_date) immediately.
 


### PR DESCRIPTION
### Issue [fenix/#1366](https://github.com/mozilla-mobile/fenix/issues/1366)

Companion PR [fenix/#2908](https://github.com/mozilla-mobile/fenix/pull/2908)

### Changes

First commit:
  - Added Kotlin-friendly `fail()` method for tests. It returns `Nothing` thus can be used everywhere where `Any` expected.

Second commit:
  - Added `Toolbar.isInUrlEditMode` property with tests.

P.S. You can take a look at companion PR to get context for this changes.

### Complexity

Simple (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~