### PR TITLE
For #1481. Use androidx runner in `support-base`.

### DIFF
--- a/components/support/base/build.gradle
+++ b/components/support/base/build.gradle
@@ -46,6 +46,8 @@ android {
             }
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -57,7 +59,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/support/base/gradle.properties
+++ b/components/support/base/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/support/base/src/test/java/mozilla/components/support/base/android/view/AutoFitTextureViewTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/android/view/AutoFitTextureViewTest.kt
@@ -6,15 +6,14 @@ package mozilla.components.support.base.android.view
 
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
-import java.lang.IllegalArgumentException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AutoFitTextureViewTest {
 
     @Test

--- a/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
@@ -5,11 +5,12 @@
 package mozilla.components.support.base.feature
 
 import android.app.Activity
+import android.view.View
+import android.view.WindowManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import android.view.View
-import android.view.WindowManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -23,10 +24,10 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ViewBoundFeatureWrapperTest {
+
     @Test
     fun `Calling onBackPressed on an empty wrapper returns false`() {
         val wrapper = ViewBoundFeatureWrapper<MockFeature>()

--- a/components/support/base/src/test/java/mozilla/components/support/base/log/logger/LoggerTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/log/logger/LoggerTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.base.log.logger
 
 import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.LogSink
 import mozilla.components.support.test.mock
@@ -14,10 +15,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class LoggerTest {
+
     lateinit var sink: LogSink
 
     @Before

--- a/components/support/base/src/test/java/mozilla/components/support/base/log/sink/AndroidLogSinkTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/log/sink/AndroidLogSinkTest.kt
@@ -4,19 +4,20 @@
 
 package mozilla.components.support.base.log.sink
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.base.log.Log
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
 import java.io.PrintWriter
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AndroidLogSinkTest {
+
     @Before
     fun setUp() {
         ShadowLog.clear()

--- a/components/support/base/src/test/java/mozilla/components/support/base/notification/NotificationIdsTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/notification/NotificationIdsTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.support.base.notification
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.base.ids.NotificationIds
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
@@ -12,10 +13,10 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class NotificationIdsTest {
+
     @After
     fun tearDown() {
         NotificationIds.clear(testContext)

--- a/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
@@ -10,6 +10,7 @@ import android.view.WindowManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -19,15 +20,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ObserverRegistryTest {
 
     @Test
@@ -293,7 +292,7 @@ class ObserverRegistryTest {
 
     @Test
     fun `observer will not get added if view is detached`() {
-        val view = mock(View::class.java)
+        val view = mock<View>()
 
         val registry = ObserverRegistry<TestObserver>()
         val observer = TestObserver()


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `support-base` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~