### PR TITLE
Don't say 'metrics ping already collected' in fresh installs

### DIFF
--- a/components/service/glean/docs/pings/metrics.md
+++ b/components/service/glean/docs/pings/metrics.md
@@ -10,17 +10,22 @@ length of this window.
 
 ## Scheduling
 The desired behaviour is to collect the ping at the first available opportunity after 4AM local
-time on a new calendar day. This breaks down into two scenarios:
+time on a new calendar day. This breaks down into three scenarios:
 
-1. the application was just started (after a crash or a long inactivity period);
-2. the application was open and the 4AM due time was hit.
+1. the application was just installed;
+2. the application was just started (after a crash or a long inactivity period);
+3. the application was open and the 4AM due time was hit;
 
-In the first case, if the `metrics` ping was already collected on the current calendar day, a new
+In the first case, since the application was just installed, if the due time for the current calendar
+day has passed, a `metrics` ping is immediately generated and scheduled for sending. Otherwise, if the
+due time for the current calendar day has not passed, a ping collection is scheduled for that time.
+
+In the second case, if the `metrics` ping was already collected on the current calendar day, a new
 collection will be scheduled for the next calendar day, at 4AM. If no collection happened yet,
 and the due time for the current calendar day has passed, a `metrics` ping is immediately generated
 and scheduled for sending.
 
-In the second case, similarly to the previous case, if the `metrics` ping was already collected on the
+In the third case, similarly to the previous case, if the `metrics` ping was already collected on the
 current calendar day when we hit 4AM, then a new collection is scheduled for the next calendar day.
 Otherwise, the `metrics` is immediately collected and scheduled for sending.
 


### PR DESCRIPTION
On fresh installs of products using glean, when no date is available for when the 'metrics' ping was sent, don't provide "today" as the default date: no ping would be sent otherwise, and it will delegate sending to the next day. This adds the missing scenario to the ping docs.

@chutten would you kindly review the additions to the `metrics.md` file? 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
