### PR TITLE
For #1481. Use androidx runner in `feature-session-bundling`.

### DIFF
--- a/components/feature/session-bundling/build.gradle
+++ b/components/feature/session-bundling/build.gradle
@@ -35,6 +35,8 @@ android {
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -58,7 +60,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.kotlin_coroutines

--- a/components/feature/session-bundling/gradle.properties
+++ b/components/feature/session-bundling/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/SessionBundleLifecycleObserverTest.kt
+++ b/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/SessionBundleLifecycleObserverTest.kt
@@ -17,12 +17,13 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SessionBundleLifecycleObserverTest {
+
     @Test
     fun `New bundle is started and sessions are removed from SessionManager`() {
         runBlocking {

--- a/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/SessionBundleStorageTest.kt
+++ b/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/SessionBundleStorageTest.kt
@@ -6,15 +6,15 @@
 
 package mozilla.components.feature.session.bundling
 
-import androidx.lifecycle.LiveData
 import android.content.Context
 import android.util.AtomicFile
 import android.util.AttributeSet
+import androidx.lifecycle.LiveData
 import androidx.paging.DataSource
 import androidx.room.DatabaseConfiguration
 import androidx.room.InvalidationTracker
 import androidx.sqlite.db.SupportSQLiteOpenHelper
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
@@ -28,6 +28,8 @@ import mozilla.components.feature.session.bundling.db.BundleDatabase
 import mozilla.components.feature.session.bundling.db.BundleEntity
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,21 +40,17 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SessionBundleStorageTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     private lateinit var engine: Engine
 
@@ -65,7 +63,7 @@ class SessionBundleStorageTest {
     fun `restore loads last bundle using lifetime`() {
         val dao: BundleDao = mock()
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { mockDatabase(dao) }
         })
         doReturn(1234567890L).`when`(storage).now()
@@ -92,7 +90,7 @@ class SessionBundleStorageTest {
 
         val database = mockDatabase(dao)
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         })
 
@@ -106,7 +104,7 @@ class SessionBundleStorageTest {
     fun `save will create new bundle`() {
         val dao: BundleDao = mock()
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { mockDatabase(dao) }
         })
 
@@ -126,14 +124,14 @@ class SessionBundleStorageTest {
     @Test
     fun `save will update existing bundle`() {
         val bundle: BundleEntity = mock()
-        `when`(bundle.stateFile(any(), any())).thenReturn(mockAtomicFile())
+        whenever(bundle.stateFile(any(), any())).thenReturn(mockAtomicFile())
 
         val dao: BundleDao = mock()
         doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
 
         val database = mockDatabase(dao)
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         })
 
@@ -154,14 +152,14 @@ class SessionBundleStorageTest {
         val atomicFile = mockAtomicFile()
 
         val bundle: BundleEntity = mock()
-        `when`(bundle.stateFile(any(), any())).thenReturn(atomicFile)
+        whenever(bundle.stateFile(any(), any())).thenReturn(atomicFile)
 
         val dao: BundleDao = mock()
         doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
 
         val database = mockDatabase(dao)
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         })
 
@@ -169,7 +167,7 @@ class SessionBundleStorageTest {
 
         assertNotNull(storage.current())
 
-        storage.remove(SessionBundleAdapter(context, engine, bundle))
+        storage.remove(SessionBundleAdapter(testContext, engine, bundle))
 
         assertNull(storage.current())
 
@@ -186,7 +184,7 @@ class SessionBundleStorageTest {
 
         val database = mockDatabase(dao)
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         })
 
@@ -209,7 +207,7 @@ class SessionBundleStorageTest {
 
         val database = mockDatabase(dao)
 
-        val storage = spy(SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = spy(SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         })
 
@@ -220,9 +218,9 @@ class SessionBundleStorageTest {
         assertEquals(bundle, (current as SessionBundleAdapter).actual)
 
         val newBundle: BundleEntity = mock()
-        `when`(newBundle.stateFile(any(), any())).thenReturn(mockAtomicFile())
+        whenever(newBundle.stateFile(any(), any())).thenReturn(mockAtomicFile())
 
-        storage.use(SessionBundleAdapter(context, engine, newBundle))
+        storage.use(SessionBundleAdapter(testContext, engine, newBundle))
 
         val updated = storage.current()
         assertTrue(updated is SessionBundleAdapter)
@@ -247,7 +245,7 @@ class SessionBundleStorageTest {
 
         val database = mockDatabase(dao)
 
-        val storage = SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         }
 
@@ -262,14 +260,14 @@ class SessionBundleStorageTest {
         val file = mockAtomicFile()
 
         val bundle: BundleEntity = mock()
-        `when`(bundle.stateFile(any(), any())).thenReturn(file)
+        whenever(bundle.stateFile(any(), any())).thenReturn(file)
 
         val dao: BundleDao = mock()
         doReturn(bundle).`when`(dao).getLastBundle(ArgumentMatchers.anyLong())
 
         val database = mockDatabase(dao)
 
-        val storage = SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         }
 
@@ -293,7 +291,7 @@ class SessionBundleStorageTest {
         val dao: BundleDao = mock()
         val database = mockDatabase(dao)
 
-        val storage = SessionBundleStorage(context, engine, Pair(2, TimeUnit.HOURS)).apply {
+        val storage = SessionBundleStorage(testContext, engine, Pair(2, TimeUnit.HOURS)).apply {
             databaseInitializer = { database }
         }
 
@@ -311,7 +309,7 @@ class SessionBundleStorageTest {
         assertTrue(current is SessionBundleAdapter)
         val adapter = current as SessionBundleAdapter
 
-        val path = adapter.actual.statePath(context, engine)
+        val path = adapter.actual.statePath(testContext, engine)
         assertTrue(path.exists())
         assertTrue(path.length() > 0)
 
@@ -360,7 +358,6 @@ class SessionBundleStorageTest {
             throw NotImplementedError()
         }
 
-        override val settings: Settings
-            get() = throw NotImplementedError()
+        override val settings: Settings get() = TODO()
     }
 }

--- a/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/adapter/SessionBundleAdapterTest.kt
+++ b/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/adapter/SessionBundleAdapterTest.kt
@@ -4,25 +4,22 @@
 
 package mozilla.components.feature.session.bundling.adapter
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.ext.writeSnapshot
 import mozilla.components.feature.session.bundling.db.BundleEntity
 import mozilla.components.feature.session.bundling.db.UrlList
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SessionBundleAdapterTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `restoreSnapshot restores snapshot from state`() {
@@ -33,9 +30,9 @@ class SessionBundleAdapterTest {
             selectedSessionIndex = 0)
 
         bundle.updateFrom(snapshot)
-        bundle.stateFile(context, mock()).writeSnapshot(snapshot)
+        bundle.stateFile(testContext, mock()).writeSnapshot(snapshot)
 
-        val restoredSnapshot = SessionBundleAdapter(context, mock(), bundle).restoreSnapshot()
+        val restoredSnapshot = SessionBundleAdapter(testContext, mock(), bundle).restoreSnapshot()
 
         assertNotNull(restoredSnapshot!!)
 
@@ -47,7 +44,7 @@ class SessionBundleAdapterTest {
     @Test
     fun `Accessing id through adapter`() {
         val bundle = BundleEntity(42, 0, UrlList(listOf()))
-        val adapter = SessionBundleAdapter(context, mock(), bundle)
+        val adapter = SessionBundleAdapter(testContext, mock(), bundle)
 
         assertEquals(42L, adapter.id)
     }
@@ -59,7 +56,7 @@ class SessionBundleAdapterTest {
             "https://www.firefox.com"
         )))
 
-        val adapter = SessionBundleAdapter(context, mock(), bundle)
+        val adapter = SessionBundleAdapter(testContext, mock(), bundle)
 
         assertEquals(2, adapter.urls.size)
         assertEquals("https://www.mozilla.org", adapter.urls[0])
@@ -70,7 +67,7 @@ class SessionBundleAdapterTest {
     fun `Accessing last save date through adapter`() {
         val bundle = BundleEntity(42, 1548165508982, UrlList(listOf()))
 
-        val adapter = SessionBundleAdapter(context, mock(), bundle)
+        val adapter = SessionBundleAdapter(testContext, mock(), bundle)
 
         assertEquals(1548165508982, adapter.lastSavedAt)
     }

--- a/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/db/BundleEntityTest.kt
+++ b/components/feature/session-bundling/src/test/java/mozilla/components/feature/session/bundling/db/BundleEntityTest.kt
@@ -4,16 +4,17 @@
 
 package mozilla.components.feature.session.bundling.db
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BundleEntityTest {
+
     @Test
     fun `updateFrom updates state and time`() {
         val bundle = BundleEntity(0, 0, UrlList(listOf()))


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-sessions-bundling` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~