### PR TITLE
Fix #3293 Feed request URL to session observer from different engines

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -324,6 +324,7 @@ class GeckoEngineSession(
                     // As the name LoadRequest.isRedirect may imply this flag is about http redirects. The flag
                     // is "True if and only if the request was triggered by an HTTP redirect."
                     onLoadRequest(
+                        url = request.uri,
                         triggeredByRedirect = request.isRedirect,
                         triggeredByWebContent = requestFromWebContent
                     )

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1680,7 +1680,7 @@ class GeckoEngineSessionTest {
         var observedTriggeredByRedirect: Boolean? = null
 
         engineSession.register(object : EngineSession.Observer {
-            override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+            override fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
                 observedTriggeredByRedirect = triggeredByRedirect
             }
         })
@@ -1705,21 +1705,26 @@ class GeckoEngineSessionTest {
         captureDelegates()
 
         val fakeUrl = "https://example.com"
+        var observedUrl: String?
         var observedTriggeredByWebContent: Boolean?
 
         engineSession.register(object : EngineSession.Observer {
-            override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+            override fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
                 observedTriggeredByWebContent = triggeredByWebContent
+                observedUrl = url
             }
         })
 
         fun fakePageLoad(expectedTriggeredByWebContent: Boolean) {
             observedTriggeredByWebContent = null
+            observedUrl = null
             navigationDelegate.value.onLoadRequest(
                 mock(), mockLoadRequest(fakeUrl, triggeredByRedirect = true))
             progressDelegate.value.onPageStop(mock(), true)
             assertNotNull(observedTriggeredByWebContent)
             assertEquals(expectedTriggeredByWebContent, observedTriggeredByWebContent!!)
+            assertNotNull(observedUrl)
+            assertEquals(fakeUrl, observedUrl)
         }
 
         // loadUrl(url: String)
@@ -1789,7 +1794,7 @@ class GeckoEngineSessionTest {
         navigationDelegate.value.onLoadRequest(
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
 
-        verify(observer, never()).onLoadRequest(anyBoolean(), anyBoolean())
+        verify(observer, never()).onLoadRequest(eq("sample:about"), anyBoolean(), anyBoolean())
     }
 
     private fun mockGeckoSession(): GeckoSession {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -326,6 +326,7 @@ class GeckoEngineSession(
                     // is "True if and only if the request was triggered by an HTTP redirect."
                     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1545170
                     onLoadRequest(
+                        url = request.uri,
                         triggeredByRedirect = request.isRedirect,
                         triggeredByWebContent = requestFromWebContent
                     )

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -230,7 +230,11 @@ class SystemEngineView @JvmOverloads constructor(
             }
 
             if (request.isForMainFrame) {
-                session?.let { it.notifyObservers { onLoadRequest(request.hasGesture(), true) } }
+                session?.let {
+                    it.notifyObservers {
+                        onLoadRequest(request.url.toString(), request.hasGesture(), true)
+                    }
+                }
             }
 
             return super.shouldInterceptRequest(view, request)

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -448,10 +448,11 @@ class SystemEngineSessionTest {
 
     @Test
     fun `shouldInterceptRequest notifies observers if request was not intercepted`() {
+        val url = "sample:about"
         val request: WebResourceRequest = mock()
         doReturn(true).`when`(request).isForMainFrame
         doReturn(true).`when`(request).hasGesture()
-        doReturn(Uri.parse("sample:about")).`when`(request).url
+        doReturn(Uri.parse(url)).`when`(request).url
 
         val engineSession = SystemEngineSession(getApplicationContext())
         engineSession.webView = spy(engineSession.webView)
@@ -463,7 +464,7 @@ class SystemEngineSessionTest {
 
         engineSession.webView.webViewClient.shouldInterceptRequest(engineSession.webView, request)
 
-        verify(observer).onLoadRequest(true, true)
+        verify(observer).onLoadRequest(anyString(), eq(true), eq(true))
 
         val redirect: WebResourceRequest = mock()
         doReturn(true).`when`(redirect).isForMainFrame
@@ -472,7 +473,7 @@ class SystemEngineSessionTest {
 
         engineSession.webView.webViewClient.shouldInterceptRequest(engineSession.webView, redirect)
 
-        verify(observer).onLoadRequest(false, true)
+        verify(observer).onLoadRequest(anyString(), eq(true), eq(true))
     }
 
     @Test
@@ -502,7 +503,7 @@ class SystemEngineSessionTest {
             engineSession.webView,
             request)
 
-        verify(observer, never()).onLoadRequest(anyBoolean(), anyBoolean())
+        verify(observer, never()).onLoadRequest(anyString(), anyBoolean(), anyBoolean())
     }
 
     @Test

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -6,8 +6,8 @@ package mozilla.components.browser.session
 
 import android.graphics.Bitmap
 import mozilla.components.browser.session.engine.EngineSessionHolder
+import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
-import mozilla.components.browser.session.engine.request.isSet
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -54,7 +54,12 @@ class Session(
         fun onProgress(session: Session, progress: Int) = Unit
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
         fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) = Unit
-        fun onLoadRequest(session: Session, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) = Unit
+        fun onLoadRequest(
+            session: Session,
+            url: String,
+            triggeredByRedirect: Boolean,
+            triggeredByWebContent: Boolean
+        ) = Unit
         fun onSearch(session: Session, searchTerms: String) = Unit
         fun onSecurityChanged(session: Session, securityInfo: SecurityInfo) = Unit
         fun onCustomTabConfigChanged(session: Session, customTabConfig: CustomTabConfig?) = Unit
@@ -202,12 +207,13 @@ class Session(
     }
 
     /**
-     * Set when a load request is received, indicating if the user was involved in the interaction.
+     * Set when a load request is received, indicating if the request came from web content, or via a redirect.
      */
-    var loadRequestTriggers: Int by Delegates.observable(0) {
+    var loadRequestMetadata: LoadRequestMetadata by Delegates.observable(LoadRequestMetadata.blank) {
         _, _, new -> notifyObservers {
             onLoadRequest(
                 this@Session,
+                new.url,
                 new.isSet(LoadRequestOption.REDIRECT),
                 new.isSet(LoadRequestOption.WEB_CONTENT)
             )

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -8,8 +8,8 @@ import android.graphics.Bitmap
 import android.os.Environment
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
-import mozilla.components.browser.session.engine.request.plus
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -48,20 +48,18 @@ internal class EngineObserver(
         }
     }
 
-    override fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
+    override fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
         if (triggeredByWebContent) {
             session.searchTerms = ""
         }
-        var triggers = LoadRequestOption.NONE.toMask()
-        if (triggeredByRedirect) {
-            triggers += LoadRequestOption.REDIRECT
-        }
 
-        if (triggeredByWebContent) {
-            triggers += LoadRequestOption.WEB_CONTENT
-        }
-
-        session.loadRequestTriggers = triggers
+        session.loadRequestMetadata = LoadRequestMetadata(
+            url,
+            arrayOf(
+                if (triggeredByRedirect) LoadRequestOption.REDIRECT else LoadRequestOption.NONE,
+                if (triggeredByWebContent) LoadRequestOption.WEB_CONTENT else LoadRequestOption.NONE
+            )
+        )
     }
 
     override fun onTitleChange(title: String) {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/request/LoadRequestMetadata.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/request/LoadRequestMetadata.kt
@@ -6,6 +6,24 @@
 
 package mozilla.components.browser.session.engine.request
 
+class LoadRequestMetadata(
+    val url: String,
+    options: Array<LoadRequestOption> = emptyArray()
+) {
+    private val optionMask: Long
+    init {
+        optionMask = options.fold(0L) { acc, it ->
+            acc or it.mask
+        }
+    }
+
+    fun isSet(option: LoadRequestOption) = optionMask and option.mask > 0
+
+    companion object {
+        val blank = LoadRequestMetadata("about:blank")
+    }
+}
+
 /**
  * Simple enum class for defining the set of characteristics of a [LoadRequest].
  *
@@ -13,14 +31,8 @@ package mozilla.components.browser.session.engine.request
  *
  * This should be generalized, but it's not clear if it will be useful enough to go into [kotlin.support].
  */
-enum class LoadRequestOption constructor(val mask: Int) {
-    NONE(0),
-    REDIRECT(1 shl 0),
-    WEB_CONTENT(1 shl 1);
-
-    fun toMask() = mask
+enum class LoadRequestOption constructor(internal val mask: Long) {
+    NONE(0L),
+    REDIRECT(1L shl 0),
+    WEB_CONTENT(1L shl 1);
 }
-
-infix operator fun LoadRequestOption.plus(other: LoadRequestOption) = this.mask or other.mask
-infix operator fun Int.plus(other: LoadRequestOption) = this or other.mask
-infix fun Int.isSet(option: LoadRequestOption) = this and option.mask > 0

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session.Source
+import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
-import mozilla.components.browser.session.engine.request.isSet
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -171,10 +171,13 @@ class SessionTest {
         val session = Session("https://www.mozilla.org")
         session.register(observer)
 
-        session.loadRequestTriggers = LoadRequestOption.REDIRECT.toMask()
+        session.loadRequestMetadata = LoadRequestMetadata(
+            "https://www.mozilla.org",
+            arrayOf(LoadRequestOption.REDIRECT)
+        )
 
-        assertTrue(session.loadRequestTriggers.isSet(LoadRequestOption.REDIRECT))
-        verify(observer, times(1)).onLoadRequest(eq(session), eq(true), eq(false))
+        assertTrue(session.loadRequestMetadata.isSet(LoadRequestOption.REDIRECT))
+        verify(observer, times(1)).onLoadRequest(eq(session), eq("https://www.mozilla.org"), eq(true), eq(false))
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -7,7 +7,6 @@ package mozilla.components.browser.session.engine
 import android.graphics.Bitmap
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.engine.request.LoadRequestOption
-import mozilla.components.browser.session.engine.request.isSet
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
@@ -443,32 +442,35 @@ class EngineObserverTest {
 
     @Test
     fun `onLoadRequest clears search terms for requests triggered by user interaction`() {
-        val session = Session("https://www.mozilla.org")
+        val url = "https://www.mozilla.org"
+        val session = Session(url)
         session.searchTerms = "Mozilla Foundation"
 
         val observer = EngineObserver(session)
-        observer.onLoadRequest(triggeredByRedirect = true, triggeredByWebContent = true)
+        observer.onLoadRequest(url = url, triggeredByRedirect = true, triggeredByWebContent = true)
 
         assertEquals("", session.searchTerms)
-        val triggeredByRedirect = session.loadRequestTriggers.isSet(LoadRequestOption.REDIRECT)
-        val triggeredByWebContent = session.loadRequestTriggers.isSet(LoadRequestOption.WEB_CONTENT)
+        val triggeredByRedirect = session.loadRequestMetadata.isSet(LoadRequestOption.REDIRECT)
+        val triggeredByWebContent = session.loadRequestMetadata.isSet(LoadRequestOption.WEB_CONTENT)
 
         assertTrue(triggeredByRedirect)
         assertTrue(triggeredByWebContent)
+        assertEquals(session.loadRequestMetadata.url, url)
     }
 
     @Test
     fun `onLoadRequest does not clear search terms for requests not triggered by user interacting with web content`() {
-        val session = Session("https://www.mozilla.org")
+        val url = "https://www.mozilla.org"
+        val session = Session(url)
         session.searchTerms = "Mozilla Foundation"
 
         val observer = EngineObserver(session)
-        observer.onLoadRequest(triggeredByRedirect = true, triggeredByWebContent = false)
+        observer.onLoadRequest(url = url, triggeredByRedirect = true, triggeredByWebContent = false)
 
         assertEquals("Mozilla Foundation", session.searchTerms)
 
-        val triggeredByRedirect = session.loadRequestTriggers.isSet(LoadRequestOption.REDIRECT)
-        val triggeredByWebContent = session.loadRequestTriggers.isSet(LoadRequestOption.WEB_CONTENT)
+        val triggeredByRedirect = session.loadRequestMetadata.isSet(LoadRequestOption.REDIRECT)
+        val triggeredByWebContent = session.loadRequestMetadata.isSet(LoadRequestOption.WEB_CONTENT)
 
         assertTrue(triggeredByRedirect)
         assertFalse(triggeredByWebContent)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -58,11 +58,12 @@ abstract class EngineSession(
         /**
          * The engine received a request to load a request.
          *
+         * @param url The string url that was requested.
          * @param triggeredByRedirect True if and only if the request was triggered by an HTTP redirect.
          * @param triggeredByWebContent True if and only if the request was triggered from within
          * web content (as opposed to via the browser chrome).
          */
-        fun onLoadRequest(triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) = Unit
+        fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) = Unit
 
         @Suppress("LongParameterList")
         fun onExternalResource(

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -60,7 +60,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaAdded(mediaAdded) }
         session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
         session.notifyInternalObservers { onCrashStateChange(true) }
-        session.notifyInternalObservers { onLoadRequest(true, true) }
+        session.notifyInternalObservers { onLoadRequest("https://www.mozilla.org", true, true) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
@@ -84,7 +84,7 @@ class EngineSessionTest {
         verify(observer).onMediaAdded(mediaAdded)
         verify(observer).onMediaRemoved(mediaRemoved)
         verify(observer).onCrashStateChange(true)
-        verify(observer).onLoadRequest(true, true)
+        verify(observer).onLoadRequest("https://www.mozilla.org", true, true)
         verifyNoMoreInteractions(observer)
     }
 
@@ -118,7 +118,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onOpenWindowRequest(windowRequest) }
         session.notifyInternalObservers { onCloseWindowRequest(windowRequest) }
         session.notifyInternalObservers { onCrashStateChange(false) }
-        session.notifyInternalObservers { onLoadRequest(true, true) }
+        session.notifyInternalObservers { onLoadRequest("https://www.mozilla.org", true, true) }
         session.unregister(observer)
 
         val mediaAdded: Media = mock()
@@ -144,7 +144,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaAdded(mediaAdded) }
         session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
         session.notifyInternalObservers { onCrashStateChange(true) }
-        session.notifyInternalObservers { onLoadRequest(false, true) }
+        session.notifyInternalObservers { onLoadRequest("https://www.mozilla.org", false, true) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -164,7 +164,7 @@ class EngineSessionTest {
         verify(observer).onOpenWindowRequest(windowRequest)
         verify(observer).onCloseWindowRequest(windowRequest)
         verify(observer).onCrashStateChange(false)
-        verify(observer).onLoadRequest(true, true)
+        verify(observer).onLoadRequest("https://www.mozilla.org", true, true)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -185,7 +185,7 @@ class EngineSessionTest {
         verify(observer, never()).onMediaAdded(mediaAdded)
         verify(observer, never()).onMediaRemoved(mediaRemoved)
         verify(observer, never()).onCrashStateChange(true)
-        verify(observer, never()).onLoadRequest(false, true)
+        verify(observer, never()).onLoadRequest("https://www.mozilla.org", false, true)
         verifyNoMoreInteractions(observer)
     }
 

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -48,8 +48,13 @@ class AppLinksFeature(
 
     @VisibleForTesting
     internal val observer: SelectionAwareSessionObserver = object : SelectionAwareSessionObserver(sessionManager) {
-        override fun onLoadRequest(session: Session, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
-            handleLoadRequest(session, triggeredByWebContent)
+        override fun onLoadRequest(
+            session: Session,
+            url: String,
+            triggeredByRedirect: Boolean,
+            triggeredByWebContent: Boolean
+        ) {
+            handleLoadRequest(session, url, triggeredByWebContent)
         }
     }
 
@@ -72,12 +77,11 @@ class AppLinksFeature(
     }
 
     @VisibleForTesting
-    internal fun handleLoadRequest(session: Session, triggeredByWebContent: Boolean) {
+    internal fun handleLoadRequest(session: Session, url: String, triggeredByWebContent: Boolean) {
         if (!triggeredByWebContent) {
             return
         }
 
-        val url = session.url
         val redirect = useCases.interceptedAppLinkRedirect.invoke(url)
 
         if (redirect.isRedirect()) {

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -47,7 +47,7 @@ class AppLinksFeatureTest {
         mockContext = mock(Context::class.java)
 
         val engine = mock(Engine::class.java)
-        mockSessionManager = Mockito.spy(SessionManager(engine))
+        mockSessionManager = spy(SessionManager(engine))
         mockFragmentManager = mock(FragmentManager::class.java)
         mockUseCases = mock(AppLinksUseCases::class.java)
 
@@ -73,16 +73,16 @@ class AppLinksFeatureTest {
         )
     }
 
-    private fun createSession(url: String, isPrivate: Boolean): Session {
+    private fun createSession(isPrivate: Boolean): Session {
         val session = mock(Session::class.java)
         `when`(session.private).thenReturn(isPrivate)
-        `when`(session.url).thenReturn(url)
         return session
     }
 
     private fun userTapsOnSession(url: String, private: Boolean) {
         feature.observer.onLoadRequest(
-            createSession(url, private),
+            createSession(private),
+            url,
             triggeredByRedirect = false,
             triggeredByWebContent = true
         )
@@ -106,14 +106,14 @@ class AppLinksFeatureTest {
 
     @Test
     fun `it tests for app links when triggered by user clicking on a link`() {
-        val session = createSession(webUrl, false)
+        val session = createSession(false)
         val subject = AppLinksFeature(
             mockContext,
             mockSessionManager,
             useCases = mockUseCases
         )
 
-        subject.handleLoadRequest(session, true)
+        subject.handleLoadRequest(session, webUrl, true)
 
         verify(mockGetRedirect).invoke(webUrl)
         verifyNoMoreInteractions(mockOpenRedirect)
@@ -127,7 +127,7 @@ class AppLinksFeatureTest {
             sessionId = "123",
             useCases = mockUseCases
         )
-        val mockSession = createSession(webUrl, false)
+        val mockSession = createSession(false)
         `when`(mockSessionManager.findSessionById(ArgumentMatchers.anyString())).thenReturn(mockSession)
 
         feature.start()
@@ -199,7 +199,8 @@ class AppLinksFeatureTest {
         featureWithDialog.start()
 
         feature.observer.onLoadRequest(
-            createSession(webUrl, true),
+            createSession(true),
+            webUrl,
             triggeredByRedirect = false,
             triggeredByWebContent = false
         )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,7 +36,10 @@ permalink: /changelog/
 
 * **lib-crash**
   * Crash reports sent to Sentry now contain optional environment information, if a parameter is passed.
-  
+
+* **browser-session**
+  * ⚠️ **This is a breaking change**: Added `url` parameter to `Session.Observer.onLoadRequest()`.
+
 # 0.55.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.54.0...v0.55.0)


### PR DESCRIPTION
This allows the slack:// (and other custom schemes).

Fixes #3293.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
