### PR TITLE
For #1481. Use androidx runner in `browser-engine-gecko-nightly`.

### DIFF
--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -24,6 +24,8 @@ android {
     packagingOptions {
         exclude 'META-INF/proguard/androidx-annotations.pro'
     }
+
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
@@ -38,8 +40,9 @@ dependencies {
     implementation Gecko.geckoview_nightly
 
     testImplementation Dependencies.androidx_test_core
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_coroutines
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
     testImplementation project(':support-test')

--- a/components/browser/engine-gecko-nightly/gradle.properties
+++ b/components/browser/engine-gecko-nightly/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove and enable globally
+android.enableUnitTestBinaryResources=true

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.engine.gecko
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -13,10 +14,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionStateTest {
+
     @Test
     fun toJSON() {
         val geckoState: GeckoSession.SessionState = mock()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -6,9 +6,9 @@ package mozilla.components.browser.engine.gecko
 
 import android.os.Handler
 import android.os.Message
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.runBlocking
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
@@ -24,10 +24,10 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.expectException
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import mozilla.components.support.utils.ThreadUtils
 import mozilla.components.test.ReflectionUtils
 import org.json.JSONObject
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -41,8 +41,6 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -51,7 +49,6 @@ import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ContextElement.TYPE_AUDIO
 import org.mozilla.geckoview.GeckoSession.ContentDelegate.ContextElement.TYPE_IMAGE
@@ -65,11 +62,11 @@ import org.mozilla.geckoview.WebRequestError
 import org.mozilla.geckoview.WebRequestError.ERROR_CATEGORY_UNKNOWN
 import org.mozilla.geckoview.WebRequestError.ERROR_MALFORMED_URI
 import org.mozilla.geckoview.WebRequestError.ERROR_UNKNOWN
-import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.Executors
 
-@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionTest {
+
     private lateinit var geckoSession: GeckoSession
     private lateinit var geckoSessionProvider: () -> GeckoSession
 
@@ -79,9 +76,6 @@ class GeckoEngineSessionTest {
     private lateinit var permissionDelegate: ArgumentCaptor<GeckoSession.PermissionDelegate>
     private lateinit var contentBlockingDelegate: ArgumentCaptor<ContentBlocking.Delegate>
     private lateinit var historyDelegate: ArgumentCaptor<GeckoSession.HistoryDelegate>
-
-    private val testMainScope = CoroutineScope(
-        Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
     @Before
     fun setup() {
@@ -121,7 +115,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun engineSessionInitialization() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
 
         verify(geckoSession).open(any())
@@ -134,7 +128,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun progressDelegateNotifiesObservers() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var observedProgress = 0
@@ -170,7 +164,7 @@ class GeckoEngineSessionTest {
         assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
         assertEquals(false, observedLoadingState)
 
-        val securityInfo = mock(GeckoSession.ProgressDelegate.SecurityInformation::class.java)
+        val securityInfo = mock<SecurityInformation>()
         progressDelegate.value.onSecurityChange(mock(), securityInfo)
         assertTrue(observedSecurityChange)
 
@@ -182,12 +176,12 @@ class GeckoEngineSessionTest {
 
     @Test
     fun navigationDelegateNotifiesObservers() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var observedUrl = ""
-        var observedCanGoBack: Boolean = false
-        var observedCanGoForward: Boolean = false
+        var observedCanGoBack = false
+        var observedCanGoForward = false
         engineSession.register(object : EngineSession.Observer {
             override fun onLocationChange(url: String) { observedUrl = url }
             override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
@@ -210,7 +204,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun contentDelegateNotifiesObserverAboutDownloads() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         val observer: EngineSession.Observer = mock()
@@ -237,7 +231,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun contentDelegateNotifiesObserverAboutWebAppManifest() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         val observer: EngineSession.Observer = mock()
@@ -260,11 +254,11 @@ class GeckoEngineSessionTest {
 
     @Test
     fun permissionDelegateNotifiesObservers() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
-        var observedContentPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
-        var observedAppPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
+        val observedContentPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
+        val observedAppPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
         engineSession.register(object : EngineSession.Observer {
             override fun onContentPermissionRequest(permissionRequest: PermissionRequest) {
                 observedContentPermissionRequests.add(permissionRequest)
@@ -281,14 +275,14 @@ class GeckoEngineSessionTest {
             geckoSession,
             "originContent",
             GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION,
-            mock(GeckoSession.PermissionDelegate.Callback::class.java)
+            mock()
         )
 
         permissionDelegate.value.onContentPermissionRequest(
             geckoSession,
             null,
             GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION,
-            mock(GeckoSession.PermissionDelegate.Callback::class.java)
+            mock()
         )
 
         permissionDelegate.value.onMediaPermissionRequest(
@@ -296,7 +290,7 @@ class GeckoEngineSessionTest {
             "originMedia",
             emptyArray(),
             emptyArray(),
-            mock(GeckoSession.PermissionDelegate.MediaCallback::class.java)
+            mock()
         )
 
         permissionDelegate.value.onMediaPermissionRequest(
@@ -304,19 +298,19 @@ class GeckoEngineSessionTest {
             "about:blank",
             null,
             null,
-            mock(GeckoSession.PermissionDelegate.MediaCallback::class.java)
+            mock()
         )
 
         permissionDelegate.value.onAndroidPermissionsRequest(
             geckoSession,
             emptyArray(),
-            mock(GeckoSession.PermissionDelegate.Callback::class.java)
+            mock()
         )
 
         permissionDelegate.value.onAndroidPermissionsRequest(
             geckoSession,
             null,
-            mock(GeckoSession.PermissionDelegate.Callback::class.java)
+            mock()
         )
 
         assertEquals(4, observedContentPermissionRequests.size)
@@ -329,7 +323,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun loadUrl() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.loadUrl("http://mozilla.org")
@@ -339,7 +333,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun loadData() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.loadData("<html><body>Hello!</body></html>")
@@ -357,7 +351,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun loadDataBase64() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.loadData("Hello!", "text/plain", "UTF-8")
@@ -372,7 +366,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun stopLoading() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.stopLoading()
@@ -382,7 +376,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun reload() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
         engineSession.loadUrl("http://mozilla.org")
 
@@ -393,7 +387,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun goBack() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.goBack()
@@ -403,7 +397,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun goForward() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.goForward()
@@ -413,7 +407,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun restoreState() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         val actualState: GeckoSession.SessionState = mock()
@@ -425,7 +419,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `restoreState does nothing for null state`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         val state = GeckoEngineSessionState(null)
@@ -442,7 +436,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun progressDelegateIgnoresInitialLoadOfAboutBlank() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var observedSecurityChange = false
@@ -465,7 +459,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun navigationDelegateIgnoresInitialLoadOfAboutBlank() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var observedUrl = ""
@@ -490,7 +484,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `keeps track of current url via onPageStart events`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -504,10 +498,10 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `notifies configured history delegate of title changes`() = runBlocking {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `notifies configured history delegate of title changes`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
@@ -528,10 +522,10 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate of title changes for private sessions`() = runBlocking {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `does not notify configured history delegate of title changes for private sessions`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext,
+            context = coroutineContext,
                 privateMode = true)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
@@ -558,34 +552,30 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun `does not notify configured history delegate for redirects`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `does not notify configured history delegate for redirects`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
 
         // Nothing breaks if history delegate isn't configured.
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-        }
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY)
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
-        }
     }
 
     @Test
-    fun `does not notify configured history delegate for top-level visits to error pages`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `does not notify configured history delegate for top-level visits to error pages`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
@@ -593,91 +583,81 @@ class GeckoEngineSessionTest {
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
         historyDelegate.value.onVisited(geckoSession, "about:neterror", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL or GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR)
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
-        }
     }
 
     @Test
-    fun `notifies configured history delegate of visits`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `notifies configured history delegate of visits`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
-        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
+        whenever(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
-        }
     }
 
     @Test
-    fun `notifies configured history delegate of reloads`() = runBlocking {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `notifies configured history delegate of reloads`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
-        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
+        whenever(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com")).thenReturn(true)
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
-        }
     }
 
     @Test
-    fun `checks with the delegate before trying to record a visit`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `checks with the delegate before trying to record a visit`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
-        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/allowed")).thenReturn(true)
-        `when`(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/not-allowed")).thenReturn(false)
+        whenever(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/allowed")).thenReturn(true)
+        whenever(historyTrackingDelegate.shouldStoreUri("https://www.mozilla.com/not-allowed")).thenReturn(false)
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
 
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(VisitType.LINK))
-        }
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
 
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/not-allowed")
-            verify(historyTrackingDelegate, never()).onVisited(eq("https://www.mozilla.com/not-allowed"), mozilla.components.support.test.any())
-        }
+        verify(historyTrackingDelegate, never()).onVisited(eq("https://www.mozilla.com/not-allowed"), any())
     }
 
     @Test
-    fun `correctly processes redirect visit flags`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `correctly processes redirect visit flags`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
-        `when`(historyTrackingDelegate.shouldStoreUri(mozilla.components.support.test.any())).thenReturn(true)
+        whenever(historyTrackingDelegate.shouldStoreUri(any())).thenReturn(true)
 
         historyDelegate.value.onVisited(
                 geckoSession,
@@ -688,10 +668,8 @@ class GeckoEngineSessionTest {
                         or GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE
         )
 
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))
-        }
 
         historyDelegate.value.onVisited(
                 geckoSession,
@@ -701,10 +679,8 @@ class GeckoEngineSessionTest {
                         or GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT
         )
 
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))
-        }
 
         // Visits below are targets of redirects, not redirects themselves.
         // Check that they're mapped to "link".
@@ -716,10 +692,8 @@ class GeckoEngineSessionTest {
                         or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
         )
 
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(VisitType.LINK))
-        }
 
         historyDelegate.value.onVisited(
                 geckoSession,
@@ -729,17 +703,15 @@ class GeckoEngineSessionTest {
                         or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
         )
 
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(VisitType.LINK))
-        }
     }
 
     @Test
-    fun `does not notify configured history delegate of visits for private sessions`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `does not notify configured history delegate of visits for private sessions`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext,
+            context = coroutineContext,
                 privateMode = true)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
@@ -748,41 +720,35 @@ class GeckoEngineSessionTest {
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate, never()).onVisited(anyString(), any())
-        }
     }
 
     @Test
-    fun `requests visited URLs from configured history delegate`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `requests visited URLs from configured history delegate`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext)
+            context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
         captureDelegates()
 
         // Nothing breaks if history delegate isn't configured.
         historyDelegate.value.getVisited(geckoSession, arrayOf("https://www.mozilla.com", "https://www.mozilla.org"))
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
-        }
 
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
         historyDelegate.value.getVisited(geckoSession, arrayOf("https://www.mozilla.com", "https://www.mozilla.org"))
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).getVisited(eq(listOf("https://www.mozilla.com", "https://www.mozilla.org")))
-        }
     }
 
     @Test
-    fun `does not request visited URLs from configured history delegate in private sessions`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+    fun `does not request visited URLs from configured history delegate in private sessions`() = runBlockingTest {
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider,
-                context = testMainScope.coroutineContext,
+            context = coroutineContext,
                 privateMode = true)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
 
@@ -791,15 +757,13 @@ class GeckoEngineSessionTest {
         engineSession.settings.historyTrackingDelegate = historyTrackingDelegate
 
         historyDelegate.value.getVisited(geckoSession, arrayOf("https://www.mozilla.com", "https://www.mozilla.org"))
-        runBlocking(testMainScope.coroutineContext) {
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate, never()).getVisited(anyList())
-        }
     }
 
     @Test
     fun websiteTitleUpdates() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         val observer: EngineSession.Observer = mock()
@@ -814,7 +778,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun trackingProtectionDelegateNotifiesObservers() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var trackerBlocked = ""
@@ -832,8 +796,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun enableTrackingProtection() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
         val session = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
         val privSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider, privateMode = true)
 
@@ -875,8 +839,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun disableTrackingProtection() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
 
         var trackerBlockingDisabledObserved = false
@@ -911,8 +875,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun settingTestingMode() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
 
         GeckoEngineSession(runtime,
                 geckoSessionProvider = geckoSessionProvider,
@@ -927,8 +891,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun settingUserAgent() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
 
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
         engineSession.settings.userAgentString
@@ -942,8 +906,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun settingUserAgentDefault() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
 
         GeckoEngineSession(runtime,
                 geckoSessionProvider = geckoSessionProvider,
@@ -954,10 +918,10 @@ class GeckoEngineSessionTest {
 
     @Test
     fun settingSuspendMediaWhenInactive() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
 
-        var engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
+        val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
         verify(geckoSession.settings, never()).suspendMediaWhenInactive = anyBoolean()
 
         assertFalse(engineSession.settings.suspendMediaWhenInactive)
@@ -969,8 +933,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun settingSuspendMediaWhenInactiveDefault() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
 
         GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
         verify(geckoSession.settings, never()).suspendMediaWhenInactive = anyBoolean()
@@ -988,7 +952,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun unsupportedSettings() {
-        val settings = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val settings = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider).settings
 
         expectException(UnsupportedSettingException::class) {
@@ -1185,107 +1149,107 @@ class GeckoEngineSessionTest {
 
     @Test
     fun geckoErrorMappingToErrorType() {
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SECURITY_SSL,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_SECURITY_SSL)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SECURITY_BAD_CERT,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_SECURITY_BAD_CERT)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_NET_INTERRUPT,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_NET_INTERRUPT)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_NET_TIMEOUT,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_NET_TIMEOUT)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_NET_RESET,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_NET_RESET)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_CONNECTION_REFUSED,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_CONNECTION_REFUSED)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNKNOWN_SOCKET_TYPE,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_UNKNOWN_SOCKET_TYPE)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_REDIRECT_LOOP,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_REDIRECT_LOOP)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_OFFLINE,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_OFFLINE)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_PORT_BLOCKED,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_PORT_BLOCKED)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNSAFE_CONTENT_TYPE,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_UNSAFE_CONTENT_TYPE)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_CORRUPTED_CONTENT,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_CORRUPTED_CONTENT)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_CONTENT_CRASHED,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_CONTENT_CRASHED)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_INVALID_CONTENT_ENCODING,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_INVALID_CONTENT_ENCODING)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNKNOWN_HOST,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_UNKNOWN_HOST)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_MALFORMED_URI,
-            GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_MALFORMED_URI)
+            GeckoEngineSession.geckoErrorToErrorType(ERROR_MALFORMED_URI)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNKNOWN_PROTOCOL,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_UNKNOWN_PROTOCOL)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_FILE_NOT_FOUND,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_FILE_NOT_FOUND)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_FILE_ACCESS_DENIED,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_FILE_ACCESS_DENIED)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_PROXY_CONNECTION_REFUSED,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_PROXY_CONNECTION_REFUSED)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_UNKNOWN_PROXY_HOST,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_UNKNOWN_PROXY_HOST)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SAFEBROWSING_MALWARE_URI,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_SAFEBROWSING_MALWARE_URI)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SAFEBROWSING_HARMFUL_URI,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_SAFEBROWSING_HARMFUL_URI)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SAFEBROWSING_PHISHING_URI,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_SAFEBROWSING_PHISHING_URI)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.ERROR_SAFEBROWSING_UNWANTED_URI,
             GeckoEngineSession.geckoErrorToErrorType(WebRequestError.ERROR_SAFEBROWSING_UNWANTED_URI)
         )
-        Assert.assertEquals(
+        assertEquals(
             ErrorType.UNKNOWN,
             GeckoEngineSession.geckoErrorToErrorType(-500)
         )
@@ -1293,8 +1257,8 @@ class GeckoEngineSessionTest {
 
     @Test
     fun defaultSettings() {
-        val runtime = mock(GeckoRuntime::class.java)
-        `when`(runtime.settings).thenReturn(mock(GeckoRuntimeSettings::class.java))
+        val runtime = mock<GeckoRuntime>()
+        whenever(runtime.settings).thenReturn(mock())
 
         val defaultSettings = DefaultSettings(trackingProtectionPolicy = TrackingProtectionPolicy.all())
 
@@ -1307,7 +1271,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun contentDelegate() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
         val delegate = engineSession.createContentDelegate()
 
@@ -1344,7 +1308,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun handleLongClick() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var result = engineSession.handleLongClick("file.mp3", TYPE_AUDIO)
@@ -1393,7 +1357,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun setDesktopMode() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
 
         var desktopModeToggled = false
@@ -1406,9 +1370,9 @@ class GeckoEngineSessionTest {
         assertTrue(desktopModeToggled)
 
         desktopModeToggled = false
-        `when`(geckoSession.settings.userAgentMode)
+        whenever(geckoSession.settings.userAgentMode)
                 .thenReturn(GeckoSessionSettings.USER_AGENT_MODE_DESKTOP)
-        `when`(geckoSession.settings.viewportMode)
+        whenever(geckoSession.settings.viewportMode)
                 .thenReturn(GeckoSessionSettings.VIEWPORT_MODE_DESKTOP)
 
         engineSession.toggleDesktopMode(true)
@@ -1423,14 +1387,14 @@ class GeckoEngineSessionTest {
 
     @Test
     fun findAll() {
-        val finderResult = mock(GeckoSession.FinderResult::class.java)
-        val sessionFinder = mock(SessionFinder::class.java)
-        `when`(sessionFinder.find("mozilla", 0))
+        val finderResult = mock<GeckoSession.FinderResult>()
+        val sessionFinder = mock<SessionFinder>()
+        whenever(sessionFinder.find("mozilla", 0))
                 .thenReturn(GeckoResult.fromValue(finderResult))
 
-        `when`(geckoSession.finder).thenReturn(sessionFinder)
+        whenever(geckoSession.finder).thenReturn(sessionFinder)
 
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var findObserved: String? = null
@@ -1457,14 +1421,14 @@ class GeckoEngineSessionTest {
 
     @Test
     fun findNext() {
-        val finderResult = mock(GeckoSession.FinderResult::class.java)
-        val sessionFinder = mock(SessionFinder::class.java)
-        `when`(sessionFinder.find(eq(null), anyInt()))
+        val finderResult = mock<GeckoSession.FinderResult>()
+        val sessionFinder = mock<SessionFinder>()
+        whenever(sessionFinder.find(eq(null), anyInt()))
                 .thenReturn(GeckoResult.fromValue(finderResult))
 
-        `when`(geckoSession.finder).thenReturn(sessionFinder)
+        whenever(geckoSession.finder).thenReturn(sessionFinder)
 
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         var findResultObserved = false
@@ -1488,10 +1452,10 @@ class GeckoEngineSessionTest {
 
     @Test
     fun clearFindMatches() {
-        val finder = mock(SessionFinder::class.java)
-        `when`(geckoSession.finder).thenReturn(finder)
+        val finder = mock<SessionFinder>()
+        whenever(geckoSession.finder).thenReturn(finder)
 
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.clearFindMatches()
@@ -1501,7 +1465,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun exitFullScreenModeTriggersExitEvent() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
         val observer: EngineSession.Observer = mock()
 
@@ -1521,7 +1485,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun exitFullscreenTrueHasNoInteraction() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.exitFullScreenMode()
@@ -1530,7 +1494,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun clearData() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
         val observer: EngineSession.Observer = mock()
 
@@ -1543,7 +1507,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `after onCrash get called geckoSession must be reset`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engineSession = GeckoEngineSession(runtime)
         val oldGeckoSession = engineSession.geckoSession
 
@@ -1557,7 +1521,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun whenOnExternalResponseDoNotProvideAFileNameMustProvideMeaningFulFileNameToTheSessionObserver() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
         var meaningFulFileName = ""
 
         val observer = object : EngineSession.Observer {
@@ -1590,7 +1554,7 @@ class GeckoEngineSessionTest {
     fun `Closing engine session should close underlying gecko session`() {
         val geckoSession = mockGeckoSession()
 
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java), geckoSessionProvider = { geckoSession })
+        val engineSession = GeckoEngineSession(mock(), geckoSessionProvider = { geckoSession })
 
         engineSession.close()
 
@@ -1612,7 +1576,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `State provided through delegate will be returned from saveState`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -1631,7 +1595,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `onCrash notifies observers about crash`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -1651,7 +1615,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `recoverFromCrash does not restore state if no state has been saved previously`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         assertFalse(engineSession.recoverFromCrash())
@@ -1660,7 +1624,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `recoverFromCrash restores last known state`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -1680,7 +1644,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `recoverFromCrash does not restore last known state if no crash occurred`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -1697,7 +1661,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `onLoadRequest will notify observers if request was not intercepted`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -1728,7 +1692,7 @@ class GeckoEngineSessionTest {
 
     @Test
     fun `onLoadRequest will notify observers if the url is loaded from the user interacting with chrome`() {
-        val engineSession = GeckoEngineSession(mock(GeckoRuntime::class.java),
+        val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
 
         captureDelegates()
@@ -1828,9 +1792,9 @@ class GeckoEngineSessionTest {
     }
 
     private fun mockGeckoSession(): GeckoSession {
-        val session = mock(GeckoSession::class.java)
-        `when`(session.settings).thenReturn(
-            mock(GeckoSessionSettings::class.java))
+        val session = mock<GeckoSession>()
+        whenever(session.settings).thenReturn(
+            mock())
         return session
     }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import android.app.Activity
 import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
@@ -16,6 +17,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -26,8 +28,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyFloat
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.ContentBlocking
@@ -38,15 +38,14 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.StorageController
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import org.mozilla.geckoview.WebExtension as GeckoWebExtension
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineTest {
 
-    private val runtime: GeckoRuntime = mock(GeckoRuntime::class.java)
-    private val context: Context = mock(Context::class.java)
+    private val runtime: GeckoRuntime = mock()
+    private val context: Context = mock()
 
     @Test
     fun createView() {
@@ -70,17 +69,17 @@ class GeckoEngineTest {
         val defaultSettings = DefaultSettings()
         val contentBlockingSettings =
                 ContentBlocking.Settings.Builder().categories(TrackingProtectionPolicy.none().categories).build()
-        val runtime = mock(GeckoRuntime::class.java)
-        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
-        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
-        `when`(runtimeSettings.webFontsEnabled).thenReturn(true)
-        `when`(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
-        `when`(runtimeSettings.fontInflationEnabled).thenReturn(true)
-        `when`(runtimeSettings.fontSizeFactor).thenReturn(1.0F)
-        `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
-        `when`(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
-        `when`(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
-        `when`(runtime.settings).thenReturn(runtimeSettings)
+        val runtime = mock<GeckoRuntime>()
+        val runtimeSettings = mock<GeckoRuntimeSettings>()
+        whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        whenever(runtimeSettings.webFontsEnabled).thenReturn(true)
+        whenever(runtimeSettings.automaticFontSizeAdjustment).thenReturn(true)
+        whenever(runtimeSettings.fontInflationEnabled).thenReturn(true)
+        whenever(runtimeSettings.fontSizeFactor).thenReturn(1.0F)
+        whenever(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
+        whenever(runtimeSettings.preferredColorScheme).thenReturn(GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM)
+        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
+        whenever(runtime.settings).thenReturn(runtimeSettings)
         val engine = GeckoEngine(context, runtime = runtime, defaultSettings = defaultSettings)
 
         assertTrue(engine.settings.javascriptEnabled)
@@ -163,15 +162,15 @@ class GeckoEngineTest {
 
     @Test
     fun defaultSettings() {
-        val runtime = mock(GeckoRuntime::class.java)
-        val runtimeSettings = mock(GeckoRuntimeSettings::class.java)
+        val runtime = mock<GeckoRuntime>()
+        val runtimeSettings = mock<GeckoRuntimeSettings>()
         val contentBlockingSettings =
                 ContentBlocking.Settings.Builder().categories(TrackingProtectionPolicy.none().categories).build()
-        `when`(runtimeSettings.javaScriptEnabled).thenReturn(true)
-        `when`(runtime.settings).thenReturn(runtimeSettings)
-        `when`(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
-        `when`(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
-        `when`(runtimeSettings.fontInflationEnabled).thenReturn(true)
+        whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
+        whenever(runtime.settings).thenReturn(runtimeSettings)
+        whenever(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
+        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
+        whenever(runtimeSettings.fontInflationEnabled).thenReturn(true)
 
         val engine = GeckoEngine(context,
             DefaultSettings(
@@ -230,13 +229,13 @@ class GeckoEngineTest {
 
     @Test
     fun `install web extension successfully`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
-        var result = GeckoResult<Void>()
+        val result = GeckoResult<Void>()
 
-        `when`(runtime.registerWebExtension(any())).thenReturn(result)
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension(
                 "test-webext",
                 "resource://android/assets/extensions/test",
@@ -256,13 +255,13 @@ class GeckoEngineTest {
 
     @Test
     fun `install web extension successfully but do not allow content messaging`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
-        var result = GeckoResult<Void>()
+        val result = GeckoResult<Void>()
 
-        `when`(runtime.registerWebExtension(any())).thenReturn(result)
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension(
                 "test-webext",
                 "resource://android/assets/extensions/test",
@@ -283,14 +282,14 @@ class GeckoEngineTest {
 
     @Test
     fun `install web extension failure`() {
-        val runtime = mock(GeckoRuntime::class.java)
+        val runtime = mock<GeckoRuntime>()
         val engine = GeckoEngine(context, runtime = runtime)
         var onErrorCalled = false
         val expected = IOException()
-        var result = GeckoResult<Void>()
+        val result = GeckoResult<Void>()
 
         var throwable: Throwable? = null
-        `when`(runtime.registerWebExtension(any())).thenReturn(result)
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension("test-webext-error", "resource://android/assets/extensions/error") { _, e ->
             onErrorCalled = true
             throwable = e
@@ -322,9 +321,9 @@ class GeckoEngineTest {
 
         var onSuccessCalled = false
 
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
         result.complete(null)
 
         val engine = GeckoEngine(context, runtime = runtime)
@@ -341,9 +340,9 @@ class GeckoEngineTest {
         var onErrorCalled = false
 
         val exception = IOException()
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearData(eq(Engine.BrowsingData.all().types.toLong()))).thenReturn(result)
         result.completeExceptionally(exception)
 
         val engine = GeckoEngine(context, runtime = runtime)
@@ -362,9 +361,9 @@ class GeckoEngineTest {
 
         var onSuccessCalled = false
 
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearDataFromHost(
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearDataFromHost(
                 eq("mozilla.org"),
                 eq(Engine.BrowsingData.all().types.toLong()))
         ).thenReturn(result)
@@ -384,9 +383,9 @@ class GeckoEngineTest {
         var onErrorCalled = false
 
         val exception = IOException()
-        var result = GeckoResult<Void>()
-        `when`(runtime.storageController).thenReturn(storageController)
-        `when`(storageController.clearDataFromHost(
+        val result = GeckoResult<Void>()
+        whenever(runtime.storageController).thenReturn(storageController)
+        whenever(storageController.clearDataFromHost(
                 eq("mozilla.org"),
                 eq(Engine.BrowsingData.all().types.toLong()))
         ).thenReturn(result)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -7,40 +7,39 @@ package mozilla.components.browser.engine.gecko
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.Robolectric.buildActivity
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoEngineViewTest {
 
     private val context: Context
-        get() = Robolectric.buildActivity(Activity::class.java).get()
+        get() = buildActivity(Activity::class.java).get()
 
     @Test
     fun render() {
         val engineView = GeckoEngineView(context)
-        val engineSession = mock(GeckoEngineSession::class.java)
-        val geckoSession = mock(GeckoSession::class.java)
-        val geckoView = mock(NestedGeckoView::class.java)
+        val engineSession = mock<GeckoEngineSession>()
+        val geckoSession = mock<GeckoSession>()
+        val geckoView = mock<NestedGeckoView>()
 
-        `when`(engineSession.geckoSession).thenReturn(geckoSession)
+        whenever(engineSession.geckoSession).thenReturn(geckoSession)
         engineView.currentGeckoView = geckoView
 
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
 
-        `when`(geckoView.session).thenReturn(geckoSession)
+        whenever(geckoView.session).thenReturn(geckoSession)
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
     }
@@ -48,11 +47,11 @@ class GeckoEngineViewTest {
     @Test
     fun captureThumbnail() {
         val engineView = GeckoEngineView(context)
-        val mockGeckoView = mock(NestedGeckoView::class.java)
+        val mockGeckoView = mock<NestedGeckoView>()
         var thumbnail: Bitmap? = null
 
         var geckoResult = GeckoResult<Bitmap>()
-        `when`(mockGeckoView.capturePixels()).thenReturn(geckoResult)
+        whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
         engineView.currentGeckoView = mockGeckoView
 
         engineView.captureThumbnail {
@@ -63,7 +62,7 @@ class GeckoEngineViewTest {
         assertNotNull(thumbnail)
 
         geckoResult = GeckoResult()
-        `when`(mockGeckoView.capturePixels()).thenReturn(geckoResult)
+        whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
 
         engineView.captureThumbnail {
             thumbnail = it

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
@@ -4,56 +4,50 @@
 
 package mozilla.components.browser.engine.gecko
 
-import kotlinx.coroutines.runBlocking
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.geckoview.GeckoResult
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
 class GeckoResultTest {
 
     @Test
-    fun awaitWithResult() {
-        val result = runBlocking {
-            GeckoResult.fromValue(42).await()
-        }
+    fun awaitWithResult() = runBlockingTest {
+        val result = GeckoResult.fromValue(42).await()
         assertEquals(42, result)
     }
 
     @Test(expected = IllegalStateException::class)
-    fun awaitWithException() {
-        runBlocking {
-            GeckoResult.fromException<Unit>(IllegalStateException()).await()
-        }
+    fun awaitWithException() = runBlockingTest {
+        GeckoResult.fromException<Unit>(IllegalStateException()).await()
     }
 
     @Test
-    fun fromResult() {
-        runBlocking {
-            val result = launchGeckoResult { 42 }
+    fun fromResult() = runBlockingTest {
+        val result = launchGeckoResult { 42 }
 
-            result.then {
-                assertEquals(42, it)
-                GeckoResult.fromValue(null)
-            }.await()
-        }
+        result.then {
+            assertEquals(42, it)
+            GeckoResult.fromValue(null)
+        }.await()
     }
 
     @Test
-    fun fromException() {
-        runBlocking {
-            val result = launchGeckoResult { throw IllegalStateException() }
+    fun fromException() = runBlockingTest {
+        val result = launchGeckoResult { throw IllegalStateException() }
 
-            result.then({
-                assertTrue("Invalid branch", false)
-                GeckoResult.fromValue(null)
-            }, {
-                assertTrue(it is IllegalStateException)
-                GeckoResult.fromValue(null)
-            }).await()
-        }
+        result.then({
+            assertTrue("Invalid branch", false)
+            GeckoResult.fromValue(null)
+        }, {
+            assertTrue(it is IllegalStateException)
+            GeckoResult.fromValue(null)
+        }).await()
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -12,6 +12,7 @@ import android.view.MotionEvent.ACTION_MOVE
 import android.view.MotionEvent.ACTION_UP
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
 import org.junit.Assert.assertEquals
@@ -23,13 +24,13 @@ import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.Robolectric.buildActivity
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class NestedGeckoViewTest {
+
     private val context: Context
-        get() = Robolectric.buildActivity(Activity::class.java).get()
+        get() = buildActivity(Activity::class.java).get()
 
     @Test
     fun `NestedGeckoView must delegate NestedScrollingChild implementation to childHelper`() {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -4,13 +4,16 @@
 
 package mozilla.components.browser.engine.gecko.fetch
 
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import mozilla.components.tooling.fetch.tests.FetchTestCases
 import okhttp3.Headers
-import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
@@ -21,16 +24,12 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
-import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebRequest
 import org.mozilla.geckoview.WebRequestError
 import org.mozilla.geckoview.WebResponse
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.TimeoutException
@@ -43,10 +42,11 @@ import java.util.concurrent.TimeoutException
  * functionality of [GeckoViewFetchClient]. That's why end-to-end tests are
  * provided in instrumented tests.
  */
-@RunWith(RobolectricTestRunner::class)
-class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
+@RunWith(AndroidJUnit4::class)
+class GeckoViewFetchUnitTestCases : FetchTestCases() {
+
     override fun createNewClient(): Client {
-        val client = GeckoViewFetchClient(ApplicationProvider.getApplicationContext(), mock(GeckoRuntime::class.java))
+        val client = GeckoViewFetchClient(testContext, mock())
         geckoWebExecutor?.let { client.executor = it }
         return client
     }
@@ -70,8 +70,8 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test
     override fun get200WithDefaultHeaders() {
-        val server = mock(MockWebServer::class.java)
-        `when`(server.url(any())).thenReturn(mock(HttpUrl::class.java))
+        val server = mock<MockWebServer>()
+        whenever(server.url(any())).thenReturn(mock())
         val host = server.url("/").host()
         val port = server.url("/").port()
         val headerMap = mapOf(
@@ -149,10 +149,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
         mockRequest()
         mockResponse(200)
 
-        val geckoResult = mock(GeckoResult::class.java)
-        `when`(geckoResult.poll(anyLong())).thenThrow(TimeoutException::class.java)
+        val geckoResult = mock<GeckoResult<*>>()
+        whenever(geckoResult.poll(anyLong())).thenThrow(TimeoutException::class.java)
         @Suppress("UNCHECKED_CAST")
-        `when`(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
+        whenever(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
 
         super.get200WithReadTimeout()
     }
@@ -176,10 +176,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get302FollowRedirects() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.redirect).thenReturn(Request.Redirect.FOLLOW)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.redirect).thenReturn(Request.Redirect.FOLLOW)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_NONE))
@@ -189,10 +189,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get302FollowRedirectsDisabled() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.redirect).thenReturn(Request.Redirect.MANUAL)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.redirect).thenReturn(Request.Redirect.MANUAL)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS))
@@ -223,14 +223,14 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     fun pollReturningNull() {
         mockResponse(200)
 
-        val geckoResult = mock(GeckoResult::class.java)
-        `when`(geckoResult.poll(anyLong())).thenReturn(null)
+        val geckoResult = mock<GeckoResult<*>>()
+        whenever(geckoResult.poll(anyLong())).thenReturn(null)
         @Suppress("UNCHECKED_CAST")
-        `when`(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
+        whenever(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
         createNewClient().fetch(request)
     }
 
@@ -238,10 +238,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get200WithCookiePolicy() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.cookiePolicy).thenReturn(Request.CookiePolicy.OMIT)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.cookiePolicy).thenReturn(Request.CookiePolicy.OMIT)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS))
@@ -249,9 +249,9 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test
     override fun get200WithContentTypeCharset() {
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
 
         mockResponse(200,
                 headerMap = mapOf("Content-Type" to "text/html; charset=ISO-8859-1"),
@@ -266,10 +266,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get200WithCacheControl() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.useCaches).thenReturn(false)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.useCaches).thenReturn(false)
         createNewClient().fetch(request)
 
         val captor = ArgumentCaptor.forClass(WebRequest::class.java)
@@ -280,31 +280,31 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test(expected = IOException::class)
     override fun getThrowsIOExceptionWhenHostNotReachable() {
-        val executor = mock(GeckoWebExecutor::class.java)
-        `when`(executor.fetch(any(), anyInt())).thenAnswer { throw WebRequestError(0, 0) }
+        val executor = mock<GeckoWebExecutor>()
+        whenever(executor.fetch(any(), anyInt())).thenAnswer { throw WebRequestError(0, 0) }
         geckoWebExecutor = executor
 
         createNewClient().fetch(Request(""))
     }
 
     private fun mockRequest(headerMap: Map<String, String>? = null, body: String? = null, method: String = "GET") {
-        val server = mock(MockWebServer::class.java)
-        `when`(server.url(any())).thenReturn(mock(HttpUrl::class.java))
-        val request = mock(RecordedRequest::class.java)
-        `when`(request.method).thenReturn(method)
+        val server = mock<MockWebServer>()
+        whenever(server.url(any())).thenReturn(mock())
+        val request = mock<RecordedRequest>()
+        whenever(request.method).thenReturn(method)
 
         headerMap?.let {
-            `when`(request.headers).thenReturn(Headers.of(headerMap))
-            `when`(request.getHeader(any())).thenAnswer { inv -> it[inv.getArgument(0)] }
+            whenever(request.headers).thenReturn(Headers.of(headerMap))
+            whenever(request.getHeader(any())).thenAnswer { inv -> it[inv.getArgument(0)] }
         }
 
         body?.let {
             val buffer = okio.Buffer()
             buffer.write(body.toByteArray())
-            `when`(request.body).thenReturn(buffer)
+            whenever(request.body).thenReturn(buffer)
         }
 
-        `when`(server.takeRequest()).thenReturn(request)
+        whenever(server.takeRequest()).thenReturn(request)
         mockWebServer = server
     }
 
@@ -314,7 +314,7 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
         body: String? = null,
         charset: Charset = Charsets.UTF_8
     ) {
-        val executor = mock(GeckoWebExecutor::class.java)
+        val executor = mock<GeckoWebExecutor>()
         val builder = WebResponse.Builder("").statusCode(statusCode)
         headerMap?.let {
             headerMap.forEach { (k, v) -> builder.addHeader(k, v) }
@@ -326,7 +326,7 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
         val response = builder.build()
 
-        `when`(executor.fetch(any(), anyInt())).thenReturn(GeckoResult.fromValue(response))
+        whenever(executor.fetch(any(), anyInt())).thenReturn(GeckoResult.fromValue(response))
         geckoWebExecutor = executor
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
@@ -1,13 +1,13 @@
 package mozilla.components.browser.engine.gecko.integration
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.runner.RunWith
 import org.junit.Test
-import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SettingUpdaterTest {
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
@@ -1,5 +1,6 @@
 package mozilla.components.browser.engine.gecko.media
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.media.Media
@@ -11,19 +12,17 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.verify
-import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.MediaElement
 import org.mozilla.geckoview.MockRecordingDevice
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoMediaDelegateTest {
+
     @Test
     fun `Added MediaElement is wrapped in GeckoMedia and forwarded to observer`() {
-        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
 
         var observedMedia: Media? = null
 
@@ -44,7 +43,7 @@ class GeckoMediaDelegateTest {
 
     @Test
     fun `WHEN MediaElement is removed THEN previously added GeckoMedia is used to notify observer`() {
-        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
 
         var addedMedia: Media? = null
         var removedMedia: Media? = null
@@ -70,7 +69,7 @@ class GeckoMediaDelegateTest {
 
     @Test
     fun `WHEN unknown media is removed THEN observer is not notified`() {
-        val engineSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val engineSession = GeckoEngineSession(mock())
 
         var onMediaRemovedExecuted = false
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko.permission
 
 import android.Manifest
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.support.test.mock
 import mozilla.components.test.ReflectionUtils
@@ -14,13 +15,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.RobolectricTestRunner
-
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoPermissionRequestTest {
 
     @Test
@@ -46,7 +45,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
+        val request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.grant()
         verify(callback).grant()
     }
@@ -56,7 +55,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
+        val request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.reject()
         verify(callback).reject()
     }
@@ -79,7 +78,7 @@ class GeckoPermissionRequestTest {
                 Permission.Generic("unknown app permission")
         )
 
-        var request = GeckoPermissionRequest.App(permissions, callback)
+        val request = GeckoPermissionRequest.App(permissions, callback)
         assertEquals(mappedPermissions, request.permissions)
     }
 
@@ -132,7 +131,7 @@ class GeckoPermissionRequestTest {
                 Permission.ContentAudioOther("audioOther", "audioOther")
         )
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         assertEquals(uri, request.uri)
         assertEquals(mappedPermissions.size, request.permissions.size)
         assertTrue(request.permissions.containsAll(mappedPermissions))
@@ -151,7 +150,7 @@ class GeckoPermissionRequestTest {
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         request.grant(request.permissions)
         verify(callback).grant(videoCamera, audioMicrophone)
     }
@@ -169,7 +168,7 @@ class GeckoPermissionRequestTest {
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         request.reject()
         verify(callback).reject()
     }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko.prompt
 import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.prompt.Choice
@@ -15,54 +16,51 @@ import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Lev
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level.PASSWORD_ENCRYPTED
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level.SECURED
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Method.HOST
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_SECURE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_PW_ENCRYPTED
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_ONLY_PASSWORD
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_PREVIOUS_FAILED
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_CROSS_ORIGIN_SUB_RESOURCE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_HOST
 import mozilla.components.concept.engine.prompt.PromptRequest.MultipleChoice
 import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
+import mozilla.components.support.ktx.kotlin.toDate
 import mozilla.components.support.test.mock
+import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
-import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoSession
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULTIPLE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
-import org.robolectric.RobolectricTestRunner
-import mozilla.components.support.ktx.kotlin.toDate
-import org.junit.Assert
-import org.junit.Assert.assertNotNull
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_CROSS_ORIGIN_SUB_RESOURCE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_HOST
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_ONLY_PASSWORD
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_PREVIOUS_FAILED
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_PW_ENCRYPTED
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_LEVEL_SECURE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.BUTTON_TYPE_NEGATIVE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.BUTTON_TYPE_NEUTRAL
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.BUTTON_TYPE_POSITIVE
-import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_MULTIPLE
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.Choice.CHOICE_TYPE_SINGLE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
 import org.robolectric.Shadows.shadowOf
 import java.io.FileInputStream
 import java.security.InvalidParameterException
-import java.util.Date
 import java.util.Calendar
 import java.util.Calendar.YEAR
+import java.util.Date
 
 typealias GeckoChoice = GeckoSession.PromptDelegate.Choice
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_SINGLE must provide a SingleChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = MultipleChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -92,7 +90,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_MULTIPLE must provide a MultipleChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = SingleChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -122,7 +120,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_MENU must provide a MenuChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = PromptRequest.MenuChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -170,7 +168,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onAlert must provide an alert PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var alertRequest: PromptRequest? = null
         var dismissWasCalled = false
         var setCheckboxValueWasCalled = false
@@ -214,7 +212,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `hitting default values`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onDateTimePrompt(mock(), null, DATETIME_TYPE_DATE, null, null, null, mock())
         gecko.onDateTimePrompt(mock(), null, DATETIME_TYPE_WEEK, null, null, null, mock())
@@ -234,7 +232,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_DATE must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         var onClearPicker = false
@@ -270,7 +268,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_DATE with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -312,7 +310,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_MONTH must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         val callback = object : TextCallback {
@@ -340,7 +338,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_MONTH with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -382,7 +380,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_WEEK must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         val callback = object : TextCallback {
@@ -410,7 +408,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_WEEK with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -452,7 +450,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_TIME must provide a TimeSelection PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
 
@@ -481,7 +479,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_TIME with time parameters must format time correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -523,7 +521,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_DATETIME_LOCAL must provide a TimeSelection PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
 
@@ -545,7 +543,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(
             mock(), "title",
-            GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
+            DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
         )
         assertTrue(dateRequest is PromptRequest.TimeSelection)
         (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
@@ -555,7 +553,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_DATETIME_LOCAL with date parameters must format time correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -627,7 +625,7 @@ class GeckoPromptDelegateTest {
     fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onSingleFileSelectedWasCalled = false
         var onMultipleFilesSelectedWasCalled = false
@@ -691,7 +689,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onAuthPrompt must provide an Authentication PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false
         var onConfirmOnlyPasswordWasCalled = false
@@ -776,13 +774,12 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onColorPrompt must provide a Color PromptRequest`() {
-
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false
         var onDismissWasCalled = false
 
-        val geckoCallback = object : GeckoSession.PromptDelegate.TextCallback {
+        val geckoCallback = object : TextCallback {
 
             override fun confirm(text: String?) {
                 onConfirmWasCalled = true
@@ -831,13 +828,13 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onTextPrompt must provide an TextPrompt PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var dismissWasCalled = false
         var confirmWasCalled = false
         var setCheckboxValueWasCalled = false
 
-        val callback = object : GeckoSession.PromptDelegate.TextCallback {
+        val callback = object : TextCallback {
 
             override fun confirm(text: String?) {
                 confirmWasCalled = true
@@ -882,7 +879,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onPopupRequest must provide a Popup PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest.Popup? = null
         var onAllowWasCalled = false
         var onDenyWasCalled = false
@@ -923,7 +920,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onButtonPrompt must provide a Confirm PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest.Confirm? = null
         var onPositiveButtonWasCalled = false
         var onNegativeButtonWasCalled = false

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.engine.gecko.prompt
+package mozilla.components.browser.engine.gecko.webextension
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
-import mozilla.components.browser.engine.gecko.webextension.GeckoPort
-import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import org.json.JSONObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -19,14 +19,12 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.WebExtension
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GeckoWebExtensionTest {
 
     @Test
@@ -45,11 +43,11 @@ class GeckoWebExtensionTest {
         // Verify messages are forwarded to message handler
         val message: Any = mock()
         val sender: WebExtension.MessageSender = mock()
-        `when`(messageHandler.onMessage(eq(message), eq(null))).thenReturn("result")
+        whenever(messageHandler.onMessage(eq(message), eq(null))).thenReturn("result")
         assertNotNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler).onMessage(eq(message), eq(null))
 
-        `when`(messageHandler.onMessage(eq(message), eq(null))).thenReturn(null)
+        whenever(messageHandler.onMessage(eq(message), eq(null))).thenReturn(null)
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(null))
 
@@ -83,7 +81,7 @@ class GeckoWebExtensionTest {
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
-        `when`(session.geckoSession).thenReturn(geckoSession)
+        whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
@@ -93,11 +91,11 @@ class GeckoWebExtensionTest {
         // Verify messages are forwarded to message handler and return value passed on
         val message: Any = mock()
         val sender: WebExtension.MessageSender = mock()
-        `when`(messageHandler.onMessage(eq(message), eq(session))).thenReturn("result")
+        whenever(messageHandler.onMessage(eq(message), eq(session))).thenReturn("result")
         assertNotNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler).onMessage(eq(message), eq(session))
 
-        `when`(messageHandler.onMessage(eq(message), eq(session))).thenReturn(null)
+        whenever(messageHandler.onMessage(eq(message), eq(session))).thenReturn(null)
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(session))
 


### PR DESCRIPTION
### Issue #1481 

  - Enable `includeAndroidResources` and `enableUnitTestBinaryResources` for `browser-engine-gecko-nightly` module.
  - Use `AndroidJUnit4` as a test runner (from AndroidX Test Ext).

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~