### PR TITLE
For #1481. Use androidx runner in `browser-engine-gecko-beta`.

### DIFF
--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -24,6 +24,8 @@ android {
     packagingOptions {
         exclude 'META-INF/proguard/androidx-annotations.pro'
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -40,10 +42,11 @@ dependencies {
     testImplementation Gecko.geckoview_beta_arm
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.testing_coroutines
     testImplementation project(':support-test')
     testImplementation project(':tooling-fetch-tests')
 

--- a/components/browser/engine-gecko-beta/gradle.properties
+++ b/components/browser/engine-gecko-beta/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -13,10 +14,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionStateTest {
+
     @Test
     fun toJSON() {
         val geckoState: GeckoSession.SessionState = mock()

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import android.app.Activity
 import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
@@ -16,6 +17,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -26,8 +28,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyFloat
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.ContentBlocking
@@ -38,15 +38,14 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.StorageController
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import org.mozilla.geckoview.WebExtension as GeckoWebExtension
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineTest {
 
-    private val runtime: GeckoRuntime = mock(GeckoRuntime::class.java)
-    private val context: Context = mock(Context::class.java)
+    private val runtime: GeckoRuntime = mock()
+    private val context: Context = mock()
 
     @Test
     fun createView() {
@@ -70,17 +69,17 @@ class GeckoEngineTest {
         val defaultSettings = DefaultSettings()
         val contentBlockingSettings =
                 ContentBlocking.Settings.Builder().categories(TrackingProtectionPolicy.none().categories).build()
-        val runtime = mock(GeckoRuntime::class.java)
-        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
-        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
-        `when`(runtimeSettings.webFontsEnabled).thenReturn(true)
-        `when`(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
-        `when`(runtimeSettings.fontInflationEnabled).thenReturn(true)
-        `when`(runtimeSettings.fontSizeFactor).thenReturn(1.0F)
-        `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
-        `when`(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
-        `when`(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
-        `when`(runtime.settings).thenReturn(runtimeSettings)
+        val runtime = mock<GeckoRuntime>()
+        val runtimeSettings = mock<GeckoRuntimeSettings>()
+        whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        whenever(runtimeSettings.webFontsEnabled).thenReturn(true)
+        whenever(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
+        whenever(runtimeSettings.fontInflationEnabled).thenReturn(true)
+        whenever(runtimeSettings.fontSizeFactor).thenReturn(1.0F)
+        whenever(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
+        whenever(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
+        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
+        whenever(runtime.settings).thenReturn(runtimeSettings)
         val engine = GeckoEngine(context, runtime = runtime, defaultSettings = defaultSettings)
 
         assertTrue(engine.settings.javascriptEnabled)
@@ -163,15 +162,15 @@ class GeckoEngineTest {
 
     @Test
     fun defaultSettings() {
-        val runtime = mock(GeckoRuntime::class.java)
-        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
+        val runtime = mock<GeckoRuntime>()
+        val runtimeSettings = mock<GeckoRuntimeSettings>()
         val contentBlockingSettings =
                 ContentBlocking.Settings.Builder().categories(TrackingProtectionPolicy.none().categories).build()
-        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
-        `when`(runtime.settings).thenReturn(runtimeSettings)
-        `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
-        `when`(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
-        `when`(runtimeSettings.fontInflationEnabled).thenReturn(true)
+        whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        whenever(runtime.settings).thenReturn(runtimeSettings)
+        whenever(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
+        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
+        whenever(runtimeSettings.fontInflationEnabled).thenReturn(true)
 
         val engine = GeckoEngine(context,
             DefaultSettings(
@@ -230,13 +229,13 @@ class GeckoEngineTest {
 
     @Test
     fun `install web extension successfully`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
-        var result = GeckoResult<Void>()
+        val result = GeckoResult<Void>()
 
-        `when`(runtime.registerWebExtension(any())).thenReturn(result)
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension(
                 "test-webext",
                 "resource://android/assets/extensions/test",
@@ -256,13 +255,13 @@ class GeckoEngineTest {
 
     @Test
     fun `install web extension successfully but do not allow content messaging`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
-        var result = GeckoResult<Void>()
+        val result = GeckoResult<Void>()
 
-        `when`(runtime.registerWebExtension(any())).thenReturn(result)
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension(
                 "test-webext",
                 "resource://android/assets/extensions/test",
@@ -283,14 +282,14 @@ class GeckoEngineTest {
 
     @Test
     fun `install web extension failure`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engine = GeckoEngine(context, runtime = runtime)
         var onErrorCalled = false
         val expected = IOException()
-        var result = GeckoResult<Void>()
+        val result = GeckoResult<Void>()
 
         var throwable: Throwable? = null
-        `when`(runtime.registerWebExtension(any())).thenReturn(result)
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension("test-webext-error", "resource://android/assets/extensions/error") { _, e ->
             onErrorCalled = true
             throwable = e
@@ -322,9 +321,9 @@ class GeckoEngineTest {
 
         var onSuccessCalled = false
 
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
         result.complete(null)
 
         val engine = GeckoEngine(context, runtime = runtime)
@@ -341,9 +340,9 @@ class GeckoEngineTest {
         var onErrorCalled = false
 
         val exception = IOException()
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
         result.completeExceptionally(exception)
 
         val engine = GeckoEngine(context, runtime = runtime)
@@ -362,9 +361,9 @@ class GeckoEngineTest {
 
         var onSuccessCalled = false
 
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearDataFromHost(
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearDataFromHost(
                 eq("mozilla.org"),
                 eq(Engine.BrowsingData.all().types.toLong()))
         ).thenReturn(result)
@@ -384,9 +383,9 @@ class GeckoEngineTest {
         var onErrorCalled = false
 
         val exception = IOException()
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearDataFromHost(
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearDataFromHost(
                 eq("mozilla.org"),
                 eq(Engine.BrowsingData.all().types.toLong()))
         ).thenReturn(result)

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -7,40 +7,39 @@ package mozilla.components.browser.engine.gecko
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.Robolectric.buildActivity
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineViewTest {
 
     private val context: Context
-        get() = Robolectric.buildActivity(Activity::class.java).get()
+        get() = buildActivity(Activity::class.java).get()
 
     @Test
     fun render() {
         val engineView = GeckoEngineView(context)
-        val engineSession = mock(GeckoEngineSession::class.java)
-        val geckoSession = mock(GeckoSession::class.java)
-        val geckoView = mock(NestedGeckoView::class.java)
+        val engineSession = mock<GeckoEngineSession>()
+        val geckoSession = mock<GeckoSession>()
+        val geckoView = mock<NestedGeckoView>()
 
-        `when`(engineSession.geckoSession).thenReturn(geckoSession)
+        whenever(engineSession.geckoSession).thenReturn(geckoSession)
         engineView.currentGeckoView = geckoView
 
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
 
-        `when`(geckoView.session).thenReturn(geckoSession)
+        whenever(geckoView.session).thenReturn(geckoSession)
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
     }
@@ -48,11 +47,11 @@ class GeckoEngineViewTest {
     @Test
     fun captureThumbnail() {
         val engineView = GeckoEngineView(context)
-        val mockGeckoView = mock(NestedGeckoView::class.java)
+        val mockGeckoView = mock<NestedGeckoView>()
         var thumbnail: Bitmap? = null
 
         var geckoResult = GeckoResult<Bitmap>()
-        `when`(mockGeckoView.capturePixels()).thenReturn(geckoResult)
+        whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
         engineView.currentGeckoView = mockGeckoView
 
         engineView.captureThumbnail {
@@ -63,7 +62,7 @@ class GeckoEngineViewTest {
         assertNotNull(thumbnail)
 
         geckoResult = GeckoResult()
-        `when`(mockGeckoView.capturePixels()).thenReturn(geckoResult)
+        whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
 
         engineView.captureThumbnail {
             thumbnail = it

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -12,6 +12,7 @@ import android.view.MotionEvent.ACTION_MOVE
 import android.view.MotionEvent.ACTION_UP
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
 import org.junit.Assert.assertEquals
@@ -23,13 +24,13 @@ import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.Robolectric.buildActivity
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class NestedGeckoViewTest {
+
     private val context: Context
-        get() = Robolectric.buildActivity(Activity::class.java).get()
+        get() = buildActivity(Activity::class.java).get()
 
     @Test
     fun `NestedGeckoView must delegate NestedScrollingChild implementation to childHelper`() {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -4,13 +4,16 @@
 
 package mozilla.components.browser.engine.gecko.fetch
 
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import mozilla.components.tooling.fetch.tests.FetchTestCases
 import okhttp3.Headers
-import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
@@ -21,16 +24,12 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
-import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebRequest
 import org.mozilla.geckoview.WebRequestError
 import org.mozilla.geckoview.WebResponse
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.TimeoutException
@@ -43,10 +42,11 @@ import java.util.concurrent.TimeoutException
  * functionality of [GeckoViewFetchClient]. That's why end-to-end tests are
  * provided in instrumented tests.
  */
-@RunWith(RobolectricTestRunner::class)
-class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
+@RunWith(AndroidJUnit4::class)
+class GeckoViewFetchUnitTestCases : FetchTestCases() {
+
     override fun createNewClient(): Client {
-        val client = GeckoViewFetchClient(ApplicationProvider.getApplicationContext(), mock(GeckoRuntime::class.java))
+        val client = GeckoViewFetchClient(testContext, mock())
         geckoWebExecutor?.let { client.executor = it }
         return client
     }
@@ -70,8 +70,8 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test
     override fun get200WithDefaultHeaders() {
-        val server = mock(MockWebServer::class.java)
-        `when`(server.url(any())).thenReturn(mock(HttpUrl::class.java))
+        val server = mock<MockWebServer>()
+        whenever(server.url(any())).thenReturn(mock())
         val host = server.url("/").host()
         val port = server.url("/").port()
         val headerMap = mapOf(
@@ -149,10 +149,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
         mockRequest()
         mockResponse(200)
 
-        val geckoResult = mock(GeckoResult::class.java)
-        `when`(geckoResult.poll(anyLong())).thenThrow(TimeoutException::class.java)
+        val geckoResult = mock<GeckoResult<*>>()
+        whenever(geckoResult.poll(anyLong())).thenThrow(TimeoutException::class.java)
         @Suppress("UNCHECKED_CAST")
-        `when`(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
+        whenever(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
 
         super.get200WithReadTimeout()
     }
@@ -176,10 +176,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get302FollowRedirects() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.redirect).thenReturn(Request.Redirect.FOLLOW)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.redirect).thenReturn(Request.Redirect.FOLLOW)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_NONE))
@@ -189,10 +189,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get302FollowRedirectsDisabled() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.redirect).thenReturn(Request.Redirect.MANUAL)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.redirect).thenReturn(Request.Redirect.MANUAL)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS))
@@ -223,14 +223,14 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     fun pollReturningNull() {
         mockResponse(200)
 
-        val geckoResult = mock(GeckoResult::class.java)
-        `when`(geckoResult.poll(anyLong())).thenReturn(null)
+        val geckoResult = mock<GeckoResult<*>>()
+        whenever(geckoResult.poll(anyLong())).thenReturn(null)
         @Suppress("UNCHECKED_CAST")
-        `when`(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
+        whenever(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
         createNewClient().fetch(request)
     }
 
@@ -238,10 +238,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get200WithCookiePolicy() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.cookiePolicy).thenReturn(Request.CookiePolicy.OMIT)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.cookiePolicy).thenReturn(Request.CookiePolicy.OMIT)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS))
@@ -249,9 +249,9 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test
     override fun get200WithContentTypeCharset() {
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
 
         mockResponse(200,
                 headerMap = mapOf("Content-Type" to "text/html; charset=ISO-8859-1"),
@@ -266,10 +266,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get200WithCacheControl() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.useCaches).thenReturn(false)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.useCaches).thenReturn(false)
         createNewClient().fetch(request)
 
         val captor = ArgumentCaptor.forClass(WebRequest::class.java)
@@ -280,31 +280,31 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test(expected = IOException::class)
     override fun getThrowsIOExceptionWhenHostNotReachable() {
-        val executor = mock(GeckoWebExecutor::class.java)
-        `when`(executor.fetch(any(), anyInt())).thenAnswer { throw WebRequestError(0, 0) }
+        val executor = mock<GeckoWebExecutor>()
+        whenever(executor.fetch(any(), anyInt())).thenAnswer { throw WebRequestError(0, 0) }
         geckoWebExecutor = executor
 
         createNewClient().fetch(Request(""))
     }
 
     private fun mockRequest(headerMap: Map<String, String>? = null, body: String? = null, method: String = "GET") {
-        val server = mock(MockWebServer::class.java)
-        `when`(server.url(any())).thenReturn(mock(HttpUrl::class.java))
-        val request = mock(RecordedRequest::class.java)
-        `when`(request.method).thenReturn(method)
+        val server = mock<MockWebServer>()
+        whenever(server.url(any())).thenReturn(mock())
+        val request = mock<RecordedRequest>()
+        whenever(request.method).thenReturn(method)
 
         headerMap?.let {
-            `when`(request.headers).thenReturn(Headers.of(headerMap))
-            `when`(request.getHeader(any())).thenAnswer { inv -> it[inv.getArgument(0)] }
+            whenever(request.headers).thenReturn(Headers.of(headerMap))
+            whenever(request.getHeader(any())).thenAnswer { inv -> it[inv.getArgument(0)] }
         }
 
         body?.let {
             val buffer = okio.Buffer()
             buffer.write(body.toByteArray())
-            `when`(request.body).thenReturn(buffer)
+            whenever(request.body).thenReturn(buffer)
         }
 
-        `when`(server.takeRequest()).thenReturn(request)
+        whenever(server.takeRequest()).thenReturn(request)
         mockWebServer = server
     }
 
@@ -314,7 +314,7 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
         body: String? = null,
         charset: Charset = Charsets.UTF_8
     ) {
-        val executor = mock(GeckoWebExecutor::class.java)
+        val executor = mock<GeckoWebExecutor>()
         val builder = WebResponse.Builder("").statusCode(statusCode)
         headerMap?.let {
             headerMap.forEach { (k, v) -> builder.addHeader(k, v) }
@@ -326,7 +326,7 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
         val response = builder.build()
 
-        `when`(executor.fetch(any(), anyInt())).thenReturn(GeckoResult.fromValue(response))
+        whenever(executor.fetch(any(), anyInt())).thenReturn(GeckoResult.fromValue(response))
         geckoWebExecutor = executor
     }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
@@ -1,13 +1,13 @@
 package mozilla.components.browser.engine.gecko.integration
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.runner.RunWith
 import org.junit.Test
-import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SettingUpdaterTest {
 
     @Test

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
@@ -1,5 +1,6 @@
 package mozilla.components.browser.engine.gecko.media
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.media.Media
@@ -11,19 +12,17 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.verify
-import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.MediaElement
 import org.mozilla.geckoview.MockRecordingDevice
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoMediaDelegateTest {
+
     @Test
     fun `Added MediaElement is wrapped in GeckoMedia and forwarded to observer`() {
-        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
 
         var observedMedia: Media? = null
 
@@ -44,7 +43,7 @@ class GeckoMediaDelegateTest {
 
     @Test
     fun `WHEN MediaElement is removed THEN previously added GeckoMedia is used to notify observer`() {
-        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
 
         var addedMedia: Media? = null
         var removedMedia: Media? = null
@@ -70,7 +69,7 @@ class GeckoMediaDelegateTest {
 
     @Test
     fun `WHEN unknown media is removed THEN observer is not notified`() {
-        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
 
         var onMediaRemovedExecuted = false
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko.permission
 
 import android.Manifest
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.support.test.mock
 import mozilla.components.test.ReflectionUtils
@@ -14,13 +15,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.RobolectricTestRunner
-
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoPermissionRequestTest {
 
     @Test
@@ -46,7 +45,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
+        val request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.grant()
         verify(callback).grant()
     }
@@ -56,7 +55,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
+        val request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.reject()
         verify(callback).reject()
     }
@@ -79,7 +78,7 @@ class GeckoPermissionRequestTest {
                 Permission.Generic("unknown app permission")
         )
 
-        var request = GeckoPermissionRequest.App(permissions, callback)
+        val request = GeckoPermissionRequest.App(permissions, callback)
         assertEquals(mappedPermissions, request.permissions)
     }
 
@@ -141,7 +140,7 @@ class GeckoPermissionRequestTest {
                 Permission.ContentAudioOther("audioOther", "audioOther")
         )
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         assertEquals(uri, request.uri)
         assertEquals(mappedPermissions.size, request.permissions.size)
         assertTrue(request.permissions.containsAll(mappedPermissions))
@@ -160,7 +159,7 @@ class GeckoPermissionRequestTest {
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         request.grant(request.permissions)
         verify(callback).grant(videoCamera, audioMicrophone)
     }
@@ -178,7 +177,7 @@ class GeckoPermissionRequestTest {
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         request.reject()
         verify(callback).reject()
     }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko.prompt
 import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.prompt.Choice
@@ -15,54 +16,51 @@ import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Lev
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level.PASSWORD_ENCRYPTED
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level.SECURED
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Method.HOST
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_SECURE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_PW_ENCRYPTED
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_ONLY_PASSWORD
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_PREVIOUS_FAILED
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_CROSS_ORIGIN_SUB_RESOURCE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_HOST
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
+import mozilla.components.support.ktx.kotlin.toDate
 import mozilla.components.support.test.mock
+import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
-import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoSession
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULTIPLE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
-import org.robolectric.RobolectricTestRunner
-import mozilla.components.support.ktx.kotlin.toDate
-import org.junit.Assert
-import org.junit.Assert.assertNotNull
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_CROSS_ORIGIN_SUB_RESOURCE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_HOST
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_ONLY_PASSWORD
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_PREVIOUS_FAILED
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_PW_ENCRYPTED
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_SECURE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.BUTTON_TYPE_NEGATIVE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.BUTTON_TYPE_NEUTRAL
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.BUTTON_TYPE_POSITIVE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULTIPLE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
 import org.robolectric.Shadows.shadowOf
 import java.io.FileInputStream
 import java.security.InvalidParameterException
-import java.util.Date
 import java.util.Calendar
 import java.util.Calendar.YEAR
+import java.util.Date
 
 typealias GeckoChoice = GeckoSession.PromptDelegate.Choice
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_SINGLE must provide a SingleChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = MultipleChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -92,7 +90,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_MULTIPLE must provide a MultipleChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = SingleChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -122,7 +120,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_MENU must provide a MenuChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = PromptRequest.MenuChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -170,7 +168,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onAlert must provide an alert PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var alertRequest: PromptRequest? = null
         var dismissWasCalled = false
         var setCheckboxValueWasCalled = false
@@ -214,7 +212,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `hitting default values`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onDateTimePrompt(mock(), null, DATETIME_TYPE_DATE, null, null, null, mock())
         gecko.onDateTimePrompt(mock(), null, DATETIME_TYPE_WEEK, null, null, null, mock())
@@ -234,7 +232,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_DATE must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         var onClearPicker = false
@@ -270,7 +268,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_DATE with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -312,7 +310,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_MONTH must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         val callback = object : TextCallback {
@@ -340,7 +338,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_MONTH with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -382,7 +380,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_WEEK must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         val callback = object : TextCallback {
@@ -410,7 +408,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_WEEK with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -452,7 +450,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_TIME must provide a TimeSelection PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
 
@@ -481,7 +479,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_TIME with time parameters must format time correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -523,7 +521,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_DATETIME_LOCAL must provide a TimeSelection PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
 
@@ -545,7 +543,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(
             mock(), "title",
-            GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
+            DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
         )
         assertTrue(dateRequest is PromptRequest.TimeSelection)
         (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
@@ -555,7 +553,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_DATETIME_LOCAL with date parameters must format time correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -627,7 +625,7 @@ class GeckoPromptDelegateTest {
     fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onSingleFileSelectedWasCalled = false
         var onMultipleFilesSelectedWasCalled = false
@@ -691,7 +689,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onAuthPrompt must provide an Authentication PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false
         var onConfirmOnlyPasswordWasCalled = false
@@ -777,12 +775,12 @@ class GeckoPromptDelegateTest {
     @Test
     fun `Calling onColorPrompt must provide a Color PromptRequest`() {
 
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false
         var onDismissWasCalled = false
 
-        val geckoCallback = object : GeckoSession.PromptDelegate.TextCallback {
+        val geckoCallback = object : TextCallback {
 
             override fun confirm(text: String?) {
                 onConfirmWasCalled = true
@@ -831,13 +829,13 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onTextPrompt must provide an TextPrompt PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var dismissWasCalled = false
         var confirmWasCalled = false
         var setCheckboxValueWasCalled = false
 
-        val callback = object : GeckoSession.PromptDelegate.TextCallback {
+        val callback = object : TextCallback {
 
             override fun confirm(text: String?) {
                 confirmWasCalled = true
@@ -882,7 +880,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onPopupRequest must provide a Popup PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest.Popup? = null
         var onAllowWasCalled = false
         var onDenyWasCalled = false
@@ -923,7 +921,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onButtonPrompt must provide a Confirm PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest.Confirm? = null
         var onPositiveButtonWasCalled = false
         var onNegativeButtonWasCalled = false

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko.prompt
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.webextension.GeckoPort
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
@@ -12,6 +13,7 @@ import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.json.JSONObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -19,14 +21,12 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.WebExtension
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoWebExtensionTest {
 
     @Test
@@ -45,11 +45,11 @@ class GeckoWebExtensionTest {
         // Verify messages are forwarded to message handler
         val message: Any = mock()
         val sender: WebExtension.MessageSender = mock()
-        `when`(messageHandler.onMessage(eq(message), eq(null))).thenReturn("result")
+        whenever(messageHandler.onMessage(eq(message), eq(null))).thenReturn("result")
         assertNotNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler).onMessage(eq(message), eq(null))
 
-        `when`(messageHandler.onMessage(eq(message), eq(null))).thenReturn(null)
+        whenever(messageHandler.onMessage(eq(message), eq(null))).thenReturn(null)
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(null))
 
@@ -83,7 +83,7 @@ class GeckoWebExtensionTest {
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
-        `when`(session.geckoSession).thenReturn(geckoSession)
+        whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
@@ -93,11 +93,11 @@ class GeckoWebExtensionTest {
         // Verify messages are forwarded to message handler and return value passed on
         val message: Any = mock()
         val sender: WebExtension.MessageSender = mock()
-        `when`(messageHandler.onMessage(eq(message), eq(session))).thenReturn("result")
+        whenever(messageHandler.onMessage(eq(message), eq(session))).thenReturn("result")
         assertNotNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler).onMessage(eq(message), eq(session))
 
-        `when`(messageHandler.onMessage(eq(message), eq(session))).thenReturn(null)
+        whenever(messageHandler.onMessage(eq(message), eq(session))).thenReturn(null)
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(session))
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-engine-gecko-beta` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~