### PR TITLE
1556684: Update the label length limit from 30 -> 61 characters.

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -20,7 +20,7 @@ import groovy.json.JsonOutput
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "0.28.1"
+String GLEAN_PARSER_VERSION = "0.29.0"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
@@ -55,7 +55,7 @@ data class LabeledMetricType<T>(
         //   this.is-not-fine
         //   this.$isnotfine
 
-        private const val MAX_LABEL_LENGTH = 30
+        private const val MAX_LABEL_LENGTH = 61
     }
 
     private val seenLabels: MutableSet<String> = mutableSetOf()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,9 @@ permalink: /changelog/
 * **browser-domains**
   * New domain autocomplete providers `ShippedDomainsProvider` and `CustomDomainsProvider` that
     should be used instead of deprecated `DomainAutoCompleteProvider`.
+    
+* **service-glean**
+  * The length limit on labels in labeled metrics has been increased from 30 to 61 characters.  See [1556684](https://bugzilla.mozilla.org/show_bug.cgi?id=1556684).
 
 # 0.55.0
 


### PR DESCRIPTION
Requires https://github.com/mozilla/glean_parser/pull/71 to be merged first.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
