### PR TITLE
For #1481. Use androidx runner in `feature-downloads`.

### DIFF
--- a/components/feature/downloads/build.gradle
+++ b/components/feature/downloads/build.gradle
@@ -20,6 +20,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -32,9 +34,9 @@ dependencies {
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
 
-    testImplementation Dependencies.testing_junit
-    testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')
     testImplementation project(':concept-engine')

--- a/components/feature/downloads/gradle.properties
+++ b/components/feature/downloads/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.downloads
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Download
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.KEY_FILE_NAME
 import org.junit.Assert.assertEquals
@@ -11,9 +12,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DownloadDialogFragmentTest {
 
     private lateinit var dialog: DownloadDialogFragment

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -8,6 +8,7 @@ import android.Manifest.permission.INTERNET
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import androidx.core.content.PermissionChecker
 import androidx.fragment.app.FragmentManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -28,15 +29,13 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DownloadsFeatureTest {
 
     private lateinit var feature: DownloadsFeature
@@ -45,7 +44,7 @@ class DownloadsFeatureTest {
 
     @Before
     fun setup() {
-        val engine = mock(Engine::class.java)
+        val engine = mock<Engine>()
         mockSessionManager = spy(SessionManager(engine))
         mockDownloadManager = mock()
         feature = DownloadsFeature(testContext,
@@ -188,7 +187,7 @@ class DownloadsFeatureTest {
     @Test
     fun `when fragmentManager is not null a confirmation dialog must be show before starting a download`() {
         val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock(FragmentManager::class.java)
+        val mockFragmentManager = mock<FragmentManager>()
 
         `when`(mockFragmentManager.beginTransaction()).thenReturn(mock())
 
@@ -215,7 +214,7 @@ class DownloadsFeatureTest {
     @Test
     fun `feature with a sessionId will re-attach to already existing fragment`() {
         val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock(FragmentManager::class.java)
+        val mockFragmentManager = mock<FragmentManager>()
         val mockDownload: Consumable<Download> = mock()
         val mockSession: Session = mock()
 
@@ -242,7 +241,7 @@ class DownloadsFeatureTest {
     @Test
     fun `feature with a selected session will re-attach to already existing fragment`() {
         val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock(FragmentManager::class.java)
+        val mockFragmentManager = mock<FragmentManager>()
         val mockDownload: Consumable<Download> = mock()
         val mockSession: Session = mock()
 
@@ -270,7 +269,7 @@ class DownloadsFeatureTest {
     @Test
     fun `shouldn't show twice a dialog if is already created`() {
         val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock(FragmentManager::class.java)
+        val mockFragmentManager = mock<FragmentManager>()
 
         `when`(mockFragmentManager.findFragmentByTag(FRAGMENT_TAG)).thenReturn(mockDialog)
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt
@@ -8,17 +8,17 @@ import android.app.Application
 import android.content.DialogInterface.BUTTON_POSITIVE
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Download
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
 class SimpleDownloadDialogFragmentTest {
 
@@ -28,7 +28,7 @@ class SimpleDownloadDialogFragmentTest {
 
     @Before
     fun setup() {
-        mockFragmentManager = mock(FragmentManager::class.java)
+        mockFragmentManager = mock()
         download = Download(
             "http://ipv4.download.thinkbroadband.com/5MB.zip",
             "5MB.zip", "application/zip", 5242880,

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt
@@ -9,6 +9,7 @@ import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
 import android.app.DownloadManager.Request
 import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Download
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
@@ -21,9 +22,8 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AndroidDownloadManagerTest {
 
     private lateinit var download: Download


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-downloads` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~