### PR TITLE
Add Startpage.com as search engine

### DIFF
--- a/components/browser/search/src/main/assets/search/list.json
+++ b/components/browser/search/src/main/assets/search/list.json
@@ -3,7 +3,7 @@
     "searchDefault": "Google",
     "searchOrder": ["Google", "Bing"],
     "visibleDefaultEngines": [
-      "google-b-m", "bing", "amazondotcom", "ddg", "twitter", "wikipedia"
+      "google-b-m", "bing", "amazondotcom", "ddg", "startpage", "twitter", "wikipedia"
     ]
   },
   "regionOverrides": {
@@ -146,7 +146,7 @@
     "da": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "amazon-co-uk", "twitter", "wikipedia-da"
+          "google-b-m", "startpage", "amazon-co-uk", "twitter", "wikipedia-da"
         ]
       }
     },
@@ -160,7 +160,7 @@
     "dsb": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazon-de", "twitter", "wikipedia-dsb"
+          "google-b-m", "bing", "startpage", "amazon-de", "twitter", "wikipedia-dsb"
         ]
       }
     },
@@ -174,31 +174,31 @@
     "en-CA": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazon-ca", "ddg", "twitter", "wikipedia"
+          "google-b-m", "bing", "amazon-ca", "ddg", "startpage", "twitter", "wikipedia"
         ]
       }
     },
     "en-GB": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazon-co-uk", "ddg", "qwant", "twitter", "wikipedia"
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "startpage", "qwant", "twitter", "wikipedia"
         ]
       },
       "RU": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazon-co-uk", "ddg", "qwant", "twitter", "wikipedia", "yandex-en"
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "startpage", "qwant", "twitter", "wikipedia", "yandex-en"
         ]
       }
     },
     "en-US": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazondotcom", "ddg", "twitter", "wikipedia"
+          "google-b-m", "bing", "amazondotcom", "ddg", "startpage", "twitter", "wikipedia"
         ]
       },
       "RU": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazondotcom", "ddg", "twitter", "wikipedia", "yandex-en"
+          "google-b-m", "bing", "amazondotcom", "ddg", "startpage", "twitter", "wikipedia", "yandex-en"
         ]
       },
       "experimental-hidden": {
@@ -224,7 +224,7 @@
     "es-AR": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "mercadolibre-ar", "twitter", "wikipedia-es"
+          "google-b-m", "mercadolibre-ar", "startpage", "twitter", "wikipedia-es"
         ]
       }
     },
@@ -238,14 +238,14 @@
     "es-ES": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "ddg", "twitter", "wikipedia-es"
+          "google-b-m", "bing", "ddg", "startpage", "twitter", "wikipedia-es"
         ]
       }
     },
     "es-MX": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazondotcom", "ddg", "mercadolibre-mx", "twitter", "wikipedia-es"
+          "google-b-m", "bing", "amazondotcom", "ddg", "mercadolibre-mx", "startpage", "twitter", "wikipedia-es"
         ]
       },
       "experimental-hidden": {
@@ -278,7 +278,7 @@
     "ff": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazon-fr", "wikipedia-fr"
+          "google-b-m", "bing", "amazon-fr", "startpage", "wikipedia-fr"
         ]
       }
     },
@@ -292,7 +292,7 @@
     "fr": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "ddg", "qwant", "twitter", "wikipedia-fr"
+          "google-b-m", "bing", "ddg", "startpage", "qwant", "twitter", "wikipedia-fr"
         ]
       }
     },
@@ -360,7 +360,7 @@
     "hr": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazon-co-uk", "ddg", "twitter", "wikipedia-hr"
+          "google-b-m", "bing", "amazon-co-uk", "ddg", "startpage", "twitter", "wikipedia-hr"
         ]
       }
     },
@@ -388,7 +388,7 @@
     "ia": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "amazondotcom", "ddg", "twitter", "wikipedia-ia"
+          "google-b-m", "bing", "amazondotcom", "ddg", "startpage", "twitter", "wikipedia-ia"
         ]
       }
     },
@@ -409,7 +409,7 @@
     "it": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "ddg", "twitter", "wikipedia-it"
+          "google-b-m", "bing", "ddg", "startpage", "twitter", "wikipedia-it"
         ]
       }
     },
@@ -561,7 +561,7 @@
     "nb-NO": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "ddg", "gulesider-mobile-NO", "twitter", "wikipedia-NO"
+          "google-b-m", "ddg", "gulesider-mobile-NO", "startpage", "twitter", "wikipedia-NO"
         ]
       }
     },
@@ -575,7 +575,7 @@
     "nl": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "bolcom-nl", "ddg", "twitter", "wikipedia-nl"
+          "google-b-m", "bing", "bolcom-nl", "ddg", "startpage", "twitter", "wikipedia-nl"
         ]
       },
       "experimental-hidden": {
@@ -587,7 +587,7 @@
     "nn-NO": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "ddg", "gulesider-mobile-NO", "twitter", "wikipedia-NN"
+          "google-b-m", "ddg", "gulesider-mobile-NO", "startpage", "twitter", "wikipedia-NN"
         ]
       }
     },
@@ -615,7 +615,7 @@
     "pl": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "bing", "ddg", "twitter", "wikipedia-pl"
+          "google-b-m", "bing", "ddg", "startpage", "twitter", "wikipedia-pl"
         ]
       }
     },
@@ -634,7 +634,7 @@
     "pt-PT": {
       "default": {
         "visibleDefaultEngines": [
-          "google-b-m", "wikipedia-pt"
+          "google-b-m", "startpage", "wikipedia-pt"
         ]
       }
     },

--- a/components/browser/search/src/main/assets/searchplugins/startpage.xml
+++ b/components/browser/search/src/main/assets/searchplugins/startpage.xml
@@ -1,0 +1,19 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<SearchPlugin xmlns="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Startpage.com</ShortName>
+<Image width="16" height="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAACXBIWXMAAAY6AAAGOgENcKWeAAAFqklEQVR4nO3bP09bVxyH8Z9Rh5iFpMlUtZKtSq3KAi+Bpcxl64aXsmaIX4BfAENZmeAVkJnJI22H4qoibaUEpELUSEkJkDTdbnWsc+nh+tq+Nsbc8+X5SB5iILY5D+ee+6+SJIlNylrTama2ZGaLwWNuYi8ABWdmth882pvrdjSpz3XtoNeadt/MGv6xIPALx/R1zGzLPTbX7e11Xn3soP1s3DKzVQLABG27rsadtUcO2s/ILuTHjCJu0IYPe6QZe6Sg15r2jd80sC7GNLj1dmNz3Z4Wfa2Zot+41uyGvEPMmCLX2o5vr5ChM7RfYrTZ4cMtczuOS8OWIANnaGJGibgG277JvvoGTcwooaFRD5qhiRlltODbzJUbtF+EEzPKamGtad/nvbeenUJ/aG6HoUQEVrKH9K4E7dcmRxyaQyTccepaeOQju+RoETMiMuebvXQ5Q/trMw4ZTUSonl77Ec7QLUYSkbpstztD+7XzKaOJiD1wa+l0hm4wkohct2GChopuw5XvniTsDEJFfcbfAwgoWJrxN7MCChYJGkoIGlK6QXOqGyrmCt9TCMSAoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCGFoCHlo5g+zGzV7LNP8r/mnq9WB//8l5+P/ppfjPEzSj78a/bnSbEP9ObU7PXfg7/nj+f9v/b61OzNkJ8fZmpBu+BmfXDVTJh5oT782Ozhg2m9O/RTvVeOP+rjl2b/fOh9PvtHNHbQLrhHPrhwdgxnwbs+u2FyPu2zZc7qCTqcLdNQHwWzJZGizCo//5oks/fYxENDJUmShLGECg7bQQpBQwpBQwpBQwpBQwpBQwpBQwpBQ0pUV9uhnJ79/sLOz9/1fW97P3aGvu+D357b+cX7Qp/PvZb7/jwELe7i4n3u4HcDyolw76dfcn8hxyd/2fHJq9L/sgi6hE5evuqJJzvLneeEGkt0N4mgJyw7I55fvLODZ+G/e0MssklGMQTdxw/BptfNem72S4Wb5UHrOUzfnQg6jDOcDcMdETbXGqIMul+ge32ex91RmqDTSMM153Gwc+Sec18DBrnRoMPjk+mMSaS4SWMFnYYazqbpepSdJNymK0ETKmJX+Xa1mbADBRWV2ldfc5MsZHC1HaQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKQQNKS4oM8YUog4c0HvM5oQsU/QUELQkNINus2YQkR75vBg98jMOowoItdxLaeH7bYYTUSu2zBBQ8X/QR8e7L41s22GFpHa9g1fOVPYYjQRqct2L4P2O4cbjCgis+Hb7cpey9HiVDgicpZdWVwJ2q9DGowoItFI186pnqvtDg92n7KDiAhs+FavqCRJkvvW6/PL7pT4AiOLEnInURbz3tag66GXOIOIEur4NnP1DdqvTYgaZdKNObtuDg28Y4WoUSJDY7ZBa+is+vyyO7W4ygjjFrgzgYWOvhW+p9D/hyscp8YUudZWisZso94k6w+T1DijiClwjdXyDs0NUnjJkVWfX675szQsQzBJ7hxIKzydPYqxg07V55fv+7OLDY5bY0wdf/nn1rCdvmGuHXTIz9ruqMhi8JhjlBFw62J30i59tMedjXuY2X/Jct6OnArorQAAAABJRU5ErkJggg==</Image>
+<Url type="application/x-suggestions+json" template="https://www.startpage.com/do/suggest">
+  <Param name="query" value="{searchTerms}"/>
+  <Param name="lang" value="{moz:locale}"/>
+  <Param name="format" value="json"/>
+</Url>
+<!-- this is effectively x-moz-phonesearch, but search service expects a text/html entry -->
+<Url type="text/html" method="GET" template="https://www.startpage.com/rvd/search">
+  <Param name="query" value="{searchTerms}" />
+  <Param name="language" value="auto" />
+</Url>
+<SearchForm>http://www.startpage.com</SearchForm>
+</SearchPlugin>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-search**
+  * Startpage.com has been added as a search engine
+
 * **browser-toolbar**
   * Updated `titleTextSize` and `textSize` to have maximum values which cannot be sized past in order
     to ensure that their view constraints will not be broken. We do this manually because autoResizeText


### PR DESCRIPTION
This adds Startpage.com as a search provider with working suggestions. It has been manually tested using the browser sample.

The changes to list.json are currently based on the list of interface and search languages which are supported by Startpage (from their [settings page](https://www.startpage.com/search/settings)), and probably needs to be double-checked.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
