### PR TITLE
For #1481. Use androidx runner in `feature-pwa`.

### DIFF
--- a/components/feature/pwa/build.gradle
+++ b/components/feature/pwa/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -33,7 +35,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_robolectric
 }

--- a/components/feature/pwa/gradle.properties
+++ b/components/feature/pwa/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/AbstractWebAppShellActivityTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/AbstractWebAppShellActivityTest.kt
@@ -8,6 +8,7 @@ import android.content.pm.ActivityInfo
 import android.view.View
 import android.view.Window
 import android.view.WindowManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -19,10 +20,10 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AbstractWebAppShellActivityTest {
+
     @Test
     fun `applyConfiguration applies orientation`() {
         val activity = spy(TestWebAppShellActivity())

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppLauncherActivityTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppLauncherActivityTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.pwa
 
 import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -15,10 +16,10 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class WebAppLauncherActivityTest {
+
     @Test
     fun `DisplayMode-Browser launches browser`() {
         val activity = spy(WebAppLauncherActivity())


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-pwa` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~