### PR TITLE
Fix UI test job error trigger

### DIFF
--- a/automation/taskcluster/androidTest/ui-test.sh
+++ b/automation/taskcluster/androidTest/ui-test.sh
@@ -100,14 +100,9 @@ echo
 echo "EXECUTE TEST(S)"
 echo
 $JAVA_BIN -jar $FLANK_BIN android run --config=$flank_template --max-test-shards=$num_shards --app=$APK_APP --test=$APK_TEST --project=$GOOGLE_PROJECT
-echo
-echo
-
 exitcode=$?
-failure_check
-echo
-echo
 
+echo
 echo
 echo "COPY ARTIFACTS"
 echo


### PR DESCRIPTION
Small change for quick fix: removing misplaced echo statements in UI test script causing exitcode to always be return job success.  


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
