### PR TITLE
For #1481. Use androidx runner in `feature-session`.

### DIFF
--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -19,6 +19,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -32,10 +34,10 @@ dependencies {
     implementation Dependencies.google_material
 
     testImplementation project(':support-test')
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
-    testImplementation Dependencies.androidx_test_core
 
     testImplementation Dependencies.androidx_browser
 }

--- a/components/feature/session/gradle.properties
+++ b/components/feature/session/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/CoordinateScrollingFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/CoordinateScrollingFeatureTest.kt
@@ -5,23 +5,23 @@
 package mozilla.components.feature.session
 
 import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.appbar.AppBarLayout
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.session.CoordinateScrollingFeature.Companion.DEFAULT_SCROLL_FLAGS
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.any
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CoordinateScrollingFeatureTest {
 
     private lateinit var scrollFeature: CoordinateScrollingFeature
@@ -31,13 +31,13 @@ class CoordinateScrollingFeatureTest {
 
     @Before
     fun setup() {
-        val engine = mock(Engine::class.java)
+        val engine = mock<Engine>()
         mockSessionManager = spy(SessionManager(engine))
-        mockEngineView = mock(EngineView::class.java)
-        mockView = mock(View::class.java)
+        mockEngineView = mock()
+        mockView = mock()
         scrollFeature = CoordinateScrollingFeature(mockSessionManager, mockEngineView, mockView)
 
-        `when`(mockView.layoutParams).thenReturn(mock(AppBarLayout.LayoutParams::class.java))
+        whenever(mockView.layoutParams).thenReturn(mock<AppBarLayout.LayoutParams>())
     }
 
     @Test
@@ -58,7 +58,7 @@ class CoordinateScrollingFeatureTest {
     fun `when session loading StateChanged and engine canScrollVertically is true must add DEFAULT_SCROLL_FLAGS `() {
 
         val session = getSelectedSession()
-        `when`(mockEngineView.canScrollVerticallyDown()).thenReturn(true)
+        whenever(mockEngineView.canScrollVerticallyDown()).thenReturn(true)
 
         scrollFeature.start()
 
@@ -74,7 +74,7 @@ class CoordinateScrollingFeatureTest {
     fun `when session loading StateChanged and engine canScrollVertically is true must add custom scrollFlags`() {
 
         val session = getSelectedSession()
-        `when`(mockEngineView.canScrollVerticallyDown()).thenReturn(true)
+        whenever(mockEngineView.canScrollVerticallyDown()).thenReturn(true)
         scrollFeature = CoordinateScrollingFeature(mockSessionManager, mockEngineView, mockView, 12)
         scrollFeature.start()
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/EngineViewPresenterTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/EngineViewPresenterTest.kt
@@ -7,18 +7,18 @@ package mozilla.components.feature.session
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Test
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 class EngineViewPresenterTest {
 
-    private val sessionManager = mock(SessionManager::class.java)
-    private val engineView = mock(EngineView::class.java)
-    private val session = mock(Session::class.java)
+    private val sessionManager = mock<SessionManager>()
+    private val engineView = mock<EngineView>()
+    private val session = mock<Session>()
 
     @Test
     fun startRegistersObserver() {
@@ -29,9 +29,9 @@ class EngineViewPresenterTest {
 
     @Test
     fun startRendersSession() {
-        val testSession = mock(Session::class.java)
-        `when`(sessionManager.selectedSession).thenReturn(session)
-        `when`(sessionManager.findSessionById("testSession")).thenReturn(testSession)
+        val testSession = mock<Session>()
+        whenever(sessionManager.selectedSession).thenReturn(session)
+        whenever(sessionManager.findSessionById("testSession")).thenReturn(testSession)
 
         var engineViewPresenter = spy(EngineViewPresenter(sessionManager, engineView))
         engineViewPresenter.start()

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/FullScreenFeatureTest.kt
@@ -10,11 +10,11 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -39,7 +39,7 @@ class FullScreenFeatureTest {
     @Test
     fun `start with a sessionId`() {
         val fullscreenFeature = spy(FullScreenFeature(sessionManager, useCases, "abc") {})
-        `when`(sessionManager.findSessionById(anyString())).thenReturn(selectedSession)
+        whenever(sessionManager.findSessionById(anyString())).thenReturn(selectedSession)
 
         fullscreenFeature.start()
 
@@ -70,8 +70,8 @@ class FullScreenFeatureTest {
         val fullscreenFeature = spy(FullScreenFeatureTest(sessionManager, useCases) {})
         val activeSession: Session = mock()
 
-        `when`(fullscreenFeature.activeSession).thenReturn(activeSession)
-        `when`(activeSession.fullScreenMode).thenReturn(false)
+        whenever(fullscreenFeature.activeSession).thenReturn(activeSession)
+        whenever(activeSession.fullScreenMode).thenReturn(false)
 
         assertFalse(fullscreenFeature.onBackPressed())
     }
@@ -82,10 +82,10 @@ class FullScreenFeatureTest {
         val engineSession: EngineSession = mock()
         val fullscreenFeature = spy(FullScreenFeatureTest(sessionManager, useCases) {})
 
-        `when`(sessionManager.getOrCreateEngineSession(activeSession)).thenReturn(engineSession)
-        `when`(fullscreenFeature.activeSession).thenReturn(activeSession)
-        `when`(activeSession.fullScreenMode).thenReturn(true)
-        `when`(useCases.exitFullscreen).thenReturn(mock())
+        whenever(sessionManager.getOrCreateEngineSession(activeSession)).thenReturn(engineSession)
+        whenever(fullscreenFeature.activeSession).thenReturn(activeSession)
+        whenever(activeSession.fullScreenMode).thenReturn(true)
+        whenever(useCases.exitFullscreen).thenReturn(mock())
 
         assertTrue(fullscreenFeature.onBackPressed())
         verify(useCases.exitFullscreen).invoke(activeSession)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.session
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.HistoryAutocompleteResult
 import mozilla.components.concept.storage.HistoryStorage
@@ -20,9 +21,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class HistoryDelegateTest {
 
     @Test

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/PictureInPictureFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/PictureInPictureFeatureTest.kt
@@ -9,17 +9,18 @@ package mozilla.components.feature.session
 import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
@@ -28,12 +29,11 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.verifyZeroInteractions
 import org.mockito.verification.VerificationMode
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 private interface PipChangedCallback : (Boolean) -> Unit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PictureInPictureFeatureTest {
 
     private val sessionManager: SessionManager = mock()
@@ -42,14 +42,14 @@ class PictureInPictureFeatureTest {
 
     @Before
     fun setUp() {
-        `when`(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
+        whenever(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
             .thenReturn(true)
     }
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.M])
     fun `on home pressed without system feature on android m and lower`() {
-        `when`(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
+        whenever(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
             .thenReturn(false)
 
         val pictureInPictureFeature = spy(PictureInPictureFeature(sessionManager, activity))
@@ -63,7 +63,7 @@ class PictureInPictureFeatureTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.N])
     fun `on home pressed without system feature on android n and above`() {
-        `when`(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
+        whenever(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
             .thenReturn(false)
 
         val pictureInPictureFeature = spy(PictureInPictureFeature(sessionManager, activity))
@@ -88,8 +88,8 @@ class PictureInPictureFeatureTest {
     fun `on home pressed with a selected session without a fullscreen mode`() {
         val pictureInPictureFeature = spy(PictureInPictureFeature(sessionManager, activity))
 
-        `when`(selectedSession.fullScreenMode).thenReturn(false)
-        `when`(sessionManager.selectedSession).thenReturn(selectedSession)
+        whenever(selectedSession.fullScreenMode).thenReturn(false)
+        whenever(sessionManager.selectedSession).thenReturn(selectedSession)
 
         assertFalse(pictureInPictureFeature.onHomePressed())
         verify(sessionManager).selectedSession
@@ -101,8 +101,8 @@ class PictureInPictureFeatureTest {
     fun `on home pressed with a selected session in fullscreen and without pip mode`() {
         val pictureInPictureFeature = spy(PictureInPictureFeature(sessionManager, activity))
 
-        `when`(selectedSession.fullScreenMode).thenReturn(true)
-        `when`(sessionManager.selectedSession).thenReturn(selectedSession)
+        whenever(selectedSession.fullScreenMode).thenReturn(true)
+        whenever(sessionManager.selectedSession).thenReturn(selectedSession)
         doReturn(false).`when`(pictureInPictureFeature).enterPipModeCompat()
 
         assertFalse(pictureInPictureFeature.onHomePressed())
@@ -115,8 +115,8 @@ class PictureInPictureFeatureTest {
     fun `on home pressed with a selected session in fullscreen and with pip mode`() {
         val pictureInPictureFeature = spy(PictureInPictureFeature(sessionManager, activity))
 
-        `when`(selectedSession.fullScreenMode).thenReturn(true)
-        `when`(sessionManager.selectedSession).thenReturn(selectedSession)
+        whenever(selectedSession.fullScreenMode).thenReturn(true)
+        whenever(sessionManager.selectedSession).thenReturn(selectedSession)
         doReturn(true).`when`(pictureInPictureFeature).enterPipModeCompat()
 
         assertTrue(pictureInPictureFeature.onHomePressed())
@@ -136,7 +136,7 @@ class PictureInPictureFeatureTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.O])
     fun `enter pip mode compat without system feature on android o`() {
-        `when`(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
+        whenever(activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE))
             .thenReturn(false)
 
         val pictureInPictureFeature = PictureInPictureFeature(sessionManager, activity)
@@ -151,7 +151,7 @@ class PictureInPictureFeatureTest {
     fun `enter pip mode compat on android o and above`() {
         val pictureInPictureFeature = PictureInPictureFeature(sessionManager, activity)
 
-        `when`(activity.enterPictureInPictureMode(any())).thenReturn(true)
+        whenever(activity.enterPictureInPictureMode(any())).thenReturn(true)
 
         assertTrue(pictureInPictureFeature.enterPipModeCompat())
         verify(activity).enterPictureInPictureMode(any())

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -8,18 +8,18 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class SessionFeatureTest {
 
-    private val sessionManager = mock(SessionManager::class.java)
-    private val engineView = mock(EngineView::class.java)
+    private val sessionManager = mock<SessionManager>()
+    private val engineView = mock<EngineView>()
     private val sessionUseCases = SessionUseCases(sessionManager)
 
     @Test
@@ -32,11 +32,11 @@ class SessionFeatureTest {
     @Test
     fun `handleBackPressed uses selectedSession`() {
         val session = Session("https://www.mozilla.org")
-        `when`(sessionManager.selectedSession).thenReturn(session)
-        `when`(sessionManager.selectedSessionOrThrow).thenReturn(session)
+        whenever(sessionManager.selectedSession).thenReturn(session)
+        whenever(sessionManager.selectedSessionOrThrow).thenReturn(session)
 
-        val engineSession = mock(EngineSession::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val engineSession = mock<EngineSession>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         val feature = SessionFeature(sessionManager, sessionUseCases, engineView)
 
@@ -52,13 +52,13 @@ class SessionFeatureTest {
     fun `handleBackPressed uses sessionId`() {
         val session = Session("https://www.mozilla.org")
         val sessionAlt = Session("https://firefox.com")
-        val engineSession = mock(EngineSession::class.java)
+        val engineSession = mock<EngineSession>()
         val sessionId = "123"
 
-        `when`(sessionManager.selectedSession).thenReturn(sessionAlt)
-        `when`(sessionManager.selectedSessionOrThrow).thenReturn(sessionAlt)
-        `when`(sessionManager.findSessionById(sessionId)).thenReturn(session)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        whenever(sessionManager.selectedSession).thenReturn(sessionAlt)
+        whenever(sessionManager.selectedSessionOrThrow).thenReturn(sessionAlt)
+        whenever(sessionManager.findSessionById(sessionId)).thenReturn(session)
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
         session.canGoBack = true
 
         val feature = SessionFeature(sessionManager, sessionUseCases, engineView, sessionId)
@@ -71,7 +71,7 @@ class SessionFeatureTest {
 
     @Test
     fun `handleBackPressed does nothing when sessionId provided but no session found`() {
-        val engineSession = mock(EngineSession::class.java)
+        val engineSession = mock<EngineSession>()
         val sessionId = "123"
 
         val feature = SessionFeature(sessionManager, sessionUseCases, engineView, sessionId)
@@ -84,7 +84,7 @@ class SessionFeatureTest {
 
     @Test
     fun `handleBackPressed does nothing when no session found`() {
-        val engineSession = mock(EngineSession::class.java)
+        val engineSession = mock<EngineSession>()
 
         val feature = SessionFeature(sessionManager, sessionUseCases, engineView)
         val result = feature.onBackPressed()

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -12,29 +12,28 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class SessionUseCasesTest {
 
-    private val sessionManager = mock(SessionManager::class.java)
-    private val selectedEngineSession = mock(EngineSession::class.java)
-    private val selectedSession = mock(Session::class.java)
+    private val sessionManager = mock<SessionManager>()
+    private val selectedEngineSession = mock<EngineSession>()
+    private val selectedSession = mock<Session>()
     private val useCases = SessionUseCases(sessionManager)
 
     @Before
     fun setup() {
-        `when`(sessionManager.selectedSessionOrThrow).thenReturn(selectedSession)
-        `when`(sessionManager.selectedSession).thenReturn(selectedSession)
-        `when`(sessionManager.getOrCreateEngineSession()).thenReturn(selectedEngineSession)
+        whenever(sessionManager.selectedSessionOrThrow).thenReturn(selectedSession)
+        whenever(sessionManager.selectedSession).thenReturn(selectedSession)
+        whenever(sessionManager.getOrCreateEngineSession()).thenReturn(selectedEngineSession)
     }
 
     @Test
@@ -60,105 +59,105 @@ class SessionUseCasesTest {
 
     @Test
     fun reload() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.reload.invoke(session)
         verify(engineSession).reload()
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.reload.invoke()
         verify(selectedEngineSession).reload()
     }
 
     @Test
     fun stopLoading() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.stopLoading.invoke(session)
         verify(engineSession).stopLoading()
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.stopLoading.invoke()
         verify(selectedEngineSession).stopLoading()
     }
 
     @Test
     fun goBack() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
 
         useCases.goBack.invoke(null)
         verify(engineSession, never()).goBack()
         verify(selectedEngineSession, never()).goBack()
 
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.goBack.invoke(session)
         verify(engineSession).goBack()
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.goBack.invoke()
         verify(selectedEngineSession).goBack()
     }
 
     @Test
     fun goForward() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
 
         useCases.goForward.invoke(null)
         verify(engineSession, never()).goForward()
         verify(selectedEngineSession, never()).goForward()
 
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.goForward.invoke(session)
         verify(engineSession).goForward()
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.goForward.invoke()
         verify(selectedEngineSession).goForward()
     }
 
     @Test
     fun requestDesktopSite() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.requestDesktopSite.invoke(true, session)
         verify(engineSession).toggleDesktopMode(true, reload = true)
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.requestDesktopSite.invoke(true)
         verify(selectedEngineSession).toggleDesktopMode(true, reload = true)
     }
 
     @Test
     fun exitFullscreen() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.exitFullscreen.invoke(session)
         verify(engineSession).exitFullScreenMode()
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.exitFullscreen.invoke()
         verify(selectedEngineSession).exitFullScreenMode()
     }
 
     @Test
     fun clearData() {
-        val engineSession = mock(EngineSession::class.java)
-        val session = mock(Session::class.java)
-        val engine = mock(Engine::class.java)
-        `when`(sessionManager.engine).thenReturn(engine)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+        val engine = mock<Engine>()
+        whenever(sessionManager.engine).thenReturn(engine)
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         useCases.clearData.invoke(session)
         verify(engine).clearData()
@@ -170,7 +169,7 @@ class SessionUseCasesTest {
         useCases.clearData.invoke(session, data = BrowsingData.select(BrowsingData.COOKIES))
         verify(engineSession).clearData(eq(BrowsingData.select(BrowsingData.COOKIES)), eq(null), any(), any())
 
-        `when`(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
         useCases.clearData.invoke()
         verify(selectedEngineSession).clearData()
     }
@@ -180,8 +179,8 @@ class SessionUseCasesTest {
         var createdSession: Session? = null
         var sessionCreatedForUrl: String? = null
 
-        `when`(sessionManager.selectedSession).thenReturn(null)
-        `when`(sessionManager.getOrCreateEngineSession(any())).thenReturn(mock())
+        whenever(sessionManager.selectedSession).thenReturn(null)
+        whenever(sessionManager.getOrCreateEngineSession(any())).thenReturn(mock())
 
         val loadUseCase = SessionUseCases.DefaultLoadUrlUseCase(sessionManager) { url ->
             sessionCreatedForUrl = url
@@ -202,8 +201,8 @@ class SessionUseCasesTest {
 
         val engineSession: EngineSession = mock()
 
-        `when`(sessionManager.selectedSession).thenReturn(null)
-        `when`(sessionManager.getOrCreateEngineSession(any())).thenReturn(engineSession)
+        whenever(sessionManager.selectedSession).thenReturn(null)
+        whenever(sessionManager.getOrCreateEngineSession(any())).thenReturn(engineSession)
 
         val loadUseCase = SessionUseCases.LoadDataUseCase(sessionManager) { url ->
             sessionCreatedForUrl = url
@@ -220,11 +219,11 @@ class SessionUseCasesTest {
 
     @Test
     fun `CrashRecoveryUseCase will invoke recoverFromCrash on engine session and reset flag`() {
-        val engineSession = mock(EngineSession::class.java)
+        val engineSession = mock<EngineSession>()
         doReturn(true).`when`(engineSession).recoverFromCrash()
 
-        val session = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+        val session = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
         assertTrue(useCases.crashRecovery.invoke(session))
 
@@ -234,17 +233,17 @@ class SessionUseCasesTest {
 
     @Test
     fun `CrashRecoveryUseCase will restore list of crashed sessions`() {
-        val engineSession1 = mock(EngineSession::class.java)
+        val engineSession1 = mock<EngineSession>()
         doReturn(true).`when`(engineSession1).recoverFromCrash()
 
-        val engineSession2 = mock(EngineSession::class.java)
+        val engineSession2 = mock<EngineSession>()
         doReturn(true).`when`(engineSession2).recoverFromCrash()
 
-        val session1 = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session1)).thenReturn(engineSession1)
+        val session1 = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session1)).thenReturn(engineSession1)
 
-        val session2 = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session2)).thenReturn(engineSession2)
+        val session2 = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session2)).thenReturn(engineSession2)
 
         assertTrue(useCases.crashRecovery.invoke(listOf(session1, session2)))
 
@@ -256,19 +255,19 @@ class SessionUseCasesTest {
 
     @Test
     fun `CrashRecoveryUseCase will restore crashed sessions`() {
-        val engineSession1 = mock(EngineSession::class.java)
+        val engineSession1 = mock<EngineSession>()
         doReturn(true).`when`(engineSession1).recoverFromCrash()
 
-        val engineSession2 = mock(EngineSession::class.java)
+        val engineSession2 = mock<EngineSession>()
         doReturn(true).`when`(engineSession2).recoverFromCrash()
 
-        val session1 = mock(Session::class.java)
-        `when`(sessionManager.getOrCreateEngineSession(session1)).thenReturn(engineSession1)
+        val session1 = mock<Session>()
+        whenever(sessionManager.getOrCreateEngineSession(session1)).thenReturn(engineSession1)
         doReturn(true).`when`(session1).crashed
 
-        val session2 = mock(Session::class.java)
+        val session2 = mock<Session>()
         doReturn(false).`when`(session2).crashed
-        `when`(sessionManager.getOrCreateEngineSession(session2)).thenReturn(engineSession2)
+        whenever(sessionManager.getOrCreateEngineSession(session2)).thenReturn(engineSession2)
 
         doReturn(listOf(session1, session2)).`when`(sessionManager).sessions
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
@@ -6,33 +6,33 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.Settings
 import mozilla.components.feature.session.SettingsUseCases.UpdateSettingUseCase
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 class SettingsUseCasesTest {
 
-    private val settings = mock(Settings::class.java)
-    private val sessionManager = mock(SessionManager::class.java)
-    private val sessionA = mock(Session::class.java)
-    private val engineSessionA = mock(EngineSession::class.java)
-    private val settingsA = mock(Settings::class.java)
-    private val sessionB = mock(Session::class.java)
-    private val engineSessionB = mock(EngineSession::class.java)
-    private val settingsB = mock(Settings::class.java)
-    private val sessionC = mock(Session::class.java)
+    private val settings = mock<Settings>()
+    private val sessionManager = mock<SessionManager>()
+    private val sessionA = mock<Session>()
+    private val engineSessionA = mock<EngineSession>()
+    private val settingsA = mock<Settings>()
+    private val sessionB = mock<Session>()
+    private val engineSessionB = mock<EngineSession>()
+    private val settingsB = mock<Settings>()
+    private val sessionC = mock<Session>()
     private val useCases = SettingsUseCases(settings, sessionManager)
 
     @Before
     fun setup() {
-        `when`(sessionManager.sessions).thenReturn(listOf(sessionA, sessionB, sessionC))
-        `when`(sessionManager.getEngineSession(sessionA)).thenReturn(engineSessionA)
-        `when`(sessionManager.getEngineSession(sessionB)).thenReturn(engineSessionB)
-        `when`(sessionManager.getEngineSession(sessionC)).thenReturn(null)
-        `when`(engineSessionA.settings).thenReturn(settingsA)
-        `when`(engineSessionB.settings).thenReturn(settingsB)
+        whenever(sessionManager.sessions).thenReturn(listOf(sessionA, sessionB, sessionC))
+        whenever(sessionManager.getEngineSession(sessionA)).thenReturn(engineSessionA)
+        whenever(sessionManager.getEngineSession(sessionB)).thenReturn(engineSessionB)
+        whenever(sessionManager.getEngineSession(sessionC)).thenReturn(null)
+        whenever(engineSessionA.settings).thenReturn(settingsA)
+        whenever(engineSessionB.settings).thenReturn(settingsB)
     }
 
     @Test

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
@@ -9,37 +9,38 @@ import android.graphics.Bitmap
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SwipeRefreshFeatureTest {
+
     private lateinit var refreshFeature: SwipeRefreshFeature
     private lateinit var mockSessionManager: SessionManager
-    private val mockLayout = mock(SwipeRefreshLayout::class.java)
-    private val mockSession = mock(Session::class.java)
-    private val useCase = mock(SessionUseCases.ReloadUrlUseCase::class.java)
+    private val mockLayout = mock<SwipeRefreshLayout>()
+    private val mockSession = mock<Session>()
+    private val useCase = mock<SessionUseCases.ReloadUrlUseCase>()
 
     @Before
     fun setup() {
-        mockSessionManager = mock(SessionManager::class.java)
+        mockSessionManager = mock()
         refreshFeature = SwipeRefreshFeature(mockSessionManager, useCase, mockLayout)
 
-        `when`(mockSessionManager.selectedSession).thenReturn(mockSession)
+        whenever(mockSessionManager.selectedSession).thenReturn(mockSession)
     }
 
     @Test
@@ -81,7 +82,7 @@ class SwipeRefreshFeatureTest {
     @Test
     fun `start with a sessionId`() {
         refreshFeature = spy(SwipeRefreshFeature(mockSessionManager, useCase, mockLayout, "abc"))
-        `when`(mockSessionManager.findSessionById(anyString())).thenReturn(mockSession)
+        whenever(mockSessionManager.findSessionById(anyString())).thenReturn(mockSession)
 
         refreshFeature.start()
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/ThumbnailsFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/ThumbnailsFeatureTest.kt
@@ -4,25 +4,23 @@
 
 package mozilla.components.feature.session
 
-import android.content.Context
-import android.graphics.Bitmap
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ThumbnailsFeatureTest {
 
     private lateinit var mockSessionManager: SessionManager
@@ -31,11 +29,10 @@ class ThumbnailsFeatureTest {
 
     @Before
     fun setup() {
-        val engine = mock(Engine::class.java)
-        val context = ApplicationProvider.getApplicationContext<Context>()
+        val engine = mock<Engine>()
         mockSessionManager = spy(SessionManager(engine))
-        mockEngineView = mock(EngineView::class.java)
-        feature = ThumbnailsFeature(context, mockEngineView, mockSessionManager)
+        mockEngineView = mock()
+        feature = ThumbnailsFeature(testContext, mockEngineView, mockSessionManager)
     }
 
     @Test
@@ -70,7 +67,7 @@ class ThumbnailsFeatureTest {
         feature.start()
 
         val session = getSelectedSession()
-        session.thumbnail = mock(Bitmap::class.java)
+        session.thumbnail = mock()
 
         feature.testLowMemory = true
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/WindowFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/WindowFeatureTest.kt
@@ -8,13 +8,13 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import mozilla.components.support.test.any
 
 class WindowFeatureTest {
 
@@ -23,8 +23,8 @@ class WindowFeatureTest {
 
     @Before
     fun setup() {
-        engine = mock(Engine::class.java)
-        sessionManager = mock(SessionManager::class.java)
+        engine = mock()
+        sessionManager = mock()
     }
 
     @Test
@@ -37,8 +37,8 @@ class WindowFeatureTest {
     @Test
     fun `observer handles open window request`() {
         val session = Session("https://www.mozilla.org")
-        val request = mock(WindowRequest::class.java)
-        `when`(request.url).thenReturn("about:blank")
+        val request = mock<WindowRequest>()
+        whenever(request.url).thenReturn("about:blank")
 
         val feature = WindowFeature(engine, sessionManager)
         feature.windowObserver.onOpenWindowRequested(session, request)
@@ -53,7 +53,7 @@ class WindowFeatureTest {
         val session = Session("https://www.mozilla.org")
 
         val feature = WindowFeature(engine, sessionManager)
-        feature.windowObserver.onCloseWindowRequested(session, mock(WindowRequest::class.java))
+        feature.windowObserver.onCloseWindowRequested(session, mock())
         verify(sessionManager).remove(session)
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.support.test.mock
@@ -21,9 +22,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class EngineViewBottomBehaviorTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-session` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~