### PR TITLE
Fixes #3370 - Stop detecting https and http links as applinks.

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -64,9 +64,17 @@ class AppLinksUseCases(
      * If that app is not available, then a market place intent is also provided.
      *
      * It will also provide a fallback.
+     *
+     * @param includeHttpAppLinks If {true} then test URLs that start with {http} and {https}.
+     * @param ignoreDefaultBrowser If {true} then do not offer an app link if the user has
+     * selected this browser as default previously. This is only applicable if {includeHttpAppLinks}
+     * is true.
+     * @param includeInstallAppFallback If {true} then offer an app-link to the installed market app
+     * if no web fallback is available.
      */
     inner class GetAppLinkRedirect internal constructor(
         private val includeHttpAppLinks: Boolean = false,
+        private val ignoreDefaultBrowser: Boolean = false,
         private val includeInstallAppFallback: Boolean = false
     ) {
         fun invoke(url: String): AppLinkRedirect {
@@ -75,7 +83,8 @@ class AppLinksUseCases(
                 intents.firstOrNull { getNonBrowserActivities(it).isNotEmpty() }
                     ?.let {
                         // The user may have decided to keep opening this type of link in this browser.
-                        if (findDefaultActivity(it)?.activityInfo?.packageName == context.packageName) {
+                        if (ignoreDefaultBrowser &&
+                            findDefaultActivity(it)?.activityInfo?.packageName == context.packageName) {
                             // in which case, this isn't an app intent anymore.
                             null
                         } else {
@@ -153,13 +162,14 @@ class AppLinksUseCases(
     val openAppLink: OpenAppLinkRedirect by lazy { OpenAppLinkRedirect(context) }
     val interceptedAppLinkRedirect: GetAppLinkRedirect by lazy {
         GetAppLinkRedirect(
-            includeHttpAppLinks = true,
+            includeHttpAppLinks = false,
             includeInstallAppFallback = false
         )
     }
     val appLinkRedirect: GetAppLinkRedirect by lazy {
         GetAppLinkRedirect(
             includeHttpAppLinks = true,
+            ignoreDefaultBrowser = false,
             includeInstallAppFallback = false
         )
     }

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -67,9 +67,9 @@ class AppLinksUseCasesTest {
         val context = createContext(appUrl to appPackage)
         val subject = AppLinksUseCases(context, emptySet())
 
-        // We will redirect to it when we click on it.
+        // We will not redirect to it when we click on it.
         val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
-        assertTrue(redirect.isRedirect())
+        assertFalse(redirect.isRedirect())
 
         // But we do from a context menu.
         val menuRedirect = subject.appLinkRedirect.invoke(appUrl)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -74,6 +74,10 @@ permalink: /changelog/
 * **browser-session**
   * Added `Session.hasParentSession` to indicate whether a `Session` was opened from a parent `Session` such as opening a new tab from a link context menu ("Open in new tab").
 
+* **feature-app-links**
+  * Add a flag to allow the app to not detect an external app if the user has told android to use the browser as default.
+  * Turn off interception of web links. 
+
 # 0.55.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.54.0...v0.55.0)


### PR DESCRIPTION
Fixes #3370.

This PR toggles off the interception of HTTP and HTTPS links by the default interception use case.

It also adds a flag to ignore web links where the user has elected to use fenix. This is in support of PR [Fenix#3338][1].

[1]: https://github.com/mozilla-mobile/fenix/issues/3338

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
