### PR TITLE
For #1481. Use androidx runner in `lib-dataprotect`.

### DIFF
--- a/components/lib/dataprotect/build.gradle
+++ b/components/lib/dataprotect/build.gradle
@@ -21,12 +21,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
     implementation Dependencies.kotlin_stdlib
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/lib/dataprotect/gradle.properties
+++ b/components/lib/dataprotect/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/lib/dataprotect/src/test/java/mozilla/components/lib/dataprotect/KeystoreTest.kt
+++ b/components/lib/dataprotect/src/test/java/mozilla/components/lib/dataprotect/KeystoreTest.kt
@@ -4,16 +4,16 @@
 
 package mozilla.components.lib.dataprotect
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.nio.charset.StandardCharsets
+import java.security.GeneralSecurityException
 import java.security.Key
 import java.security.KeyStore
-import java.security.GeneralSecurityException
 import java.security.SecureRandom
 import java.security.Security
 import javax.crypto.Cipher
@@ -42,8 +42,9 @@ internal class MockStoreWrapper : KeyStoreWrapper() {
     }
 }
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class KeystoreTest {
+
     private var wrapper = MockStoreWrapper()
     private var rng = SecureRandom()
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `lib-dataprotect` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~