### PR TITLE
For #1481. Use androidx runner in `feature-tabs`.

### DIFF
--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -20,6 +20,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 
@@ -44,7 +46,7 @@ dependencies {
 
     testImplementation project(':support-test')
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/feature/tabs/gradle.properties
+++ b/components/feature/tabs/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.tabs
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
@@ -19,10 +20,10 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabsUseCasesTest {
+
     @Test
     fun `SelectTabUseCase - session will be selected in session manager`() {
         val sessionManager: SessionManager = mock()

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractorTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractorTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.tabs.tabstray
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.TabsUseCases
@@ -12,10 +13,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabsTrayInteractorTest {
+
     @Test
     fun `interactor registers and unregisters from tabstray`() {
         val tabsTray: TabsTray = mock()

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -4,8 +4,9 @@
 
 package mozilla.components.feature.tabs.tabstray
 
-import androidx.lifecycle.LifecycleOwner
 import android.view.View
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.tabstray.TabsTray
@@ -23,10 +24,10 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabsTrayPresenterTest {
+
     @Test
     fun `start and stop will register and unregister`() {
         val sessionManager: SessionManager = mock()

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabCounterToolbarButtonTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabCounterToolbarButtonTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.tabs.toolbar
 
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.support.test.any
@@ -20,10 +21,10 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TabCounterToolbarButtonTest {
+
     @Test
     fun `TabCounter has initial count set`() {
         val sessionManager = SessionManager(mock())

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabsToolbarFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabsToolbarFeatureTest.kt
@@ -9,13 +9,14 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Test
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class TabsToolbarFeatureTest {
+
     @Test
     fun `feature adds "tabs" button to toolbar`() {
         val toolbar: Toolbar = mock()
@@ -30,8 +31,8 @@ class TabsToolbarFeatureTest {
         val toolbar: Toolbar = mock()
         val sessionManager: SessionManager = mock()
         val session: Session = mock()
-        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
-        `when`(session.isCustomTabSession()).thenReturn(true)
+        whenever(sessionManager.findSessionById(anyString())).thenReturn(session)
+        whenever(session.isCustomTabSession()).thenReturn(true)
 
         TabsToolbarFeature(toolbar, sessionManager, "123") {}
 
@@ -43,8 +44,8 @@ class TabsToolbarFeatureTest {
         val toolbar: Toolbar = mock()
         val sessionManager: SessionManager = mock()
         val session: Session = mock()
-        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
-        `when`(session.isCustomTabSession()).thenReturn(false)
+        whenever(sessionManager.findSessionById(anyString())).thenReturn(session)
+        whenever(session.isCustomTabSession()).thenReturn(false)
 
         TabsToolbarFeature(toolbar, sessionManager, "123") {}
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `feature-tabs` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~