### PR TITLE
Closes #3232: Keep returnig 'profile' if we hit auth problems.

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -264,7 +264,8 @@ open class FxaAccountManager(
 
     fun accountProfile(): Profile? {
         return when (state) {
-            AccountState.AuthenticatedWithProfile -> profile
+            AccountState.AuthenticatedWithProfile,
+            AccountState.AuthenticationProblem -> profile
             else -> null
         }
     }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -801,7 +801,7 @@ class FxaAccountManagerTest {
         reset(accountObserver)
         assertEquals("auth://url", manager.beginAuthenticationAsync().await())
         assertEquals(mockAccount, manager.authenticatedAccount())
-        assertNull(manager.accountProfile())
+        assertEquals(profile, manager.accountProfile())
 
         manager.finishAuthenticationAsync("dummyCode", "dummyState").await()
 


### PR DESCRIPTION
Should have landed together with #3233, but alas.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
