### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `browser-storage-sync` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -14,7 +14,6 @@ object KotlinCompiler {
     val projectsWithWarningsAsErrorsDisabled = setOf(
         "browser-domains",
         "browser-engine-servo",
-        "browser-storage-sync",
         "feature-accounts",
         "feature-contextmenu",
         "feature-downloads",

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.concept.storage.BookmarkInfo
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +17,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class PlacesBookmarksStorageTest {
@@ -34,7 +34,7 @@ class PlacesBookmarksStorageTest {
     private val newSeparator = BookmarkNode(BookmarkNodeType.SEPARATOR, "654", "987",
             null, null, null, null)
 
-    class TestablePlacesBookmarksStorage(override val places: Connection) : PlacesBookmarksStorage(RuntimeEnvironment.application)
+    class TestablePlacesBookmarksStorage(override val places: Connection) : PlacesBookmarksStorage(testContext)
 
     @Before
     fun setup() {

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.storage.VisitType
 import mozilla.components.concept.sync.AuthInfo
 import mozilla.components.concept.sync.SyncStatus
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -23,10 +24,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class PlacesHistoryStorageTest {
+
     private lateinit var history: PlacesHistoryStorage
 
     @Before
@@ -469,7 +470,7 @@ class PlacesHistoryStorageTest {
 
     // We can't test 'sync' stuff yet, since that exercises the network and we can't mock that out currently.
     // Instead, we test that our wrappers act correctly.
-    class MockingPlacesHistoryStorage(override val places: Connection) : PlacesHistoryStorage(RuntimeEnvironment.application)
+    class MockingPlacesHistoryStorage(override val places: Connection) : PlacesHistoryStorage(testContext)
 
     @Test
     fun `storage passes through sync calls`() = runBlocking {


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~