### PR TITLE
For #1481. Use androidx runner in `browser-menu`.

### DIFF
--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -34,7 +36,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.androidx_test_core

--- a/components/browser/menu/gradle.properties
+++ b/components/browser/menu/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.menu
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
@@ -17,9 +18,8 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuAdapterTest {
 
     @Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuBuilderTest.kt
@@ -7,14 +7,14 @@ package mozilla.components.browser.menu
 import android.view.View
 import android.widget.ImageButton
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuBuilderTest {
 
     @Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -4,17 +4,17 @@
 
 package mozilla.components.browser.menu
 
-import android.content.Context
 import android.view.Gravity
 import android.view.View
 import android.widget.Button
 import android.widget.PopupWindow
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -26,14 +26,11 @@ import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowDisplay
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `show returns non-null popup window`() {
@@ -41,11 +38,11 @@ class BrowserMenuTest {
             SimpleBrowserMenuItem("Hello") {},
             SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(context, items)
+        val adapter = BrowserMenuAdapter(testContext, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(context)
+        val anchor = Button(testContext)
         val popup = menu.show(anchor)
 
         assertNotNull(popup)
@@ -57,11 +54,11 @@ class BrowserMenuTest {
             SimpleBrowserMenuItem("Hello") {},
             SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(context, items)
+        val adapter = BrowserMenuAdapter(testContext, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(context)
+        val anchor = Button(testContext)
         val popup = menu.show(anchor)
 
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
@@ -78,11 +75,11 @@ class BrowserMenuTest {
             SimpleBrowserMenuItem("Hello") {},
             SimpleBrowserMenuItem("World") {})
 
-        val adapter = spy(BrowserMenuAdapter(context, items))
+        val adapter = spy(BrowserMenuAdapter(testContext, items))
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(context)
+        val anchor = Button(testContext)
         val popup = menu.show(anchor)
 
         val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
@@ -96,7 +93,7 @@ class BrowserMenuTest {
     @Test
     fun `invalidate is a no-op if the menu is closed`() {
         val items = listOf(SimpleBrowserMenuItem("Hello") {})
-        val menu = BrowserMenu(BrowserMenuAdapter(context, items))
+        val menu = BrowserMenu(BrowserMenuAdapter(testContext, items))
 
         menu.invalidate()
     }
@@ -107,11 +104,11 @@ class BrowserMenuTest {
             SimpleBrowserMenuItem("Hello") {},
             SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(context, items)
+        val adapter = BrowserMenuAdapter(testContext, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(context)
+        val anchor = Button(testContext)
         val popup = menu.show(anchor)
 
         assertTrue(popup.isShowing)
@@ -123,11 +120,11 @@ class BrowserMenuTest {
             SimpleBrowserMenuItem("Hello") {},
             SimpleBrowserMenuItem("World") {})
 
-        val adapter = BrowserMenuAdapter(context, items)
+        val adapter = BrowserMenuAdapter(testContext, items)
 
         val menu = BrowserMenu(adapter)
 
-        val anchor = Button(context)
+        val anchor = Button(testContext)
         val popup = menu.show(anchor)
 
         assertTrue(popup.isShowing)
@@ -150,7 +147,7 @@ class BrowserMenuTest {
         val params = CoordinatorLayout.LayoutParams(100, 100)
         params.gravity = Gravity.BOTTOM
 
-        val view = View(context)
+        val view = View(testContext)
         view.layoutParams = params
 
         assertEquals(
@@ -164,7 +161,7 @@ class BrowserMenuTest {
         val params = CoordinatorLayout.LayoutParams(100, 100)
         params.gravity = Gravity.TOP
 
-        val view = View(context)
+        val view = View(testContext)
         view.layoutParams = params
 
         assertEquals(
@@ -283,7 +280,7 @@ class BrowserMenuTest {
     }
 
     private fun createMockViewWith(y: Int): View {
-        val view = spy(View(context))
+        val view = spy(View(testContext))
         doAnswer { invocation ->
             val locationInWindow = (invocation.getArgument(0) as IntArray)
             locationInWindow[0] = 0

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -3,6 +3,7 @@ package mozilla.components.browser.menu.item
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.CheckBox
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import mozilla.components.support.test.robolectric.testContext
@@ -13,9 +14,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuCompoundButtonTest {
 
     @Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import org.junit.Assert.assertEquals
@@ -21,9 +22,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuHighlightableItemTest {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import org.junit.Assert.assertEquals
@@ -21,9 +22,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuImageTextTest {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -9,6 +9,7 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import mozilla.components.support.test.robolectric.testContext
@@ -22,9 +23,8 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuItemToolbarTest {
 
     @Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.menu.item
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import mozilla.components.support.test.robolectric.testContext
@@ -17,9 +18,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SimpleBrowserMenuItemTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-menu` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~