### PR TITLE
For #1481. Use androidx runner in `feature-customtabs`.

### DIFF
--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -39,7 +41,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/feature/customtabs/gradle.properties
+++ b/components/feature/customtabs/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/customtabs/src/test/java/AbstractCustomTabsServiceTest.kt
+++ b/components/feature/customtabs/src/test/java/AbstractCustomTabsServiceTest.kt
@@ -4,13 +4,13 @@
 
 package mozilla.components.browser.session.tab
 
-import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.IBinder
 import android.support.customtabs.ICustomTabsCallback
 import android.support.customtabs.ICustomTabsService
 import androidx.browser.customtabs.CustomTabsService
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.customtabs.AbstractCustomTabsService
 import mozilla.components.support.test.mock
@@ -22,11 +22,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AbstractCustomTabsServiceTest {
 
     @Test
@@ -36,30 +34,30 @@ class AbstractCustomTabsServiceTest {
                 get() = mock()
         }
 
-        val customTabsServiceStub = customTabsService.onBind(mock(Intent::class.java))
+        val customTabsServiceStub = customTabsService.onBind(mock())
         assertNotNull(customTabsServiceStub)
 
         val stub = customTabsServiceStub as ICustomTabsService.Stub
 
-        val callback = mock(ICustomTabsCallback::class.java)
+        val callback = mock<ICustomTabsCallback>()
         doReturn(mock<IBinder>()).`when`(callback).asBinder()
 
         assertTrue(stub.warmup(123))
         assertTrue(stub.newSession(callback))
-        assertNull(stub.extraCommand("", mock(Bundle::class.java)))
-        assertFalse(stub.updateVisuals(mock(ICustomTabsCallback::class.java), mock(Bundle::class.java)))
-        assertFalse(stub.requestPostMessageChannel(mock(ICustomTabsCallback::class.java), mock(Uri::class.java)))
+        assertNull(stub.extraCommand("", mock()))
+        assertFalse(stub.updateVisuals(mock(), mock()))
+        assertFalse(stub.requestPostMessageChannel(mock(), mock()))
         assertEquals(CustomTabsService.RESULT_FAILURE_DISALLOWED,
-            stub.postMessage(mock(ICustomTabsCallback::class.java), "", mock(Bundle::class.java)))
+            stub.postMessage(mock(), "", mock()))
         assertFalse(stub.validateRelationship(
-            mock(ICustomTabsCallback::class.java),
+            mock(),
             0,
-            mock(Uri::class.java),
-            mock(Bundle::class.java)))
+            mock(),
+            mock()))
         assertTrue(stub.mayLaunchUrl(
-            mock(ICustomTabsCallback::class.java),
-            mock(Uri::class.java),
-            mock(Bundle::class.java), emptyList<Bundle>()))
+            mock(),
+            mock(),
+            mock(), emptyList<Bundle>()))
     }
 
     @Test
@@ -74,7 +72,7 @@ class AbstractCustomTabsServiceTest {
                 }
         }
 
-        val stub = customTabsService.onBind(mock(Intent::class.java)) as ICustomTabsService.Stub
+        val stub = customTabsService.onBind(mock()) as ICustomTabsService.Stub
 
         assertTrue(stub.warmup(42))
 
@@ -89,7 +87,7 @@ class AbstractCustomTabsServiceTest {
             override val engine: Engine = engine
         }
 
-        val stub = customTabsService.onBind(mock(Intent::class.java)) as ICustomTabsService.Stub
+        val stub = customTabsService.onBind(mock()) as ICustomTabsService.Stub
 
         assertTrue(stub.mayLaunchUrl(mock(), Uri.parse("https://www.mozilla.org"), Bundle(), listOf()))
 

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -7,13 +7,12 @@
 package mozilla.components.feature.customtabs
 
 import android.app.PendingIntent
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageButton
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.Session
@@ -42,13 +41,9 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CustomTabsToolbarFeatureTest {
-
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `start without sessionId invokes nothing`() {
@@ -183,7 +178,7 @@ class CustomTabsToolbarFeatureTest {
 
         feature.initialize(session)
 
-        val button = extractActionView(toolbar, context.getString(R.string.mozac_feature_customtabs_exit_button))
+        val button = extractActionView(toolbar, testContext.getString(R.string.mozac_feature_customtabs_exit_button))
         button?.performClick()
 
         assertTrue(closeClicked)


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-customtabs` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~