### PR TITLE
For #1481. Use androidx runner in `browser-engine-system`.

### DIFF
--- a/components/browser/engine-system/build.gradle
+++ b/components/browser/engine-system/build.gradle
@@ -24,6 +24,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -37,8 +39,7 @@ dependencies {
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
-
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/browser/engine-system/gradle.properties
+++ b/components/browser/engine-system/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/NestedWebViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/NestedWebViewTest.kt
@@ -4,16 +4,16 @@
 
 package mozilla.components.browser.engine.system
 
-import android.content.Context
 import android.view.MotionEvent.ACTION_CANCEL
 import android.view.MotionEvent.ACTION_DOWN
 import android.view.MotionEvent.ACTION_MOVE
 import android.view.MotionEvent.ACTION_UP
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -23,16 +23,13 @@ import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class NestedWebViewTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `NestedWebView must delegate NestedScrollingChild implementation to childHelper`() {
-        val nestedWebView = NestedWebView(context)
+        val nestedWebView = NestedWebView(testContext)
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
 
@@ -69,7 +66,7 @@ class NestedWebViewTest {
 
     @Test
     fun `verify onTouchEvent when ACTION_DOWN`() {
-        val nestedWebView = NestedWebView(context)
+        val nestedWebView = NestedWebView(testContext)
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
 
@@ -79,7 +76,7 @@ class NestedWebViewTest {
 
     @Test
     fun `verify onTouchEvent when ACTION_MOVE`() {
-        val nestedWebView = NestedWebView(context)
+        val nestedWebView = NestedWebView(testContext)
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
 
@@ -106,14 +103,14 @@ class NestedWebViewTest {
 
     @Test
     fun `verify onTouchEvent when ACTION_UP or ACTION_CANCEL`() {
-        val nestedWebView = NestedWebView(context)
+        val nestedWebView = NestedWebView(testContext)
         val mockChildHelper: NestedScrollingChildHelper = mock()
         nestedWebView.childHelper = mockChildHelper
 
-        nestedWebView.onTouchEvent(mozilla.components.support.test.mockMotionEvent(ACTION_UP))
+        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_UP))
         verify(mockChildHelper).stopNestedScroll()
 
-        nestedWebView.onTouchEvent(mozilla.components.support.test.mockMotionEvent(ACTION_CANCEL))
+        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_CANCEL))
         verify(mockChildHelper, times(2)).stopNestedScroll()
     }
 }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt
@@ -5,16 +5,17 @@
 package mozilla.components.browser.engine.system
 
 import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SystemEngineSessionStateTest {
+
     @Test
     fun toJSON() {
         val state = SystemEngineSessionState(Bundle().apply {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -12,16 +12,17 @@ import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.webkit.WebViewDatabase
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.engine.system.matcher.UrlMatcher
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -35,24 +36,21 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.doThrow
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import java.lang.reflect.Modifier
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SystemEngineSessionTest {
 
     @Test
     fun webChromeClientNotifiesObservers() {
-        val engineSession = SystemEngineSession(getApplicationContext())
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineSession = SystemEngineSession(testContext)
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         var observedProgress = 0
@@ -69,8 +67,8 @@ class SystemEngineSessionTest {
         var loadedUrl: String? = null
         var loadHeaders: Map<String, String>? = null
 
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = spy(object : WebView(getApplicationContext()) {
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = spy(object : WebView(testContext) {
             override fun loadUrl(url: String?, additionalHttpHeaders: MutableMap<String, String>?) {
                 loadedUrl = url
                 loadHeaders = additionalHttpHeaders
@@ -94,8 +92,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun loadData() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         engineSession.loadData("<html><body>Hello!</body></html>")
         verify(webView, never()).loadData(anyString(), eq("text/html"), eq("UTF-8"))
@@ -114,8 +112,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun stopLoading() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         engineSession.stopLoading()
         verify(webView, never()).stopLoading()
@@ -128,8 +126,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun reload() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         engineSession.reload()
         verify(webView, never()).reload()
@@ -142,8 +140,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun goBack() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         engineSession.goBack()
         verify(webView, never()).goBack()
@@ -156,8 +154,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun goForward() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         engineSession.goForward()
         verify(webView, never()).goForward()
@@ -170,8 +168,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun saveState() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         engineSession.saveState()
         verify(webView, never()).saveState(any(Bundle::class.java))
@@ -184,10 +182,10 @@ class SystemEngineSessionTest {
 
     @Test
     fun saveStateRunsOnMainThread() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
+        val engineSession = spy(SystemEngineSession(testContext))
         var calledOnMainThread = false
         var saveStateCalled = false
-        val webView = object : WebView(getApplicationContext()) {
+        val webView = object : WebView(testContext) {
             override fun saveState(outState: Bundle?): WebBackForwardList? {
                 saveStateCalled = true
                 calledOnMainThread = Looper.getMainLooper().isCurrentThread
@@ -203,11 +201,11 @@ class SystemEngineSessionTest {
 
     @Test
     fun restoreState() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
 
         try {
-            engineSession.restoreState(mock(EngineSessionState::class.java))
+            engineSession.restoreState(mock())
             fail("Expected IllegalArgumentException")
         } catch (e: IllegalArgumentException) {}
         engineSession.restoreState(SystemEngineSessionState(Bundle()))
@@ -223,9 +221,9 @@ class SystemEngineSessionTest {
     fun enableTrackingProtection() {
         SystemEngineView.URL_MATCHER = UrlMatcher(arrayOf(""))
 
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
-        `when`(webView.context).thenReturn(getApplicationContext())
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
+        whenever(webView.context).thenReturn(testContext)
         engineSession.webView = webView
 
         var enabledObserved: Boolean? = null
@@ -244,7 +242,7 @@ class SystemEngineSessionTest {
 
     @Test
     fun disableTrackingProtection() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
+        val engineSession = spy(SystemEngineSession(testContext))
         var enabledObserved: Boolean? = null
         engineSession.register(object : EngineSession.Observer {
             override fun onTrackerBlockingEnabledChange(enabled: Boolean) {
@@ -263,21 +261,21 @@ class SystemEngineSessionTest {
     @Test
     @Suppress("Deprecation")
     fun initSettings() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
+        val engineSession = spy(SystemEngineSession(testContext))
         assertNotNull(engineSession.internalSettings)
 
-        val webViewSettings = mock(WebSettings::class.java)
-        `when`(webViewSettings.displayZoomControls).thenReturn(true)
-        `when`(webViewSettings.allowContentAccess).thenReturn(true)
-        `when`(webViewSettings.allowFileAccess).thenReturn(true)
-        `when`(webViewSettings.mediaPlaybackRequiresUserGesture).thenReturn(true)
-        `when`(webViewSettings.supportMultipleWindows()).thenReturn(false)
+        val webViewSettings = mock<WebSettings>()
+        whenever(webViewSettings.displayZoomControls).thenReturn(true)
+        whenever(webViewSettings.allowContentAccess).thenReturn(true)
+        whenever(webViewSettings.allowFileAccess).thenReturn(true)
+        whenever(webViewSettings.mediaPlaybackRequiresUserGesture).thenReturn(true)
+        whenever(webViewSettings.supportMultipleWindows()).thenReturn(false)
 
-        val webView = mock(WebView::class.java)
-        `when`(webView.context).thenReturn(getApplicationContext())
-        `when`(webView.settings).thenReturn(webViewSettings)
-        `when`(webView.isVerticalScrollBarEnabled).thenReturn(true)
-        `when`(webView.isHorizontalScrollBarEnabled).thenReturn(true)
+        val webView = mock<WebView>()
+        whenever(webView.context).thenReturn(testContext)
+        whenever(webView.settings).thenReturn(webViewSettings)
+        whenever(webView.isVerticalScrollBarEnabled).thenReturn(true)
+        whenever(webView.isHorizontalScrollBarEnabled).thenReturn(true)
         engineSession.webView = webView
 
         assertFalse(engineSession.settings.javascriptEnabled)
@@ -371,13 +369,13 @@ class SystemEngineSessionTest {
                 displayZoomControls = true,
                 loadWithOverviewMode = true,
                 supportMultipleWindows = true)
-        val engineSession = spy(SystemEngineSession(getApplicationContext(), defaultSettings))
+        val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
 
-        val webView = mock(WebView::class.java)
-        `when`(webView.context).thenReturn(getApplicationContext())
+        val webView = mock<WebView>()
+        whenever(webView.context).thenReturn(testContext)
 
-        val webViewSettings = mock(WebSettings::class.java)
-        `when`(webView.settings).thenReturn(webViewSettings)
+        val webViewSettings = mock<WebSettings>()
+        whenever(webView.settings).thenReturn(webViewSettings)
 
         engineSession.webView = webView
 
@@ -425,9 +423,9 @@ class SystemEngineSessionTest {
 
         val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
 
-        val engineSession = SystemEngineSession(getApplicationContext(), defaultSettings)
+        val engineSession = SystemEngineSession(testContext, defaultSettings)
         engineSession.webView = spy(engineSession.webView)
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         val request: WebResourceRequest = mock()
@@ -454,9 +452,9 @@ class SystemEngineSessionTest {
         doReturn(true).`when`(request).hasGesture()
         doReturn(Uri.parse(url)).`when`(request).url
 
-        val engineSession = SystemEngineSession(getApplicationContext())
+        val engineSession = SystemEngineSession(testContext)
         engineSession.webView = spy(engineSession.webView)
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         val observer: EngineSession.Observer = mock()
@@ -491,9 +489,9 @@ class SystemEngineSessionTest {
 
         val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
 
-        val engineSession = SystemEngineSession(getApplicationContext(), defaultSettings)
+        val engineSession = SystemEngineSession(testContext, defaultSettings)
         engineSession.webView = spy(engineSession.webView)
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         val observer: EngineSession.Observer = mock()
@@ -519,9 +517,9 @@ class SystemEngineSessionTest {
 
         val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
 
-        val engineSession = SystemEngineSession(getApplicationContext(), defaultSettings)
+        val engineSession = SystemEngineSession(testContext, defaultSettings)
         engineSession.webView = spy(engineSession.webView)
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         val request: WebResourceRequest = mock()
@@ -540,9 +538,9 @@ class SystemEngineSessionTest {
     fun onLoadRequestWithoutInterceptor() {
         val defaultSettings = DefaultSettings()
 
-        val engineSession = SystemEngineSession(getApplicationContext(), defaultSettings)
+        val engineSession = SystemEngineSession(testContext, defaultSettings)
         engineSession.webView = spy(engineSession.webView)
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         val request: WebResourceRequest = mock()
@@ -568,9 +566,9 @@ class SystemEngineSessionTest {
 
         val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
 
-        val engineSession = SystemEngineSession(getApplicationContext(), defaultSettings)
+        val engineSession = SystemEngineSession(testContext, defaultSettings)
         engineSession.webView = spy(engineSession.webView)
-        val engineView = SystemEngineView(getApplicationContext())
+        val engineView = SystemEngineView(testContext)
         engineView.render(engineSession)
 
         val request: WebResourceRequest = mock()
@@ -635,9 +633,9 @@ class SystemEngineSessionTest {
     @Test
     fun desktopMode() {
         val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
-        val webViewSettings = mock(WebSettings::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
+        val webViewSettings = mock<WebSettings>()
         var desktopMode = false
         engineSession.register(object : EngineSession.Observer {
             override fun onDesktopModeChange(enabled: Boolean) {
@@ -646,8 +644,8 @@ class SystemEngineSessionTest {
         })
 
         engineSession.webView = webView
-        `when`(webView.settings).thenReturn(webViewSettings)
-        `when`(webViewSettings.userAgentString).thenReturn(userAgentMobile)
+        whenever(webView.settings).thenReturn(webViewSettings)
+        whenever(webViewSettings.userAgentString).thenReturn(userAgentMobile)
 
         engineSession.toggleDesktopMode(true)
         verify(webViewSettings).useWideViewPort = true
@@ -665,7 +663,7 @@ class SystemEngineSessionTest {
     fun desktopModeUA() {
         val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
         val userAgentDesktop = "Mozilla/5.0 (Linux; diordnA 9) AppleWebKit/537.36 eliboM Safari/537.36"
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
+        val engineSession = spy(SystemEngineSession(testContext))
 
         assertEquals(engineSession.toggleDesktopUA(userAgentMobile, false), userAgentMobile)
         assertEquals(engineSession.toggleDesktopUA(userAgentMobile, true), userAgentDesktop)
@@ -673,8 +671,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun findAll() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
         engineSession.findAll("mozilla")
         verify(webView, never()).findAllAsync(anyString())
 
@@ -692,8 +690,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun findNext() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
         engineSession.findNext(true)
         verify(webView, never()).findNext(any(Boolean::class.java))
 
@@ -704,8 +702,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun clearFindMatches() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
         engineSession.clearFindMatches()
         verify(webView, never()).clearMatches()
 
@@ -716,15 +714,15 @@ class SystemEngineSessionTest {
 
     @Test
     fun clearDataMakingExpectedCalls() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
         val webStorage: WebStorage = mock()
         val webViewDatabase: WebViewDatabase = mock()
-        val context: Context = getApplicationContext()
+        val context: Context = testContext
 
         doReturn(webStorage).`when`(engineSession).webStorage()
         doReturn(webViewDatabase).`when`(engineSession).webViewDatabase(context)
-        `when`(webView.context).thenReturn(context)
+        whenever(webView.context).thenReturn(context)
         engineSession.webView = webView
 
         // clear all data by default
@@ -800,16 +798,16 @@ class SystemEngineSessionTest {
 
     @Test
     fun clearDataInvokesSuccessCallback() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
         val webStorage: WebStorage = mock()
         val webViewDatabase: WebViewDatabase = mock()
-        val context: Context = getApplicationContext()
+        val context: Context = testContext
         var onSuccessCalled = false
 
         doReturn(webStorage).`when`(engineSession).webStorage()
         doReturn(webViewDatabase).`when`(engineSession).webViewDatabase(context)
-        `when`(webView.context).thenReturn(context)
+        whenever(webView.context).thenReturn(context)
         engineSession.webView = webView
 
         engineSession.clearData(onSuccess = { onSuccessCalled = true })
@@ -818,16 +816,16 @@ class SystemEngineSessionTest {
 
     @Test
     fun clearDataInvokesErrorCallback() {
-        val engineSession = spy(SystemEngineSession(getApplicationContext()))
-        val webView = mock(WebView::class.java)
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
         val webViewDatabase: WebViewDatabase = mock()
-        val context: Context = getApplicationContext()
+        val context: Context = testContext
         var onErrorCalled = false
 
         val exception = RuntimeException()
         doThrow(exception).`when`(engineSession).webStorage()
         doReturn(webViewDatabase).`when`(engineSession).webViewDatabase(context)
-        `when`(webView.context).thenReturn(context)
+        whenever(webView.context).thenReturn(context)
         engineSession.webView = webView
 
         engineSession.clearData(onError = {
@@ -839,9 +837,9 @@ class SystemEngineSessionTest {
 
     @Test
     fun testExitFullscreenModeWithWebViewAndCallBack() {
-        val engineSession = SystemEngineSession(getApplicationContext())
-        val engineView = SystemEngineView(getApplicationContext())
-        val customViewCallback = mock(WebChromeClient.CustomViewCallback::class.java)
+        val engineSession = SystemEngineSession(testContext)
+        val engineView = SystemEngineView(testContext)
+        val customViewCallback = mock<WebChromeClient.CustomViewCallback>()
 
         engineView.render(engineSession)
         engineSession.exitFullScreenMode()
@@ -854,8 +852,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun closeDestroysWebView() {
-        val engineSession = SystemEngineSession(getApplicationContext())
-        val webView = mock(WebView::class.java)
+        val engineSession = SystemEngineSession(testContext)
+        val webView = mock<WebView>()
         engineSession.webView = webView
 
         engineSession.close()
@@ -864,8 +862,8 @@ class SystemEngineSessionTest {
 
     @Test
     fun `recoverFromCrash does not restore state`() {
-        val engineSession = SystemEngineSession(getApplicationContext())
-        val webView = mock(WebView::class.java)
+        val engineSession = SystemEngineSession(testContext)
+        val webView = mock<WebView>()
         engineSession.webView = webView
 
         assertFalse(engineSession.recoverFromCrash())

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt
@@ -4,10 +4,10 @@
 
 package mozilla.components.browser.engine.system
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -15,12 +15,9 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SystemEngineTest {
-
-    private val context: Context = ApplicationProvider.getApplicationContext()
 
     @Before
     fun setup() {
@@ -31,13 +28,13 @@ class SystemEngineTest {
 
     @Test
     fun createView() {
-        val engine = SystemEngine(context)
-        assertTrue(engine.createView(context) is SystemEngineView)
+        val engine = SystemEngine(testContext)
+        assertTrue(engine.createView(testContext) is SystemEngineView)
     }
 
     @Test
     fun createSession() {
-        val engine = SystemEngine(context)
+        val engine = SystemEngine(testContext)
         assertTrue(engine.createSession() is SystemEngineSession)
 
         try {
@@ -49,13 +46,13 @@ class SystemEngineTest {
 
     @Test
     fun name() {
-        val engine = SystemEngine(context)
+        val engine = SystemEngine(testContext)
         assertEquals("System", engine.name())
     }
 
     @Test
     fun settings() {
-        var engine = SystemEngine(context, DefaultSettings(
+        val engine = SystemEngine(testContext, DefaultSettings(
                 remoteDebuggingEnabled = true,
                 trackingProtectionPolicy = EngineSession.TrackingProtectionPolicy.all()
         ))
@@ -75,6 +72,6 @@ class SystemEngineTest {
         assertEquals("test-ua-string-test", engine.settings.userAgentString)
 
         // It should be possible to specify a custom ua-string default
-        assertEquals("foo", SystemEngine(context, DefaultSettings(userAgentString = "foo")).settings.userAgentString)
+        assertEquals("foo", SystemEngine(testContext, DefaultSettings(userAgentString = "foo")).settings.userAgentString)
     }
 }

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/TrieTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/TrieTest.kt
@@ -4,15 +4,14 @@
 
 package mozilla.components.browser.engine.system.matcher
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TrieTest {
 
     @Test

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/UrlMatcherTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/UrlMatcherTest.kt
@@ -5,23 +5,22 @@
 package mozilla.components.browser.engine.system.matcher
 
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import java.io.StringReader
 import java.util.HashMap
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class UrlMatcherTest {
 
     @Test
@@ -252,7 +251,7 @@ class UrlMatcherTest {
 
     @Test
     fun isWebFont() {
-        assertFalse(UrlMatcher.isWebFont(mock(Uri::class.java)))
+        assertFalse(UrlMatcher.isWebFont(mock()))
         assertFalse(UrlMatcher.isWebFont(Uri.parse("mozilla.org")))
         assertTrue(UrlMatcher.isWebFont(Uri.parse("/fonts/test.woff2")))
         assertTrue(UrlMatcher.isWebFont(Uri.parse("/fonts/test.woff")))

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/WhiteListTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/matcher/WhiteListTest.kt
@@ -5,17 +5,16 @@
 package mozilla.components.browser.engine.system.matcher
 
 import android.util.JsonReader
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
 import java.io.StringReader
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class WhiteListTest {
 
     /**

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/permission/SystemPermissionRequestTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/permission/SystemPermissionRequestTest.kt
@@ -9,24 +9,24 @@ import android.webkit.PermissionRequest
 import android.webkit.PermissionRequest.RESOURCE_AUDIO_CAPTURE
 import android.webkit.PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID
 import android.webkit.PermissionRequest.RESOURCE_VIDEO_CAPTURE
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SystemPermissionRequestTest {
 
     @Test
     fun `uri is equal to native request origin`() {
         val nativeRequest: PermissionRequest = mock()
-        `when`(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
-        `when`(nativeRequest.resources).thenReturn(emptyArray())
+        whenever(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
+        whenever(nativeRequest.resources).thenReturn(emptyArray())
         val request = SystemPermissionRequest(nativeRequest)
         assertEquals(request.uri, "https://mozilla.org")
     }
@@ -34,8 +34,8 @@ class SystemPermissionRequestTest {
     @Test
     fun `resources are correctly mapped to permissions`() {
         val nativeRequest: PermissionRequest = mock()
-        `when`(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
-        `when`(nativeRequest.resources).thenReturn(
+        whenever(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
+        whenever(nativeRequest.resources).thenReturn(
             arrayOf(
                 RESOURCE_AUDIO_CAPTURE,
                 RESOURCE_VIDEO_CAPTURE,
@@ -55,8 +55,8 @@ class SystemPermissionRequestTest {
     @Test
     fun `reject denies native request`() {
         val nativeRequest: PermissionRequest = mock()
-        `when`(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
-        `when`(nativeRequest.resources).thenReturn(emptyArray())
+        whenever(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
+        whenever(nativeRequest.resources).thenReturn(emptyArray())
 
         val request = SystemPermissionRequest(nativeRequest)
         request.reject()
@@ -72,8 +72,8 @@ class SystemPermissionRequestTest {
         )
 
         val nativeRequest: PermissionRequest = mock()
-        `when`(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
-        `when`(nativeRequest.resources).thenReturn(resources)
+        whenever(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
+        whenever(nativeRequest.resources).thenReturn(resources)
 
         val request = SystemPermissionRequest(nativeRequest)
         request.grant()
@@ -89,8 +89,8 @@ class SystemPermissionRequestTest {
         )
 
         val nativeRequest: PermissionRequest = mock()
-        `when`(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
-        `when`(nativeRequest.resources).thenReturn(resources)
+        whenever(nativeRequest.origin).thenReturn(Uri.parse("https://mozilla.org"))
+        whenever(nativeRequest.resources).thenReturn(resources)
 
         val request = SystemPermissionRequest(nativeRequest)
         request.grant(listOf(Permission.ContentAudioCapture(RESOURCE_AUDIO_CAPTURE)))

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/window/SystemWindowRequestTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/window/SystemWindowRequestTest.kt
@@ -6,26 +6,26 @@ package mozilla.components.browser.engine.system.window
 
 import android.os.Message
 import android.webkit.WebView
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.system.SystemEngineSession
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SystemWindowRequestTest {
 
     @Test
     fun `init request`() {
-        val curWebView = mock(WebView::class.java)
-        val newWebView = mock(WebView::class.java)
+        val curWebView = mock<WebView>()
+        val newWebView = mock<WebView>()
         val request = SystemWindowRequest(curWebView, newWebView, true, true)
 
         assertTrue(request.openAsDialog)
@@ -35,20 +35,20 @@ class SystemWindowRequestTest {
 
     @Test
     fun `prepare sets webview on engine session`() {
-        val curWebView = mock(WebView::class.java)
-        val newWebView = mock(WebView::class.java)
+        val curWebView = mock<WebView>()
+        val newWebView = mock<WebView>()
         val request = SystemWindowRequest(curWebView, newWebView)
 
-        val engineSession = SystemEngineSession(ApplicationProvider.getApplicationContext())
+        val engineSession = SystemEngineSession(testContext)
         request.prepare(engineSession)
         assertSame(newWebView, engineSession.webView)
     }
 
     @Test
     fun `start sends message to target`() {
-        val curWebView = mock(WebView::class.java)
-        val newWebView = mock(WebView::class.java)
-        val resultMsg = mock(Message::class.java)
+        val curWebView = mock<WebView>()
+        val newWebView = mock<WebView>()
+        val resultMsg = mock<Message>()
 
         SystemWindowRequest(curWebView, newWebView, false, false).start()
         verify(resultMsg, never()).sendToTarget()
@@ -60,7 +60,7 @@ class SystemWindowRequestTest {
         SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
         verify(resultMsg, never()).sendToTarget()
 
-        resultMsg.obj = mock(WebView.WebViewTransport::class.java)
+        resultMsg.obj = mock<WebView.WebViewTransport>()
         SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
         verify(resultMsg, times(1)).sendToTarget()
     }


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-engine-system` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~