### PR TITLE
Closes #3247: QrScanner: Remove image cropping before processing

### DIFF
--- a/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFragment.kt
+++ b/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFragment.kt
@@ -552,8 +552,7 @@ class QrFragment : Fragment() {
             }
 
             try {
-                val image = bitmap.crop(bitmap.width / 4, bitmap.height / 4, bitmap.width / 2, bitmap.height / 2)
-                val rawResult = multiFormatReader.decodeWithState(image)
+                val rawResult = multiFormatReader.decodeWithState(bitmap)
                 if (rawResult != null) {
                     qrState = STATE_QRCODE_EXIST
                     scanCompleteListener?.onScanComplete(rawResult.toString())

--- a/components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFragmentTest.kt
+++ b/components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFragmentTest.kt
@@ -16,10 +16,12 @@ import com.google.zxing.MultiFormatReader
 import com.google.zxing.NotFoundException
 import mozilla.components.support.base.android.view.AutoFitTextureView
 import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -125,6 +127,21 @@ class QrFragmentTest {
         QrFragment.qrState = QrFragment.STATE_FIND_QRCODE
         assertNull(task.processImage(bitmap))
         verify(reader, never()).decodeWithState(any())
+    }
+
+    @Test
+    fun `async scanning decodes original unmodified image`() {
+        val listener = mock(QrFragment.OnScanCompleteListener::class.java)
+        val reader = mock(MultiFormatReader::class.java)
+        val task = QrFragment.AsyncScanningTask(listener, reader)
+        val imageCaptor = argumentCaptor<BinaryBitmap>()
+
+        val bitmap = mock(BinaryBitmap::class.java)
+
+        QrFragment.qrState = QrFragment.STATE_DECODE_PROGRESS
+        task.processImage(bitmap)
+        verify(reader).decodeWithState(imageCaptor.capture())
+        assertSame(bitmap, imageCaptor.value)
     }
 
     @Test


### PR DESCRIPTION
This fixes: https://github.com/mozilla-mobile/fenix/issues/2565 (due to incorrect image cropping)

The scanner works a lot better in general and is still fast even on old devices. 