### PR TITLE
Turn on ComplexMethod `ignoreSingleWhenExpression` lint rule

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
@@ -46,7 +46,7 @@ internal class GeckoMedia(
 private class MediaDelegate(
     private val media: Media
 ) : MediaElement.Delegate {
-    @Suppress("ComplexMethod")
+
     override fun onPlaybackStateChange(mediaElement: MediaElement, mediaState: Int) {
         when (mediaState) {
             MEDIA_STATE_PLAY -> media.playbackState = Media.PlaybackState.PLAY

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -4,24 +4,24 @@
 
 package mozilla.components.browser.engine.gecko.permission
 
+import android.Manifest.permission.ACCESS_COARSE_LOCATION
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.CAMERA
+import android.Manifest.permission.RECORD_AUDIO
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.concept.engine.permission.PermissionRequest
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_APPLICATION
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_BROWSER
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_CAMERA
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_MICROPHONE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_OTHER
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_SCREEN
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_WINDOW
-import android.Manifest.permission.ACCESS_COARSE_LOCATION
-import android.Manifest.permission.ACCESS_FINE_LOCATION
-import android.Manifest.permission.CAMERA
-import android.Manifest.permission.RECORD_AUDIO
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
 /**
  * Gecko-based implementation of [PermissionRequest].
@@ -118,26 +118,30 @@ sealed class GeckoPermissionRequest constructor(
         }
 
         companion object {
-            @Suppress("ComplexMethod", "SwitchIntDef")
-            fun mapPermission(mediaSource: MediaSource): Permission {
+            fun mapPermission(mediaSource: MediaSource): Permission =
                 if (mediaSource.type == MediaSource.TYPE_AUDIO) {
-                    return when (mediaSource.source) {
-                        SOURCE_AUDIOCAPTURE -> Permission.ContentAudioCapture(mediaSource.id, mediaSource.name)
-                        SOURCE_MICROPHONE -> Permission.ContentAudioMicrophone(mediaSource.id, mediaSource.name)
-                        SOURCE_OTHER -> Permission.ContentAudioOther(mediaSource.id, mediaSource.name)
-                        else -> Permission.Generic(mediaSource.id, mediaSource.name)
-                    }
+                    mapAudioPermission(mediaSource)
                 } else {
-                    return when (mediaSource.source) {
-                        SOURCE_CAMERA -> Permission.ContentVideoCamera(mediaSource.id, mediaSource.name)
-                        SOURCE_APPLICATION -> Permission.ContentVideoApplication(mediaSource.id, mediaSource.name)
-                        SOURCE_BROWSER -> Permission.ContentVideoBrowser(mediaSource.id, mediaSource.name)
-                        SOURCE_SCREEN -> Permission.ContentVideoScreen(mediaSource.id, mediaSource.name)
-                        SOURCE_WINDOW -> Permission.ContentVideoWindow(mediaSource.id, mediaSource.name)
-                        SOURCE_OTHER -> Permission.ContentVideoOther(mediaSource.id, mediaSource.name)
-                        else -> Permission.Generic(mediaSource.id, mediaSource.name)
-                    }
+                    mapVideoPermission(mediaSource)
                 }
+
+            @Suppress("SwitchIntDef")
+            private fun mapAudioPermission(mediaSource: MediaSource) = when (mediaSource.source) {
+                SOURCE_AUDIOCAPTURE -> Permission.ContentAudioCapture(mediaSource.id, mediaSource.name)
+                SOURCE_MICROPHONE -> Permission.ContentAudioMicrophone(mediaSource.id, mediaSource.name)
+                SOURCE_OTHER -> Permission.ContentAudioOther(mediaSource.id, mediaSource.name)
+                else -> Permission.Generic(mediaSource.id, mediaSource.name)
+            }
+
+            @Suppress("ComplexMethod", "SwitchIntDef")
+            private fun mapVideoPermission(mediaSource: MediaSource) = when (mediaSource.source) {
+                SOURCE_CAMERA -> Permission.ContentVideoCamera(mediaSource.id, mediaSource.name)
+                SOURCE_APPLICATION -> Permission.ContentVideoApplication(mediaSource.id, mediaSource.name)
+                SOURCE_BROWSER -> Permission.ContentVideoBrowser(mediaSource.id, mediaSource.name)
+                SOURCE_SCREEN -> Permission.ContentVideoScreen(mediaSource.id, mediaSource.name)
+                SOURCE_WINDOW -> Permission.ContentVideoWindow(mediaSource.id, mediaSource.name)
+                SOURCE_OTHER -> Permission.ContentVideoOther(mediaSource.id, mediaSource.name)
+                else -> Permission.Generic(mediaSource.id, mediaSource.name)
             }
         }
     }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -383,7 +383,6 @@ class SystemEngineSession(
          * Chromium's mapping (internal error code, to Android WebView error code) is described at:
          * https://goo.gl/vspwct (ErrorCodeConversionHelper.java)
          */
-        @Suppress("ComplexMethod")
         internal fun webViewErrorToErrorType(errorCode: Int) =
             when (errorCode) {
                 WebViewClient.ERROR_UNKNOWN -> ErrorType.UNKNOWN

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSessionState.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSessionState.kt
@@ -45,24 +45,27 @@ private fun shouldSerialize(value: Any?): Boolean {
     }
 }
 
-@Suppress("ComplexMethod")
 private fun JSONObject.toBundle(): Bundle {
     val bundle = Bundle()
 
     keys().forEach { key ->
         val value = get(key)
-        when (value) {
-            is Int -> bundle.putInt(key, value)
-            is Double -> bundle.putDouble(key, value)
-            is Long -> bundle.putLong(key, value)
-            is Float -> bundle.putFloat(key, value)
-            is Char -> bundle.putChar(key, value)
-            is Short -> bundle.putShort(key, value)
-            is Byte -> bundle.putByte(key, value)
-            is String -> bundle.putString(key, value)
-            is Boolean -> bundle.putBoolean(key, value)
-        }
+        bundle.put(key, value)
     }
 
     return bundle
+}
+
+private fun Bundle.put(key: String, value: Any) {
+    when (value) {
+        is Int -> putInt(key, value)
+        is Double -> putDouble(key, value)
+        is Long -> putLong(key, value)
+        is Float -> putFloat(key, value)
+        is Char -> putChar(key, value)
+        is Short -> putShort(key, value)
+        is Byte -> putByte(key, value)
+        is String -> putString(key, value)
+        is Boolean -> putBoolean(key, value)
+    }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/decoder/ico/IconDirectoryEntry.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/decoder/ico/IconDirectoryEntry.kt
@@ -21,36 +21,34 @@ internal data class IconDirectoryEntry(
     val payloadIsPNG: Boolean,
     val directoryIndex: Int
 ) : Comparable<IconDirectoryEntry> {
-    @Suppress("ReturnCount", "ComplexMethod")
-    override fun compareTo(other: IconDirectoryEntry): Int {
-        return when {
-            width > other.width -> 1
-            width < other.width -> -1
 
-            // Where both images exceed the max BPP, take the smaller of the two BPP values.
-            bitsPerPixel >= MAX_BITS_PER_PIXEL && other.bitsPerPixel >= MAX_BITS_PER_PIXEL &&
-                bitsPerPixel < other.bitsPerPixel -> 1
-            bitsPerPixel >= MAX_BITS_PER_PIXEL && other.bitsPerPixel >= MAX_BITS_PER_PIXEL &&
-                bitsPerPixel > other.bitsPerPixel -> -1
+    override fun compareTo(other: IconDirectoryEntry): Int = when {
+        width > other.width -> 1
+        width < other.width -> -1
 
-            // Otherwise, take the larger of the BPP values.
-            bitsPerPixel > other.bitsPerPixel -> 1
-            bitsPerPixel < other.bitsPerPixel -> -1
+        // Where both images exceed the max BPP, take the smaller of the two BPP values.
+        bitsPerPixel >= MAX_BITS_PER_PIXEL && other.bitsPerPixel >= MAX_BITS_PER_PIXEL &&
+            bitsPerPixel < other.bitsPerPixel -> 1
+        bitsPerPixel >= MAX_BITS_PER_PIXEL && other.bitsPerPixel >= MAX_BITS_PER_PIXEL &&
+            bitsPerPixel > other.bitsPerPixel -> -1
 
-            // Prefer large palettes.
-            paletteSize > other.paletteSize -> 1
-            paletteSize < other.paletteSize -> -1
+        // Otherwise, take the larger of the BPP values.
+        bitsPerPixel > other.bitsPerPixel -> 1
+        bitsPerPixel < other.bitsPerPixel -> -1
 
-            // Prefer smaller payloads.
-            payloadSize < other.payloadSize -> 1
-            payloadSize > other.payloadSize -> -1
+        // Prefer large palettes.
+        paletteSize > other.paletteSize -> 1
+        paletteSize < other.paletteSize -> -1
 
-            // If all else fails, prefer PNGs over BMPs. They tend to be smaller.
-            payloadIsPNG && !other.payloadIsPNG -> 1
-            !payloadIsPNG && other.payloadIsPNG -> -1
+        // Prefer smaller payloads.
+        payloadSize < other.payloadSize -> 1
+        payloadSize > other.payloadSize -> -1
 
-            else -> return 0
-        }
+        // If all else fails, prefer PNGs over BMPs. They tend to be smaller.
+        payloadIsPNG && !other.payloadIsPNG -> 1
+        !payloadIsPNG && other.payloadIsPNG -> -1
+
+        else -> 0
     }
 
     fun toBitmap(data: ByteArray): Bitmap? {

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/pipeline/IconResourceComparator.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/pipeline/IconResourceComparator.kt
@@ -12,32 +12,30 @@ import kotlin.math.min
  * first.
  */
 internal object IconResourceComparator : Comparator<IconRequest.Resource> {
-    @Suppress("ComplexMethod", "ReturnCount")
+
+    @Suppress("ComplexMethod")
     override fun compare(resource: IconRequest.Resource, other: IconRequest.Resource): Int {
-        if (resource.url == other.url) {
+        return if (resource.url == other.url) {
             // Two resources pointing to the same URL are always referencing the same icon. So treat them as equal.
-            return 0
+            0
+        } else if (resource.type != other.type) {
+            if (resource.type.rank() > other.type.rank()) -1 else 1
+        } else if (resource.maxSize != other.maxSize) {
+            if (resource.maxSize > other.maxSize) -1 else 1
+        } else {
+            // If there's no other way to choose, we prefer container types.
+            // They *might* contain an image larger than the size given in the <link> tag.
+            val isResourceContainerType = resource.isContainerType
+            val isOtherContainerType = other.isContainerType
+            if (isResourceContainerType != isOtherContainerType) {
+                if (isResourceContainerType) -1 else 1
+            } else {
+                // There's no way to know which icon might be better. However we need to pick a consistent one
+                // to avoid breaking set implementations (See Fennec Bug 1331808).
+                // Therefore we are  picking one by just comparing the URLs.
+                resource.url.compareTo(other.url)
+            }
         }
-
-        if (resource.type != other.type) {
-            return if (resource.type.rank() > other.type.rank()) -1 else 1
-        }
-
-        if (resource.maxSize != other.maxSize) {
-            return if (resource.maxSize > other.maxSize) -1 else 1
-        }
-
-        // If there's no other way to choose, we prefer container types. They *might* contain an image larger than the
-        // size given in the <link> tag.
-        val isResourceContainerType = resource.isContainerType
-        val isOtherContainerType = other.isContainerType
-        if (isResourceContainerType != isOtherContainerType) {
-            return if (isResourceContainerType) -1 else 1
-        }
-
-        // There's no way to know which icon might be better. However we need to pick a consistent one to avoid breaking
-        // set implementations (See Fennec Bug 1331808). Therefore we are  picking one by just comparing the URLs.
-        return resource.url.compareTo(other.url)
     }
 }
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt
@@ -26,36 +26,30 @@ internal fun AuthInfo.into(): SyncAuthInfo {
 /**
  * Conversion from a generic [VisitType] into its richer comrade within the 'places' lib.
  */
-@SuppressWarnings("ComplexMethod")
-internal fun VisitType.into(): mozilla.appservices.places.VisitType {
-    return when (this) {
-        VisitType.NOT_A_VISIT -> mozilla.appservices.places.VisitType.UPDATE_PLACE
-        VisitType.LINK -> mozilla.appservices.places.VisitType.LINK
-        VisitType.RELOAD -> mozilla.appservices.places.VisitType.RELOAD
-        VisitType.TYPED -> mozilla.appservices.places.VisitType.TYPED
-        VisitType.BOOKMARK -> mozilla.appservices.places.VisitType.BOOKMARK
-        VisitType.EMBED -> mozilla.appservices.places.VisitType.EMBED
-        VisitType.REDIRECT_PERMANENT -> mozilla.appservices.places.VisitType.REDIRECT_PERMANENT
-        VisitType.REDIRECT_TEMPORARY -> mozilla.appservices.places.VisitType.REDIRECT_TEMPORARY
-        VisitType.DOWNLOAD -> mozilla.appservices.places.VisitType.DOWNLOAD
-        VisitType.FRAMED_LINK -> mozilla.appservices.places.VisitType.FRAMED_LINK
-    }
+internal fun VisitType.into() = when (this) {
+    VisitType.NOT_A_VISIT -> mozilla.appservices.places.VisitType.UPDATE_PLACE
+    VisitType.LINK -> mozilla.appservices.places.VisitType.LINK
+    VisitType.RELOAD -> mozilla.appservices.places.VisitType.RELOAD
+    VisitType.TYPED -> mozilla.appservices.places.VisitType.TYPED
+    VisitType.BOOKMARK -> mozilla.appservices.places.VisitType.BOOKMARK
+    VisitType.EMBED -> mozilla.appservices.places.VisitType.EMBED
+    VisitType.REDIRECT_PERMANENT -> mozilla.appservices.places.VisitType.REDIRECT_PERMANENT
+    VisitType.REDIRECT_TEMPORARY -> mozilla.appservices.places.VisitType.REDIRECT_TEMPORARY
+    VisitType.DOWNLOAD -> mozilla.appservices.places.VisitType.DOWNLOAD
+    VisitType.FRAMED_LINK -> mozilla.appservices.places.VisitType.FRAMED_LINK
 }
 
-@SuppressWarnings("ComplexMethod")
-internal fun mozilla.appservices.places.VisitType.into(): VisitType {
-    return when (this) {
-        mozilla.appservices.places.VisitType.UPDATE_PLACE -> VisitType.NOT_A_VISIT
-        mozilla.appservices.places.VisitType.LINK -> VisitType.LINK
-        mozilla.appservices.places.VisitType.RELOAD -> VisitType.RELOAD
-        mozilla.appservices.places.VisitType.TYPED -> VisitType.TYPED
-        mozilla.appservices.places.VisitType.BOOKMARK -> VisitType.BOOKMARK
-        mozilla.appservices.places.VisitType.EMBED -> VisitType.EMBED
-        mozilla.appservices.places.VisitType.REDIRECT_PERMANENT -> VisitType.REDIRECT_PERMANENT
-        mozilla.appservices.places.VisitType.REDIRECT_TEMPORARY -> VisitType.REDIRECT_TEMPORARY
-        mozilla.appservices.places.VisitType.DOWNLOAD -> VisitType.DOWNLOAD
-        mozilla.appservices.places.VisitType.FRAMED_LINK -> VisitType.FRAMED_LINK
-    }
+internal fun mozilla.appservices.places.VisitType.into() = when (this) {
+    mozilla.appservices.places.VisitType.UPDATE_PLACE -> VisitType.NOT_A_VISIT
+    mozilla.appservices.places.VisitType.LINK -> VisitType.LINK
+    mozilla.appservices.places.VisitType.RELOAD -> VisitType.RELOAD
+    mozilla.appservices.places.VisitType.TYPED -> VisitType.TYPED
+    mozilla.appservices.places.VisitType.BOOKMARK -> VisitType.BOOKMARK
+    mozilla.appservices.places.VisitType.EMBED -> VisitType.EMBED
+    mozilla.appservices.places.VisitType.REDIRECT_PERMANENT -> VisitType.REDIRECT_PERMANENT
+    mozilla.appservices.places.VisitType.REDIRECT_TEMPORARY -> VisitType.REDIRECT_TEMPORARY
+    mozilla.appservices.places.VisitType.DOWNLOAD -> VisitType.DOWNLOAD
+    mozilla.appservices.places.VisitType.FRAMED_LINK -> VisitType.FRAMED_LINK
 }
 
 internal fun mozilla.appservices.places.VisitInfo.into(): VisitInfo {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
@@ -144,17 +144,14 @@ private fun parseTextDirection(json: JSONObject): WebAppManifest.TextDirection {
     }
 }
 
-@Suppress("ComplexMethod") // It's not really that complex..
-private fun parseOrientation(json: JSONObject): WebAppManifest.Orientation {
-    return when (json.optString("orientation")) {
-        "any" -> WebAppManifest.Orientation.ANY
-        "natural" -> WebAppManifest.Orientation.NATURAL
-        "landscape" -> WebAppManifest.Orientation.LANDSCAPE
-        "portrait" -> WebAppManifest.Orientation.PORTRAIT
-        "portrait-primary" -> WebAppManifest.Orientation.PORTRAIT_PRIMARY
-        "portrait-secondary" -> WebAppManifest.Orientation.PORTRAIT_SECONDARY
-        "landscape-primary" -> WebAppManifest.Orientation.LANDSCAPE_PRIMARY
-        "landscape-secondary" -> WebAppManifest.Orientation.LANDSCAPE_SECONDARY
-        else -> WebAppManifest.Orientation.ANY
-    }
+private fun parseOrientation(json: JSONObject) = when (json.optString("orientation")) {
+    "any" -> WebAppManifest.Orientation.ANY
+    "natural" -> WebAppManifest.Orientation.NATURAL
+    "landscape" -> WebAppManifest.Orientation.LANDSCAPE
+    "portrait" -> WebAppManifest.Orientation.PORTRAIT
+    "portrait-primary" -> WebAppManifest.Orientation.PORTRAIT_PRIMARY
+    "portrait-secondary" -> WebAppManifest.Orientation.PORTRAIT_SECONDARY
+    "landscape-primary" -> WebAppManifest.Orientation.LANDSCAPE_PRIMARY
+    "landscape-secondary" -> WebAppManifest.Orientation.LANDSCAPE_SECONDARY
+    else -> WebAppManifest.Orientation.ANY
 }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Activity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Activity.kt
@@ -12,7 +12,6 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
  * Sets the requested orientation of the [Activity] to the orientation provided by the given [WebAppManifest] (See
  * [WebAppManifest.orientation] and [WebAppManifest.Orientation].
  */
-@Suppress("ComplexMethod") // Lots of branches... but not complex.
 fun Activity.applyOrientation(manifest: WebAppManifest) {
     when (manifest.orientation) {
         WebAppManifest.Orientation.NATURAL ->

--- a/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/parser/Parser.kt
+++ b/components/lib/jexl/src/main/java/mozilla/components/lib/jexl/parser/Parser.kt
@@ -83,7 +83,7 @@ internal class Parser(
                 state = stopState
             }
         } else if (stateMap.map.containsKey(token.type)) {
-            val nextState = stateMap.map[token.type]!!
+            val nextState = stateMap.map.getValue(token.type)
 
             if (nextState.handler != null) {
                 // Use handler for this transition
@@ -96,7 +96,7 @@ internal class Parser(
 
             nextState.state?.let { state = it }
         } else if (stopMap.containsKey(token.type)) {
-            return stopMap[token.type]!!
+            return stopMap.getValue(token.type)
         } else {
             throw ParserException("Token ${token.raw} (${token.type}) unexpected in state $state")
         }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -18,8 +18,8 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthException
 import mozilla.components.concept.sync.DeviceCapability
 import mozilla.components.concept.sync.DeviceEvent
-import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.DeviceEventsObserver
+import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
 import mozilla.components.concept.sync.StatePersistenceCallback
@@ -30,15 +30,14 @@ import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.FxaException
 import mozilla.components.service.fxa.FxaPanicException
 import mozilla.components.service.fxa.SharedPrefAccountStorage
-import java.util.concurrent.ConcurrentLinkedQueue
-import kotlin.coroutines.CoroutineContext
-
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import java.io.Closeable
 import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Propagated via [AccountObserver.onError] if we fail to load a locally stored account during
@@ -164,53 +163,41 @@ open class FxaAccountManager(
          * @return An optional [AccountState] if provided state+event combination results in a
          * state transition. Note that states may transition into themselves.
          */
-        @Suppress("ComplexMethod")
-        internal fun nextState(state: AccountState, event: Event): AccountState? {
-            return when (state) {
-                AccountState.Start -> {
-                    when (event) {
-                        Event.Init -> AccountState.Start
-                        Event.AccountNotFound -> AccountState.NotAuthenticated
-                        Event.AccountRestored -> AccountState.AuthenticatedNoProfile
-                        else -> null
-                    }
+        internal fun nextState(state: AccountState, event: Event): AccountState? =
+            when (state) {
+                AccountState.Start -> when (event) {
+                    Event.Init -> AccountState.Start
+                    Event.AccountNotFound -> AccountState.NotAuthenticated
+                    Event.AccountRestored -> AccountState.AuthenticatedNoProfile
+                    else -> null
                 }
-                AccountState.NotAuthenticated -> {
-                    when (event) {
-                        Event.Authenticate -> AccountState.NotAuthenticated
-                        Event.FailedToAuthenticate -> AccountState.NotAuthenticated
-                        is Event.Pair -> AccountState.NotAuthenticated
-                        is Event.Authenticated -> AccountState.AuthenticatedNoProfile
-                        else -> null
-                    }
+                AccountState.NotAuthenticated -> when (event) {
+                    Event.Authenticate -> AccountState.NotAuthenticated
+                    Event.FailedToAuthenticate -> AccountState.NotAuthenticated
+                    is Event.Pair -> AccountState.NotAuthenticated
+                    is Event.Authenticated -> AccountState.AuthenticatedNoProfile
+                    else -> null
                 }
-                AccountState.AuthenticatedNoProfile -> {
-                    when (event) {
-                        is Event.AuthenticationError -> AccountState.AuthenticationProblem
-                        Event.FetchProfile -> AccountState.AuthenticatedNoProfile
-                        Event.FetchedProfile -> AccountState.AuthenticatedWithProfile
-                        Event.FailedToFetchProfile -> AccountState.AuthenticatedNoProfile
-                        Event.Logout -> AccountState.NotAuthenticated
-                        else -> null
-                    }
+                AccountState.AuthenticatedNoProfile -> when (event) {
+                    is Event.AuthenticationError -> AccountState.AuthenticationProblem
+                    Event.FetchProfile -> AccountState.AuthenticatedNoProfile
+                    Event.FetchedProfile -> AccountState.AuthenticatedWithProfile
+                    Event.FailedToFetchProfile -> AccountState.AuthenticatedNoProfile
+                    Event.Logout -> AccountState.NotAuthenticated
+                    else -> null
                 }
-                AccountState.AuthenticatedWithProfile -> {
-                    when (event) {
-                        is Event.AuthenticationError -> AccountState.AuthenticationProblem
-                        Event.Logout -> AccountState.NotAuthenticated
-                        else -> null
-                    }
+                AccountState.AuthenticatedWithProfile -> when (event) {
+                    is Event.AuthenticationError -> AccountState.AuthenticationProblem
+                    Event.Logout -> AccountState.NotAuthenticated
+                    else -> null
                 }
-                AccountState.AuthenticationProblem -> {
-                    when (event) {
-                        Event.Authenticate -> AccountState.AuthenticationProblem
-                        Event.FailedToAuthenticate -> AccountState.AuthenticationProblem
-                        is Event.Authenticated -> AccountState.AuthenticatedNoProfile
-                        Event.Logout -> AccountState.NotAuthenticated
-                        else -> null
-                    }
+                AccountState.AuthenticationProblem -> when (event) {
+                    Event.Authenticate -> AccountState.AuthenticationProblem
+                    Event.FailedToAuthenticate -> AccountState.AuthenticationProblem
+                    is Event.Authenticated -> AccountState.AuthenticatedNoProfile
+                    Event.Logout -> AccountState.NotAuthenticated
+                    else -> null
                 }
-            }
         }
     }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaDeviceManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaDeviceManager.kt
@@ -20,12 +20,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import mozilla.components.concept.sync.ConstellationState
-import mozilla.components.concept.sync.DeviceEvent
 import mozilla.components.concept.sync.DeviceConstellation
 import mozilla.components.concept.sync.DeviceConstellationObserver
+import mozilla.components.concept.sync.DeviceEvent
 import mozilla.components.concept.sync.DeviceEventsObserver
 import mozilla.components.support.base.log.logger.Logger
-
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import java.util.concurrent.TimeUnit
@@ -161,7 +160,6 @@ internal class WorkManagerDeviceRefreshWorker(
 ) : CoroutineWorker(context, params) {
     private val logger = Logger("DeviceManagerPollWorker")
 
-    @Suppress("ReturnCount", "ComplexMethod")
     override suspend fun doWork(): Result {
         logger.info("Polling for new events via ${DeviceManagerProvider.deviceManager}")
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/StorageEngineManager.kt
@@ -13,9 +13,9 @@ import mozilla.components.service.glean.private.StringMetricType
 import mozilla.components.service.glean.private.TimespanMetricType
 import mozilla.components.service.glean.private.TimingDistributionMetricType
 import mozilla.components.service.glean.private.UuidMetricType
+import mozilla.components.support.ktx.android.org.json.getOrPutJSONObject
 import org.json.JSONArray
 import org.json.JSONObject
-import mozilla.components.support.ktx.android.org.json.getOrPutJSONObject
 
 /**
  * This singleton is the one interface to all the available storage engines:
@@ -138,7 +138,6 @@ internal class StorageEngineManager(
         *
         * @return A storage engine, or null if none exists
         */
-        @Suppress("ComplexMethod")
         internal fun <T> getStorageEngineForMetric(subMetric: T): StorageEngine? {
             // Every metric that supports labels needs an entry here
             return when (subMetric) {

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/Map.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/Map.kt
@@ -14,37 +14,39 @@ import java.io.Serializable
 /**
  * Converts a Map to a Bundle
  */
-@Suppress("ComplexMethod")
 fun <K, V> Map<K, V>.toBundle(): Bundle {
     return Bundle().apply {
         forEach { (k, v) ->
             val key = k.toString()
-
-            when (v) {
-                is IBinder -> putBinder(key, v)
-                is Boolean -> putBoolean(key, v)
-                is BooleanArray -> putBooleanArray(key, v)
-                is Bundle -> putBundle(key, v)
-                is Byte -> putByte(key, v)
-                is ByteArray -> putByteArray(key, v)
-                is Char -> putChar(key, v)
-                is CharArray -> putCharArray(key, v)
-                is CharSequence -> putCharSequence(key, v)
-                is Double -> putDouble(key, v)
-                is DoubleArray -> putDoubleArray(key, v)
-                is Float -> putFloat(key, v)
-                is FloatArray -> putFloatArray(key, v)
-                is Int -> putInt(key, v)
-                is IntArray -> putIntArray(key, v)
-                is Long -> putLong(key, v)
-                is LongArray -> putLongArray(key, v)
-                is Parcelable -> putParcelable(key, v)
-                is Serializable -> putSerializable(key, v)
-                is Short -> putShort(key, v)
-                is ShortArray -> putShortArray(key, v)
-                is Size -> putSize(key, v)
-                is SizeF -> putSizeF(key, v)
-            }
+            put(key, v)
         }
+    }
+}
+
+private fun <V> Bundle.put(key: String, value: V) {
+    when (value) {
+        is IBinder -> putBinder(key, value)
+        is Boolean -> putBoolean(key, value)
+        is BooleanArray -> putBooleanArray(key, value)
+        is Bundle -> putBundle(key, value)
+        is Byte -> putByte(key, value)
+        is ByteArray -> putByteArray(key, value)
+        is Char -> putChar(key, value)
+        is CharArray -> putCharArray(key, value)
+        is CharSequence -> putCharSequence(key, value)
+        is Double -> putDouble(key, value)
+        is DoubleArray -> putDoubleArray(key, value)
+        is Float -> putFloat(key, value)
+        is FloatArray -> putFloatArray(key, value)
+        is Int -> putInt(key, value)
+        is IntArray -> putIntArray(key, value)
+        is Long -> putLong(key, value)
+        is LongArray -> putLongArray(key, value)
+        is Parcelable -> putParcelable(key, value)
+        is Serializable -> putSerializable(key, value)
+        is Short -> putShort(key, value)
+        is ShortArray -> putShortArray(key, value)
+        is Size -> putSize(key, value)
+        is SizeF -> putSizeF(key, value)
     }
 }

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -82,7 +82,7 @@ complexity:
   ComplexMethod:
     active: true
     threshold: 10
-    ignoreSingleWhenExpression: false
+    ignoreSingleWhenExpression: true
   LabeledExpression:
     active: false
   LargeClass:


### PR DESCRIPTION
Most of our "complex" methods are just big when expressions, and we suppress the lint rather than refactoring the code. I think it makes more sense just to have the linter ignore those cases.

I also made small refactorings for functions that were slightly too complex, but I can pull those out if this change is too big.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
