### PR TITLE
Closes #3221: QrScanner: Clearer exception when device does not have a camera

### DIFF
--- a/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFragment.kt
+++ b/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFragment.kt
@@ -326,13 +326,19 @@ class QrFragment : Fragment() {
      * Opens the camera specified by [QrFragment.cameraId].
      */
     @SuppressLint("MissingPermission")
+    @Suppress("ThrowsCount")
     internal fun openCamera(width: Int, height: Int) {
-        setUpCameraOutputs(width, height)
-        configureTransform(width, height)
-
-        val activity = activity
-        val manager = activity?.getSystemService(Context.CAMERA_SERVICE) as CameraManager?
         try {
+            setUpCameraOutputs(width, height)
+            if (cameraId == null) {
+                throw IllegalStateException("No camera found on device")
+            }
+
+            configureTransform(width, height)
+
+            val activity = activity
+            val manager = activity?.getSystemService(Context.CAMERA_SERVICE) as CameraManager?
+
             if (!cameraOpenCloseLock.tryAcquire(CAMERA_CLOSE_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
                 throw IllegalStateException("Time out waiting to lock camera opening.")
             }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -18,6 +18,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat.checkSelfPermission
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.ktx.R
+import android.hardware.camera2.CameraManager
 
 /**
  * The (visible) version name of the application, as specified by the <manifest> tag's versionName
@@ -62,6 +63,13 @@ fun Context.isOSOnLowMemory(): Boolean {
 fun Context.isPermissionGranted(vararg permission: String): Boolean {
     return permission.all { checkSelfPermission(this, it) == PERMISSION_GRANTED }
 }
+
+/**
+ * Checks whether or not the device has a camera.
+ *
+ * @return true if a camera was found, otherwise false.
+ */
+fun Context.hasCamera(): Boolean = systemService<CameraManager>(Context.CAMERA_SERVICE).cameraIdList.isNotEmpty()
 
 /**
  *  Shares content via [ACTION_SEND] intent.

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
@@ -5,11 +5,13 @@
 package mozilla.components.support.ktx.android.content
 
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.app.Activity
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.hardware.camera2.CameraManager
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.support.test.argumentCaptor
 import org.junit.Assert.assertEquals
@@ -20,9 +22,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowApplication
 import org.robolectric.shadows.ShadowProcess
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowCameraCharacteristics
 
 @RunWith(RobolectricTestRunner::class)
 class ContextTest {
@@ -122,5 +127,15 @@ class ContextTest {
         }
 
         assertFalse(wasExecuted)
+    }
+
+    @Test
+    fun `hasCamera returns true if the device has a camera`() {
+        val context = Robolectric.buildActivity(Activity::class.java).get()
+        assertFalse(context.hasCamera())
+
+        val cameraManager: CameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        shadowOf(cameraManager).addCamera("camera0", ShadowCameraCharacteristics.newCameraCharacteristics())
+        assertTrue(context.hasCamera())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -132,6 +132,9 @@ permalink: /changelog/
 
   * Checkout the component documentation for more details.
 
+* **support-ktx**
+  * Added `Context.hasCamera()` to check if the device has a camera.
+
 # 0.54.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.53.0...v0.54.0)


### PR DESCRIPTION
This provides a clearer a exception and a utility method for applications to check if the device has a camera. 

