### PR TITLE
For #1481. Use androidx runner in `browser-search`.

### DIFF
--- a/components/browser/search/build.gradle
+++ b/components/browser/search/build.gradle
@@ -29,6 +29,8 @@ android {
             }
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 
@@ -43,7 +45,7 @@ dependencies {
     testImplementation Dependencies.kotlin_coroutines_test
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/search/gradle.properties
+++ b/components/browser/search/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineManagerTest.kt
@@ -11,6 +11,7 @@ import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.search.provider.SearchEngineList
@@ -28,12 +29,11 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SearchEngineManagerTest {
 
     @Test

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineParserTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineParserTest.kt
@@ -4,17 +4,18 @@
 
 package mozilla.components.browser.search
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SearchEngineParserTest {
+
     @Test
     fun `SearchEngine can be parsed from assets`() {
         val searchEngine = SearchEngineParser().load(

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineTest.kt
@@ -6,17 +6,18 @@ package mozilla.components.browser.search
 
 import android.graphics.Bitmap
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SearchEngineTest {
+
     @Test
     fun `Build and verify basic search URL for search engine`() {
         val resultUri = Uri.parse("https://www.mozilla.org/?q={searchTerms}")

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/provider/AssetsSearchEngineProviderTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/provider/AssetsSearchEngineProviderTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.search.provider
 
 import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.provider.filter.SearchEngineFilter
@@ -13,9 +14,8 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AssetsSearchEngineProviderTest {
 
     @Test

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/provider/localization/LocaleSearchLocalizationProviderTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/provider/localization/LocaleSearchLocalizationProviderTest.kt
@@ -4,16 +4,16 @@
 
 package mozilla.components.browser.search.provider.localization
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.util.Locale
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class LocaleSearchLocalizationProviderTest {
     private var cachedLocale: Locale? = null
 

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/ParserTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/ParserTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.browser.search.suggestions
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ParserTest {
+
     @Test
     fun `can parse a response from Google`() {
         val json = "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/suggestions/SearchSuggestionClientTest.kt
@@ -4,16 +4,16 @@
 
 package mozilla.components.browser.search.suggestions
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.search.SearchEngineParser
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SearchSuggestionClientTest {
 
     companion object {


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-search` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~