### PR TITLE
For #1481. Use androidx runner in `browser-errorpages`.

### DIFF
--- a/components/browser/errorpages/build.gradle
+++ b/components/browser/errorpages/build.gradle
@@ -28,6 +28,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -37,7 +39,7 @@ dependencies {
 
     testImplementation project(':support-test')
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/errorpages/gradle.properties
+++ b/components/browser/errorpages/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -6,6 +6,7 @@
 
 package mozilla.components.browser.errorpages
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.errorpages.ErrorPages.createErrorPage
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
@@ -16,9 +17,8 @@ import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ErrorPagesTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-errorpages` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Trivial (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~