### PR TITLE
Read web app manifest in browser-icons

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/Icon.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/Icon.kt
@@ -12,11 +12,13 @@ import android.graphics.Bitmap
  * @property bitmap The loaded icon as a [Bitmap].
  * @property color The dominant color of the icon. Will be null if no color could be extracted.
  * @property source The source of the icon.
+ * @param maskable True if the icon represents as full-bleed icon that can be cropped to other shapes.
  */
 data class Icon(
     val bitmap: Bitmap,
     val color: Int? = null,
-    val source: Source
+    val source: Source,
+    val maskable: Boolean = false
 ) {
     /**
      * The source of an [Icon].

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/IconRequest.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/IconRequest.kt
@@ -19,6 +19,7 @@ data class IconRequest(
     val size: Size = Size.DEFAULT,
     val resources: List<Resource> = emptyList()
 ) {
+
     /**
      * Supported sizes.
      *
@@ -36,12 +37,14 @@ data class IconRequest(
      * @param type The type of the icon.
      * @param sizes Optional list of icon sizes provided by this resource (if known).
      * @param mimeType Optional MIME type of this icon resource (if known).
+     * @param maskable True if the icon represents as full-bleed icon that can be cropped to other shapes.
      */
     data class Resource(
         val url: String,
         val type: Type,
         val sizes: List<HtmlSize> = emptyList(),
-        val mimeType: String? = null
+        val mimeType: String? = null,
+        val maskable: Boolean = false
     ) {
         /**
          * An icon resource type.
@@ -115,7 +118,14 @@ data class IconRequest(
             /**
              * An icon found in Mozilla's "tippy top" list.
              */
-            TIPPY_TOP
+            TIPPY_TOP,
+
+            /**
+             * A Web App Manifest image.
+             *
+             * https://developer.mozilla.org/en-US/docs/Web/Manifest/icons
+             */
+            MANIFEST_ICON
         }
     }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/IconMessage.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/IconMessage.kt
@@ -7,12 +7,15 @@ package mozilla.components.browser.icons.extension
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.org.json.asSequence
+import mozilla.components.support.ktx.android.org.json.toJSONArray
 import mozilla.components.support.ktx.android.org.json.tryGetString
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
 private val typeMap: Map<String, IconRequest.Resource.Type> = mutableMapOf(
+    "manifest" to IconRequest.Resource.Type.MANIFEST_ICON,
     "icon" to IconRequest.Resource.Type.FAVICON,
     "shortcut icon" to IconRequest.Resource.Type.FAVICON,
     "fluid-icon" to IconRequest.Resource.Type.FLUID_ICON,
@@ -38,32 +41,25 @@ private fun Map<String, IconRequest.Resource.Type>.reverseLookup(type: IconReque
 }
 
 internal fun List<IconRequest.Resource>.toJSON(): JSONArray {
-    val array = JSONArray()
-
-    for (resource in this) {
+    return mapNotNull { resource ->
         if (resource.type == IconRequest.Resource.Type.TIPPY_TOP) {
             // Ignore the URLs coming from the "tippy top" list.
-            continue
+            return@mapNotNull null
         }
 
-        val item = JSONObject()
+        JSONObject().apply {
+            put("href", resource.url)
 
-        item.put("href", resource.url)
+            resource.mimeType?.let { put("mimeType", it) }
 
-        resource.mimeType?.let { item.put("mimeType", it) }
+            put("type", typeMap.reverseLookup(resource.type))
 
-        item.put("type", typeMap.reverseLookup(resource.type))
+            val sizeArray = resource.sizes.map { size -> size.toString() }.toJSONArray()
+            put("sizes", sizeArray)
 
-        val sizeArray = JSONArray()
-        resource.sizes.forEach { size ->
-            sizeArray.put("${size.width}x${size.height}")
+            put("maskable", resource.maskable)
         }
-        item.put("sizes", sizeArray)
-
-        array.put(item)
-    }
-
-    return array
+    }.toJSONArray()
 }
 
 internal fun JSONObject.toIconRequest(): IconRequest? {
@@ -78,25 +74,26 @@ internal fun JSONObject.toIconRequest(): IconRequest? {
 }
 
 internal fun JSONArray.toIconResources(): List<IconRequest.Resource> {
-    val resources = mutableListOf<IconRequest.Resource>()
-
-    for (i in 0 until length()) {
-        val resource = getJSONObject(i).toIconResource()
-        resource?.let { resources.add(it) }
-    }
-
-    return resources
+    return asSequence { i -> getJSONObject(i) }
+        .mapNotNull { it.toIconResource() }
+        .toList()
 }
 
 private fun JSONObject.toIconResource(): IconRequest.Resource? {
     try {
         val url = getString("href")
-        val type = typeMap[getString("type")]
-            ?: return null
+        val type = typeMap[getString("type")] ?: return null
         val sizes = optJSONArray("sizes").toResourceSizes()
         val mimeType = tryGetString("mimeType")
+        val maskable = optBoolean("maskable", false)
 
-        return IconRequest.Resource(url, type, sizes, if (mimeType.isNullOrEmpty()) null else mimeType)
+        return IconRequest.Resource(
+            url = url,
+            type = type,
+            sizes = sizes,
+            mimeType = if (mimeType.isNullOrEmpty()) null else mimeType,
+            maskable = maskable
+        )
     } catch (e: JSONException) {
         Logger.warn("Could not parse message from icons extensions", e)
         return null
@@ -104,17 +101,12 @@ private fun JSONObject.toIconResource(): IconRequest.Resource? {
 }
 
 private fun JSONArray?.toResourceSizes(): List<Size> {
-    this ?: return emptyList()
+    val array = this ?: return emptyList()
 
     return try {
-        val sizes = mutableListOf<Size>()
-
-        for (i in 0 until length()) {
-            val raw = getString(i)
-            Size.parse(raw)?.let { sizes.add(it) }
-        }
-
-        sizes
+        array.asSequence { i -> getString(i) }
+            .mapNotNull { raw -> Size.parse(raw) }
+            .toList()
     } catch (e: JSONException) {
         Logger.warn("Could not parse message from icons extensions", e)
         emptyList()

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/WebAppManifest.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/WebAppManifest.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.extension
+
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.concept.engine.manifest.WebAppManifest.Icon.Purpose
+
+fun WebAppManifest.toIconRequest() = IconRequest(
+    url = startUrl,
+    size = IconRequest.Size.LAUNCHER,
+    resources = icons.mapNotNull { it.toIconResource() }
+)
+
+private fun WebAppManifest.Icon.toIconResource(): IconRequest.Resource? {
+    if (Purpose.MASKABLE !in purpose && Purpose.ANY !in purpose) return null
+
+    return IconRequest.Resource(
+        url = src,
+        type = IconRequest.Resource.Type.MANIFEST_ICON,
+        sizes = sizes,
+        mimeType = type,
+        maskable = Purpose.MASKABLE in purpose
+    )
+}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/Size.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/Size.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.concept.engine.manifest
 
+import kotlin.math.max
+import kotlin.math.min
+
 /**
  * Represents dimensions for an image.
  * Corresponds to values of the "sizes" HTML attribute.
@@ -15,6 +18,17 @@ data class Size(
     val width: Int,
     val height: Int
 ) {
+
+    /**
+     * Gets the longest length between width and height.
+     */
+    val maxLength get() = max(width, height)
+
+    /**
+     * Gets the shortest length between width and height.
+     */
+    val minLength get() = min(width, height)
+
     override fun toString() = if (this == ANY) "any" else "${width}x$height"
 
     companion object {
@@ -24,7 +38,7 @@ data class Size(
         val ANY = Size(Int.MAX_VALUE, Int.MAX_VALUE)
 
         /**
-         * Parse a value from an HTML sizes attribute (512x512, 16x16, etc).
+         * Parses a value from an HTML sizes attribute (512x512, 16x16, etc).
          * Returns null if the value was invalid.
          */
         fun parse(raw: String): Size? {

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/SizeTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/SizeTest.kt
@@ -21,8 +21,20 @@ class SizeTest {
     }
 
     @Test
+    fun `get max and min lengths`() {
+        assertEquals(512, Size(512, 256).maxLength)
+        assertEquals(256, Size(512, 256).minLength)
+        assertEquals(250, Size(100, 250).maxLength)
+        assertEquals(100, Size(100, 250).minLength)
+    }
+
+    @Test
     fun `parse any size`() {
         assertEquals(Size.ANY, Size.parse("any"))
+        assertEquals(Size.ANY.width, Size.parse("any")!!.maxLength)
+        assertEquals(Size.ANY.height, Size.parse("any")!!.maxLength)
+        assertEquals(Size.ANY.width, Size.parse("any")!!.minLength)
+        assertEquals(Size.ANY.height, Size.parse("any")!!.minLength)
     }
 
     @Test

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Session.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Session.kt
@@ -7,7 +7,6 @@ package mozilla.components.feature.pwa.ext
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.manifest.WebAppManifest.Icon.Purpose
-import kotlin.math.min
 
 private const val MIN_INSTALLABLE_ICON_SIZE = 192
 
@@ -27,7 +26,7 @@ fun Session.installableManifest(): WebAppManifest? {
     val installable = manifest.icons.any { icon ->
         (Purpose.ANY in icon.purpose || Purpose.MASKABLE in icon.purpose) &&
             icon.sizes.any { size ->
-                min(size.width, size.height) >= MIN_INSTALLABLE_ICON_SIZE
+                size.minLength >= MIN_INSTALLABLE_ICON_SIZE
             }
     }
     return if (installable) manifest else null

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/org/json/JSONArray.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/org/json/JSONArray.kt
@@ -7,24 +7,17 @@ package mozilla.components.support.ktx.android.org.json
 import org.json.JSONArray
 import org.json.JSONException
 
-/*
+/**
  * Convenience method to convert a JSONArray into a sequence.
+ *
+ * @param getter callback to get the value for an index in the array.
  */
-fun JSONArray.asSequence(): Sequence<Any> {
-    return object : Sequence<Any> {
-
-        override fun iterator() = object : Iterator<Any> {
-            val it = (0 until this@asSequence.length()).iterator()
-
-            override fun next(): Any {
-                val i = it.next()
-                return this@asSequence.get(i)
-            }
-
-            override fun hasNext() = it.hasNext()
-        }
-    }
+inline fun <V> JSONArray.asSequence(crossinline getter: JSONArray.(Int) -> V): Sequence<V> {
+    val indexRange = 0 until length()
+    return indexRange.asSequence().map { i -> getter(i) }
 }
+
+fun JSONArray.asSequence(): Sequence<Any> = asSequence { i -> get(i) }
 
 /**
  * Convenience method to convert a JSONArray into a List
@@ -33,10 +26,8 @@ fun JSONArray.asSequence(): Sequence<Any> {
  */
 @Suppress("UNCHECKED_CAST")
 fun <T> JSONArray?.toList(): List<T> {
-    if (this != null) {
-        return asSequence().map { it as T }.toList()
-    }
-    return listOf()
+    val array = this ?: return emptyList()
+    return array.asSequence().map { it as T }.toList()
 }
 
 // #2305: inline this function when Android gradle plugin v3.4.0 is released
@@ -60,4 +51,8 @@ fun <T, R : Any> JSONArray.mapNotNull(getFromArray: JSONArray.(index: Int) -> T,
     }
 
     return transformedResults
+}
+
+fun Iterable<Any>.toJSONArray() = JSONArray().also { array ->
+    forEach { array.put(it) }
 }


### PR DESCRIPTION
Updates browser-icons so it also checks the Web App Manifest along with other sources. This will be used for PWAs later too.

Large icons are now scaled rather than thrown out, since [some sites](https://proxx.app/) only supply large icons.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
