### PR TITLE
For #1481. Use androidx runner in `concept-fetch`.

### DIFF
--- a/components/concept/fetch/build.gradle
+++ b/components/concept/fetch/build.gradle
@@ -21,13 +21,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
     implementation Dependencies.kotlin_stdlib
     testImplementation Dependencies.kotlin_coroutines
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver

--- a/components/concept/fetch/gradle.properties
+++ b/components/concept/fetch/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt
+++ b/components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.fetch
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -11,17 +12,16 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.lang.IllegalStateException
 import java.net.URLEncoder
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class RequestTest {
+
     @Test
     fun `URL-only Request`() {
         val request = Request("https://www.mozilla.org")


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `concept-fetch` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~