### PR TITLE
Clear out account state and attempt recovery during authentication errrors

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val jna = "5.2.0"
     const val disklrucache = "2.0.2"
 
-    const val mozilla_appservices = "0.31.0"
+    const val mozilla_appservices = "0.31.2"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -25,12 +25,13 @@ class AuthException(type: AuthExceptionType, cause: Exception? = null) : Throwab
  */
 @SuppressWarnings("TooManyFunctions")
 interface OAuthAccount : AutoCloseable {
-    fun beginOAuthFlowAsync(scopes: Array<String>, wantsKeys: Boolean): Deferred<String?>
-    fun beginPairingFlowAsync(pairingUrl: String, scopes: Array<String>): Deferred<String?>
+    fun beginOAuthFlowAsync(scopes: Set<String>, wantsKeys: Boolean): Deferred<String?>
+    fun beginPairingFlowAsync(pairingUrl: String, scopes: Set<String>): Deferred<String?>
     fun getProfileAsync(ignoreCache: Boolean): Deferred<Profile?>
     fun getProfileAsync(): Deferred<Profile?>
     fun completeOAuthFlowAsync(code: String, state: String): Deferred<Boolean>
     fun getAccessTokenAsync(singleScope: String): Deferred<AccessTokenInfo?>
+    fun checkAuthorizationStatusAsync(singleScope: String): Deferred<Boolean?>
     fun getTokenServerEndpointURL(): String
     fun registerPersistenceCallback(callback: StatePersistenceCallback)
     fun deviceConstellation(): DeviceConstellation

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -45,6 +45,7 @@ internal sealed class Event {
             return this.javaClass.simpleName
         }
     }
+    object RecoveredFromAuthenticationProblem : Event()
     object FetchProfile : Event()
     object FetchedProfile : Event()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@ permalink: /changelog/
   * `FxaAccountManager` will now attempt to automatically recover from a certain class of temporary auth problems.
   * `FirefoxAccount` grew a new method: `checkAuthorizationStatusAsync`, used to facilitate above flows.
   * It is no longer necessary to pass in the "profile" scope to `FxaAccountManager`, as it will always obtain it regardless. Specifying that scope has no effect.
+  * ⚠️ **This is a breaking change**: `FirefoxAccount` methods that used to take `Array<String>` of scopes now take `Set<String>` of scopes.
 
 * **browser-domains**
   * New domain autocomplete providers `ShippedDomainsProvider` and `CustomDomainsProvider` that

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,12 @@ permalink: /changelog/
 * **samples-firefox-accounts**
   * Switch FxA sample to production servers, fix pairing.
 
+* **service-firefox-accounts**
+  * `FxaAccountManager` will is now able to complete re-authentication flow after encountering an auth problem (e.g. password change)
+  * `FxaAccountManager` will now attempt to automatically recover from a certain class of temporary auth problems.
+  * `FirefoxAccount` grew a new method: `checkAuthorizationStatusAsync`, used to facilitate above flows.
+  * It is no longer necessary to pass in the "profile" scope to `FxaAccountManager`, as it will always obtain it regardless. Specifying that scope has no effect.
+
 * **browser-domains**
   * New domain autocomplete providers `ShippedDomainsProvider` and `CustomDomainsProvider` that
     should be used instead of deprecated `DomainAutoCompleteProvider`.

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -30,9 +30,9 @@ import kotlin.coroutines.CoroutineContext
 @Suppress("TooManyFunctions")
 open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener, CoroutineScope {
     private lateinit var account: FirefoxAccount
-    private var scopesWithoutKeys: Array<String> = arrayOf("profile")
-    private var scopesWithKeys: Array<String> = arrayOf("profile", "https://identity.mozilla.com/apps/oldsync")
-    private var scopes: Array<String> = scopesWithoutKeys
+    private var scopesWithoutKeys: Set<String> = setOf("profile")
+    private var scopesWithKeys: Set<String> = setOf("profile", "https://identity.mozilla.com/apps/oldsync")
+    private var scopes: Set<String> = scopesWithoutKeys
     private var wantsKeys: Boolean = false
 
     private lateinit var qrFeature: QrFeature


### PR DESCRIPTION
Logic is now in place, but this still needs some tests and changelog entries.
Changes should be backwards-compatible.

Depends on https://github.com/mozilla/application-services/pull/1244

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
