### PR TITLE
Issue #1447 - Depend on "fat" GeckoView build from browser-engine-gecko-nightly.

### DIFF
--- a/automation/taskcluster/androidTest/ui-test.sh
+++ b/automation/taskcluster/androidTest/ui-test.sh
@@ -76,14 +76,12 @@ set +e
 
 if [[ "${device_type,,}" == "x86" ]]
 then
-    deviceType="X86"
     flank_template="$FLANK_CONF_X86"
 else
-    deviceType="Arm"
     flank_template="$FLANK_CONF_ARM"
 fi
 
-APK_APP="./samples/${component}/build/outputs/apk/geckoNightly${deviceType}/debug/samples-browser-geckoNightly-${deviceType,,}-debug.apk"
+APK_APP="./samples/${component}/build/outputs/apk/geckoNightlyUniversal/debug/samples-browser-geckoNightly-universal-debug.apk"
 APK_TEST="./components/${component}/engine-gecko-nightly/build/outputs/apk/androidTest/debug/browser-engine-gecko-nightly-debug-androidTest.apk"
 
 

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -90,7 +90,7 @@ def create_module_tasks(module):
                 ["ServoArm", "ServoX86", "SystemUniversal"],
                 [
                     "GeckoBetaAarch64", "GeckoBetaArm", "GeckoBetaX86",
-                    "GeckoNightlyAarch64", "GeckoNightlyArm", "GeckoNightlyX86",
+                    "GeckoNightlyUniversal",
                     "GeckoReleaseAarch64", "GeckoReleaseArm", "GeckoReleaseX86"
                 ]
             ),

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "69.0.20190529095015"
+    const val nightly_version = "69.0.20190602094449"
 
     /**
      * GeckoView Beta Version.
@@ -21,9 +21,7 @@ internal object GeckoVersions {
 
 @Suppress("MaxLineLength")
 object Gecko {
-    const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${GeckoVersions.nightly_version}"
+    const val geckoview_nightly = "org.mozilla.geckoview:geckoview-nightly:${GeckoVersions.nightly_version}"
 
     const val geckoview_beta_arm = "org.mozilla.geckoview:geckoview-beta-armeabi-v7a:${GeckoVersions.beta_version}"
     const val geckoview_beta_x86 = "org.mozilla.geckoview:geckoview-beta-x86:${GeckoVersions.beta_version}"

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -30,14 +30,12 @@ dependencies {
     implementation project(':concept-engine')
     implementation project(':concept-fetch')
     implementation project(':support-ktx')
-    implementation project(path: ':support-utils')
+    implementation project(':support-utils')
+
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 
-    // We only compile against the ARM artifact. External module will decide which module to provide by build configuration.
-    // As the Kotlin/Java API is the same for all ABIs it is not important which one we import here.
-    compileOnly Gecko.geckoview_nightly_arm
-    testImplementation Gecko.geckoview_nightly_arm
+    implementation Gecko.geckoview_nightly
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
@@ -50,7 +48,6 @@ dependencies {
     androidTestImplementation Dependencies.androidx_test_core
     androidTestImplementation Dependencies.androidx_test_runner
     androidTestImplementation Dependencies.androidx_test_rules
-    androidTestImplementation Gecko.geckoview_nightly_arm
     androidTestImplementation project(':tooling-fetch-tests')
 }
 

--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // We only compile against Sentry and GeckoView. It's up to the app to add those dependencies if it wants to
     // send crash reports to Socorro (GV) or Sentry.
     compileOnly Dependencies.thirdparty_sentry
-    compileOnly Gecko.geckoview_nightly_arm
+    compileOnly Gecko.geckoview_nightly
     testImplementation Dependencies.thirdparty_sentry
 
     testImplementation project(':support-test')

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,9 @@ permalink: /changelog/
 * **engine-system**:
   * Added `EngineView.canScrollVerticallyUp()` for pull to refresh.
 
+* **browser-engine-gecko-nightly**
+  * This component now has a hard dependency on the new [universal GeckoView build](https://bugzilla.mozilla.org/show_bug.cgi?id=1508976) that is no longer architecture specific (ARM, x86, ..). With that apps no longer need to specify the GeckoView build themselves and synchronize the used version with Android Components. Additionally apps can now make use of [APK splits](https://developer.android.com/studio/build/configure-apk-splits) or [Android App Bundles (AAB)](https://developer.android.com/guide/app-bundle).
+
 * **service-glean**
   * Disabling telemetry through `setUploadEnabled` now clears all metrics (except first_run_date) immediately.
 

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -48,7 +48,7 @@ android {
         servo {
             dimension "engine"
         }
-        
+
         // Processor architecture
         arm {
             dimension "abi"
@@ -76,7 +76,13 @@ android {
             setIgnore(true)
         }
 
-        if (flavors.contains("gecko") && flavors.contains("universal")) {
+        // Only allow "universal" flavors of "system" and "geckoviewNightly" engines
+        if (flavors.contains("universal") && !(flavors.contains("system") || flavors.contains("geckonightly"))) {
+            setIgnore(true)
+        }
+
+        // Ignore all non-universal GeckoView Nightly builds
+        if (!flavors.contains("universal") && flavors.contains("geckonightly")) {
             setIgnore(true)
         }
 
@@ -87,10 +93,6 @@ android {
 }
 
 configurations {
-    geckoNightlyArmImplementation {}
-    geckoNightlyX86Implementation {}
-    geckoNightlyAarch64Implementation {}
-
     geckoBetaArmImplementation {}
     geckoBetaX86Implementation {}
     geckoBetaAarch64Implementation {}
@@ -150,9 +152,7 @@ dependencies {
     servoArmImplementation Dependencies.mozilla_servo_arm
 
     geckoNightlyImplementation project(':browser-engine-gecko-nightly')
-    geckoNightlyArmImplementation Gecko.geckoview_nightly_arm
-    geckoNightlyX86Implementation Gecko.geckoview_nightly_x86
-    geckoNightlyAarch64Implementation Gecko.geckoview_nightly_aarch64
+    geckoNightlyImplementation Gecko.geckoview_nightly
 
     geckoBetaImplementation project(':browser-engine-gecko-beta')
     geckoBetaArmImplementation Gecko.geckoview_beta_arm


### PR DESCRIPTION
This will unlock some shiny things:
* We can get rid of mirroring the geckoview version in the app projects (Yay!)
* We can stop using a flavor dimension for different architectures (YAY!)
* We can build and deploy AABs.

... only with GeckoView Nightly for now. The other ones will follow later on.

Looking forward to applying some of those optimizations to RB and start experimenting with AABs - before we later on apply that to Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
