### PR TITLE
For #1481. Use androidx runner in `browser-toolbar`.

### DIFF
--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -39,7 +41,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/toolbar/gradle.properties
+++ b/components/browser/toolbar/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
@@ -5,14 +5,14 @@
 package mozilla.components.browser.toolbar.behavior
 
 import android.animation.ValueAnimator
-import android.content.Context
+import android.view.Gravity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
-import android.view.Gravity
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.snackbar.Snackbar
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -22,16 +22,13 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BrowserToolbarBottomBehaviorTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Starting a nested scroll should cancel an ongoing snap animation`() {
-        val behavior = BrowserToolbarBottomBehavior(context, attrs = null)
+        val behavior = BrowserToolbarBottomBehavior(testContext, attrs = null)
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -51,7 +48,7 @@ class BrowserToolbarBottomBehaviorTest {
 
     @Test
     fun `Behavior should not accept nested scrolls on the horizontal axis`() {
-        val behavior = BrowserToolbarBottomBehavior(context, attrs = null)
+        val behavior = BrowserToolbarBottomBehavior(testContext, attrs = null)
 
         val acceptsNestedScroll = behavior.onStartNestedScroll(
             coordinatorLayout = mock(),
@@ -66,7 +63,7 @@ class BrowserToolbarBottomBehaviorTest {
 
     @Test
     fun `Behavior will snap toolbar up if toolbar is more than 50% visible`() {
-        val behavior = spy(BrowserToolbarBottomBehavior(context, attrs = null))
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -100,7 +97,7 @@ class BrowserToolbarBottomBehaviorTest {
 
     @Test
     fun `Behavior will snap toolbar down if toolbar is less than 50% visible`() {
-        val behavior = spy(BrowserToolbarBottomBehavior(context, attrs = null))
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -134,7 +131,7 @@ class BrowserToolbarBottomBehaviorTest {
 
     @Test
     fun `Behavior will apply translation to toolbar for nested scroll`() {
-        val behavior = spy(BrowserToolbarBottomBehavior(context, attrs = null))
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
 
         val child = mock<BrowserToolbar>()
         doReturn(100).`when`(child).height
@@ -154,14 +151,14 @@ class BrowserToolbarBottomBehaviorTest {
 
     @Test
     fun `Behavior will position snackbar above toolbar`() {
-        val behavior = BrowserToolbarBottomBehavior(context, attrs = null)
+        val behavior = BrowserToolbarBottomBehavior(testContext, attrs = null)
 
         val toolbar: BrowserToolbar = mock()
         doReturn(4223).`when`(toolbar).id
 
         val layoutParams: CoordinatorLayout.LayoutParams = CoordinatorLayout.LayoutParams(0, 0)
 
-        val snackbarLayout = Snackbar.SnackbarLayout(context)
+        val snackbarLayout = Snackbar.SnackbarLayout(testContext)
         snackbarLayout.layoutParams = layoutParams
 
         behavior.layoutDependsOn(

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -11,6 +11,7 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
@@ -36,10 +37,9 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DisplayToolbarTest {
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
@@ -4,13 +4,12 @@
 
 package mozilla.components.browser.toolbar.edit
 
-import android.content.Context
 import android.graphics.Rect
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
@@ -20,6 +19,7 @@ import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.processor.CollectionProcessor
 import mozilla.components.support.ktx.android.view.forEach
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -30,17 +30,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class EditToolbarTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `entered text is forwarded to async autocomplete filter`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.editToolbar.urlView.onAttachedToWindow()
 
         val latch = CountDownLatch(1)
@@ -67,7 +64,7 @@ class EditToolbarTest {
         var listenerInvoked = false
         var value = false
 
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         toolbar.setOnEditFocusChangeListener { hasFocus ->
             listenerInvoked = true
             value = hasFocus
@@ -91,7 +88,7 @@ class EditToolbarTest {
     @Test
     fun `entering text emits commit fact`() {
         CollectionProcessor.withFactCollection { facts ->
-            val toolbar = BrowserToolbar(context)
+            val toolbar = BrowserToolbar(testContext)
             toolbar.editToolbar.urlView.onAttachedToWindow()
 
             assertEquals(0, facts.size)
@@ -124,7 +121,7 @@ class EditToolbarTest {
     @Test
     fun `entering text emits commit fact with autocomplete metadata`() {
         CollectionProcessor.withFactCollection { facts ->
-            val toolbar = BrowserToolbar(context)
+            val toolbar = BrowserToolbar(testContext)
             toolbar.editToolbar.urlView.onAttachedToWindow()
 
             assertEquals(0, facts.size)
@@ -168,7 +165,7 @@ class EditToolbarTest {
     @Test
     fun `clearView gone on init`() {
         val toolbar = mock(BrowserToolbar::class.java)
-        val editToolbar = EditToolbar(context, toolbar)
+        val editToolbar = EditToolbar(testContext, toolbar)
         val clearView = extractClearView(editToolbar)
         assertTrue(clearView.visibility == View.GONE)
     }
@@ -176,7 +173,7 @@ class EditToolbarTest {
     @Test
     fun `clearView clears text in urlView`() {
         val toolbar = mock(BrowserToolbar::class.java)
-        val editToolbar = EditToolbar(context, toolbar)
+        val editToolbar = EditToolbar(testContext, toolbar)
         val clearView = extractClearView(editToolbar)
 
         editToolbar.urlView.setText("https://www.mozilla.org")
@@ -190,7 +187,7 @@ class EditToolbarTest {
     @Test
     fun `fun updateClearViewVisibility updates clearView`() {
         val toolbar = mock(BrowserToolbar::class.java)
-        val editToolbar = EditToolbar(context, toolbar)
+        val editToolbar = EditToolbar(testContext, toolbar)
         val clearView = extractClearView(editToolbar)
 
         editToolbar.updateClearViewVisibility("")
@@ -202,7 +199,7 @@ class EditToolbarTest {
 
     @Test
     fun `clearView changes image color filter on update`() {
-        val toolbar = BrowserToolbar(context)
+        val toolbar = BrowserToolbar(testContext)
         val editToolbar = toolbar.editToolbar
         editToolbar.clearViewColor = R.color.photonBlue40
 
@@ -212,7 +209,7 @@ class EditToolbarTest {
     @Test
     fun `WHEN edit actions are added THEN views are measured correctly`() {
         val toolbar: BrowserToolbar = mock()
-        val editToolbar = EditToolbar(context, toolbar)
+        val editToolbar = EditToolbar(testContext, toolbar)
 
         editToolbar.addEditAction(BrowserToolbar.Button(mock(), "Microphone") {})
         editToolbar.addEditAction(BrowserToolbar.Button(mock(), "QR code scanner") {})
@@ -249,7 +246,7 @@ class EditToolbarTest {
     @Test
     fun `WHEN edit actions are added THEN views are layout correctly`() {
         val toolbar: BrowserToolbar = mock()
-        val editToolbar = EditToolbar(context, toolbar)
+        val editToolbar = EditToolbar(testContext, toolbar)
 
         editToolbar.addEditAction(BrowserToolbar.Button(mock(), "Microphone") {})
         editToolbar.addEditAction(BrowserToolbar.Button(mock(), "QR code scanner") {})


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-toolbar` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~