### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `service-glean` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -13,7 +13,6 @@ object KotlinCompiler {
     @JvmStatic
     val projectsWithWarningsAsErrorsDisabled = setOf(
         "browser-domains",
-        "feature-prompts",
-        "service-glean"
+        "feature-prompts"
     )
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -22,22 +22,21 @@ import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.private.StringMetricType
-import mozilla.components.service.glean.private.TimeUnit as GleanTimeUnit
 import mozilla.components.service.glean.private.UuidMetricType
-import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.StorageEngineManager
+import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.utils.getLanguageFromLocale
 import mozilla.components.service.glean.utils.getLocaleTag
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,11 +48,12 @@ import org.robolectric.RobolectricTestRunner
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
-import java.lang.AssertionError
+import java.time.Instant
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import mozilla.components.service.glean.private.TimeUnit as GleanTimeUnit
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -373,7 +373,8 @@ class GleanTest {
             sendInPings = listOf("glean_ping_info"),
             timeUnit = GleanTimeUnit.Day
         )
-        firstRunDateMetric.set(Date(2200, 1, 1))
+        firstRunDateMetric.set(Date.from(
+            Instant.parse("2200-01-01T00:00:00.00Z")))
 
         assertTrue(GleanInternalMetrics.clientId.testHasValue())
         assertTrue(GleanInternalMetrics.firstRunDate.testHasValue())

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
@@ -4,22 +4,19 @@
 
 package mozilla.components.service.glean.private
 
-import android.content.Context
 import android.os.SystemClock
-import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
-import org.junit.Test
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 // Declared here, since Kotlin can not declare nested enum classes.
 enum class clickKeys {
@@ -184,8 +181,6 @@ class EventMetricTypeTest {
 
     @Test
     fun `events should not record when upload is disabled`() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-
         val eventMetric = EventMetricType<testNameKeys>(
             disabled = false,
             category = "ui",


### PR DESCRIPTION
### Issue #2346

Extracted `.convertAllowedToStrings()` and improved it's readability.

### Complexity

Easy+ (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~