### PR TITLE
Fix for intermittent test failures in Glean

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -238,7 +238,7 @@ class GleanTest {
         runBlocking {
             gleanSpy.handleBackgroundEvent()
         }
-        assertFalse(isWorkScheduled(PingUploadWorker.PING_WORKER_TAG))
+        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     @Test
@@ -248,7 +248,7 @@ class GleanTest {
         runBlocking {
             Glean.handleBackgroundEvent()
         }
-        assertFalse(isWorkScheduled(PingUploadWorker.PING_WORKER_TAG))
+        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
@@ -8,7 +8,7 @@ import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.checkPingSchema
 import mozilla.components.service.glean.getContextWithMockedInfo
 import mozilla.components.service.glean.getMockWebServer
-import mozilla.components.service.glean.isWorkScheduled
+import mozilla.components.service.glean.getWorkerStatus
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.triggerWorkManager
@@ -131,7 +131,7 @@ class PingTypeTest {
         Glean.sendPingsByName(listOf("unknown"))
 
         assertFalse("We shouldn't have any pings scheduled",
-            isWorkScheduled(PingUploadWorker.PING_WORKER_TAG)
+            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued
         )
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -18,7 +18,7 @@ import mozilla.components.service.glean.checkPingSchema
 import mozilla.components.service.glean.triggerWorkManager
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.getMockWebServer
-import mozilla.components.service.glean.isWorkScheduled
+import mozilla.components.service.glean.getWorkerStatus
 import mozilla.components.service.glean.utils.getISOTimeString
 import mozilla.components.service.glean.utils.parseISOTimeString
 import org.json.JSONObject
@@ -429,13 +429,13 @@ class MetricsPingSchedulerTest {
         val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext<Context>())
 
         // No work should be enqueued at the beginning of the test.
-        assertFalse(isWorkScheduled(MetricsPingWorker.TAG))
+        assertFalse(getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
 
         // Manually schedule a collection task for today.
         mps.schedulePingCollection(Calendar.getInstance(), sendTheNextCalendarDay = false)
 
         // We expect the worker to be scheduled.
-        assertTrue(isWorkScheduled(MetricsPingWorker.TAG))
+        assertTrue(getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
     }
 
     // @Test


### PR DESCRIPTION
Due to upgrading WorkManager dependency, testing of WorkManager now works so all of the tests depending on our workaround in `triggerWorkManager` needed a fix to prevent intermittent failures.  This required us to use the WorkManager TestDriver to trigger the conditions and now we test WorkManager as it is supposed to be tested.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
