### PR TITLE
Closes #3217 requestFromWebContent make app-links less sensitive

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -116,6 +116,7 @@ class GeckoEngineSession(
      * See [EngineSession.reload]
      */
     override fun reload() {
+        requestFromWebContent = false
         geckoSession.reload()
     }
 
@@ -123,6 +124,7 @@ class GeckoEngineSession(
      * See [EngineSession.goBack]
      */
     override fun goBack() {
+        requestFromWebContent = false
         geckoSession.goBack()
     }
 
@@ -130,6 +132,7 @@ class GeckoEngineSession(
      * See [EngineSession.goForward]
      */
     override fun goForward() {
+        requestFromWebContent = false
         geckoSession.goForward()
     }
 
@@ -202,7 +205,7 @@ class GeckoEngineSession(
         }
 
         if (reload) {
-            geckoSession.reload()
+            this.reload()
         }
     }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -42,6 +42,7 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
 import org.mozilla.geckoview.AllowOrDeny
@@ -1694,6 +1695,79 @@ class GeckoEngineSessionTest {
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
         assertFalse(observedTriggeredByRedirect!!)
+    }
+
+    @Test
+    fun `onLoadRequest will notify observers if the url is loaded from the user interacting with chrome`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+            geckoSessionProvider = geckoSessionProvider)
+
+        captureDelegates()
+
+        val fakeUrl = "https://example.com"
+        var observedTriggeredByWebContent: Boolean?
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+                observedTriggeredByWebContent = triggeredByWebContent
+            }
+        })
+
+        fun fakePageLoad(expectedTriggeredByWebContent: Boolean) {
+            observedTriggeredByWebContent = null
+            navigationDelegate.value.onLoadRequest(
+                mock(), mockLoadRequest(fakeUrl, triggeredByRedirect = true))
+            progressDelegate.value.onPageStop(mock(), true)
+            assertNotNull(observedTriggeredByWebContent)
+            assertEquals(expectedTriggeredByWebContent, observedTriggeredByWebContent!!)
+        }
+
+        // loadUrl(url: String)
+        engineSession.loadUrl(fakeUrl)
+        verify(geckoSession).loadUri(fakeUrl)
+        fakePageLoad(false)
+
+        // subsequent page loads _are_ from web content
+        fakePageLoad(true)
+
+        // loadData(data: String, mimeType: String, encoding: String)
+        val fakeData = "data://"
+        val fakeMimeType = ""
+        val fakeEncoding = ""
+        engineSession.loadData(data = fakeData, mimeType = fakeMimeType, encoding = fakeEncoding)
+        verify(geckoSession).loadString(fakeData, fakeMimeType)
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // reload()
+        engineSession.reload()
+        verify(geckoSession).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goBack()
+        engineSession.goBack()
+        verify(geckoSession).goBack()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goForward()
+        engineSession.goForward()
+        verify(geckoSession).goForward()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // toggleDesktopMode()
+        engineSession.toggleDesktopMode(false, reload = true)
+        // This is the second time in this test, so we actually want two invocations.
+        verify(geckoSession, times(2)).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -117,6 +117,7 @@ class GeckoEngineSession(
      * See [EngineSession.reload]
      */
     override fun reload() {
+        requestFromWebContent = false
         geckoSession.reload()
     }
 
@@ -124,6 +125,7 @@ class GeckoEngineSession(
      * See [EngineSession.goBack]
      */
     override fun goBack() {
+        requestFromWebContent = false
         geckoSession.goBack()
     }
 
@@ -131,6 +133,7 @@ class GeckoEngineSession(
      * See [EngineSession.goForward]
      */
     override fun goForward() {
+        requestFromWebContent = false
         geckoSession.goForward()
     }
 
@@ -203,7 +206,7 @@ class GeckoEngineSession(
         }
 
         if (reload) {
-            geckoSession.reload()
+            this.reload()
         }
     }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -44,6 +44,7 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
 import org.mozilla.geckoview.AllowOrDeny
@@ -1719,6 +1720,79 @@ class GeckoEngineSessionTest {
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
         assertFalse(observedTriggeredByRedirect!!)
+    }
+
+    @Test
+    fun `onLoadRequest will notify observers if the url is loaded from the user interacting with chrome`() {
+        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+            geckoSessionProvider = geckoSessionProvider)
+
+        captureDelegates()
+
+        val fakeUrl = "https://example.com"
+        var observedTriggeredByWebContent: Boolean?
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+                observedTriggeredByWebContent = triggeredByWebContent
+            }
+        })
+
+        fun fakePageLoad(expectedTriggeredByWebContent: Boolean) {
+            observedTriggeredByWebContent = null
+            navigationDelegate.value.onLoadRequest(
+                mock(), mockLoadRequest(fakeUrl, triggeredByRedirect = true))
+            progressDelegate.value.onPageStop(mock(), true)
+            assertNotNull(observedTriggeredByWebContent)
+            assertEquals(expectedTriggeredByWebContent, observedTriggeredByWebContent!!)
+        }
+
+        // loadUrl(url: String)
+        engineSession.loadUrl(fakeUrl)
+        verify(geckoSession).loadUri(fakeUrl)
+        fakePageLoad(false)
+
+        // subsequent page loads _are_ from web content
+        fakePageLoad(true)
+
+        // loadData(data: String, mimeType: String, encoding: String)
+        val fakeData = "data://"
+        val fakeMimeType = ""
+        val fakeEncoding = ""
+        engineSession.loadData(data = fakeData, mimeType = fakeMimeType, encoding = fakeEncoding)
+        verify(geckoSession).loadString(fakeData, fakeMimeType)
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // reload()
+        engineSession.reload()
+        verify(geckoSession).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goBack()
+        engineSession.goBack()
+        verify(geckoSession).goBack()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goForward()
+        engineSession.goForward()
+        verify(geckoSession).goForward()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // toggleDesktopMode()
+        engineSession.toggleDesktopMode(false, reload = true)
+        // This is the second time in this test, so we actually want two invocations.
+        verify(geckoSession, times(2)).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -112,6 +112,7 @@ class GeckoEngineSession(
      * See [EngineSession.reload]
      */
     override fun reload() {
+        requestFromWebContent = false
         geckoSession.reload()
     }
 
@@ -119,6 +120,7 @@ class GeckoEngineSession(
      * See [EngineSession.goBack]
      */
     override fun goBack() {
+        requestFromWebContent = false
         geckoSession.goBack()
     }
 
@@ -126,6 +128,7 @@ class GeckoEngineSession(
      * See [EngineSession.goForward]
      */
     override fun goForward() {
+        requestFromWebContent = false
         geckoSession.goForward()
     }
 
@@ -217,7 +220,7 @@ class GeckoEngineSession(
         }
 
         if (reload) {
-            geckoSession.reload()
+            this.reload()
         }
     }
 


### PR DESCRIPTION
Fixes #3217 and [fenix#3058](https://github.com/mozilla-mobile/fenix/issues/3058).

This PR adds extra resets for the `requestFromWebContent` flag in `GeckoEngineSession`. This means that app-link detection does not happen when the user goes back or forward or during a reload.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~ Bug fix.
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
