### PR TITLE
For #1481. Use androidx runner in `browser-session`.

### DIFF
--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -39,7 +41,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/session/gradle.properties
+++ b/components/browser/session/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/ext/AtomicFileKtTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/ext/AtomicFileKtTest.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.browser.session.ext
 
-import android.content.Context
 import android.util.AtomicFile
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.SnapshotSerializer
@@ -16,6 +15,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -23,16 +23,13 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AtomicFileKtTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `writeSnapshot - Fails write on IOException`() {
@@ -62,7 +59,7 @@ class AtomicFileKtTest {
 
     @Test
     fun `readSnapshot - Returns null on corrupt JSON`() {
-        val file = getFileForEngine(context, engine = mock())
+        val file = getFileForEngine(testContext, engine = mock())
 
         val stream = file.startWrite()
         stream.bufferedWriter().write("{ name: 'Foo")

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
@@ -7,8 +7,7 @@ package mozilla.components.browser.session.storage
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session
@@ -19,6 +18,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -36,15 +36,12 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SessionStorageTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Restored snapshot should contain sessions of saved snapshot`() {
@@ -76,7 +73,7 @@ class SessionStorageTest {
         )
 
         // Persist the snapshot
-        val storage = SessionStorage(context, engine)
+        val storage = SessionStorage(testContext, engine)
         val persisted = storage.save(sessionsSnapshot)
         assertTrue(persisted)
 
@@ -110,7 +107,7 @@ class SessionStorageTest {
         val engine = mock(Engine::class.java)
         `when`(engine.name()).thenReturn("gecko")
 
-        val storage = spy(SessionStorage(context, engine))
+        val storage = spy(SessionStorage(testContext, engine))
         storage.save(SessionManager.Snapshot(emptyList(), SessionManager.NO_SELECTION))
 
         verify(storage).clear()
@@ -140,7 +137,7 @@ class SessionStorageTest {
         )
 
         // Persist the snapshot
-        val storage = SessionStorage(context, engine)
+        val storage = SessionStorage(testContext, engine)
         val persisted = storage.save(sessionsSnapshot)
         assertTrue(persisted)
 
@@ -156,7 +153,7 @@ class SessionStorageTest {
         val engine = mock(Engine::class.java)
         `when`(engine.name()).thenReturn("gecko")
 
-        val storage = SessionStorage(context, engine)
+        val storage = SessionStorage(testContext, engine)
 
         val session = Session("http://mozilla.org")
         val engineSession = mock(EngineSession::class.java)
@@ -385,7 +382,7 @@ class SessionStorageTest {
 
         val lifecycle = LifecycleRegistry(mock(LifecycleOwner::class.java))
 
-        val storage = SessionStorage(context, engine)
+        val storage = SessionStorage(testContext, engine)
         storage.autoSave(mock())
             .periodicallyInForeground(300, TimeUnit.SECONDS, scheduler, lifecycle)
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SnapshotSerializerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SnapshotSerializerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.session.storage
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -11,10 +12,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SnapshotSerializerTest {
+
     @Test
     fun `Serialize and deserialize session`() {
         val originalSession = Session(

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/tab/CustomTabConfigTest.kt
@@ -5,15 +5,15 @@
 package mozilla.components.browser.session.tab
 
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
-import androidx.browser.customtabs.CustomTabsIntent
 import android.util.DisplayMetrics
-import androidx.test.core.app.ApplicationProvider
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.SafeIntent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -24,12 +24,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CustomTabConfigTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun isCustomTabIntent() {
@@ -148,7 +145,7 @@ class CustomTabConfigTest {
         val builder = CustomTabsIntent.Builder()
 
         val bitmap = mock(Bitmap::class.java)
-        val intent = PendingIntent.getActivity(context, 0, Intent("testAction"), 0)
+        val intent = PendingIntent.getActivity(testContext, 0, Intent("testAction"), 0)
         builder.setActionButton(bitmap, "desc", intent)
 
         val customTabsIntent = builder.build()


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-session` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~