### PR TITLE
For #2346. Enable kotlin warningsAsErrors for `feature-downloads` module.

### DIFF
--- a/buildSrc/src/main/java/KotlinCompiler.kt
+++ b/buildSrc/src/main/java/KotlinCompiler.kt
@@ -16,7 +16,6 @@ object KotlinCompiler {
         "browser-engine-servo",
         "browser-storage-sync",
         "feature-accounts",
-        "feature-downloads",
         "feature-prompts",
         "feature-search",
         "feature-sitepermissions",

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -95,7 +95,10 @@ class DownloadsFeature(
      * Notifies the feature that the permissions request was completed. It will then
      * either trigger or clear the pending download.
      */
-    fun onPermissionsResult(permissions: Array<String>, grantResults: IntArray) {
+    fun onPermissionsResult(
+        @Suppress("UNUSED_PARAMETER") permissions: Array<String>,
+        @Suppress("UNUSED_PARAMETER") grantResults: IntArray
+    ) {
         if (applicationContext.isPermissionGranted(INTERNET, WRITE_EXTERNAL_STORAGE)) {
             activeSession?.let { session ->
                 session.download.consume {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt
@@ -4,10 +4,10 @@
 
 package mozilla.components.feature.downloads
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import mozilla.components.browser.session.Download
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.KEY_FILE_NAME
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,7 +21,6 @@ class DownloadDialogFragmentTest {
 
     @Before
     fun setup() {
-
         dialog = object : DownloadDialogFragment() {}
         download = Download(
             "http://ipv4.download.thinkbroadband.com/5MB.zip",

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadManagerTest.kt
@@ -8,12 +8,11 @@ import android.Manifest.permission.INTERNET
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
 import android.app.DownloadManager.Request
-import android.content.Context
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
 import mozilla.components.browser.session.Download
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -29,8 +28,6 @@ class DownloadManagerTest {
 
     private lateinit var download: Download
     private lateinit var downloadManager: DownloadManager
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Before
     fun setup() {
@@ -39,7 +36,7 @@ class DownloadManagerTest {
             "", "application/zip", 5242880,
             "Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"
         )
-        downloadManager = DownloadManager(context)
+        downloadManager = DownloadManager(testContext)
     }
 
     @Test(expected = SecurityException::class)
@@ -126,7 +123,7 @@ class DownloadManagerTest {
     private fun notifyDownloadCompleted(id: Long) {
         val intent = Intent(ACTION_DOWNLOAD_COMPLETE)
         intent.putExtra(android.app.DownloadManager.EXTRA_DOWNLOAD_ID, id)
-        context.sendBroadcast(intent)
+        testContext.sendBroadcast(intent)
     }
 
     private fun grantPermissions() {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -6,11 +6,8 @@ package mozilla.components.feature.downloads
 
 import android.Manifest.permission.INTERNET
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-import android.content.Context
 import androidx.core.content.PermissionChecker
 import androidx.fragment.app.FragmentManager
-import androidx.test.core.app.ApplicationProvider
-import org.junit.Assert.assertTrue
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -18,22 +15,24 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.FRAGMENT_TAG
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
-import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.grantPermission
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.spy
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verifyNoMoreInteractions
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -42,20 +41,21 @@ class DownloadsFeatureTest {
     private lateinit var feature: DownloadsFeature
     private lateinit var mockDownloadManager: DownloadManager
     private lateinit var mockSessionManager: SessionManager
-    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Before
     fun setup() {
         val engine = mock(Engine::class.java)
         mockSessionManager = spy(SessionManager(engine))
         mockDownloadManager = mock()
-        feature = DownloadsFeature(context, downloadManager = mockDownloadManager, sessionManager = mockSessionManager)
+        feature = DownloadsFeature(testContext,
+            downloadManager = mockDownloadManager,
+            sessionManager = mockSessionManager)
     }
 
     @Test
     fun `when valid sessionId is provided, observe it's session`() {
         feature = spy(DownloadsFeature(
-            context,
+            testContext,
             downloadManager = mockDownloadManager,
             sessionManager = mockSessionManager,
             sessionId = "123"
@@ -71,7 +71,7 @@ class DownloadsFeatureTest {
     @Test
     fun `when sessionId is NOT provided, observe selected session`() {
         feature = spy(DownloadsFeature(
-            context,
+            testContext,
             downloadManager = mockDownloadManager,
             sessionManager = mockSessionManager
         ))
@@ -193,8 +193,11 @@ class DownloadsFeatureTest {
 
         val featureWithDialog =
             DownloadsFeature(
-                context, downloadManager = mockDownloadManager, sessionManager = mockSessionManager,
-                fragmentManager = mockFragmentManager, dialog = mockDialog
+                testContext,
+                downloadManager = mockDownloadManager,
+                sessionManager = mockSessionManager,
+                fragmentManager = mockFragmentManager,
+                dialog = mockDialog
             )
 
         grantPermissions()
@@ -223,7 +226,7 @@ class DownloadsFeatureTest {
 
         val feature =
             DownloadsFeature(
-                context,
+                testContext,
                 downloadManager = mockDownloadManager,
                 sessionId = "sessionId",
                 sessionManager = mockSessionManager,
@@ -251,7 +254,7 @@ class DownloadsFeatureTest {
 
         val feature =
             DownloadsFeature(
-                context,
+                testContext,
                 downloadManager = mockDownloadManager,
                 sessionId = "sessionId",
                 sessionManager = mockSessionManager,
@@ -272,7 +275,9 @@ class DownloadsFeatureTest {
 
         val featureWithDialog =
             DownloadsFeature(
-                context, downloadManager = mockDownloadManager, sessionManager = mockSessionManager,
+                testContext,
+                downloadManager = mockDownloadManager,
+                sessionManager = mockSessionManager,
                 fragmentManager = mockFragmentManager
             )
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt
@@ -9,13 +9,13 @@ import android.content.DialogInterface.BUTTON_POSITIVE
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentManager
 import mozilla.components.browser.session.Download
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -46,7 +46,7 @@ class SimpleDownloadDialogFragmentTest {
         }
 
         dialog.onStartDownload = onStartDownload
-        dialog.testingContext = RuntimeEnvironment.application
+        dialog.testingContext = testContext
 
         performClick(BUTTON_POSITIVE)
 


### PR DESCRIPTION
### Issue #2346

Trivial changes in tests.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~