### PR TITLE
Replaced ViewGroup.forEach with core-ktx

### DIFF
--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':support-ktx')
 
     implementation Dependencies.androidx_appcompat
+    implementation Dependencies.androidx_core_ktx
     implementation Dependencies.androidx_recyclerview
     implementation Dependencies.androidx_cardview
 

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -16,6 +16,7 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.view.forEach
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.isVisible
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -35,7 +36,6 @@ import mozilla.components.concept.toolbar.AutocompleteResult
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.base.log.logger.Logger
-import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.ui.autocomplete.AutocompleteView
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import mozilla.components.ui.autocomplete.OnFilterListener

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -912,32 +912,27 @@ class DisplayToolbarTest {
 
         private inline fun <reified T> extractView(
             displayToolbar: DisplayToolbar,
-            otherCondition: (T) -> Boolean = { _ -> true }
+            otherCondition: (T) -> Boolean = { true }
         ): T? {
             displayToolbar.forEach {
                 if (it is T && otherCondition(it)) {
                     return it
                 }
             }
-
             return null
         }
     }
 }
 
 infix fun View.assertIn(group: ViewGroup) {
-    var found = false
-
     group.forEach {
         if (this == it) {
             println("Checking $this == $it")
-            found = true
+            return
         }
     }
 
-    if (!found) {
-        throw AssertionError("View not found in ViewGroup")
-    }
+    throw AssertionError("View not found in ViewGroup")
 }
 
 infix fun View.assertNotIn(group: ViewGroup) {

--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':ui-icons')
 
+    implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.core.view.forEach
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.Session
@@ -22,7 +23,6 @@ import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.browser.session.tab.CustomTabMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
-import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/ViewGroup.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/ViewGroup.kt
@@ -6,12 +6,11 @@ package mozilla.components.support.ktx.android.view
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.forEach
 
 /**
  * Performs the given action on each View in this ViewGroup.
  */
-fun ViewGroup.forEach(action: (View) -> Unit) {
-    for (index in 0 until childCount) {
-        action(getChildAt(index))
-    }
-}
+@Deprecated("Use Android KTX instead",
+    ReplaceWith("forEach(action)", "androidx.core.view.forEach"))
+inline fun ViewGroup.forEach(action: (View) -> Unit) = forEach(action)

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/Map.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/Map.kt
@@ -5,48 +5,14 @@
 package mozilla.components.support.ktx.kotlin
 
 import android.os.Bundle
-import android.os.IBinder
-import android.os.Parcelable
-import android.util.Size
-import android.util.SizeF
-import java.io.Serializable
+import androidx.core.os.bundleOf
 
 /**
  * Converts a Map to a Bundle
  */
+@Suppress("SpreadOperator")
+@Deprecated("Use Android KTX bundleOf()")
 fun <K, V> Map<K, V>.toBundle(): Bundle {
-    return Bundle().apply {
-        forEach { (k, v) ->
-            val key = k.toString()
-            put(key, v)
-        }
-    }
-}
-
-private fun <V> Bundle.put(key: String, value: V) {
-    when (value) {
-        is IBinder -> putBinder(key, value)
-        is Boolean -> putBoolean(key, value)
-        is BooleanArray -> putBooleanArray(key, value)
-        is Bundle -> putBundle(key, value)
-        is Byte -> putByte(key, value)
-        is ByteArray -> putByteArray(key, value)
-        is Char -> putChar(key, value)
-        is CharArray -> putCharArray(key, value)
-        is CharSequence -> putCharSequence(key, value)
-        is Double -> putDouble(key, value)
-        is DoubleArray -> putDoubleArray(key, value)
-        is Float -> putFloat(key, value)
-        is FloatArray -> putFloatArray(key, value)
-        is Int -> putInt(key, value)
-        is IntArray -> putIntArray(key, value)
-        is Long -> putLong(key, value)
-        is LongArray -> putLongArray(key, value)
-        is Parcelable -> putParcelable(key, value)
-        is Serializable -> putSerializable(key, value)
-        is Short -> putShort(key, value)
-        is ShortArray -> putShortArray(key, value)
-        is Size -> putSize(key, value)
-        is SizeF -> putSizeF(key, value)
-    }
+    val pairs = mapKeys { (key) -> key.toString() }.toList().toTypedArray()
+    return bundleOf(*pairs)
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/MapTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/MapTest.kt
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith
 import java.io.Serializable
 
 @RunWith(AndroidJUnit4::class)
+@Suppress("Deprecation")
 class MapTest {
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,10 @@ permalink: /changelog/
 * **feature-prompts**
   * Improved month picker UI, now we have the same widget as Fennec.
 
+* **support-ktx**
+  * Deprecated `ViewGroup.forEach` in favour of Android Core KTX.
+  * Deprecated `Map.toBundle()` in favour of Android Core KTX `bundleOf`.
+
 # 5.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v4.0.0...v5.0.0)


### PR DESCRIPTION
Replacing support functions with equivalent core-ktx functions.

`ViewGroup.forEach()` in core-ktx is identical.

Also removed `Map.toBundle()` because `bundleOf()` has the same behaviour. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features