### PR TITLE
For #3213: Sets max text size for browser toolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -682,9 +682,9 @@ class BrowserToolbar @JvmOverloads constructor(
     }
 
     companion object {
-        private const val MAX_TITLE_SIZE = 10f
-        private const val MAX_TEXT_SIZE_WITH_TITLE = 8f
-        private const val MAX_TEXT_SIZE = 20f
+        internal const val MAX_TITLE_SIZE = 10f
+        internal const val MAX_TEXT_SIZE_WITH_TITLE = 8f
+        internal const val MAX_TEXT_SIZE = 20f
         private const val DEFAULT_TOOLBAR_HEIGHT_DP = 56
         internal const val ACTION_PADDING_DP = 16
         internal val DEFAULT_PADDING =

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -212,22 +212,26 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     /**
-     * Sets the size of the text for the title displayed in the toolbar.
+     * Sets the size of the text for the title displayed in the toolbar up to the MAX_TITLE_SIZE
+     * Also resizes url text size to accommodate the title.
      */
     var titleTextSize: Float
         get() = displayToolbar.titleView.textSize
         set(value) {
-            displayToolbar.titleView.textSize = value
+            val newSize = minOf(value, MAX_TITLE_SIZE)
+            displayToolbar.titleView.textSize = newSize
+            textSize = MAX_TEXT_SIZE_WITH_TITLE
         }
 
     /**
-     * Sets the size of the text for the URL/search term displayed in the toolbar.
+     * Sets the size of the text for the URL/search term displayed in the toolbar up to the MAX_TITLE_SIZE.
      */
     var textSize: Float
         get() = displayToolbar.urlView.textSize
         set(value) {
-            displayToolbar.urlView.textSize = value
-            editToolbar.urlView.textSize = value
+            val newSize = minOf(value, MAX_TEXT_SIZE)
+            displayToolbar.urlView.textSize = newSize
+            editToolbar.urlView.textSize = newSize
         }
 
     /**
@@ -678,6 +682,9 @@ class BrowserToolbar @JvmOverloads constructor(
     }
 
     companion object {
+        private const val MAX_TITLE_SIZE = 10f
+        private const val MAX_TEXT_SIZE_WITH_TITLE = 8f
+        private const val MAX_TEXT_SIZE = 20f
         private const val DEFAULT_TOOLBAR_HEIGHT_DP = 56
         internal const val ACTION_PADDING_DP = 16
         internal val DEFAULT_PADDING =

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -758,11 +758,42 @@ class BrowserToolbarTest {
     fun `titleTextSize changes display titleView`() {
         val toolbar = BrowserToolbar(context)
 
-        assertTrue(toolbar.displayToolbar.titleView.textSize != 12f)
+        assertTrue(toolbar.displayToolbar.titleView.textSize != 4f)
 
+        toolbar.titleTextSize = 4f
+
+        assertEquals(4f, toolbar.displayToolbar.titleView.textSize)
+    }
+
+    @Test
+    fun `setting titleTextSize updated textSize`() {
+        val toolbar = BrowserToolbar(context)
+
+        assertNotEquals(BrowserToolbar.MAX_TEXT_SIZE_WITH_TITLE, toolbar.displayToolbar.urlView.textSize)
         toolbar.titleTextSize = 12f
+        assertEquals(BrowserToolbar.MAX_TEXT_SIZE_WITH_TITLE, toolbar.displayToolbar.urlView.textSize)
+    }
 
-        assertEquals(12f, toolbar.displayToolbar.titleView.textSize)
+    @Test
+    fun `setting textSize above max sets it to max`() {
+        val toolbar = BrowserToolbar(context)
+
+        assertNotEquals(BrowserToolbar.MAX_TEXT_SIZE, toolbar.displayToolbar.urlView.textSize)
+
+        toolbar.textSize = 100f
+
+        assertEquals(BrowserToolbar.MAX_TEXT_SIZE, toolbar.displayToolbar.urlView.textSize)
+    }
+
+    @Test
+    fun `setting titleTextSize above max sets it to max`() {
+        val toolbar = BrowserToolbar(context)
+
+        assertNotEquals(BrowserToolbar.MAX_TITLE_SIZE, toolbar.displayToolbar.titleView.textSize)
+
+        toolbar.titleTextSize = 100f
+
+        assertEquals(BrowserToolbar.MAX_TITLE_SIZE, toolbar.displayToolbar.titleView.textSize)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-toolbar**
+  * Updated `titleTextSize` and `textSize` to have maximum values which cannot be sized past in order
+    to ensure that their view constraints will not be broken. We do this manually because autoResizeText
+    does not work with views that have a non-fixed height.
+
 # 0.55.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.54.0...v0.55.0)


### PR DESCRIPTION
I paired on this with @csadilek for a while. This is the best solution we could come up with, as `AutoSizingTextViews` don't seem to work with our custom `onMeasure` implementation (likely due to the fact that the height is calculated not set directly).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
