### PR TITLE
For #1481. Use androidx runner in `browser-icons`.

### DIFF
--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -31,6 +31,8 @@ android {
             resources.srcDirs += ['src/test/resources']
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -49,10 +51,10 @@ dependencies {
     testImplementation project(':lib-fetch-okhttp')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
-    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.testing_robolectric
 
     androidTestImplementation Dependencies.androidx_test_core
     androidTestImplementation Dependencies.androidx_test_runner

--- a/components/browser/icons/gradle.properties
+++ b/components/browser/icons/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.icons
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.icons.generator.IconGenerator
 import mozilla.components.concept.engine.manifest.Size
@@ -24,9 +25,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserIconsTest {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/decoder/AndroidIconDecoderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/decoder/AndroidIconDecoderTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.icons.decoder
 
 import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertNotNull
@@ -15,10 +16,10 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AndroidIconDecoderTest {
+
     @Test
     fun `WHEN decoding PNG THEN returns non-null bitmap`() {
         val decoder = AndroidIconDecoder()

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/decoder/ICOIconDecoderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/decoder/ICOIconDecoderTest.kt
@@ -4,16 +4,17 @@
 
 package mozilla.components.browser.icons.decoder
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.decoder.ico.IconDirectoryEntry
 import mozilla.components.browser.icons.decoder.ico.decodeDirectoryEntries
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ICOIconDecoderTest {
+
     @Test
     fun `Decoding microsoft favicon`() {
         val icon = loadIcon("microsoft_favicon.ico")

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageHandlerTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageHandlerTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.icons.extension
 
 import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -24,10 +25,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class IconMessageHandlerTest {
+
     @Test
     fun `Complex message (TheVerge) is transformed into IconRequest and loaded`() = runBlocking {
         val session: Session = mock()

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageKtTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageKtTest.kt
@@ -4,15 +4,16 @@
 
 package mozilla.components.browser.icons.extension
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.engine.manifest.Size
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class IconMessageKtTest {
+
     @Test
     fun `Serializing and deserializing icon resources`() {
         val resources = listOf(

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/generator/DefaultIconGeneratorTest.kt
@@ -4,28 +4,25 @@
 
 package mozilla.components.browser.icons.generator
 
-import android.content.Context
 import android.graphics.Bitmap
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DefaultIconGeneratorTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun getRepresentativeCharacter() = runBlocking {
-        val generator = DefaultIconGenerator(context)
+        val generator = DefaultIconGenerator(testContext)
 
         assertEquals("M", generator.getRepresentativeCharacter("https://mozilla.org"))
         assertEquals("W", generator.getRepresentativeCharacter("http://wikipedia.org"))
@@ -75,7 +72,7 @@ class DefaultIconGeneratorTest {
 
     @Test
     fun pickColor() {
-        val generator = DefaultIconGenerator(context)
+        val generator = DefaultIconGenerator(testContext)
 
         val color = generator.pickColor("http://m.facebook.com")
 
@@ -96,15 +93,15 @@ class DefaultIconGeneratorTest {
 
     @Test
     fun generate() = runBlocking {
-        val generator = DefaultIconGenerator(context)
+        val generator = DefaultIconGenerator(testContext)
 
-        val icon = generator.generate(context, IconRequest(
+        val icon = generator.generate(testContext, IconRequest(
             url = "https://m.facebook.com"))
 
         assertNotNull(icon.bitmap)
         assertNotNull(icon.color)
 
-        val dp32 = context.resources.pxToDp(32)
+        val dp32 = testContext.resources.pxToDp(32)
         assertEquals(dp32, icon.bitmap!!.width)
         assertEquals(dp32, icon.bitmap!!.height)
 

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/DataUriIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/DataUriIconLoaderTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.icons.loader
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.support.test.mock
@@ -12,10 +13,10 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DataUriIconLoaderTest {
+
     @Test
     fun `Loader returns null for http(s) urls`() {
         val loader = DataUriIconLoader()

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/FailureCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/FailureCacheTest.kt
@@ -4,16 +4,17 @@
 
 package mozilla.components.browser.icons.loader
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class FailureCacheTest {
+
     @Test
     fun `Cache should remember URLs for limited amount of time`() {
         val cache = spy(FailureCache())

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/HttpIconLoaderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/HttpIconLoaderTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.icons.loader
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
@@ -28,11 +29,11 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class HttpIconLoaderTest {
+
     @Test
     fun `Loader downloads data and uses appropriate headers`() {
         val clients = listOf(

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/DiskCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/DiskCacheTest.kt
@@ -4,26 +4,23 @@
 
 package mozilla.components.browser.icons.utils
 
-import android.content.Context
 import android.graphics.Bitmap
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.`when`
-import org.robolectric.RobolectricTestRunner
 import java.io.OutputStream
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DiskCacheTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Writing and reading resources`() {
@@ -50,9 +47,9 @@ class DiskCacheTest {
         )
 
         val request = IconRequest("https://www.mozilla.org", resources = resources)
-        cache.putResources(context, request)
+        cache.putResources(testContext, request)
 
-        val restoredResources = cache.getResources(context, request)
+        val restoredResources = cache.getResources(testContext, request)
         assertEquals(3, restoredResources.size)
         assertEquals(resources, restoredResources)
     }
@@ -78,9 +75,9 @@ class DiskCacheTest {
             true
         }
 
-        cache.putIconBitmap(context, resource, bitmap)
+        cache.putIconBitmap(testContext, resource, bitmap)
 
-        val data = cache.getIconData(context, resource)
+        val data = cache.getIconData(testContext, resource)
         assertNotNull(data!!)
         assertEquals("Hello World", String(data))
     }

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/MemoryCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/MemoryCacheTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.icons.utils
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.icons.loader.IconLoader
@@ -16,10 +17,10 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class MemoryCacheTest {
+
     @Test
     fun `Verify memory components interaction`() {
         val cache = MemoryCache()


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-icons` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).
  - Removed unused test dependencies.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~