### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `feature-sitepermissions` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -19,7 +19,6 @@ object KotlinCompiler {
         "feature-downloads",
         "feature-prompts",
         "feature-search",
-        "feature-sitepermissions",
         "service-glean",
         "support-test",
         "ui-tabcounter"

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
@@ -12,16 +12,16 @@ import android.widget.Button
 import android.widget.CheckBox
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature.PromptsStyling
 import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 
@@ -30,7 +30,7 @@ class SitePermissionsDialogFragmentTest {
 
     private val context: Context
         get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext(),
+            testContext,
             R.style.Theme_AppCompat
         )
 

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
@@ -5,12 +5,10 @@
 package mozilla.components.feature.sitepermissions
 
 import android.Manifest
-import android.content.Context
 import android.content.pm.PackageManager.PERMISSION_DENIED
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -24,13 +22,14 @@ import mozilla.components.concept.engine.permission.Permission.ContentVideoCamer
 import mozilla.components.concept.engine.permission.Permission.ContentVideoCapture
 import mozilla.components.concept.engine.permission.Permission.Generic
 import mozilla.components.concept.engine.permission.PermissionRequest
-import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
+import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -40,9 +39,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.anyString
-import org.mockito.Mockito.verify
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import java.security.InvalidParameterException
 import java.util.UUID
@@ -55,7 +54,6 @@ class SitePermissionsFeatureTest {
     private lateinit var mockOnNeedToRequestPermissions: OnNeedToRequestPermissions
     private lateinit var mockStorage: SitePermissionsStorage
     private lateinit var mockFragmentManager: FragmentManager
-    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Before
     fun setup() {
@@ -66,7 +64,7 @@ class SitePermissionsFeatureTest {
         mockFragmentManager = mockFragmentManager()
 
         sitePermissionFeature = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = mockOnNeedToRequestPermissions,
             storage = mockStorage,
@@ -82,7 +80,7 @@ class SitePermissionsFeatureTest {
         var wasCalled = false
 
         sitePermissionFeature = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = {
                 wasCalled = true
@@ -103,7 +101,7 @@ class SitePermissionsFeatureTest {
         val session = getSelectedSession()
 
         sitePermissionFeature = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = {
             },
@@ -129,7 +127,7 @@ class SitePermissionsFeatureTest {
         var wasCalled = false
 
         sitePermissionFeature = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = {
                 wasCalled = true
@@ -164,7 +162,7 @@ class SitePermissionsFeatureTest {
         var wasCalled = false
 
         sitePermissionFeature = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = {
                 wasCalled = true
@@ -339,7 +337,7 @@ class SitePermissionsFeatureTest {
             doReturn(permissions).`when`(mockRequest).permissions
 
             val feature = SitePermissionsFeature(
-                context = context,
+                context = testContext,
                 sessionManager = mockSessionManager,
                 fragmentManager = mockFragmentManager,
                 onNeedToRequestPermissions = mockOnNeedToRequestPermissions,
@@ -657,7 +655,7 @@ class SitePermissionsFeatureTest {
     fun `calling onPermissionsResult on a feature session with a sessionId will call grant on the permissionsRequest and consume it`() {
         val session = Session("", id = "sessionIdCustomTabs")
         sitePermissionFeature = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionId = "sessionIdCustomTabs",
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = mockOnNeedToRequestPermissions,

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsRulesTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsRulesTest.kt
@@ -4,9 +4,7 @@
 
 package mozilla.components.feature.sitepermissions
 
-import android.content.Context
 import android.view.View
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.permission.Permission.ContentAudioCapture
@@ -18,6 +16,7 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ASK_TO_ALLOW
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BLOCKED
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -34,18 +33,17 @@ class SitePermissionsRulesTest {
     private lateinit var rules: SitePermissionsFeature
     private lateinit var mockOnNeedToRequestPermissions: OnNeedToRequestPermissions
     private lateinit var mockStorage: SitePermissionsStorage
-    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Before
     fun setup() {
         val engine = Mockito.mock(Engine::class.java)
-        anchorView = View(ApplicationProvider.getApplicationContext())
+        anchorView = View(testContext)
         mockSessionManager = Mockito.spy(SessionManager(engine))
         mockOnNeedToRequestPermissions = mock()
         mockStorage = mock()
 
         rules = SitePermissionsFeature(
-            context = context,
+            context = testContext,
             sessionManager = mockSessionManager,
             onNeedToRequestPermissions = mockOnNeedToRequestPermissions,
             storage = mockStorage,


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~