### PR TITLE
Increase the StringMetricType length limit to 100

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StringsStorageEngine.kt
@@ -27,7 +27,7 @@ internal open class StringsStorageEngineImplementation(
 ) : GenericStorageEngine<String>() {
     companion object {
         // Maximum length of any passed value string, in characters.
-        private const val MAX_LENGTH_VALUE = 50
+        internal const val MAX_LENGTH_VALUE = 100
     }
 
     override fun deserializeSingleMetric(metricName: String, value: Any?): String? {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -206,11 +206,14 @@ class StringsStorageEngineTest {
             sendInPings = listOf("store1")
         )
 
-        stringMetric.set("0123456789012345678901234567890123456789012345678901234567890123456789")
+        val testString = "012345678901234567890".repeat(20)
+        val expectedString = testString.take(StringsStorageEngineImplementation.MAX_LENGTH_VALUE)
+
+        stringMetric.set(testString)
         // Check that data was truncated.
         assertTrue(stringMetric.testHasValue())
         assertEquals(
-            "01234567890123456789012345678901234567890123456789",
+            expectedString,
             stringMetric.testGetValue()
         )
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,7 @@ permalink: /changelog/
 
 * **service-glean**
   * Disabling telemetry through `setUploadEnabled` now clears all metrics (except first_run_date) immediately.
+  * The string length limit for `StringMetricType` was raised from 50 to 100 characters.
 
 * **feature-session**
   * Added `SwipeRefreshFeature` which adds pull to refresh to browsers.


### PR DESCRIPTION
This is required for Fenix to submit longer strings. See [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1552905#c9) for more context.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
