### PR TITLE
For #1481. Use androidx runner in `ui-doorhanger`.

### DIFF
--- a/components/ui/doorhanger/build.gradle
+++ b/components/ui/doorhanger/build.gradle
@@ -21,6 +21,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -34,7 +36,7 @@ dependencies {
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/ui/doorhanger/gradle.properties
+++ b/components/ui/doorhanger/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/ui/doorhanger/src/test/java/mozilla/components/ui/doorhanger/DoorhangerPromptTest.kt
+++ b/components/ui/doorhanger/src/test/java/mozilla/components/ui/doorhanger/DoorhangerPromptTest.kt
@@ -6,7 +6,6 @@
 
 package mozilla.components.ui.doorhanger
 
-import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
@@ -16,19 +15,17 @@ import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DoorhangerPromptTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Create complex prompt doorhanger`() {
@@ -39,14 +36,14 @@ class DoorhangerPromptTest {
             title = "Allow wikipedia.org to use your camera and microphone?",
             controlGroups = listOf(
                 DoorhangerPrompt.ControlGroup(
-                    icon = AppCompatResources.getDrawable(context, android.R.drawable.ic_menu_camera),
+                    icon = AppCompatResources.getDrawable(testContext, android.R.drawable.ic_menu_camera),
                     controls = listOf(
                         DoorhangerPrompt.Control.RadioButton("Front-facing camera"),
                         DoorhangerPrompt.Control.RadioButton("Selfie camera")
                     )
                 ),
                 DoorhangerPrompt.ControlGroup(
-                    icon = AppCompatResources.getDrawable(context, android.R.drawable.ic_btn_speak_now),
+                    icon = AppCompatResources.getDrawable(testContext, android.R.drawable.ic_btn_speak_now),
                     controls = listOf(
                         DoorhangerPrompt.Control.RadioButton("Speakerphone"),
                         DoorhangerPrompt.Control.RadioButton("Headset microphone"),
@@ -68,10 +65,10 @@ class DoorhangerPromptTest {
             onDismiss = {}
         )
 
-        val doorhanger = prompt.createDoorhanger(context)
+        val doorhanger = prompt.createDoorhanger(testContext)
         assertNotNull(doorhanger)
 
-        val popupWindow = doorhanger.show(View(context))
+        val popupWindow = doorhanger.show(View(testContext))
         assertNotNull(popupWindow)
 
         val contentView = popupWindow.contentView
@@ -157,10 +154,10 @@ class DoorhangerPromptTest {
         val button3 = DoorhangerPrompt.Control.RadioButton("Selfie camera")
 
         val controlGroup = DoorhangerPrompt.ControlGroup(
-            icon = AppCompatResources.getDrawable(context, android.R.drawable.ic_menu_camera),
+            icon = AppCompatResources.getDrawable(testContext, android.R.drawable.ic_menu_camera),
             controls = listOf(button1, button2, button3))
 
-        val view = controlGroup.createView(context, LinearLayout(context))
+        val view = controlGroup.createView(testContext, LinearLayout(testContext))
         val group = view.findViewById<RadioGroup>(R.id.group)
 
         val radioButton1 = group.getChildAt(0) as RadioButton
@@ -195,7 +192,7 @@ class DoorhangerPromptTest {
         val controlGroup = DoorhangerPrompt.ControlGroup(
             controls = listOf(checkbox1, checkbox2))
 
-        val view = controlGroup.createView(context, LinearLayout(context))
+        val view = controlGroup.createView(testContext, LinearLayout(testContext))
         val group = view.findViewById<RadioGroup>(R.id.group)
 
         val checkBoxView1 = group.getChildAt(0) as CheckBox
@@ -226,10 +223,10 @@ class DoorhangerPromptTest {
         assertFalse(button3.checked)
 
         val controlGroup = DoorhangerPrompt.ControlGroup(
-            icon = AppCompatResources.getDrawable(context, android.R.drawable.ic_menu_camera),
+            icon = AppCompatResources.getDrawable(testContext, android.R.drawable.ic_menu_camera),
             controls = listOf(button1, button2, button3))
 
-        controlGroup.createView(context, LinearLayout(context))
+        controlGroup.createView(testContext, LinearLayout(testContext))
 
         assertTrue(button1.checked)
         assertFalse(button2.checked)
@@ -240,7 +237,7 @@ class DoorhangerPromptTest {
     fun `Button has label assigned`() {
         val button = DoorhangerPrompt.Button("Hello World", positive = true, onClick = {})
 
-        val view = button.createView(context, LinearLayout(context), onClick = {})
+        val view = button.createView(testContext, LinearLayout(testContext), onClick = {})
 
         assertTrue(view is Button)
         val buttonView = view as Button
@@ -254,7 +251,7 @@ class DoorhangerPromptTest {
 
         var buttonClicked = false
 
-        val view = button.createView(context, LinearLayout(context), onClick = {
+        val view = button.createView(testContext, LinearLayout(testContext), onClick = {
             buttonClicked = true
         })
 

--- a/components/ui/doorhanger/src/test/java/mozilla/components/ui/doorhanger/DoorhangerTest.kt
+++ b/components/ui/doorhanger/src/test/java/mozilla/components/ui/doorhanger/DoorhangerTest.kt
@@ -6,11 +6,11 @@
 
 package mozilla.components.ui.doorhanger
 
-import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -18,17 +18,14 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DoorhangerTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `show returns non-null popup window`() {
-        val doorhanger = Doorhanger(TextView(context))
-        val popupWindow = doorhanger.show(View(context))
+        val doorhanger = Doorhanger(TextView(testContext))
+        val popupWindow = doorhanger.show(View(testContext))
 
         assertNotNull(popupWindow)
         assertTrue(popupWindow.isShowing)
@@ -36,13 +33,13 @@ class DoorhangerTest {
 
     @Test
     fun `popup window contains passed in view`() {
-        val view = TextView(context).apply {
+        val view = TextView(testContext).apply {
             id = 42
             text = "Mozilla!"
         }
 
         val doorhanger = Doorhanger(view)
-        val popupWindow = doorhanger.show(View(context))
+        val popupWindow = doorhanger.show(View(testContext))
 
         assertEquals(
             "Mozilla!",
@@ -52,9 +49,9 @@ class DoorhangerTest {
 
     @Test
     fun `popup window passed in view is wrapped`() {
-        val view = TextView(context)
+        val view = TextView(testContext)
         val doorhanger = Doorhanger(view)
-        val popupWindow = doorhanger.show(View(context))
+        val popupWindow = doorhanger.show(View(testContext))
 
         assertNotEquals(view, popupWindow.contentView)
         assertTrue(popupWindow.contentView is ViewGroup)
@@ -64,11 +61,11 @@ class DoorhangerTest {
     fun `dismissing popup window invokes callback`() {
         var dismissCallbackInvoked = false
 
-        val doorhanger = Doorhanger(TextView(context), onDismiss = {
+        val doorhanger = Doorhanger(TextView(testContext), onDismiss = {
             dismissCallbackInvoked = true
         })
 
-        val popupWindow = doorhanger.show(View(context))
+        val popupWindow = doorhanger.show(View(testContext))
 
         assertFalse(dismissCallbackInvoked)
 
@@ -79,8 +76,8 @@ class DoorhangerTest {
 
     @Test
     fun `dismiss on doorhanger is forwarded to popup window`() {
-        val doorhanger = Doorhanger(TextView(context))
-        val popupWindow = doorhanger.show(View(context))
+        val doorhanger = Doorhanger(TextView(testContext))
+        val popupWindow = doorhanger.show(View(testContext))
 
         assertTrue(popupWindow.isShowing)
 
@@ -91,7 +88,7 @@ class DoorhangerTest {
 
     @Test
     fun `calling dismiss on a not-showing doorhanger is a no-op`() {
-        val doorhanger = Doorhanger(TextView(context))
+        val doorhanger = Doorhanger(TextView(testContext))
         doorhanger.dismiss()
     }
 }


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `ui-doorhanger` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~