### PR TITLE
For #1481. Use androidx runner in `service-pocket`.

### DIFF
--- a/components/service/pocket/build.gradle
+++ b/components/service/pocket/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -29,9 +31,9 @@ dependencies {
     implementation project(':concept-fetch')
 
     testImplementation Dependencies.kotlin_reflect
-    testImplementation Dependencies.androidx_test_core
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 

--- a/components/service/pocket/gradle.properties
+++ b/components/service/pocket/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointRawTest.kt
@@ -4,23 +4,23 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers.Names.USER_AGENT
 import mozilla.components.concept.fetch.Response
 import mozilla.components.service.pocket.helpers.MockResponses
 import mozilla.components.service.pocket.helpers.assertRequestParams
-import mozilla.components.service.pocket.helpers.assertSuccessfulRequestReturnsResponseBody
 import mozilla.components.service.pocket.helpers.assertResponseIsClosed
+import mozilla.components.service.pocket.helpers.assertSuccessfulRequestReturnsResponseBody
 import mozilla.components.support.ktx.kotlin.toUri
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 
 private const val VALID_API_KEY = "apiKey"
@@ -31,7 +31,7 @@ private val TEST_URL = "https://mozilla.org".toUri()
 // From Firefox for Fire TV
 private const val TEST_USER_AGENT = "Mozilla/5.0 (Linux; Android 7.1.2) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/3.0 Chrome/59.0.3017.125 Safari/537.36"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketEndpointRawTest {
 
     private lateinit var endpoint: PocketEndpointRaw
@@ -48,11 +48,11 @@ class PocketEndpointRawTest {
         successResponse = MockResponses.getSuccess()
         defaultResponse = errorResponse
 
-        client = mock(Client::class.java).also {
+        client = mock<Client>().also {
             `when`(it.fetch(any())).thenReturn(defaultResponse)
         }
 
-        urls = mock(PocketURLs::class.java).also {
+        urls = mock<PocketURLs>().also {
             `when`(it.globalVideoRecs).thenReturn(TEST_URL)
         }
         endpoint = PocketEndpointRaw(client, urls, TEST_USER_AGENT)

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketEndpointTest.kt
@@ -4,27 +4,27 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.pocket.helpers.PocketTestResource
 import mozilla.components.service.pocket.helpers.assertResponseIsFailure
 import mozilla.components.service.pocket.net.PocketResponse
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
 private const val VALID_API_KEY = "apiKey"
 private const val VALID_USER_AGENT = "userAgent"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketEndpointTest {
 
     private lateinit var endpoint: PocketEndpoint
@@ -35,11 +35,11 @@ class PocketEndpointTest {
 
     @Before
     fun setUp() {
-        raw = mock(PocketEndpointRaw::class.java)
-        jsonParser = mock(PocketJSONParser::class.java)
+        raw = mock()
+        jsonParser = mock()
         endpoint = PocketEndpoint(raw, jsonParser)
 
-        client = mock(Client::class.java)
+        client = mock()
     }
 
     @Test

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketJSONParserTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketJSONParserTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.pocket.PocketJSONParser.Companion.KEY_VIDEO_RECOMMENDATIONS_INNER
 import mozilla.components.service.pocket.data.PocketGlobalVideoRecommendation
 import mozilla.components.service.pocket.helpers.PocketTestResource
@@ -14,7 +15,6 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 private const val TEST_DATA_SIZE = 20
 
@@ -26,7 +26,7 @@ private val TEST_AUTHOR = PocketGlobalVideoRecommendation.Author(
     url = "https://www.nytimes.com/"
 )
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketJSONParserTest {
 
     private lateinit var parser: PocketJSONParser

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointRawTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointRawTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_TYPE
 import mozilla.components.concept.fetch.Headers.Names.USER_AGENT
@@ -17,6 +18,7 @@ import mozilla.components.service.pocket.helpers.assertResponseIsClosed
 import mozilla.components.service.pocket.helpers.assertSuccessfulRequestReturnsResponseBody
 import mozilla.components.support.ktx.kotlin.toUri
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -24,8 +26,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import java.net.URLEncoder
 
@@ -34,7 +34,7 @@ private const val EXPECTED_ACCESS_TOKEN = "12345" // Amazing, that's the same co
 
 private val TEST_URL = "https://mozilla.org".toUri()
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketListenEndpointRawTest {
 
     private lateinit var subject: PocketListenEndpointRaw
@@ -49,8 +49,8 @@ class PocketListenEndpointRawTest {
         errorResponse = MockResponses.getError()
         successResponse = MockResponses.getSuccess()
 
-        client = mock(Client::class.java)
-        urls = mock(PocketListenURLs::class.java).also {
+        client = mock()
+        urls = mock<PocketListenURLs>().also {
             `when`(it.articleService).thenReturn(TEST_URL)
         }
 

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenEndpointTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.pocket.data.PocketListenArticleMetadata
@@ -11,6 +12,7 @@ import mozilla.components.service.pocket.helpers.PocketTestResource
 import mozilla.components.service.pocket.helpers.assertResponseIsFailure
 import mozilla.components.service.pocket.net.PocketResponse
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -20,15 +22,13 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
 private const val VALID_ACCESS_TOKEN = "accessToken"
 private const val VALID_USER_AGENT = "userAgent"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketListenEndpointTest {
 
     private lateinit var subject: PocketListenEndpoint
@@ -39,12 +39,12 @@ class PocketListenEndpointTest {
 
     @Before
     fun setUp() {
-        raw = mock(PocketListenEndpointRaw::class.java)
-        jsonParser = mock(PocketListenJSONParser::class.java)
+        raw = mock()
+        jsonParser = mock()
 
         subject = PocketListenEndpoint(raw, jsonParser)
 
-        client = mock(Client::class.java)
+        client = mock()
     }
 
     @Test

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenJSONParserTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenJSONParserTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.pocket.helpers.PocketTestResource
 import org.json.JSONArray
 import org.junit.Assert.assertEquals
@@ -11,9 +12,8 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketListenJSONParserTest {
 
     private lateinit var subject: PocketListenJSONParser

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenURLsTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketListenURLsTest.kt
@@ -4,13 +4,13 @@
 
 package mozilla.components.service.pocket
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketListenURLsTest {
 
     private lateinit var urls: PocketListenURLs

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketURLsTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketURLsTest.kt
@@ -5,15 +5,15 @@
 package mozilla.components.service.pocket
 
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 private const val TEST_KEY = "pocketAPIKey"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PocketURLsTest {
 
     private lateinit var urls: PocketURLs

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/ConceptFetchKtTest.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/ConceptFetchKtTest.kt
@@ -9,12 +9,12 @@ import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -38,7 +38,7 @@ class ConceptFetchKtTest {
         failureResponse = spy(Response(TEST_URL, 404, MutableHeaders(), failureResponseBody))
         testRequest = Request(TEST_URL)
 
-        client = mock(Client::class.java).also {
+        client = mock<Client>().also {
             `when`(it.fetch(any())).thenReturn(defaultResponse)
         }
     }

--- a/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/MockResponses.kt
+++ b/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/MockResponses.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.pocket.helpers
 
 import mozilla.components.concept.fetch.Response
+import mozilla.components.support.test.mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
@@ -12,6 +13,7 @@ import org.mockito.Mockito.mock
  * A collection of helper functions to generate mock [Response]s.
  */
 object MockResponses {
+
     fun getError(): Response = getMockResponse(404)
 
     fun getSuccess(): Response = getMockResponse(200).also {
@@ -22,7 +24,7 @@ object MockResponses {
         `when`(it.body).thenReturn(body)
     }
 
-    fun getMockResponse(status: Int): Response = mock(Response::class.java).also {
+    fun getMockResponse(status: Int): Response = mock<Response>().also {
         `when`(it.status).thenReturn(status)
     }
 }


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `service-pocket` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~