### PR TITLE
For #1481. Use androidx runner in `ui-progress`.

### DIFF
--- a/components/ui/progress/build.gradle
+++ b/components/ui/progress/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -30,7 +32,7 @@ dependencies {
 
     testImplementation project(":support-test")
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/ui/progress/gradle.properties
+++ b/components/ui/progress/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/ui/progress/src/test/java/mozilla/components/ui/progress/AnimatedProgressBarTest.kt
+++ b/components/ui/progress/src/test/java/mozilla/components/ui/progress/AnimatedProgressBarTest.kt
@@ -7,6 +7,7 @@
 package mozilla.components.ui.progress
 
 import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -14,9 +15,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AnimatedProgressBarTest {
 
     @Test

--- a/components/ui/progress/src/test/java/mozilla/components/ui/progress/ShiftDrawableTest.kt
+++ b/components/ui/progress/src/test/java/mozilla/components/ui/progress/ShiftDrawableTest.kt
@@ -7,21 +7,21 @@ package mozilla.components.ui.progress
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ShiftDrawableTest {
 
     @Test
     fun draw() {
-        val canvas = mock(Canvas::class.java)
-        val wrappedDrawable = mock(Drawable::class.java)
+        val canvas = mock<Canvas>()
+        val wrappedDrawable = mock<Drawable>()
         val drawable = ShiftDrawable(wrappedDrawable)
 
         drawable.bounds = Rect(1, 2, 3, 4)


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `ui-progress` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~