### PR TITLE
Fixes for ObserverRegistry

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -97,10 +97,22 @@ class ObserverRegistry<T> : Observable<T> {
 
     @Synchronized
     override fun unregisterObservers() {
+        // Remove all registered observers
         observers.toList().forEach { observer ->
             unregister(observer)
         }
 
+        // There can still be view observers for views that are not attached yet and therefore the observers were not
+        // registered yet. Let's remove them too.
+        viewObservers.keys.toList().forEach { observer ->
+            unregister(observer)
+        }
+
+        // If any of our sets and maps is not empty now then this would be a serious bug.
+        check(observers.isEmpty())
+        check(pausedObservers.isEmpty())
+        check(lifecycleObservers.isEmpty())
+        check(viewObservers.isEmpty())
     }
 
     @Synchronized

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.base.observer
 
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
 import androidx.lifecycle.Lifecycle.Event.ON_PAUSE
 import androidx.lifecycle.Lifecycle.Event.ON_RESUME
@@ -22,6 +23,7 @@ import java.util.WeakHashMap
  *
  * ObserverRegistry is thread-safe.
  */
+@Suppress("TooManyFunctions")
 class ObserverRegistry<T> : Observable<T> {
     private val observers = mutableSetOf<T>()
     private val lifecycleObservers = WeakHashMap<T, LifecycleBoundObserver<T>>()
@@ -90,7 +92,7 @@ class ObserverRegistry<T> : Observable<T> {
         lifecycleObservers[observer]?.remove()
         viewObservers[observer]?.remove()
 
-        // Remove lifecyle/view observers from map
+        // Remove lifecycle/view observers from map
         lifecycleObservers.remove(observer)
         viewObservers.remove(observer)
     }
@@ -109,10 +111,7 @@ class ObserverRegistry<T> : Observable<T> {
         }
 
         // If any of our sets and maps is not empty now then this would be a serious bug.
-        check(observers.isEmpty())
-        check(pausedObservers.isEmpty())
-        check(lifecycleObservers.isEmpty())
-        check(viewObservers.isEmpty())
+        checkInternalCollectionsAreEmpty()
     }
 
     @Synchronized
@@ -150,6 +149,15 @@ class ObserverRegistry<T> : Observable<T> {
         // The registry is getting observed if there are registered observer or if there are registered view observers
         // that will register an observer as soon as their views are attached.
         return observers.isNotEmpty() || viewObservers.isNotEmpty()
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun checkInternalCollectionsAreEmpty(): Boolean {
+        check(observers.isEmpty())
+        check(pausedObservers.isEmpty())
+        check(lifecycleObservers.isEmpty())
+        check(viewObservers.isEmpty())
+        return true
     }
 
     /**

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -96,14 +96,10 @@ class ObserverRegistry<T> : Observable<T> {
 
     @Synchronized
     override fun unregisterObservers() {
-        observers.forEach {
-            lifecycleObservers[it]?.remove()
+        observers.toList().forEach { observer ->
+            unregister(observer)
         }
 
-        observers.clear()
-        pausedObservers.clear()
-        lifecycleObservers.clear()
-        viewObservers.clear()
     }
 
     @Synchronized

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -19,6 +19,8 @@ import java.util.WeakHashMap
 /**
  * A helper for classes that want to get observed. This class keeps track of registered observers
  * and can automatically unregister observers if a LifecycleOwner is provided.
+ *
+ * ObserverRegistry is thread-safe.
  */
 class ObserverRegistry<T> : Observable<T> {
     private val observers = mutableSetOf<T>()
@@ -75,7 +77,6 @@ class ObserverRegistry<T> : Observable<T> {
 
     /**
      * Unregisters an observer. Does nothing if [observer] is not registered.
-     * This method is thread-safe.
      *
      * @param observer the observer to unregister.
      */

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -134,7 +134,7 @@ class ObserverRegistry<T> : Observable<T> {
 
     @Synchronized
     override fun isObserved(): Boolean {
-        return !observers.isEmpty()
+        return observers.isNotEmpty()
     }
 
     /**

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/ObserverRegistry.kt
@@ -147,7 +147,9 @@ class ObserverRegistry<T> : Observable<T> {
 
     @Synchronized
     override fun isObserved(): Boolean {
-        return observers.isNotEmpty()
+        // The registry is getting observed if there are registered observer or if there are registered view observers
+        // that will register an observer as soon as their views are attached.
+        return observers.isNotEmpty() || viewObservers.isNotEmpty()
     }
 
     /**

--- a/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
@@ -10,6 +10,8 @@ import android.view.WindowManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -352,6 +354,21 @@ class ObserverRegistryTest {
         }
 
         assertFalse(observer.notified)
+    }
+
+    @Test
+    fun `unregisterObservers will unregister from view`() {
+        val view: View = mock()
+        doReturn(true).`when`(view).isAttachedToWindow
+
+        val registry = ObserverRegistry<TestObserver>()
+        val observer = TestObserver()
+
+        registry.register(observer, view)
+        verify(view).addOnAttachStateChangeListener(any())
+
+        registry.unregisterObservers()
+        verify(view).removeOnAttachStateChangeListener(any())
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ permalink: /changelog/
 * **service-glean**
   * The length limit on labels in labeled metrics has been increased from 30 to 61 characters.  See [1556684](https://bugzilla.mozilla.org/show_bug.cgi?id=1556684).
 
+* **support-base**
+  * Fixed multiple potential leaks in `ObserverRegistry` (used internally by many classes in other components like `SessionManager`, `EngineSession` and others).
+
 # 0.55.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.54.0...v0.55.0)


### PR DESCRIPTION
Multiple fixes:

- #3277: Removed partial locking and added `@Synchronized` to the public API. The previous version was too fancy and didn't synchronize on important parts and probably caused visibility issues when not called from the same thread.
- #3278: It seems overkill to optimize for `unregisterObservers` and the safest way to avoid inconsistencies is to call `unregisterObserver()` for every registered observer.
- I added a check to `unregisterObservers()` to make sure all our internal maps/sets are empty after that. That immediately exploded and surprised me. Then I saw that there may be view observers for views that are not attached yet (we changed that some time ago). Now we are correctly clearing those too.
- Then I noticed that `isObserving()` may be lying if there's such a view observer waiting to register. So I made `isObserving()` look at those too.
- Overall this "not yet attached view and therefore not yet registered observer NOT in observers set" is adding a lot of complexity and edge cases. We may want to revisit that for `browser-state` which offers a similar mechanism.
  - Also: **We will keep a reference to a `View` and its `Context`** forever if it is never getting attached - which may be possible. We could use a `WeakReference<View>` but then we still keep `ViewBoundObserver` (and the `Observer`) around. I looked at `ReferenceQueue` but using that still requires us to manually look into the queue from certain hooks (That's what `WeakHashMap` seems to do internally). We may want to file another follow-up for this one.
- Finally I added some more tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
