### PR TITLE
For #1481. Use androidx runner in `concept-engine`.

### DIFF
--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -23,6 +23,8 @@ android {
     androidExtensions {
         experimental = true
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -39,7 +41,7 @@ dependencies {
     api project(':concept-storage')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 

--- a/components/concept/engine/gradle.properties
+++ b/components/concept/engine/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
@@ -7,23 +7,20 @@ package mozilla.components.concept.engine
 import android.content.Context
 import android.graphics.Bitmap
 import android.widget.FrameLayout
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
-import java.lang.ClassCastException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class EngineViewTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `asView method returns underlying Android view`() {
-        val engineView = createDummyEngineView(context)
+        val engineView = createDummyEngineView(testContext)
 
         val view = engineView.asView()
 
@@ -38,7 +35,7 @@ class EngineViewTest {
 
     @Test
     fun lifecycleObserver() {
-        val engineView = spy(createDummyEngineView(context))
+        val engineView = spy(createDummyEngineView(testContext))
         val observer = LifecycleObserver(engineView)
 
         observer.onCreate()

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/SizeTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/SizeTest.kt
@@ -4,14 +4,15 @@
 
 package mozilla.components.concept.engine.manifest
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SizeTest {
+
     @Test
     fun `parse standard sizes`() {
         assertEquals(Size(512, 512), Size.parse("512x512"))

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.engine.manifest
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -11,10 +12,10 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class WebAppManifestParserTest {
+
     @Test
     fun `Parsing example manifest from MDN`() {
         val json = loadManifest("example_mdn.json")


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `concept-engine` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~