### PR TITLE
For #1481. Use androidx runner in `feature-qr`.

### DIFF
--- a/components/feature/qr/build.gradle
+++ b/components/feature/qr/build.gradle
@@ -22,6 +22,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -38,7 +40,7 @@ dependencies {
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/feature/qr/gradle.properties
+++ b/components/feature/qr/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFeatureTest.kt
+++ b/components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFeatureTest.kt
@@ -5,34 +5,30 @@
 package mozilla.components.feature.qr
 
 import android.Manifest
-import android.content.Context
 import android.content.pm.PackageManager
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.qr.QrFeature.Companion.QR_FRAGMENT_TAG
 import mozilla.components.support.test.any
-import org.junit.Assert.assertTrue
-import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.grantPermission
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class QrFeatureTest {
-
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `feature requests permission if required`() {
@@ -40,7 +36,7 @@ class QrFeatureTest {
 
         var permissionRequested = false
 
-        val feature = QrFeature(context,
+        val feature = QrFeature(testContext,
             fragmentManager = fragmentManager,
             onNeedToRequestPermissions = { permissionRequested = true }
         )
@@ -54,7 +50,7 @@ class QrFeatureTest {
         val fragmentManager = mockFragmentManager()
         grantPermission(Manifest.permission.CAMERA)
 
-        val feature = QrFeature(context,
+        val feature = QrFeature(testContext,
             fragmentManager = fragmentManager,
             onNeedToRequestPermissions = { },
             onScanResult = { }
@@ -68,7 +64,7 @@ class QrFeatureTest {
     fun `onPermissionsResult displays scanner only if permission granted`() {
         val fragmentManager = mockFragmentManager()
 
-        val feature = QrFeature(context, fragmentManager = fragmentManager)
+        val feature = QrFeature(testContext, fragmentManager = fragmentManager)
 
         assertFalse(feature.scan())
 
@@ -84,7 +80,7 @@ class QrFeatureTest {
     fun `scan result is forwarded to caller`() {
         var scanResultReceived = ""
 
-        val feature = QrFeature(context,
+        val feature = QrFeature(testContext,
             fragmentManager = mockFragmentManager(),
             onScanResult = { result -> scanResultReceived = result }
         )
@@ -99,11 +95,11 @@ class QrFeatureTest {
     fun `qr fragment is removed on back pressed`() {
         val fragmentManager = mockFragmentManager()
         val fragment: QrFragment = mock()
-        `when`(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG)).thenReturn(fragment)
+        whenever(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG)).thenReturn(fragment)
 
         val feature = spy(
             QrFeature(
-                context,
+                testContext,
                 fragmentManager = fragmentManager,
                 onScanResult = { }
             )
@@ -117,11 +113,11 @@ class QrFeatureTest {
     fun `start attaches scan complete listener`() {
         val fragmentManager = mockFragmentManager()
 
-        val feature = QrFeature(context, fragmentManager = fragmentManager, onScanResult = { })
+        val feature = QrFeature(testContext, fragmentManager = fragmentManager, onScanResult = { })
         feature.start()
 
         val fragment: QrFragment = mock()
-        `when`(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG)).thenReturn(fragment)
+        whenever(fragmentManager.findFragmentByTag(QR_FRAGMENT_TAG)).thenReturn(fragment)
         feature.start()
 
         verify(fragment).scanCompleteListener = feature.scanCompleteListener


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-qr` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~