### PR TITLE
Closes #3344: Add getProvidedDefaultSearchEngine to SearchEngineManager to get the provided default search engine.

### DIFF
--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -91,12 +91,22 @@ class SearchEngineManager(
     @Synchronized
     fun getDefaultSearchEngine(context: Context, name: String = EMPTY): SearchEngine {
         val searchEngineList = getSearchEngineList(context)
-        val providedDefault = searchEngineList.default ?: searchEngineList.list[0]
+        val providedDefault = getProvidedDefaultSearchEngine(context)
 
         return when (name) {
             EMPTY -> defaultSearchEngine ?: providedDefault
             else -> searchEngineList.list.find { it.name == name } ?: providedDefault
         }
+    }
+
+    /**
+     * Returns the provided default search engine or the first search engine if the default
+     * is not set.
+     */
+    @Synchronized
+    fun getProvidedDefaultSearchEngine(context: Context): SearchEngine {
+        val searchEngineList = getSearchEngineList(context)
+        return searchEngineList.default ?: searchEngineList.list[0]
     }
 
     /**

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -187,6 +187,37 @@ class SearchEngineManagerTest {
     }
 
     @Test
+    fun `manager returns first engine as provided default if default cannot be found`() = runBlockingTest {
+        val provider = mockProvider(listOf(
+                mockSearchEngine("mozsearch"),
+                mockSearchEngine("google"),
+                mockSearchEngine("bing")))
+
+        val manager = SearchEngineManager(listOf(provider))
+
+        val default = manager.getProvidedDefaultSearchEngine(testContext)
+        assertEquals("mozsearch", default.identifier)
+    }
+
+    @Test
+    fun `manager returns default engine as provided default from the provider`() = runBlockingTest {
+        val mozSearchEngine = mockSearchEngine("mozsearch")
+        val provider = mockProvider(
+            engines = listOf(
+                mockSearchEngine("google"),
+                mozSearchEngine,
+                mockSearchEngine("bing")
+            ),
+            default = mozSearchEngine
+        )
+
+        val manager = SearchEngineManager(listOf(provider))
+
+        val default = manager.getProvidedDefaultSearchEngine(testContext)
+        assertEquals("mozsearch", default.identifier)
+    }
+
+    @Test
     fun `manager registers for locale changes`() = runBlockingTest {
         val provider = spy(mockProvider(listOf(
             mockSearchEngine("mozsearch"),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,10 @@ permalink: /changelog/
   * Added `endOfMenuAlwaysVisible` property/parameter to `BrowserMenuBuilder` constructor and to `BrowserMenu.show` function.
     When is set to true makes sure the bottom of the menu is always visible, this allows use cases like [#3211](https://github.com/mozilla-mobile/android-components/issues/3211).
 
+* **browser-search**
+  * Added `getProvidedDefaultSearchEngine` to `SearchEngineManager` to return the provided default search engine or the first
+    search engine if the default is not set. This allows use cases like [#3344](https://github.com/mozilla-mobile/android-components/issues/3344).
+
 * 🛑 Removed deprecated components (See blog posting):
   * feature-session-bundling
   * ui-progress


### PR DESCRIPTION
Fixes #3344

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
