### PR TITLE
 Closes #3232: Keep returning an account even after we hit authentication problems

### DIFF
--- a/components/feature/sync/src/main/java/mozilla/components/feature/sync/BackgroundSyncManager.kt
+++ b/components/feature/sync/src/main/java/mozilla/components/feature/sync/BackgroundSyncManager.kt
@@ -151,15 +151,17 @@ abstract class GeneralSyncManager : SyncManager, Observable<SyncStatusObserver> 
         syncDispatcher = null
     }
 
-    override fun syncNow(startup: Boolean) {
-        synchronized(this) {
-            // TODO This is a workaround until we figure out why we get into this state.
-            // https://github.com/mozilla-mobile/android-components/issues/3226
-            syncDispatcher?.let {
-                logger.debug("Requesting immediate sync")
-                it.syncNow(startup)
-            }
+    override fun syncNow(startup: Boolean) = synchronized(this) {
+        // TODO This is a workaround until we figure out why we get into this state.
+        // https://github.com/mozilla-mobile/android-components/issues/3226
+
+        // We may not have an 'account' here (and by extension, syncDispatcher) if we hit auth
+        // problems.
+        syncDispatcher?.let {
+            logger.debug("Requesting immediate sync")
+            it.syncNow(startup)
         }
+        Unit
     }
 
     override fun isSyncRunning(): Boolean {

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -237,12 +237,14 @@ open class FxaAccountManager(
 
     /**
      * Main point for interaction with an [OAuthAccount] instance.
-     * @return [OAuthAccount] if we're in an authenticated state, null otherwise.
+     * @return [OAuthAccount] if we're in an authenticated state, null otherwise. Returned [OAuthAccount]
+     * may need to be re-authenticated; consumers are expected to check [accountNeedsReauth].
      */
     fun authenticatedAccount(): OAuthAccount? {
         return when (state) {
             AccountState.AuthenticatedWithProfile,
-            AccountState.AuthenticatedNoProfile -> account
+            AccountState.AuthenticatedNoProfile,
+            AccountState.AuthenticationProblem -> account
             else -> null
         }
     }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -795,11 +795,12 @@ class FxaAccountManagerTest {
 
         verify(accountObserver, times(1)).onAuthenticationProblems()
         assertTrue(manager.accountNeedsReauth())
+        assertEquals(mockAccount, manager.authenticatedAccount())
 
         // Able to re-authenticate.
         reset(accountObserver)
         assertEquals("auth://url", manager.beginAuthenticationAsync().await())
-        assertNull(manager.authenticatedAccount())
+        assertEquals(mockAccount, manager.authenticatedAccount())
         assertNull(manager.accountProfile())
 
         manager.finishAuthenticationAsync("dummyCode", "dummyState").await()


### PR DESCRIPTION
This is a follow-up to #3093.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
