### PR TITLE
For #1481. Use androidx runner in `browser-storage-memory`.

### DIFF
--- a/components/browser/storage-memory/build.gradle
+++ b/components/browser/storage-memory/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -28,7 +30,7 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 

--- a/components/browser/storage-memory/gradle.properties
+++ b/components/browser/storage-memory/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
+++ b/components/browser/storage-memory/src/test/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorageTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.storage.memory
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.PageObservation
 import mozilla.components.concept.storage.VisitType
@@ -11,11 +12,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.lang.Thread.sleep
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class InMemoryHistoryStorageTest {
+
     @Test
     fun `store can be used to track visit information`() = runBlocking {
         val history = InMemoryHistoryStorage()


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-storage-memory` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~