### PR TITLE
For #1481. Use androidx runner in `support-test`.

### DIFF
--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -28,12 +28,14 @@ android {
 
         lintConfig file("lint.xml")
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
     implementation Dependencies.kotlin_stdlib
 
-    implementation Dependencies.testing_junit
+    implementation Dependencies.androidx_test_junit
     implementation Dependencies.testing_mockito
     implementation (Dependencies.testing_robolectric) {
         exclude group: 'org.apache.maven'
@@ -43,6 +45,7 @@ dependencies {
     implementation Dependencies.androidx_test_core
 
     testImplementation Dependencies.androidx_core
+    testImplementation Dependencies.androidx_test_junit
     testImplementation project(':support-ktx')
 }
 

--- a/components/support/test/gradle.properties
+++ b/components/support/test/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/support/test/src/test/java/PermissionsTest.kt
+++ b/components/support/test/src/test/java/PermissionsTest.kt
@@ -5,14 +5,14 @@
 package mozilla.components.support.test.robolectric
 
 import android.Manifest.permission.INTERNET
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.ktx.android.content.isPermissionGranted
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PermissionsTest {
 
     @Test

--- a/components/support/test/src/test/java/mozilla/components/support/test/robolectric/ExtensionsTest.kt
+++ b/components/support/test/src/test/java/mozilla/components/support/test/robolectric/ExtensionsTest.kt
@@ -7,12 +7,12 @@
 package mozilla.components.support.test.robolectric
 
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExtensionsTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `support-test` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~