### PR TITLE
Implement canScrollVerticallyUp in gecko beta

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -56,6 +56,7 @@ class GeckoEngineSession(
 
     internal lateinit var geckoSession: GeckoSession
     internal var currentUrl: String? = null
+    internal var scrollY: Int = 0
     internal var job: Job = Job()
     private var lastSessionState: GeckoSession.SessionState? = null
     private var stateBeforeCrash: GeckoSession.SessionState? = null
@@ -565,6 +566,12 @@ class GeckoEngineSession(
         }
     }
 
+    private fun createScrollDelegate() = object : GeckoSession.ScrollDelegate {
+        override fun onScrollChanged(session: GeckoSession, scrollX: Int, scrollY: Int) {
+            this@GeckoEngineSession.scrollY = scrollY
+        }
+    }
+
     @Suppress("ComplexMethod")
     fun handleLongClick(elementSrc: String?, elementType: Int, uri: String? = null): HitResult? {
         return when (elementType) {
@@ -621,6 +628,7 @@ class GeckoEngineSession(
         geckoSession.promptDelegate = GeckoPromptDelegate(this)
         geckoSession.historyDelegate = createHistoryDelegate()
         geckoSession.mediaDelegate = GeckoMediaDelegate(this)
+        geckoSession.scrollDelegate = createScrollDelegate()
     }
 
     companion object {

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -91,6 +91,8 @@ class GeckoEngineView @JvmOverloads constructor(
         currentSession?.apply { unregister(observer) }
     }
 
+    override fun canScrollVerticallyUp() = currentSession?.let { it.scrollY > 0 } != false
+
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
     override fun setVerticalClipping(clippingHeight: Int) {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -91,10 +91,7 @@ class GeckoEngineView @JvmOverloads constructor(
         currentSession?.apply { unregister(observer) }
     }
 
-    override fun canScrollVerticallyUp(): Boolean {
-        val result = currentSession?.let { it.scrollY > 0 } != false
-        return result
-    }
+    override fun canScrollVerticallyUp() = currentSession?.let { it.scrollY > 0 } != false
 
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,10 +35,8 @@ permalink: /changelog/
   * `OAuthAccount` and `DeviceConstellation` methods that returned `Deferred<T>` (for some T) now return `Deferred<T?>`, where `null` means failure.
   * `FirefoxAccount`, `FirefoxDeviceConstellation` and `FirefoxDeviceManager` now handle all expected `FxAException`.
 
-* **engine-gecko-nightly**, **engine-system**, **concept-engine**:
-  * Added `EngineView.canScrollVerticallyUp()` for pull to refresh.
-
 * **engine-gecko-nightly**, **engine-gecko-beta**, **concept-engine**
+  * Added `EngineView.canScrollVerticallyUp()` for pull to refresh.
   * Added engine API to clear browsing data.
 
   ```kotlin
@@ -52,6 +50,9 @@ permalink: /changelog/
   engine.clearData(BrowsingData.select(BrowsingData.COOKIES), host = "mozilla.org")
   ```
 
+* **engine-system**:
+  * Added `EngineView.canScrollVerticallyUp()` for pull to refresh.
+
 * **service-glean**
   * Disabling telemetry through `setUploadEnabled` now clears all metrics (except first_run_date) immediately.
 
@@ -60,7 +61,7 @@ permalink: /changelog/
 
 * **feature-tab-collections**
   * Added option to remove all collections and their tabs: `TabCollectionStorage.removeAllCollections()`.
-  
+
 * **feature-media**
   * Added `RecordingDevicesNotificationFeature` to show an ongoing notification while recording devices (camera, microphone) are used by web content.
 


### PR DESCRIPTION
This allows `SwipeRefreshFeature` to work on gecko-engine-beta.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
