### PR TITLE
DiskCache: Synchronize cache writes. Bail out if cache cannot be written.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,9 @@ permalink: /changelog/
 * **support-base**
   * Fixed multiple potential leaks in `ObserverRegistry` (used internally by many classes in other components like `SessionManager`, `EngineSession` and others).
 
+* **browser-icons**
+  * Fixed possible `NullPointerException` when disk cache is written to concurrently.
+
 # 0.55.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.54.0...v0.55.0)


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/fenix/issues/3211

There were two issues with the previous implementation:
* We can't write to the cache concurrently and in this case edit() will
  return null. We should synchronize our writes to avoid not writing
  anything to disk while another write is in-flight.
* In cases where edit() still returns null (stale snapshot) we just
  bail out.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
