### PR TITLE
For #1481. Use androidx runner in `lib-crash`.

### DIFF
--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -22,6 +22,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -41,7 +43,7 @@ dependencies {
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/lib/crash/gradle.properties
+++ b/components/lib/crash/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
@@ -6,14 +6,14 @@ package mozilla.components.lib.crash
 
 import android.app.Activity
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -26,14 +26,11 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import java.lang.reflect.Modifier
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CrashReporterTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Before
     fun setUp() {
@@ -46,7 +43,7 @@ class CrashReporterTest {
 
         CrashReporter(
             services = listOf(mock())
-        ).install(context)
+        ).install(testContext)
 
         val newHandler = Thread.getDefaultUncaughtExceptionHandler()
         assertNotNull(newHandler)
@@ -57,7 +54,7 @@ class CrashReporterTest {
     @Test(expected = IllegalArgumentException::class)
     fun `CrashReporter throws if no service is defined`() {
         CrashReporter(emptyList())
-            .install(context)
+            .install(testContext)
     }
 
     @Test
@@ -67,11 +64,11 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(service),
             shouldPrompt = CrashReporter.Prompt.NEVER
-        ).install(context))
+        ).install(testContext))
 
         val crash: Crash.UncaughtExceptionCrash = mock()
 
-        reporter.onCrash(context, crash)
+        reporter.onCrash(testContext, crash)
 
         verify(reporter).submitReport(crash)
         verify(reporter, never()).showPrompt(any(), eq(crash))
@@ -86,11 +83,11 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(service),
             shouldPrompt = CrashReporter.Prompt.ALWAYS
-        ).install(context))
+        ).install(testContext))
 
         val crash: Crash.UncaughtExceptionCrash = mock()
 
-        reporter.onCrash(context, crash)
+        reporter.onCrash(testContext, crash)
 
         verify(reporter, never()).submitReport(crash)
         verify(reporter).showPrompt(any(), eq(crash))
@@ -105,11 +102,11 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(service),
             shouldPrompt = CrashReporter.Prompt.ONLY_NATIVE_CRASH
-        ).install(context))
+        ).install(testContext))
 
         val crash: Crash.UncaughtExceptionCrash = mock()
 
-        reporter.onCrash(context, crash)
+        reporter.onCrash(testContext, crash)
 
         verify(reporter).submitReport(crash)
         verify(reporter, never()).showPrompt(any(), eq(crash))
@@ -124,11 +121,11 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(service),
             shouldPrompt = CrashReporter.Prompt.ONLY_NATIVE_CRASH
-        ).install(context))
+        ).install(testContext))
 
         val crash: Crash.NativeCodeCrash = mock()
 
-        reporter.onCrash(context, crash)
+        reporter.onCrash(testContext, crash)
 
         verify(reporter, never()).submitReport(crash)
         verify(reporter).showPrompt(any(), eq(crash))
@@ -141,7 +138,7 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(mock()),
             shouldPrompt = CrashReporter.Prompt.ONLY_NATIVE_CRASH
-        ).install(context))
+        ).install(testContext))
 
         assertTrue(reporter.enabled)
     }
@@ -153,12 +150,12 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(service),
             shouldPrompt = CrashReporter.Prompt.ALWAYS
-        ).install(context))
+        ).install(testContext))
 
         reporter.enabled = false
 
         val crash: Crash.UncaughtExceptionCrash = mock()
-        reporter.onCrash(context, crash)
+        reporter.onCrash(testContext, crash)
 
         verify(reporter, never()).submitReport(crash)
         verify(reporter, never()).showPrompt(any(), eq(crash))
@@ -186,7 +183,7 @@ class CrashReporterTest {
         val reporter = spy(CrashReporter(
             services = listOf(service),
             shouldPrompt = CrashReporter.Prompt.NEVER
-        ).install(context))
+        ).install(testContext))
 
         reporter.onCrash(
             mock(),
@@ -218,7 +215,7 @@ class CrashReporterTest {
             CrashReporter.requireInstance
         }
 
-        reporter.install(context)
+        reporter.install(testContext)
 
         assertNotNull(CrashReporter.requireInstance)
     }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashTest.kt
@@ -5,17 +5,17 @@
 package mozilla.components.lib.crash
 
 import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.RuntimeException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CrashTest {
+
     @Test
     fun `fromIntent() can deserialize a GeckoView crash Intent`() {
         val originalCrash = Crash.NativeCodeCrash(

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt
@@ -6,13 +6,14 @@ package mozilla.components.lib.crash
 
 import android.content.ComponentName
 import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class NativeCodeCrashTest {
+
     @Test
     fun `Creating NativeCodeCrash object from sample GeckoView intent`() {
         val intent = Intent("org.mozilla.gecko.ACTION_CRASHED")

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/UncaughtExceptionCrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/UncaughtExceptionCrashTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.lib.crash
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class UncaughtExceptionCrashTest {
+
     @Test
     fun `UncaughtExceptionCrash wraps exception`() {
         val exception = RuntimeException("Kaput")

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
@@ -5,12 +5,12 @@
 package mozilla.components.lib.crash.handler
 
 import android.content.ComponentName
-import android.content.Context
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.CrashReporterService
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -19,12 +19,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CrashHandlerServiceTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @After
     fun tearDown() {
@@ -46,7 +43,7 @@ class CrashHandlerServiceTest {
                     caughtCrash = crash
                 }
             })
-        ).install(context)
+        ).install(testContext)
 
         val intent = Intent("org.mozilla.gecko.ACTION_CRASHED")
         intent.component = ComponentName(

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/ExceptionHandlerTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/ExceptionHandlerTest.kt
@@ -4,13 +4,13 @@
 
 package mozilla.components.lib.crash.handler
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.fail
@@ -19,12 +19,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExceptionHandlerTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `ExceptionHandler forwards crashes to CrashReporter`() {
@@ -45,7 +42,7 @@ class ExceptionHandlerTest {
         ))
 
         val handler = ExceptionHandler(
-            context,
+            testContext,
             crashReporter)
 
         val exception = RuntimeException("Hello World")
@@ -66,7 +63,7 @@ class ExceptionHandlerTest {
         val defaultExceptionHandler: Thread.UncaughtExceptionHandler = mock()
 
         val handler = ExceptionHandler(
-            context,
+            testContext,
             mock(),
             defaultExceptionHandler
         )

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/prompt/CrashReporterActivityTest.kt
@@ -9,7 +9,7 @@ import android.content.Intent
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.crash.Crash
@@ -17,6 +17,7 @@ import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.R
 import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -24,12 +25,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CrashReporterActivityTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Pressing close button sends report`() {
@@ -38,7 +36,7 @@ class CrashReporterActivityTest {
         CrashReporter(
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
             services = listOf(service)
-        ).install(context)
+        ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"))
 
@@ -69,7 +67,7 @@ class CrashReporterActivityTest {
         CrashReporter(
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
             services = listOf(service)
-        ).install(context)
+        ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"))
 
@@ -102,7 +100,7 @@ class CrashReporterActivityTest {
                 theme = android.R.style.Theme_DeviceDefault // Yolo!
             ),
             services = listOf(mock())
-        ).install(context)
+        ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"))
 
@@ -127,7 +125,7 @@ class CrashReporterActivityTest {
         CrashReporter(
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
             services = listOf(service)
-        ).install(context)
+        ).install(testContext)
 
         val crash = Crash.UncaughtExceptionCrash(RuntimeException("Hello World"))
 

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt
@@ -4,27 +4,24 @@
 
 package mozilla.components.lib.crash.service
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.test.any
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class MozillaSocorroServiceTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `MozillaSocorroService sends native code crashes to GeckoView crash reporter`() {
         val service = spy(MozillaSocorroService(
-            context,
+            testContext,
             "Test App"
         ))
         doNothing().`when`(service).sendViaGeckoViewCrashReporter(any())
@@ -39,7 +36,7 @@ class MozillaSocorroServiceTest {
     @Test
     fun `MozillaSocorroService does not send uncaught exception crashes`() {
         val service = spy(MozillaSocorroService(
-            context,
+            testContext,
             "Test App"
         ))
         doNothing().`when`(service).sendViaGeckoViewCrashReporter(any())

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SentryServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SentryServiceTest.kt
@@ -4,8 +4,7 @@
 
 package mozilla.components.lib.crash.service
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.SentryClient
 import io.sentry.SentryClientFactory
 import io.sentry.dsn.Dsn
@@ -13,6 +12,7 @@ import mozilla.components.lib.crash.Crash
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -20,12 +20,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SentryServiceTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `SentryService disables exception handler and forwards tags`() {
@@ -41,7 +38,7 @@ class SentryServiceTest {
         }
 
         SentryService(
-            context,
+            testContext,
             "https://not:real6@sentry.prod.example.net/405",
             clientFactory = factory,
             tags = mapOf(
@@ -69,7 +66,7 @@ class SentryServiceTest {
         }
 
         val service = SentryService(
-            context,
+            testContext,
             "https://not:real6@sentry.prod.example.net/405",
             clientFactory = factory)
 
@@ -84,7 +81,7 @@ class SentryServiceTest {
         val client: SentryClient = mock()
 
         val service = SentryService(
-            context,
+            testContext,
             "https://not:real6@sentry.prod.example.net/405",
             clientFactory = object : SentryClientFactory() {
                 override fun createSentryClient(dsn: Dsn?): SentryClient = client
@@ -101,7 +98,7 @@ class SentryServiceTest {
         val client: SentryClient = mock()
 
         val service = SentryService(
-            context,
+            testContext,
             "https://not:real6@sentry.prod.example.net/405",
             clientFactory = object : SentryClientFactory() {
                 override fun createSentryClient(dsn: Dsn?): SentryClient = client
@@ -117,7 +114,7 @@ class SentryServiceTest {
         val client: SentryClient = mock()
 
         SentryService(
-            context,
+            testContext,
             "https://not:real6@sentry.prod.example.net/405",
             clientFactory = object : SentryClientFactory() {
                 override fun createSentryClient(dsn: Dsn?): SentryClient = client
@@ -133,7 +130,7 @@ class SentryServiceTest {
         val client: SentryClient = mock()
         val environmentString = "production"
 
-        SentryService(context,
+        SentryService(testContext,
                 "https://fake:notreal@sentry.prod.example.net/405",
                 clientFactory = object : SentryClientFactory() {
                     override fun createSentryClient(dsn: Dsn?): SentryClient = client
@@ -141,7 +138,7 @@ class SentryServiceTest {
                 environment = environmentString)
         verify(client).environment = eq(environmentString)
 
-        SentryService(context,
+        SentryService(testContext,
                 "https://fake:notreal@sentry.prod.example.net/405",
                 clientFactory = object : SentryClientFactory() {
                     override fun createSentryClient(dsn: Dsn?): SentryClient = client


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `lib-crash` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~