### PR TITLE
For #1481. Use androidx runner in `lib-publicsuffixlist`.

### DIFF
--- a/components/lib/publicsuffixlist/build.gradle
+++ b/components/lib/publicsuffixlist/build.gradle
@@ -23,6 +23,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -31,7 +33,7 @@ dependencies {
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/lib/publicsuffixlist/gradle.properties
+++ b/components/lib/publicsuffixlist/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/lib/publicsuffixlist/src/test/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListTest.kt
+++ b/components/lib/publicsuffixlist/src/test/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListTest.kt
@@ -1,23 +1,20 @@
 package mozilla.components.lib.publicsuffixlist
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PublicSuffixListTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     private val publicSuffixList
-        get() = PublicSuffixList(context)
+        get() = PublicSuffixList(testContext)
 
     @Test
     fun `Verify getPublicSuffixPlusOne for known domains`() = runBlocking {
@@ -336,12 +333,12 @@ class PublicSuffixListTest {
     @Test
     fun `Accessing with and without prefetch`() = runBlocking {
         run {
-            val publicSuffixList = PublicSuffixList(context)
+            val publicSuffixList = PublicSuffixList(testContext)
             assertEquals("org", publicSuffixList.getPublicSuffix("mozilla.org").await())
         }
 
         run {
-            val publicSuffixList = PublicSuffixList(context).apply {
+            val publicSuffixList = PublicSuffixList(testContext).apply {
                 prefetch().await()
             }
             assertEquals("org", publicSuffixList.getPublicSuffix("mozilla.org").await())


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `lib-publicsuffixlist` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~