### PR TITLE
For #1481. Use androidx runner in `lib-fetch-okhttp`.

### DIFF
--- a/components/lib/fetch-okhttp/build.gradle
+++ b/components/lib/fetch-okhttp/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -32,7 +34,7 @@ dependencies {
 
     testImplementation project(':support-test')
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation project(':tooling-fetch-tests')

--- a/components/lib/fetch-okhttp/gradle.properties
+++ b/components/lib/fetch-okhttp/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/lib/fetch-okhttp/src/test/java/mozilla/components/lib/fetch/okhttp/OkHttpFetchTestCases.kt
+++ b/components/lib/fetch-okhttp/src/test/java/mozilla/components/lib/fetch/okhttp/OkHttpFetchTestCases.kt
@@ -4,15 +4,16 @@
 
 package mozilla.components.lib.fetch.okhttp
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.tooling.fetch.tests.FetchTestCases
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-class OkHttpFetchTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
+@RunWith(AndroidJUnit4::class)
+class OkHttpFetchTestCases : FetchTestCases() {
 
     override fun createNewClient(): Client = OkHttpClient(okhttp3.OkHttpClient(), testContext)
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `lib-fetch-okhttp` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~