### PR TITLE
Issue #2364: Always clear previous provider suggestions

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
@@ -51,11 +51,8 @@ internal class SuggestionsAdapter(
         // Start with the current list of suggestions
         val updatedSuggestions = suggestions.toMutableList()
 
-        if (!provider.shouldClearSuggestions) {
-            // This provider doesn't want its suggestions to be cleared when the typed text changes. This means now
-            // that there are new suggestions we need to remove the previous suggestions of this provider.
-            suggestionMap[provider]?.let { updatedSuggestions.removeAll(it) }
-        }
+        // Remove previous suggestions of this provider.
+        suggestionMap[provider]?.let { updatedSuggestions.removeAll(it) }
 
         // Remember which suggestions this provider added
         suggestionMap[provider] = providerSuggestions

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -42,6 +43,34 @@ class SuggestionsAdapterTest {
 
         adapter.addSuggestions(mockProvider(), suggestions)
 
+        assertEquals(3, adapter.itemCount)
+        assertEquals(suggestions, adapter.suggestions)
+    }
+
+    @Test
+    fun `addSuggestions() always clears previous suggestions of provider`() {
+        val adapter = SuggestionsAdapter(mock())
+
+        val provider = mockProvider()
+        `when`(provider.shouldClearSuggestions).thenReturn(true)
+
+        assertEquals(0, adapter.itemCount)
+
+        val suggestions = listOf<AwesomeBar.Suggestion>(mock(), mock(), mock())
+        adapter.addSuggestions(provider, suggestions)
+        assertEquals(3, adapter.itemCount)
+        assertEquals(suggestions, adapter.suggestions)
+
+        adapter.addSuggestions(provider, suggestions)
+        assertEquals(3, adapter.itemCount)
+        assertEquals(suggestions, adapter.suggestions)
+
+        // shouldClearSuggestions is used to indicate whether or not
+        // suggestions should be cleared right away on input changes.
+        // When we're adding newly computed suggestions, we should
+        // always clear old ones to prevent duplicates.
+        `when`(provider.shouldClearSuggestions).thenReturn(false)
+        adapter.addSuggestions(provider, suggestions)
         assertEquals(3, adapter.itemCount)
         assertEquals(suggestions, adapter.suggestions)
     }


### PR DESCRIPTION
Filed https://github.com/mozilla-mobile/android-components/issues/3288 as a follow-up to remove `shouldClearSuggestions`.