### PR TITLE
For #1481. Use androidx runner in `browser-tabstray`.

### DIFF
--- a/components/browser/tabstray/build.gradle
+++ b/components/browser/tabstray/build.gradle
@@ -24,6 +24,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -41,8 +43,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/tabstray/gradle.properties
+++ b/components/browser/tabstray/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/BrowserTabsTrayTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/BrowserTabsTrayTest.kt
@@ -4,26 +4,23 @@
 
 package mozilla.components.browser.tabstray
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserTabsTrayTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `holders will unsubscribe if view gets detached`() {
         val adapter: TabsAdapter = mock()
-        val tabsTray = BrowserTabsTray(context, tabsAdapter = adapter)
+        val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter)
 
         val shadow = Shadows.shadowOf(tabsTray)
         shadow.callOnDetachedFromWindow()
@@ -34,7 +31,7 @@ class BrowserTabsTrayTest {
     @Test
     fun `TabsTray concept methods are forwarded to adapter`() {
         val adapter: TabsAdapter = mock()
-        val tabsTray = BrowserTabsTray(context, tabsAdapter = adapter)
+        val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter)
 
         val sessions = listOf<Session>()
 
@@ -60,7 +57,7 @@ class BrowserTabsTrayTest {
     @Test
     fun `TabsTray is set on adapter`() {
         val adapter = TabsAdapter()
-        val tabsTray = BrowserTabsTray(context, tabsAdapter = adapter)
+        val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter)
 
         assertEquals(tabsTray, adapter.tabsTray)
     }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
@@ -6,15 +6,15 @@
 
 package mozilla.components.browser.tabstray
 
-import android.content.Context
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.ItemTouchHelper
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
@@ -22,13 +22,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabTouchCallbackTest {
-
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `onSwiped notifies observers`() {
@@ -53,7 +49,7 @@ class TabTouchCallbackTest {
 
     @Test
     fun `onChildDraw alters alpha of ViewHolder on swipe gesture`() {
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, TabViewHolderTest.mockTabsTrayWithStyles())
         val callback = TabTouchCallback(mock())
 

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
@@ -4,17 +4,17 @@
 
 package mozilla.components.browser.tabstray
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.tabstray.TabsTray
-import mozilla.components.support.test.mock
 import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -25,16 +25,13 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabViewHolderTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `URL from session is assigned to view`() {
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
@@ -50,7 +47,7 @@ class TabViewHolderTest {
 
     @Test
     fun `Holder registers to session and updates view`() {
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
@@ -67,7 +64,7 @@ class TabViewHolderTest {
 
     @Test
     fun `After unbind holder is no longer registered to session`() {
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
@@ -90,7 +87,7 @@ class TabViewHolderTest {
             it.register(observer)
         }
 
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
         val session = Session("https://www.mozilla.org")
@@ -108,7 +105,7 @@ class TabViewHolderTest {
             it.register(observer)
         }
 
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
         val session = Session("https://www.mozilla.org")
@@ -126,7 +123,7 @@ class TabViewHolderTest {
             it.register(observer)
         }
 
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
         val session = Session("https://www.mozilla.org")
@@ -144,7 +141,7 @@ class TabViewHolderTest {
             it.register(observer)
         }
 
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
         val session = Session("https://www.mozilla.org")
@@ -164,7 +161,7 @@ class TabViewHolderTest {
             it.register(observer)
         }
 
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
         val session = spy(Session("https://www.mozilla.org"))
 
@@ -183,7 +180,7 @@ class TabViewHolderTest {
 
     @Test
     fun `thumbnail from session is assigned to thumbnail image view`() {
-        val view = LayoutInflater.from(context).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val thumbnailView = view.findViewById<ImageView>(R.id.mozac_browser_tabstray_thumbnail)
 
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -4,11 +4,11 @@
 
 package mozilla.components.browser.tabstray
 
-import android.content.Context
 import android.widget.LinearLayout
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,12 +16,9 @@ import org.mockito.Mockito
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabsAdapterTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `itemCount will reflect number of sessions`() {
@@ -54,7 +51,7 @@ class TabsAdapterTest {
         val adapter = TabsAdapter()
         adapter.tabsTray = mockTabsTrayWithStyles()
 
-        val view = LinearLayout(context)
+        val view = LinearLayout(testContext)
 
         val holder1 = adapter.createViewHolder(view, 0)
         val holder2 = adapter.createViewHolder(view, 0)

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/thumbnail/TabThumbnailViewTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/thumbnail/TabThumbnailViewTest.kt
@@ -6,32 +6,30 @@
 
 package mozilla.components.browser.tabstray.thumbnail
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.Robolectric.buildAttributeSet
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabThumbnailViewTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `view should always use Matrix ScaleType`() {
-        val view = TabThumbnailView(context, mock())
+        val view = TabThumbnailView(testContext, emptyAttributeSet())
         assertEquals(ImageView.ScaleType.MATRIX, view.scaleType)
     }
 
     @Test
     fun `view updates matrix when changed`() {
-        val view = TabThumbnailView(context, mock())
+        val view = TabThumbnailView(testContext, emptyAttributeSet())
         val matrix = view.imageMatrix
         val drawable: Drawable = mock()
 
@@ -48,7 +46,7 @@ class TabThumbnailViewTest {
 
     @Test
     fun `view updates don't change matrix if no changes to frame`() {
-        val view = TabThumbnailView(context, mock())
+        val view = TabThumbnailView(testContext, emptyAttributeSet())
         val drawable: Drawable = mock()
 
         `when`(drawable.intrinsicWidth).thenReturn(5)
@@ -66,3 +64,5 @@ class TabThumbnailViewTest {
         assertEquals(matrix, matrix2)
     }
 }
+
+private fun emptyAttributeSet() = buildAttributeSet().build()


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-tabstray` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~