### PR TITLE
For #1481. Use androidx runner in `service-fretboard`.

### DIFF
--- a/components/service/fretboard/build.gradle
+++ b/components/service/fretboard/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -30,7 +32,7 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-base')
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver

--- a/components/service/fretboard/gradle.properties
+++ b/components/service/fretboard/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/DeviceUuidFactoryTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/DeviceUuidFactoryTest.kt
@@ -6,29 +6,29 @@ package mozilla.components.service.fretboard
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DeviceUuidFactoryTest {
+
     @Test
     fun uuidNoPreference() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        val editor = mock(SharedPreferences.Editor::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        val editor = mock<SharedPreferences.Editor>()
         `when`(editor.putString(anyString(), any())).thenReturn(editor)
         `when`(sharedPreferences.edit()).thenReturn(editor)
-        `when`(sharedPreferences.getString(eq("device_uuid"), ArgumentMatchers.any())).thenReturn(null)
+        `when`(sharedPreferences.getString(eq("device_uuid"), any())).thenReturn(null)
         `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
         val uuid = DeviceUuidFactory(context).uuid
         verify(editor).putString("device_uuid", uuid)
@@ -37,8 +37,8 @@ class DeviceUuidFactoryTest {
     @Test
     fun uuidSavedInPreferences() {
         val savedUuid = "99111a0f-ca5d-4de1-913a-daba905c53b2"
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getString(eq("device_uuid"), any())).thenReturn(savedUuid)
         `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
         assertEquals(savedUuid, DeviceUuidFactory(context).uuid)

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentEvaluatorTest.kt
@@ -8,6 +8,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -21,9 +23,8 @@ import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExperimentEvaluatorTest {
 
     @Test
@@ -42,12 +43,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("other.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -78,12 +79,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -119,12 +120,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("other.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -157,12 +158,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -212,12 +213,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -269,12 +270,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -308,12 +309,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -366,12 +367,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -415,12 +416,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -472,12 +473,12 @@ class ExperimentEvaluatorTest {
             ),
             1528916183)
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         val packageInfo = PackageInfo()
         packageInfo.versionName = "test.version"
         `when`(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
@@ -502,8 +503,8 @@ class ExperimentEvaluatorTest {
 
     @Test
     fun evaluateActivateOverride() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("id"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
@@ -515,8 +516,8 @@ class ExperimentEvaluatorTest {
 
     @Test
     fun evaluateDeactivateOverride() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         `when`(sharedPreferences.getBoolean(eq("name"), anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(anyString(), eq(Context.MODE_PRIVATE))).thenReturn(sharedPreferences)
         val evaluator = ExperimentEvaluator()
@@ -530,14 +531,14 @@ class ExperimentEvaluatorTest {
     fun evaluateNoExperimentSameAsDescriptor() {
         val savedExperiment = Experiment("wrongid", name = "wrongname")
         val descriptor = ExperimentDescriptor("testname")
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         assertNull(ExperimentEvaluator().evaluate(context, descriptor, listOf(savedExperiment), 20))
     }
 
     @Test
     fun setOverrideActivate() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         val sharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
         `when`(sharedPreferencesEditor.putBoolean(anyString(), anyBoolean())).thenReturn(sharedPreferencesEditor)
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
@@ -549,8 +550,8 @@ class ExperimentEvaluatorTest {
 
     @Test
     fun setOverrideDeactivate() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         val sharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
         `when`(sharedPreferencesEditor.putBoolean(eq("exp-2-name"), anyBoolean())).thenReturn(sharedPreferencesEditor)
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
@@ -562,8 +563,8 @@ class ExperimentEvaluatorTest {
 
     @Test
     fun clearOverride() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         val sharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
         `when`(sharedPreferencesEditor.remove(anyString())).thenReturn(sharedPreferencesEditor)
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
@@ -575,8 +576,8 @@ class ExperimentEvaluatorTest {
 
     @Test
     fun clearAllOverrides() {
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
         val sharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
         `when`(sharedPreferencesEditor.clear()).thenReturn(sharedPreferencesEditor)
         `when`(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentPayloadTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentPayloadTest.kt
@@ -4,15 +4,16 @@
 
 package mozilla.components.service.fretboard
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExperimentPayloadTest {
+
     @Test
     fun get() {
         val payload = ExperimentPayload()

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ExperimentTest.kt
@@ -4,15 +4,16 @@
 
 package mozilla.components.service.fretboard
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExperimentTest {
+
     @Test
     fun testEquals() {
         val experiment = Experiment(

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/FretboardTest.kt
@@ -8,10 +8,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import mozilla.components.service.fretboard.storage.flatfile.FlatFileExperimentStorage
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -25,18 +27,17 @@ import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 import kotlin.reflect.full.functions
 import kotlin.reflect.jvm.isAccessible
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class FretboardTest {
 
     @Test
     fun loadExperiments() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
         verify(experimentStorage).retrieve()
@@ -44,8 +45,8 @@ class FretboardTest {
 
     @Test
     fun updateExperimentsStorageNotLoaded() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
         verify(experimentStorage, times(1)).retrieve()
@@ -55,10 +56,10 @@ class FretboardTest {
 
     @Test
     fun updateExperimentsEmptyStorage() {
-        val experimentSource = mock(ExperimentSource::class.java)
+        val experimentSource = mock<ExperimentSource>()
         val result = ExperimentsSnapshot(listOf(), null)
         `when`(experimentSource.getExperiments(result)).thenReturn(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentStorage = mock<ExperimentStorage>()
         `when`(experimentStorage.retrieve()).thenReturn(result)
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
@@ -68,9 +69,9 @@ class FretboardTest {
 
     @Test
     fun updateExperimentsFromStorage() {
-        val experimentSource = mock(ExperimentSource::class.java)
+        val experimentSource = mock<ExperimentSource>()
         `when`(experimentSource.getExperiments(ExperimentsSnapshot(listOf(Experiment("id0", "name0")), null))).thenReturn(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentStorage = mock<ExperimentStorage>()
         `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(listOf(Experiment("id0", "name0")), null))
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.updateExperiments()
@@ -80,8 +81,8 @@ class FretboardTest {
 
     @Test
     fun experiments() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
             Experiment("first-id", "first-name"),
             Experiment("second-id", "second-name")
@@ -99,8 +100,8 @@ class FretboardTest {
 
     @Test
     fun experimentsNoExperiments() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf<Experiment>()
         `when`(experimentStorage.retrieve()).thenReturn(ExperimentsSnapshot(experiments, null))
         val fretboard = Fretboard(experimentSource, experimentStorage)
@@ -110,8 +111,8 @@ class FretboardTest {
 
     @Test
     fun getActiveExperiments() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -138,18 +139,18 @@ class FretboardTest {
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -161,8 +162,8 @@ class FretboardTest {
 
     @Test
     fun getExperimentsMap() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
                 Experiment("first-id",
                         name = "first-name",
@@ -189,18 +190,18 @@ class FretboardTest {
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -214,8 +215,8 @@ class FretboardTest {
 
     @Test
     fun isInExperiment() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         var experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -228,18 +229,18 @@ class FretboardTest {
         var fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -262,8 +263,8 @@ class FretboardTest {
 
     @Test
     fun withExperiment() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         var experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -276,18 +277,18 @@ class FretboardTest {
         var fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -324,8 +325,8 @@ class FretboardTest {
 
     @Test
     fun getExperiment() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -344,8 +345,8 @@ class FretboardTest {
 
     @Test
     fun setOverride() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -358,9 +359,9 @@ class FretboardTest {
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)
         `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
@@ -368,9 +369,9 @@ class FretboardTest {
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -391,8 +392,8 @@ class FretboardTest {
 
     @Test
     fun clearOverride() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -405,9 +406,9 @@ class FretboardTest {
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.remove(ArgumentMatchers.anyString())).thenReturn(prefsEditor)
         `when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)
@@ -416,9 +417,9 @@ class FretboardTest {
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -436,8 +437,8 @@ class FretboardTest {
 
     @Test
     fun clearAllOverrides() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         val experiments = listOf(
             Experiment("first-id",
                 name = "first-name",
@@ -450,9 +451,9 @@ class FretboardTest {
         val fretboard = Fretboard(experimentSource, experimentStorage)
         fretboard.loadExperiments()
 
-        val context = mock(Context::class.java)
+        val context = mock<Context>()
         `when`(context.packageName).thenReturn("test.appId")
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefsEditor.clear()).thenReturn(prefsEditor)
         `when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)
@@ -461,9 +462,9 @@ class FretboardTest {
         `when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -> invocation.arguments[1] as Boolean }
         `when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)
 
-        val packageInfo = mock(PackageInfo::class.java)
+        val packageInfo = mock<PackageInfo>()
         packageInfo.versionName = "version.name"
-        val packageManager = mock(PackageManager::class.java)
+        val packageManager = mock<PackageManager>()
         `when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
@@ -481,11 +482,11 @@ class FretboardTest {
 
     @Test
     fun updateExperimentsException() {
-        val source = mock(ExperimentSource::class.java)
+        val source = mock<ExperimentSource>()
         doAnswer {
             throw ExperimentDownloadException("test")
         }.`when`(source).getExperiments(any())
-        val storage = mock(ExperimentStorage::class.java)
+        val storage = mock<ExperimentStorage>()
         `when`(storage.retrieve()).thenReturn(ExperimentsSnapshot(listOf(), null))
         val fretboard = Fretboard(source, storage)
         fretboard.updateExperiments()
@@ -493,11 +494,11 @@ class FretboardTest {
 
     @Test
     fun getUserBucket() {
-        val context = mock(Context::class.java)
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
         `when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)
         `when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)
@@ -510,8 +511,8 @@ class FretboardTest {
 
     @Test
     fun getUserBucketWithOverridenClientId() {
-        val experimentSource = mock(ExperimentSource::class.java)
-        val experimentStorage = mock(ExperimentStorage::class.java)
+        val experimentSource = mock<ExperimentSource>()
+        val experimentStorage = mock<ExperimentStorage>()
 
         val fretboard1 = Fretboard(experimentSource, experimentStorage, object : ValuesProvider() {
             override fun getClientId(context: Context): String = "c641eacf-c30c-4171-b403-f077724e848a"
@@ -528,8 +529,8 @@ class FretboardTest {
 
     @Test
     fun evenDistribution() {
-        val context = mock(Context::class.java)
-        val sharedPrefs = mock(SharedPreferences::class.java)
+        val context = mock<Context>()
+        val sharedPrefs = mock<SharedPreferences>()
         val prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(sharedPrefs.edit()).thenReturn(prefsEditor)
         `when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)
@@ -567,7 +568,7 @@ class FretboardTest {
 
     @Test
     fun loadingCorruptJSON() {
-        val experimentSource = mock(ExperimentSource::class.java)
+        val experimentSource = mock<ExperimentSource>()
 
         val file = File(testContext.filesDir, "corrupt-experiments.json")
         file.writer().use {

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/JSONExperimentParserTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/JSONExperimentParserTest.kt
@@ -4,14 +4,15 @@
 
 package mozilla.components.service.fretboard
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class JSONExperimentParserTest {
+
     @Test
     fun toJson() {
         val experiment = Experiment("sample-id",

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ValuesProviderTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/ValuesProviderTest.kt
@@ -4,23 +4,23 @@
 
 package mozilla.components.service.fretboard
 
-import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
 import java.util.Locale
 import java.util.MissingResourceException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ValuesProviderTest {
+
     @Test
     fun `get language has three letter code`() {
         Locale.setDefault(Locale("en", "US"))
-        assertEquals("eng", ValuesProvider().getLanguage(mock(Context::class.java)))
+        assertEquals("eng", ValuesProvider().getLanguage(mock()))
     }
 
     @Test
@@ -29,18 +29,18 @@ class ValuesProviderTest {
         `when`(locale.isO3Language).thenThrow(MissingResourceException("", "", ""))
         `when`(locale.language).thenReturn("language")
         Locale.setDefault(locale)
-        assertEquals("language", ValuesProvider().getLanguage(mock(Context::class.java)))
+        assertEquals("language", ValuesProvider().getLanguage(mock()))
     }
 
     @Test
     fun `get country has three letter code`() {
         Locale.setDefault(Locale("en", "US"))
-        assertEquals("USA", ValuesProvider().getCountry(mock(Context::class.java)))
+        assertEquals("USA", ValuesProvider().getCountry(mock()))
     }
 
     @Test
     fun `get country doesn't have three letter code`() {
         Locale.setDefault(Locale("cnr", "CS"))
-        assertEquals("CS", ValuesProvider().getCountry(mock(Context::class.java)))
+        assertEquals("CS", ValuesProvider().getCountry(mock()))
     }
 }

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSourceTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/source/kinto/KintoExperimentSourceTest.kt
@@ -4,29 +4,30 @@
 
 package mozilla.components.service.fretboard.source.kinto
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Response
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentsSnapshot
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class KintoExperimentSourceTest {
+
     private val baseUrl = "http://mydomain.test"
     private val bucketName = "fretboard"
     private val collectionName = "experiments"
 
     @Test
     fun noExperiments() {
-        val httpClient = mock(Client::class.java)
+        val httpClient = mock<Client>()
 
         val url = "$baseUrl/buckets/$bucketName/collections/$collectionName/records"
         `when`(httpClient.fetch(any()))
@@ -39,7 +40,7 @@ class KintoExperimentSourceTest {
 
     @Test
     fun getExperimentsNoDiff() {
-        val httpClient = mock(Client::class.java)
+        val httpClient = mock<Client>()
 
         val url = "$baseUrl/buckets/$bucketName/collections/$collectionName/records"
         `when`(httpClient.fetch(any())).thenReturn(
@@ -65,7 +66,7 @@ class KintoExperimentSourceTest {
 
     @Test
     fun getExperimentsDiffAdd() {
-        val httpClient = mock(Client::class.java)
+        val httpClient = mock<Client>()
         val url = "$baseUrl/buckets/$bucketName/collections/$collectionName/records?_since=1523549890000"
         `when`(httpClient.fetch(any())).thenReturn(
             Response(url,
@@ -99,7 +100,7 @@ class KintoExperimentSourceTest {
 
     @Test
     fun getExperimentsDiffDelete() {
-        val httpClient = mock(Client::class.java)
+        val httpClient = mock<Client>()
 
         val storageExperiment = Experiment("id",
             "name",
@@ -140,7 +141,7 @@ class KintoExperimentSourceTest {
 
     @Test
     fun getExperimentsDiffUpdate() {
-        val httpClient = mock(Client::class.java)
+        val httpClient = mock<Client>()
         val url = "$baseUrl/buckets/$bucketName/collections/$collectionName/records?_since=1523549800000"
         `when`(httpClient.fetch(any())).thenReturn(
             Response(url,
@@ -173,7 +174,7 @@ class KintoExperimentSourceTest {
 
     @Test
     fun getExperimentsEmptyDiff() {
-        val httpClient = mock(Client::class.java)
+        val httpClient = mock<Client>()
         val url = "$baseUrl/buckets/$bucketName/collections/$collectionName/records?_since=1523549895713"
         `when`(httpClient.fetch(any())).thenReturn(
             Response(url,

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/source/kinto/SignatureVerifierTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/source/kinto/SignatureVerifierTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.fretboard.source.kinto
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentDownloadException
@@ -18,12 +19,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.util.Date
 import java.util.Calendar
+import java.util.Date
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SignatureVerifierTest {
+
     private lateinit var server: MockWebServer
 
     @Before

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/storage/flatfile/ExperimentsSerializerTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/storage/flatfile/ExperimentsSerializerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.fretboard.storage.flatfile
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentsSnapshot
 import org.json.JSONException
@@ -12,9 +13,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-val experimentsJson = """
+const val experimentsJson = """
                               {
                                   "experiments": [
                                       {
@@ -56,8 +56,9 @@ val experimentsJson = """
                               }
                               """
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExperimentsSerializerTest {
+
     @Test
     fun fromJsonValid() {
         val experimentsResult = ExperimentsSerializer().fromJson(experimentsJson)

--- a/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorageTest.kt
+++ b/components/service/fretboard/src/test/java/mozilla/components/service/fretboard/storage/flatfile/FlatFileExperimentStorageTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.fretboard.storage.flatfile
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.fretboard.Experiment
 import mozilla.components.service.fretboard.ExperimentsSnapshot
 import mozilla.components.support.test.robolectric.testContext
@@ -14,12 +15,11 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class FlatFileExperimentStorageTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `service-fretboard` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~