### PR TITLE
For #1481. Use androidx runner in `feature-findinpage`.

### DIFF
--- a/components/feature/findinpage/build.gradle
+++ b/components/feature/findinpage/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -31,7 +33,7 @@ dependencies {
     implementation Dependencies.androidx_constraintlayout
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')

--- a/components/feature/findinpage/gradle.properties
+++ b/components/feature/findinpage/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/FindInPageFeatureTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/FindInPageFeatureTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 class FindInPageFeatureTest {
+
     @Test
     fun `start is forwarded to presenter and interactor`() {
         val presenter: FindInPagePresenter = mock()

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPageInteractorTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPageInteractorTest.kt
@@ -4,9 +4,8 @@
 
 package mozilla.components.feature.findinpage.internal
 
-import android.content.Context
 import android.view.View
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
@@ -16,18 +15,16 @@ import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.processor.CollectionProcessor
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class FindInPageInteractorTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Start will register interactor as listener and emit a fact`() {
@@ -55,7 +52,7 @@ class FindInPageInteractorTest {
     @Test
     fun `FindInPageView-Listener implementation can get invoked without binding to session`() {
         val view: FindInPageView = mock()
-        `when`(view.asView()).thenReturn(View(context))
+        `when`(view.asView()).thenReturn(View(testContext))
 
         val interactor = FindInPageInteractor(mock(), mock(), view, mock())
 
@@ -70,7 +67,7 @@ class FindInPageInteractorTest {
     @Test
     fun `OnPreviousResult updates engine session`() {
         val view: FindInPageView = mock()
-        `when`(view.asView()).thenReturn(View(context))
+        `when`(view.asView()).thenReturn(View(testContext))
 
         val engineSession: EngineSession = mock()
 
@@ -88,7 +85,7 @@ class FindInPageInteractorTest {
     @Test
     fun `onNextResult updates engine session`() {
         val view: FindInPageView = mock()
-        `when`(view.asView()).thenReturn(View(context))
+        `when`(view.asView()).thenReturn(View(testContext))
 
         val engineSession: EngineSession = mock()
 
@@ -106,7 +103,7 @@ class FindInPageInteractorTest {
     @Test
     fun `onNextResult blurs focused engine view`() {
         val view: FindInPageView = mock()
-        `when`(view.asView()).thenReturn(View(context))
+        `when`(view.asView()).thenReturn(View(testContext))
 
         val actualEngineView: View = mock()
         val engineView: EngineView = mock()
@@ -178,7 +175,7 @@ class FindInPageInteractorTest {
     fun `interactor emits the facts`() {
         CollectionProcessor.withFactCollection { facts ->
             val view: FindInPageView = mock()
-            `when`(view.asView()).thenReturn(View(context))
+            `when`(view.asView()).thenReturn(View(testContext))
 
             val actualEngineView: View = mock()
             val engineView: EngineView = mock()

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPagePresenterTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPagePresenterTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class FindInPagePresenterTest {
+
     @Test
     fun `bind registers on session with view scope`() {
         val actualView: View = mock()

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
@@ -4,30 +4,27 @@
 
 package mozilla.components.feature.findinpage.view
 
-import android.content.Context
 import android.widget.EditText
 import androidx.appcompat.widget.AppCompatImageButton
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.feature.findinpage.R
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class FindInPageBarTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `Clicking close button invokes onClose method of listener`() {
         val listener: FindInPageView.Listener = mock()
 
-        val view = FindInPageBar(context)
+        val view = FindInPageBar(testContext)
         view.listener = listener
 
         view.findViewById<AppCompatImageButton>(R.id.find_in_page_close_btn)
@@ -40,7 +37,7 @@ class FindInPageBarTest {
     fun `Clicking next button invokes onNextResult method of listener`() {
         val listener: FindInPageView.Listener = mock()
 
-        val view = FindInPageBar(context)
+        val view = FindInPageBar(testContext)
         view.listener = listener
 
         view.findViewById<AppCompatImageButton>(R.id.find_in_page_next_btn)
@@ -53,7 +50,7 @@ class FindInPageBarTest {
     fun `Clicking previous button invokes onPreviousResult method of listener`() {
         val listener: FindInPageView.Listener = mock()
 
-        val view = FindInPageBar(context)
+        val view = FindInPageBar(testContext)
         view.listener = listener
 
         view.findViewById<AppCompatImageButton>(R.id.find_in_page_prev_btn)
@@ -66,7 +63,7 @@ class FindInPageBarTest {
     fun `Entering text invokes onFindAll method of listener`() {
         val listener: FindInPageView.Listener = mock()
 
-        val view = FindInPageBar(context)
+        val view = FindInPageBar(testContext)
         view.listener = listener
 
         view.findViewById<EditText>(R.id.find_in_page_query_text)
@@ -79,7 +76,7 @@ class FindInPageBarTest {
     fun `Clearing text invokes onClearMatches method of listener`() {
         val listener: FindInPageView.Listener = mock()
 
-        val view = FindInPageBar(context)
+        val view = FindInPageBar(testContext)
         view.listener = listener
 
         view.findViewById<EditText>(R.id.find_in_page_query_text)
@@ -90,7 +87,7 @@ class FindInPageBarTest {
 
     @Test
     fun `displayResult with matches will update views`() {
-        val view = spy(FindInPageBar(context))
+        val view = spy(FindInPageBar(testContext))
 
         view.displayResult(Session.FindResult(0, 100, false))
 
@@ -104,7 +101,7 @@ class FindInPageBarTest {
 
     @Test
     fun `displayResult with no matches will update views`() {
-        val view = spy(FindInPageBar(context))
+        val view = spy(FindInPageBar(testContext))
 
         view.displayResult(Session.FindResult(0, 0, false))
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-findinpage` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~