### PR TITLE
For #1481. Use androidx runner in `feature-prompts`.

### DIFF
--- a/components/feature/prompts/build.gradle
+++ b/components/feature/prompts/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -30,8 +32,7 @@ dependencies {
     implementation Dependencies.google_material
 
     testImplementation Dependencies.androidx_test_core
-
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')

--- a/components/feature/prompts/gradle.properties
+++ b/components/feature/prompts/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AlertDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AlertDialogFragmentTest.kt
@@ -4,16 +4,14 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
-import android.content.DialogInterface
 import android.content.DialogInterface.BUTTON_POSITIVE
-import android.view.ContextThemeWrapper
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import mozilla.components.support.test.mock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.R.id
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -22,16 +20,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AlertDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext<Context>(),
-            androidx.appcompat.R.style.Theme_AppCompat
-        )
 
     @Test
     fun `build dialog`() {
@@ -40,7 +31,7 @@ class AlertDialogFragmentTest {
             AlertDialogFragment.newInstance("sessionId", "title", "message", true)
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -67,7 +58,7 @@ class AlertDialogFragmentTest {
             AlertDialogFragment.newInstance("sessionId", "title", "message", false)
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -89,12 +80,12 @@ class AlertDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
 
-        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
         verify(mockFeature).onCancel("sessionId")
@@ -111,7 +102,7 @@ class AlertDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -137,7 +128,7 @@ class AlertDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         fragment.onCancel(null)
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AuthenticationDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/AuthenticationDialogFragmentTest.kt
@@ -4,14 +4,13 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
 import android.content.DialogInterface
-import android.view.ContextThemeWrapper
 import android.view.View.GONE
 import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.R.id
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -20,16 +19,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AuthenticationDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext<Context>(),
-            androidx.appcompat.R.style.Theme_AppCompat
-        )
 
     @Test
     fun `build dialog`() {
@@ -45,7 +37,7 @@ class AuthenticationDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -89,7 +81,7 @@ class AuthenticationDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -114,7 +106,7 @@ class AuthenticationDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -122,7 +114,7 @@ class AuthenticationDialogFragmentTest {
 
         val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
 
-        val defaultTitle = context.getString(AuthenticationDialogFragment.DEFAULT_TITLE)
+        val defaultTitle = appCompatContext.getString(AuthenticationDialogFragment.DEFAULT_TITLE)
         assertEquals(titleTextView.text.toString(), defaultTitle)
     }
 
@@ -144,7 +136,7 @@ class AuthenticationDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -173,7 +165,7 @@ class AuthenticationDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         fragment.onCancel(null)
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ChoiceDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ChoiceDialogFragmentTest.kt
@@ -1,21 +1,20 @@
 package mozilla.components.feature.prompts
 
-import android.content.Context
 import android.content.DialogInterface.BUTTON_NEGATIVE
 import android.content.DialogInterface.BUTTON_POSITIVE
 import android.os.Parcelable
-import androidx.recyclerview.widget.RecyclerView
-import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.concept.engine.prompt.Choice
 import mozilla.components.feature.prompts.ChoiceAdapter.Companion.TYPE_GROUP
 import mozilla.components.feature.prompts.ChoiceAdapter.Companion.TYPE_MENU
-import mozilla.components.feature.prompts.ChoiceAdapter.Companion.TYPE_MULTIPLE
 import mozilla.components.feature.prompts.ChoiceAdapter.Companion.TYPE_MENU_SEPARATOR
+import mozilla.components.feature.prompts.ChoiceAdapter.Companion.TYPE_MULTIPLE
 import mozilla.components.feature.prompts.ChoiceAdapter.Companion.TYPE_SINGLE
 import mozilla.components.feature.prompts.ChoiceAdapter.GroupViewHolder
 import mozilla.components.feature.prompts.ChoiceAdapter.MenuViewHolder
@@ -26,31 +25,28 @@ import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.MULTIPL
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.SINGLE_CHOICE_DIALOG_TYPE
 import mozilla.components.feature.prompts.ChoiceDialogFragment.Companion.newInstance
 import mozilla.components.support.test.mock
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mockito.spy
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ChoiceDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(getApplicationContext<Context>(), androidx.appcompat.R.style.Theme_AppCompat)
 
     @Test
     fun `Build single choice dialog`() {
 
         val fragment = spy(newInstance(arrayOf(), "sessionId", SINGLE_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -62,7 +58,7 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(arrayOf(), "sessionId", MENU_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -74,7 +70,7 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(arrayOf(), "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -86,7 +82,7 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(arrayOf(), "sessionId", -1))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         fragment.onCreateDialog(null)
     }
@@ -98,10 +94,10 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", SINGLE_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), TYPE_SINGLE) as SingleViewHolder
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_SINGLE) as SingleViewHolder
         val labelView = holder.labelView
         adapter.bindViewHolder(holder, 0)
 
@@ -116,10 +112,10 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", MENU_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_MENU) as MenuViewHolder
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MENU) as MenuViewHolder
         val labelView = holder.labelView
         adapter.bindViewHolder(holder, 0)
 
@@ -134,10 +130,10 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", MENU_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_MENU_SEPARATOR)
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MENU_SEPARATOR)
         adapter.bindViewHolder(holder, 0)
 
         assertEquals(1, adapter.itemCount)
@@ -151,10 +147,10 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", MENU_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
-        adapter.onCreateViewHolder(LinearLayout(context), -1)
+        adapter.onCreateViewHolder(LinearLayout(testContext), -1)
     }
 
     @Test
@@ -170,7 +166,7 @@ class ChoiceDialogFragmentTest {
 
         var fragment = spy(newInstance(choices, "sessionId", SINGLE_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         var adapter = getAdapterFrom(fragment)
         var type = adapter.getItemViewType(0)
@@ -178,7 +174,7 @@ class ChoiceDialogFragmentTest {
         assertEquals(type, TYPE_SINGLE)
 
         fragment = spy(newInstance(choices, "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         adapter = getAdapterFrom(fragment)
 
@@ -186,7 +182,7 @@ class ChoiceDialogFragmentTest {
         assertEquals(type, TYPE_GROUP)
 
         fragment = spy(newInstance(choices, "sessionId", MENU_CHOICE_DIALOG_TYPE))
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         adapter = getAdapterFrom(fragment)
 
@@ -197,7 +193,7 @@ class ChoiceDialogFragmentTest {
         assertEquals(type, TYPE_MENU_SEPARATOR)
 
         fragment = spy(newInstance(choices, "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         adapter = getAdapterFrom(fragment)
 
@@ -213,13 +209,13 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
 
         val holder =
-                adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_MULTIPLE) as MultipleViewHolder
-        val groupHolder = adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_GROUP) as GroupViewHolder
+            adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MULTIPLE) as MultipleViewHolder
+        val groupHolder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_GROUP) as GroupViewHolder
 
         adapter.bindViewHolder(holder, 0)
         adapter.bindViewHolder(groupHolder, 1)
@@ -241,15 +237,15 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
 
         assertEquals(2, adapter.itemCount)
 
-        val groupHolder = adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_GROUP) as GroupViewHolder
+        val groupHolder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_GROUP) as GroupViewHolder
         val holder =
-                adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_MULTIPLE) as MultipleViewHolder
+            adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MULTIPLE) as MultipleViewHolder
 
         adapter.bindViewHolder(groupHolder, 0)
         adapter.bindViewHolder(holder, 1)
@@ -270,7 +266,7 @@ class ChoiceDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
         doNothing().`when`(fragment).dismiss()
 
         val dialog = fragment.onCreateDialog(null)
@@ -278,7 +274,7 @@ class ChoiceDialogFragmentTest {
 
         val adapter = getAdapterFrom(fragment)
 
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), TYPE_SINGLE) as SingleViewHolder
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_SINGLE) as SingleViewHolder
 
         adapter.bindViewHolder(holder, 0)
 
@@ -300,7 +296,7 @@ class ChoiceDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
         doNothing().`when`(fragment).dismiss()
 
         val dialog = fragment.onCreateDialog(null)
@@ -308,7 +304,7 @@ class ChoiceDialogFragmentTest {
 
         val adapter = getAdapterFrom(fragment)
 
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), TYPE_MENU)
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MENU)
 
         adapter.bindViewHolder(holder, 0)
 
@@ -328,7 +324,7 @@ class ChoiceDialogFragmentTest {
         val fragment = spy(newInstance(choices, "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
 
         fragment.feature = mockFeature
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
         doNothing().`when`(fragment).dismiss()
 
         val dialog = fragment.onCreateDialog(null)
@@ -336,7 +332,7 @@ class ChoiceDialogFragmentTest {
 
         val adapter = dialog.findViewById<RecyclerView>(R.id.recyclerView).adapter as ChoiceAdapter
 
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_MULTIPLE)
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MULTIPLE)
 
         adapter.bindViewHolder(holder, 1)
 
@@ -364,7 +360,7 @@ class ChoiceDialogFragmentTest {
         val fragment = spy(newInstance(choices, "sessionId", MULTIPLE_CHOICE_DIALOG_TYPE))
 
         fragment.feature = mockFeature
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
         doNothing().`when`(fragment).dismiss()
 
         val dialog = fragment.onCreateDialog(null)
@@ -373,7 +369,7 @@ class ChoiceDialogFragmentTest {
         val adapter = dialog.findViewById<RecyclerView>(R.id.recyclerView).adapter as ChoiceAdapter
 
         val holder =
-            adapter.onCreateViewHolder(LinearLayout(context), ChoiceAdapter.TYPE_MULTIPLE) as MultipleViewHolder
+            adapter.onCreateViewHolder(LinearLayout(testContext), TYPE_MULTIPLE) as MultipleViewHolder
 
         adapter.bindViewHolder(holder, 0)
 
@@ -408,7 +404,7 @@ class ChoiceDialogFragmentTest {
 
         val fragment = spy(newInstance(choices, "sessionId", SINGLE_CHOICE_DIALOG_TYPE))
         fragment.feature = mockFeature
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
         doNothing().`when`(fragment).dismiss()
 
         val dialog = fragment.onCreateDialog(null)
@@ -416,7 +412,7 @@ class ChoiceDialogFragmentTest {
 
         val adapter = dialog.findViewById<RecyclerView>(R.id.recyclerView).adapter as ChoiceAdapter
 
-        val groupViewHolder = adapter.onCreateViewHolder(LinearLayout(context), adapter.getItemViewType(0))
+        val groupViewHolder = adapter.onCreateViewHolder(LinearLayout(testContext), adapter.getItemViewType(0))
             as GroupViewHolder
 
         adapter.bindViewHolder(groupViewHolder, 0)
@@ -425,7 +421,7 @@ class ChoiceDialogFragmentTest {
         assertEquals(groupViewHolder.labelView.text, "group1")
 
         val singleViewHolder =
-            adapter.onCreateViewHolder(LinearLayout(context), adapter.getItemViewType(1)) as SingleViewHolder
+            adapter.onCreateViewHolder(LinearLayout(testContext), adapter.getItemViewType(1)) as SingleViewHolder
 
         adapter.bindViewHolder(singleViewHolder, 1)
 
@@ -448,7 +444,7 @@ class ChoiceDialogFragmentTest {
     }
 
     private fun getAdapterFrom(fragment: ChoiceDialogFragment): ChoiceAdapter {
-        val inflater = LayoutInflater.from(context)
+        val inflater = LayoutInflater.from(testContext)
         val view = fragment.createDialogContentView(inflater)
         val recyclerViewId = R.id.recyclerView
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ColorPickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ColorPickerDialogFragmentTest.kt
@@ -4,33 +4,26 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
 import android.content.DialogInterface
-import androidx.recyclerview.widget.RecyclerView
-import android.view.ContextThemeWrapper
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.test.core.app.ApplicationProvider
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.ColorPickerDialogFragment.ColorAdapter
 import mozilla.components.feature.prompts.ColorPickerDialogFragment.ColorViewHolder
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ColorPickerDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext<Context>(),
-            androidx.appcompat.R.style.Theme_AppCompat
-        )
 
     @Test
     fun `build dialog`() {
@@ -39,7 +32,7 @@ class ColorPickerDialogFragmentTest {
             ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -60,7 +53,7 @@ class ColorPickerDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -84,7 +77,7 @@ class ColorPickerDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -106,7 +99,7 @@ class ColorPickerDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         fragment.onCancel(null)
 
@@ -119,10 +112,10 @@ class ColorPickerDialogFragmentTest {
         val fragment = spy(
             ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
         )
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), 0) as ColorViewHolder
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), 0) as ColorViewHolder
         val labelView = holder.itemView as TextView
         adapter.bindViewHolder(holder, 0)
 
@@ -136,10 +129,10 @@ class ColorPickerDialogFragmentTest {
         val fragment = spy(
             ColorPickerDialogFragment.newInstance("sessionId", "#e66465")
         )
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val adapter = getAdapterFrom(fragment)
-        val holder = adapter.onCreateViewHolder(LinearLayout(context), 0) as ColorViewHolder
+        val holder = adapter.onCreateViewHolder(LinearLayout(testContext), 0) as ColorViewHolder
         val colorItem = holder.itemView as TextView
         adapter.bindViewHolder(holder, 0)
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ConfirmDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ConfirmDialogFragmentTest.kt
@@ -4,29 +4,21 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
 import android.content.DialogInterface
-import android.view.ContextThemeWrapper
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ConfirmDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext<Context>(),
-            androidx.appcompat.R.style.Theme_AppCompat
-        )
 
     @Test
     fun `build dialog`() {
@@ -41,7 +33,7 @@ class ConfirmDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -79,7 +71,7 @@ class ConfirmDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -107,7 +99,7 @@ class ConfirmDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/MultiButtonDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/MultiButtonDialogFragmentTest.kt
@@ -4,16 +4,15 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import android.content.DialogInterface
 import android.content.DialogInterface.BUTTON_POSITIVE
-import android.view.ContextThemeWrapper
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import mozilla.components.support.test.mock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.R.id
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -22,16 +21,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class MultiButtonDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext<Context>(),
-            androidx.appcompat.R.style.Theme_AppCompat
-        )
 
     @Test
     fun `Build dialog`() {
@@ -48,7 +40,7 @@ class MultiButtonDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -57,7 +49,7 @@ class MultiButtonDialogFragmentTest {
         val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
         val messageTextView = dialog.findViewById<TextView>(android.R.id.message)
         val checkBox = dialog.findViewById<CheckBox>(id.no_more_dialogs_check_box)
-        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         val negativeButton = (dialog).getButton(DialogInterface.BUTTON_NEGATIVE)
         val neutralButton = (dialog).getButton(DialogInterface.BUTTON_NEUTRAL)
 
@@ -90,7 +82,7 @@ class MultiButtonDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -118,12 +110,12 @@ class MultiButtonDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
 
-        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
         verify(mockFeature).onConfirm("sessionId", false to MultiButtonDialogFragment.ButtonType.POSITIVE)
@@ -146,7 +138,7 @@ class MultiButtonDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -174,7 +166,7 @@ class MultiButtonDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -202,7 +194,7 @@ class MultiButtonDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -234,7 +226,7 @@ class MultiButtonDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         fragment.onCancel(null)
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -21,7 +21,7 @@ import android.webkit.MimeTypeMap
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
@@ -40,6 +40,7 @@ import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -47,20 +48,18 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import java.security.InvalidParameterException
 import java.util.Date
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PromptFeatureTest {
 
     private lateinit var mockSessionManager: SessionManager
@@ -69,7 +68,7 @@ class PromptFeatureTest {
 
     @Before
     fun setup() {
-        val engine = Mockito.mock(Engine::class.java)
+        val engine = mock<Engine>()
         mockFragmentManager = mockFragmentManager()
 
         mockSessionManager = spy(SessionManager(engine))
@@ -521,13 +520,12 @@ class PromptFeatureTest {
         val code = 1
         var onRequestPermissionWasCalled = false
         val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
-        val context = ApplicationProvider.getApplicationContext<Context>()
 
         promptFeature = PromptFeature(null, mockFragment, mockSessionManager, null, mockFragmentManager) {
             onRequestPermissionWasCalled = true
         }
 
-        doReturn(context).`when`(mockFragment).requireContext()
+        doReturn(testContext).`when`(mockFragment).requireContext()
 
         promptFeature.handleFilePickerRequest(filePickerRequest)
 
@@ -540,13 +538,12 @@ class PromptFeatureTest {
         val mockFragment: Fragment = mock()
         var onRequestPermissionWasCalled = false
         val filePickerRequest = PromptRequest.File(emptyArray(), false, { _, _ -> }, { _, _ -> }) {}
-        val context = ApplicationProvider.getApplicationContext<Context>()
 
         promptFeature = PromptFeature(null, mockFragment, mockSessionManager, null, mockFragmentManager) {
             onRequestPermissionWasCalled = true
         }
 
-        doReturn(context).`when`(mockFragment).requireContext()
+        doReturn(testContext).`when`(mockFragment).requireContext()
 
         grantPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
 
@@ -1048,9 +1045,8 @@ class PromptFeatureTest {
 
     private fun stubContext() {
         val mockFragment: Fragment = mock()
-        val context = ApplicationProvider.getApplicationContext<Context>()
 
-        doReturn(context).`when`(mockFragment).requireContext()
+        doReturn(testContext).`when`(mockFragment).requireContext()
 
         promptFeature = PromptFeature(null, mockFragment, mockSessionManager, null, mockFragmentManager) {}
     }

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
@@ -4,35 +4,26 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
-import android.content.DialogInterface
 import android.content.DialogInterface.BUTTON_POSITIVE
-import android.view.ContextThemeWrapper
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import mozilla.components.support.test.mock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.R.id
 import mozilla.components.support.ktx.android.view.isVisible
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TextPromptDialogFragmentTest {
-
-    private val context: Context
-        get() = ContextThemeWrapper(
-            ApplicationProvider.getApplicationContext<Context>(),
-            androidx.appcompat.R.style.Theme_AppCompat
-        )
 
     @Test
     fun `build dialog`() {
@@ -41,7 +32,7 @@ class TextPromptDialogFragmentTest {
             TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", true)
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -78,7 +69,7 @@ class TextPromptDialogFragmentTest {
             TextPromptDialogFragment.newInstance("sessionId", "title", "label", "defaultValue", false)
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
 
@@ -100,12 +91,12 @@ class TextPromptDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
 
-        val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+        val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)
         positiveButton.performClick()
 
         verify(mockFeature).onConfirm("sessionId", false to "defaultValue")
@@ -122,7 +113,7 @@ class TextPromptDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -148,7 +139,7 @@ class TextPromptDialogFragmentTest {
 
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         fragment.onCancel(null)
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TimePickerDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TimePickerDialogFragmentTest.kt
@@ -4,40 +4,33 @@
 
 package mozilla.components.feature.prompts
 
-import android.content.Context
 import android.content.DialogInterface.BUTTON_NEGATIVE
-import android.content.DialogInterface.BUTTON_POSITIVE
 import android.content.DialogInterface.BUTTON_NEUTRAL
+import android.content.DialogInterface.BUTTON_POSITIVE
 import android.os.Build.VERSION_CODES.LOLLIPOP
-
-import android.view.ContextThemeWrapper
 import android.widget.DatePicker
 import android.widget.TextView
 import android.widget.TimePicker
 import androidx.appcompat.app.AlertDialog
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.TimePickerDialogFragment.Companion.SELECTION_TYPE_DATE_AND_TIME
 import mozilla.components.feature.prompts.TimePickerDialogFragment.Companion.SELECTION_TYPE_TIME
 import mozilla.components.support.ktx.kotlin.toDate
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.verify
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
+import org.mockito.Mockito.verify
 import org.robolectric.annotation.Config
 import java.util.Calendar
 import java.util.Date
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TimePickerDialogFragmentTest {
-    private val context: Context
-        get() = ContextThemeWrapper(
-                ApplicationProvider.getApplicationContext(),
-                R.style.Theme_AppCompat
-        )
 
     @Test
     fun `build dialog`() {
@@ -48,7 +41,7 @@ class TimePickerDialogFragmentTest {
                 TimePickerDialogFragment.newInstance("sessionId", "title", initialDate, minDate, maxDate)
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -83,7 +76,7 @@ class TimePickerDialogFragmentTest {
         )
         fragment.feature = mockFeature
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -108,7 +101,7 @@ class TimePickerDialogFragmentTest {
                 TimePickerDialogFragment.newInstance("sessionId", "", Date(), null, null)
         )
         fragment.feature = mockFeature
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(testContext).`when`(fragment).requireContext()
         fragment.onCancel(null)
         verify(mockFeature).onCancel("sessionId")
     }
@@ -142,7 +135,7 @@ class TimePickerDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -180,7 +173,7 @@ class TimePickerDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -207,7 +200,7 @@ class TimePickerDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()
@@ -229,7 +222,7 @@ class TimePickerDialogFragmentTest {
             )
         )
 
-        doReturn(context).`when`(fragment).requireContext()
+        doReturn(appCompatContext).`when`(fragment).requireContext()
 
         val dialog = fragment.onCreateDialog(null)
         dialog.show()

--- a/components/feature/prompts/src/test/java/mozilla/ext/context.kt
+++ b/components/feature/prompts/src/test/java/mozilla/ext/context.kt
@@ -1,0 +1,15 @@
+/*
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.ext
+
+import android.content.Context
+import androidx.appcompat.R
+import androidx.appcompat.view.ContextThemeWrapper
+import mozilla.components.support.test.robolectric.testContext
+
+internal val appCompatContext: Context
+    get() = ContextThemeWrapper(testContext, R.style.Theme_AppCompat)

--- a/components/feature/prompts/src/test/java/mozilla/ext/context.kt
+++ b/components/feature/prompts/src/test/java/mozilla/ext/context.kt
@@ -1,8 +1,6 @@
-/*
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.ext
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-prompts` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~