### PR TITLE
Uplift recording devices API to browser-engine-gecko-beta.

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -11,7 +11,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Beta Version.
      */
-    const val beta_version = "68.0.20190603093516"
+    const val beta_version = "68.0.20190604110028"
 
     /**
      * GeckoView Release Version.

--- a/components/browser/engine-gecko-beta/src/test/java/org/mozilla/geckoview/MockRecordingDevice.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/org/mozilla/geckoview/MockRecordingDevice.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.geckoview
+
+import mozilla.components.test.ReflectionUtils
+
+internal class MockRecordingDevice(
+    type: Long,
+    status: Long
+) : GeckoSession.MediaDelegate.RecordingDevice() {
+    init {
+        ReflectionUtils.setField(this, "type", type)
+        ReflectionUtils.setField(this, "status", status)
+    }
+}


### PR DESCRIPTION
Adding the API we already have in browser-engine-gecko-nightly to browser-engine-gecko-beta now that the GV APIs are available.