### PR TITLE
For #1481. Use androidx runner in `browser-engine-servo`.

### DIFF
--- a/components/browser/engine-servo/build.gradle
+++ b/components/browser/engine-servo/build.gradle
@@ -24,6 +24,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -41,7 +43,7 @@ dependencies {
 
     testImplementation project(':support-test')
 
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/engine-servo/gradle.properties
+++ b/components/browser/engine-servo/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionStateTest.kt
+++ b/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionStateTest.kt
@@ -6,13 +6,13 @@
 
 package mozilla.components.browser.engine.servo
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ServoEngineSessionStateTest {
 
     @Test

--- a/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionTest.kt
+++ b/components/browser/engine-servo/src/test/java/mozilla/components/browser/engine/servo/ServoEngineSessionTest.kt
@@ -7,6 +7,7 @@
 package mozilla.components.browser.engine.servo
 
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
@@ -15,9 +16,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mozilla.servoview.ServoView
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ServoEngineSessionTest {
 
     @Test


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-engine-servo` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~