### PR TITLE
For #1481. Use androidx runner in `feature-contextmenu`.

### DIFF
--- a/components/feature/contextmenu/build.gradle
+++ b/components/feature/contextmenu/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -31,7 +33,7 @@ dependencies {
     implementation Dependencies.google_material
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 

--- a/components/feature/contextmenu/gradle.properties
+++ b/components/feature/contextmenu/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -8,6 +8,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -28,9 +29,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ContextMenuCandidateTest {
 
     private lateinit var snackbarDelegate: TestSnackbarDelegate

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFeatureTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFeatureTest.kt
@@ -4,12 +4,11 @@
 
 package mozilla.components.feature.contextmenu
 
-import android.content.Context
 import android.view.HapticFeedbackConstants
 import android.view.View
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
@@ -20,6 +19,7 @@ import mozilla.components.support.base.facts.processor.CollectionProcessor
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -30,13 +30,10 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ContextMenuFeatureTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `New HitResult for selected session will cause fragment transaction`() {
@@ -50,7 +47,7 @@ class ContextMenuFeatureTest {
         val feature = ContextMenuFeature(
             fragmentManager,
             sessionManager,
-            ContextMenuCandidate.defaultCandidates(context, mock(), mock()),
+            ContextMenuCandidate.defaultCandidates(testContext, mock(), mock()),
             engineView)
 
         feature.start()
@@ -74,7 +71,7 @@ class ContextMenuFeatureTest {
         val feature = ContextMenuFeature(
             fragmentManager,
             sessionManager,
-            ContextMenuCandidate.defaultCandidates(context, mock(), mock()),
+            ContextMenuCandidate.defaultCandidates(testContext, mock(), mock()),
             engineView)
 
         feature.start()
@@ -106,7 +103,7 @@ class ContextMenuFeatureTest {
         val feature = ContextMenuFeature(
             fragmentManager,
             sessionManager,
-            ContextMenuCandidate.defaultCandidates(context, mock(), mock()),
+            ContextMenuCandidate.defaultCandidates(testContext, mock(), mock()),
             engineView)
 
         feature.start()
@@ -137,7 +134,7 @@ class ContextMenuFeatureTest {
         val feature = ContextMenuFeature(
             fragmentManager,
             sessionManager,
-            ContextMenuCandidate.defaultCandidates(context, mock(), mock()),
+            ContextMenuCandidate.defaultCandidates(testContext, mock(), mock()),
             engineView)
 
         feature.start()
@@ -166,7 +163,7 @@ class ContextMenuFeatureTest {
         val feature = ContextMenuFeature(
             fragmentManager,
             sessionManager,
-            ContextMenuCandidate.defaultCandidates(context, mock(), mock()),
+            ContextMenuCandidate.defaultCandidates(testContext, mock(), mock()),
             engineView)
 
         feature.start()
@@ -214,7 +211,7 @@ class ContextMenuFeatureTest {
         val feature = ContextMenuFeature(
             mock(),
             sessionManager,
-            ContextMenuCandidate.defaultCandidates(context, mock(), mock()),
+            ContextMenuCandidate.defaultCandidates(testContext, mock(), mock()),
             engineView)
 
         assertFalse(session.hitResult.isConsumed())

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -20,9 +21,8 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ContextMenuFragmentTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-contextmenu` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~