### PR TITLE
Issue #2364: getItemId is not synchronized

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
@@ -7,7 +7,6 @@ package mozilla.components.browser.awesomebar
 import android.content.Context
 import android.util.AttributeSet
 import android.util.LruCache
-import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -185,15 +184,14 @@ class BrowserAwesomeBar @JvmOverloads constructor(
 
     /**
      * Returns a unique suggestion ID to make sure ID's can't collide
-     * across providers. This method is not thread-safe and must be
-     * invoked on the main thread.
+     * across providers.
      *
      * @param suggestion the suggestion for which a unique ID should be
      * generated.
      *
      * @return the unique ID.
      */
-    @MainThread
+    @Synchronized
     fun getUniqueSuggestionId(suggestion: AwesomeBar.Suggestion): Long {
         val key = suggestion.provider.id + "/" + suggestion.id
         return uniqueSuggestionIds[key] ?: run {

--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
@@ -111,7 +111,7 @@ internal class SuggestionsAdapter(
         return ViewHolderWrapper(layout.createViewHolder(awesomeBar, view, viewType), view)
     }
 
-    override fun getItemId(position: Int): Long {
+    override fun getItemId(position: Int): Long = synchronized(suggestions) {
         val suggestion = suggestions[position]
         return awesomeBar.getUniqueSuggestionId(suggestion)
     }


### PR DESCRIPTION
@pocmo digging further into remaining possible causes of https://github.com/mozilla-mobile/android-components/issues/2364, I just saw that we have all but one method synchronized in `SuggestionsAdapter`, which doesn't seem right.

If `removeProviders` or `allProviders` (and therefore removeSuggestions or addSuggestions) are ever not called on the main thread this would cause trouble. I haven't been able to observe any of these not being called on the main thread, but since we're synchronizing all other methods, we should add the same guard here?

