### PR TITLE
Parse web app manifest icon purpose as set

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifest.kt
@@ -91,14 +91,14 @@ data class WebAppManifest(
      * @property sizes A list of image dimensions.
      * @property type A hint as to the media type of the image. The purpose of this member is to allow a user agent to
      * quickly ignore images of media types it does not support.
-     * @property purpose Defines the purpose of the image, for example that the image is intended to serve some special
+     * @property purpose Defines the purposes of the image, for example that the image is intended to serve some special
      * purpose in the context of the host OS (i.e., for better integration).
      */
     data class Icon(
         val src: String,
         val sizes: List<Size> = emptyList(),
         val type: String? = null,
-        val purpose: Purpose = Purpose.ANY
+        val purpose: Set<Purpose> = setOf(Purpose.ANY)
     ) {
         enum class Purpose {
             /**

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
@@ -72,12 +72,12 @@ class WebAppManifestParserTest {
         assertEquals(168, manifest.icons[4].sizes[0].height)
         assertEquals(192, manifest.icons[5].sizes[0].height)
 
-        assertEquals(WebAppManifest.Icon.Purpose.ANY, manifest.icons[0].purpose)
-        assertEquals(WebAppManifest.Icon.Purpose.ANY, manifest.icons[1].purpose)
-        assertEquals(WebAppManifest.Icon.Purpose.ANY, manifest.icons[2].purpose)
-        assertEquals(WebAppManifest.Icon.Purpose.ANY, manifest.icons[3].purpose)
-        assertEquals(WebAppManifest.Icon.Purpose.ANY, manifest.icons[4].purpose)
-        assertEquals(WebAppManifest.Icon.Purpose.ANY, manifest.icons[5].purpose)
+        assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), manifest.icons[0].purpose)
+        assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), manifest.icons[1].purpose)
+        assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), manifest.icons[2].purpose)
+        assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), manifest.icons[3].purpose)
+        assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), manifest.icons[4].purpose)
+        assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), manifest.icons[5].purpose)
     }
 
     @Test
@@ -108,7 +108,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(192, sizes[0].width)
             assertEquals(192, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
 
         manifest.icons[1].apply {
@@ -117,7 +117,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(512, sizes[0].width)
             assertEquals(512, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
     }
 
@@ -150,7 +150,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(192, sizes[0].width)
             assertEquals(192, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
 
         manifest.icons[1].apply {
@@ -159,7 +159,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(512, sizes[0].width)
             assertEquals(512, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
     }
 
@@ -214,7 +214,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(64, sizes[0].width)
             assertEquals(64, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
 
         manifest.icons[1].apply {
@@ -223,7 +223,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(64, sizes[0].width)
             assertEquals(64, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
 
         manifest.icons[2].apply {
@@ -232,7 +232,7 @@ class WebAppManifestParserTest {
             assertEquals(1, sizes.size)
             assertEquals(128, sizes[0].width)
             assertEquals(128, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.ANY, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.ANY), purpose)
         }
     }
 
@@ -276,7 +276,7 @@ class WebAppManifestParserTest {
             assertEquals(96, sizes[1].height)
             assertEquals(128, sizes[2].width)
             assertEquals(128, sizes[2].height)
-            assertEquals(WebAppManifest.Icon.Purpose.BADGE, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.BADGE), purpose)
         }
 
         manifest.icons[1].apply {
@@ -286,7 +286,7 @@ class WebAppManifestParserTest {
             assertEquals("image/png", type)
             assertEquals(512, sizes[0].width)
             assertEquals(512, sizes[0].height)
-            assertEquals(WebAppManifest.Icon.Purpose.MASKABLE, purpose)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.MASKABLE, WebAppManifest.Icon.Purpose.ANY), purpose)
         }
     }
 

--- a/components/concept/engine/src/test/resources/manifests/unusual.json
+++ b/components/concept/engine/src/test/resources/manifests/unusual.json
@@ -12,7 +12,7 @@
       "src": "/images/icon/512-512.png",
       "type": "image/png",
       "sizes": "512x512",
-      "purpose": "maskable"
+      "purpose": "maskable foo any"
     }
   ],
   "start_url": "/start",


### PR DESCRIPTION
https://w3c.github.io/manifest/#dfn-processing-the-purpose-member-of-an-image

Spec defines that the purpose member of an icon in the manifest should be a set, so that an icon can have multiple purposes. I've updated the parser to align with the description in spec.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
