### PR TITLE
Closes #3341: Allow restoring Tab/TabCollection without reusing session ids.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/ext/AtomicFile.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/ext/AtomicFile.kt
@@ -47,7 +47,8 @@ fun AtomicFile.writeSnapshot(
  */
 fun AtomicFile.readSnapshotItem(
     engine: Engine,
-    serializer: SnapshotSerializer = SnapshotSerializer()
+    restoreSessionId: Boolean,
+    serializer: SnapshotSerializer = SnapshotSerializer(restoreSessionId)
 ): SessionManager.Snapshot.Item? {
     return readAndDeserialize { json ->
         serializer.itemFromJSON(engine, JSONObject(json))

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/ext/AtomicFileKtTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/ext/AtomicFileKtTest.kt
@@ -153,7 +153,7 @@ class AtomicFileKtTest {
 
         file.writeSnapshotItem(item)
 
-        val restoredItem = file.readSnapshotItem(engine)
+        val restoredItem = file.readSnapshotItem(engine, restoreSessionId = true)
         assertNotNull(restoredItem!!)
         assertNotNull(restoredItem.engineSessionState!!)
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SessionStorageTest.kt
@@ -445,14 +445,14 @@ class SessionStorageTest {
         json.put("url", "testUrl")
         json.put("source", Source.NEW_TAB.name)
         json.put("parentUuid", "")
-        assertEquals(Source.NEW_TAB, deserializeSession(json).source)
+        assertEquals(Source.NEW_TAB, deserializeSession(json, restoreId = true).source)
 
         val jsonInvalid = JSONObject()
         jsonInvalid.put("uuid", "testId")
         jsonInvalid.put("url", "testUrl")
         jsonInvalid.put("source", "invalidSource")
         jsonInvalid.put("parentUuid", "")
-        assertEquals(Source.NONE, deserializeSession(jsonInvalid).source)
+        assertEquals(Source.NONE, deserializeSession(jsonInvalid, restoreId = true).source)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/Tab.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/Tab.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.tab.collections
 
 import android.content.Context
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.Engine
 
 /**
@@ -29,6 +30,15 @@ interface Tab {
 
     /**
      * Restores a single tab from this collection and returns a matching [SessionManager.Snapshot].
+     *
+     * @param restoreSessionId If true the original [Session.id] of [Session]s will be restored. Otherwise a new ID
+     * will be generated. An app may prefer to use a new ID if it expects sessions to get restored multiple times -
+     * otherwise breaking the promise of a unique ID per [Session].
      */
-    fun restore(context: Context, engine: Engine, tab: Tab): SessionManager.Snapshot
+    fun restore(
+        context: Context,
+        engine: Engine,
+        tab: Tab,
+        restoreSessionId: Boolean = false
+    ): SessionManager.Snapshot
 }

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/TabCollection.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/TabCollection.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.tab.collections
 
 import android.content.Context
+import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 
@@ -29,11 +30,28 @@ interface TabCollection {
 
     /**
      * Restores all tabs in this collection and returns a matching [SessionManager.Snapshot].
+     *
+     * @param restoreSessionId If true the original [Session.id] of [Session]s will be restored. Otherwise a new ID
+     * will be generated. An app may prefer to use a new ID if it expects sessions to get restored multiple times -
+     * otherwise breaking the promise of a unique ID per [Session].
      */
-    fun restore(context: Context, engine: Engine): SessionManager.Snapshot
+    fun restore(
+        context: Context,
+        engine: Engine,
+        restoreSessionId: Boolean = false
+    ): SessionManager.Snapshot
 
     /**
      * Restores a subset of the tabs in this collection and returns a matching [SessionManager.Snapshot].
+     *
+     * @param restoreSessionId If true the original [Session.id] of [Session]s will be restored. Otherwise a new ID
+     * will be generated. An app may prefer to use a new ID if it expects sessions to get restored multiple times -
+     * otherwise breaking the promise of a unique ID per [Session].
      */
-    fun restoreSubset(context: Context, engine: Engine, tabs: List<Tab>): SessionManager.Snapshot
+    fun restoreSubset(
+        context: Context,
+        engine: Engine,
+        tabs: List<Tab>,
+        restoreSessionId: Boolean = false
+    ): SessionManager.Snapshot
 }

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/adapter/TabAdapter.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/adapter/TabAdapter.kt
@@ -26,8 +26,13 @@ internal class TabAdapter(
     /**
      * Restores a single tab from this collection and returns a matching [SessionManager.Snapshot].
      */
-    override fun restore(context: Context, engine: Engine, tab: Tab): SessionManager.Snapshot {
-        val item = entity.getStateFile(context.filesDir).readSnapshotItem(engine)
+    override fun restore(
+        context: Context,
+        engine: Engine,
+        tab: Tab,
+        restoreSessionId: Boolean
+    ): SessionManager.Snapshot {
+        val item = entity.getStateFile(context.filesDir).readSnapshotItem(engine, restoreSessionId)
         return SessionManager.Snapshot(if (item == null) emptyList() else listOf(item), SessionManager.NO_SELECTION)
     }
 

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/adapter/TabCollectionAdapter.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/adapter/TabCollectionAdapter.kt
@@ -29,18 +29,28 @@ internal class TabCollectionAdapter(
     override val id: Long
         get() = entity.collection.id!!
 
-    override fun restore(context: Context, engine: Engine): SessionManager.Snapshot {
-        return restore(context, engine, entity.tabs)
+    override fun restore(context: Context, engine: Engine, restoreSessionId: Boolean): SessionManager.Snapshot {
+        return restore(context, engine, entity.tabs, restoreSessionId)
     }
 
-    override fun restoreSubset(context: Context, engine: Engine, tabs: List<Tab>): SessionManager.Snapshot {
+    override fun restoreSubset(
+        context: Context,
+        engine: Engine,
+        tabs: List<Tab>,
+        restoreSessionId: Boolean
+    ): SessionManager.Snapshot {
         val entities = entity.tabs.filter { candidate -> tabs.find { tab -> tab.id == candidate.id } != null }
-        return restore(context, engine, entities)
+        return restore(context, engine, entities, restoreSessionId)
     }
 
-    private fun restore(context: Context, engine: Engine, tabs: List<TabEntity>): SessionManager.Snapshot {
+    private fun restore(
+        context: Context,
+        engine: Engine,
+        tabs: List<TabEntity>,
+        restoreSessionId: Boolean
+    ): SessionManager.Snapshot {
         val items = tabs.mapNotNull { tab ->
-            tab.getStateFile(context.filesDir).readSnapshotItem(engine)
+            tab.getStateFile(context.filesDir).readSnapshotItem(engine, restoreSessionId)
         }
         return SessionManager.Snapshot(items, SessionManager.NO_SELECTION)
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,11 @@ permalink: /changelog/
 * **browser-menu**
   * Added `endOfMenuAlwaysVisible` property/parameter to `BrowserMenuBuilder` constructor and to `BrowserMenu.show` function.
     When is set to true makes sure the bottom of the menu is always visible, this allows use cases like [#3211](https://github.com/mozilla-mobile/android-components/issues/3211).
+    
+* **feature-tab-collections**
+  * Tabs can now be restored without restoring the ID of the `Session` by using the `restoreSessionId` flag. An app may
+    prefer to use new IDs if it expects sessions to get restored multiple times - otherwise breaking the promise of a
+    unique ID.
 
 * **browser-search**
   * Added `getProvidedDefaultSearchEngine` to `SearchEngineManager` to return the provided default search engine or the first


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
