### PR TITLE
Closes #3288: Deprecate shouldClearSuggestions and rename optionallyClearSuggestions to removeAllSuggestions in SuggestionProvider.

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/BrowserAwesomeBar.kt
@@ -137,7 +137,7 @@ class BrowserAwesomeBar @JvmOverloads constructor(
         job?.cancel()
 
         job = scope.launch {
-            suggestionsAdapter.optionallyClearSuggestions()
+            suggestionsAdapter.removeAllSuggestions()
 
             providers.forEach { provider ->
                 launch {

--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/SuggestionsAdapter.kt
@@ -75,15 +75,13 @@ internal class SuggestionsAdapter(
     }
 
     /**
-     * Removes all suggestions except the ones from providers that have set shouldClearSuggestions to false.
+     * Removes all suggestions.
      */
-    fun optionallyClearSuggestions() = synchronized(suggestions) {
+    fun removeAllSuggestions() = synchronized(suggestions) {
         val updatedSuggestions = suggestions.toMutableList()
 
         suggestionMap.keys.forEach { provider ->
-            if (provider.shouldClearSuggestions) {
-                suggestionMap[provider]?.let { updatedSuggestions.removeAll(it) }
-            }
+            suggestionMap[provider]?.let { updatedSuggestions.removeAll(it) }
         }
 
         updateTo(updatedSuggestions)

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/BrowserAwesomeBarTest.kt
@@ -452,10 +452,10 @@ class BrowserAwesomeBarTest {
         runBlocking {
             val inOrder = inOrder(adapter, provider)
             awesomeBar.onInputChanged("Hello!")
-            verify(adapter, never()).optionallyClearSuggestions()
+            verify(adapter, never()).removeAllSuggestions()
             mainRunnable?.run()
 
-            inOrder.verify(adapter).optionallyClearSuggestions()
+            inOrder.verify(adapter).removeAllSuggestions()
             inOrder.verify(provider).onInputChanged("Hello!")
         }
     }

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/SuggestionsAdapterTest.kt
@@ -33,12 +33,14 @@ class SuggestionsAdapterTest {
     fun `addSuggestions() should add suggestions of provider`() {
         val adapter = SuggestionsAdapter(mock())
 
+        val provider: AwesomeBar.SuggestionProvider = mock()
+
         val suggestions = listOf<AwesomeBar.Suggestion>(
             mock(), mock(), mock())
 
         assertEquals(0, adapter.itemCount)
 
-        adapter.addSuggestions(mockProvider(), suggestions)
+        adapter.addSuggestions(provider, suggestions)
 
         assertEquals(3, adapter.itemCount)
         assertEquals(suggestions, adapter.suggestions)
@@ -48,8 +50,7 @@ class SuggestionsAdapterTest {
     fun `addSuggestions() always clears previous suggestions of provider`() {
         val adapter = SuggestionsAdapter(mock())
 
-        val provider = mockProvider()
-        `when`(provider.shouldClearSuggestions).thenReturn(true)
+        val provider: AwesomeBar.SuggestionProvider = mock()
 
         assertEquals(0, adapter.itemCount)
 
@@ -61,21 +62,12 @@ class SuggestionsAdapterTest {
         adapter.addSuggestions(provider, suggestions)
         assertEquals(3, adapter.itemCount)
         assertEquals(suggestions, adapter.suggestions)
-
-        // shouldClearSuggestions is used to indicate whether or not
-        // suggestions should be cleared right away on input changes.
-        // When we're adding newly computed suggestions, we should
-        // always clear old ones to prevent duplicates.
-        `when`(provider.shouldClearSuggestions).thenReturn(false)
-        adapter.addSuggestions(provider, suggestions)
-        assertEquals(3, adapter.itemCount)
-        assertEquals(suggestions, adapter.suggestions)
     }
 
     @Test
     fun `removeSuggestions() should remove suggestions of provider`() {
         val adapter = SuggestionsAdapter(mock())
-        val provider = mockProvider()
+        val provider: AwesomeBar.SuggestionProvider = mock()
         val suggestions = listOf<AwesomeBar.Suggestion>(
                 mock(), mock(), mock())
 
@@ -91,45 +83,25 @@ class SuggestionsAdapterTest {
     fun `clearSuggestions removes suggestions from adapter`() {
         val adapter = SuggestionsAdapter(mock())
 
-        adapter.addSuggestions(mockProvider(), listOf(
+        val provider: AwesomeBar.SuggestionProvider = mock()
+
+        adapter.addSuggestions(provider, listOf(
             mock(), mock(), mock()))
 
         assertEquals(3, adapter.itemCount)
 
-        adapter.optionallyClearSuggestions()
+        adapter.removeAllSuggestions()
 
         assertEquals(0, adapter.itemCount)
-    }
-
-    @Test
-    fun `clearSuggestions does not remove suggestions if provider has set shouldClearSuggestions to false`() {
-        val adapter = SuggestionsAdapter(mock())
-
-        adapter.addSuggestions(mockProvider(shouldClearSuggestions = false), listOf(
-            mock(), mock(), mock()))
-
-        assertEquals(3, adapter.itemCount)
-
-        adapter.optionallyClearSuggestions()
-
-        assertEquals(3, adapter.itemCount)
-
-        adapter.addSuggestions(mockProvider(shouldClearSuggestions = true), listOf(
-            mock(), mock(), mock(), mock()
-        ))
-
-        assertEquals(7, adapter.itemCount)
-
-        adapter.optionallyClearSuggestions()
-
-        assertEquals(3, adapter.itemCount)
     }
 
     @Test
     fun `Suggestions are getting ordered by weight descending`() {
         val adapter = SuggestionsAdapter(mock())
 
-        adapter.addSuggestions(mockProvider(), listOf(
+        val provider: AwesomeBar.SuggestionProvider = mock()
+
+        adapter.addSuggestions(provider, listOf(
             AwesomeBar.Suggestion(mock(), title = "Hello", score = 10),
             AwesomeBar.Suggestion(mock(), title = "World", score = 2),
             AwesomeBar.Suggestion(mock(), title = "How", score = 7),
@@ -156,7 +128,9 @@ class SuggestionsAdapterTest {
     fun `Adapter uses different view holder for suggestions with chips`() {
         val adapter = SuggestionsAdapter(mock())
 
-        adapter.addSuggestions(mockProvider(), listOf(
+        val provider: AwesomeBar.SuggestionProvider = mock()
+
+        adapter.addSuggestions(provider, listOf(
             AwesomeBar.Suggestion(mock(), title = "Test"),
             AwesomeBar.Suggestion(mock(), title = "World", chips = listOf(
                 AwesomeBar.Suggestion.Chip("Chip1"),
@@ -199,11 +173,13 @@ class SuggestionsAdapterTest {
 
         val suggestion: AwesomeBar.Suggestion = mock()
 
+        val provider: AwesomeBar.SuggestionProvider = mock()
+
         val viewHolder: SuggestionViewHolder = mock()
         val wrapper = ViewHolderWrapper(viewHolder, mock())
         doReturn(wrapper).`when`(adapter).onCreateViewHolder(any(), anyInt())
 
-        adapter.addSuggestions(mockProvider(), listOf(suggestion))
+        adapter.addSuggestions(provider, listOf(suggestion))
 
         adapter.onBindViewHolder(wrapper, 0)
 
@@ -259,13 +235,5 @@ class SuggestionsAdapterTest {
         adapter.onViewRecycled(wrapper)
 
         verify(viewHolder).recycle()
-    }
-
-    private fun mockProvider(
-        shouldClearSuggestions: Boolean = true
-    ): AwesomeBar.SuggestionProvider {
-        val provider: AwesomeBar.SuggestionProvider = mock()
-        doReturn(shouldClearSuggestions).`when`(provider).shouldClearSuggestions
-        return provider
     }
 }

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -163,13 +163,5 @@ interface AwesomeBar {
          * Fired when the user has cancelled their interaction with the awesome bar.
          */
         fun onInputCancelled() = Unit
-
-        /**
-         * If true an [AwesomeBar] implementation can clear the previous suggestions of this provider as soon as the
-         * user continues to type. If this is false an [AwesomeBar] implementation is allowed to keep the previous
-         * suggestions around until the provider returns a new list of suggestions for the updated text.
-         */
-        val shouldClearSuggestions
-            get() = true
     }
 }

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -55,10 +55,6 @@ class ClipboardSuggestionProvider(
             }
         ))
     }
-
-    override val shouldClearSuggestions: Boolean
-        // We do not want the suggestion of this provider to disappear and re-appear when text changes.
-        get() = false
 }
 
 private fun findUrl(text: String): String? {

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProvider.kt
@@ -37,10 +37,6 @@ class HistoryStorageSuggestionProvider(
         return suggestions.sortedByDescending { it.score }.distinctBy { it.id }.into()
     }
 
-    override val shouldClearSuggestions: Boolean
-        // We do not want the suggestion of this provider to disappear and re-appear when text changes.
-        get() = false
-
     private fun Iterable<SearchResult>.into(): List<AwesomeBar.Suggestion> {
         return this.map {
             AwesomeBar.Suggestion(

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProvider.kt
@@ -139,10 +139,6 @@ class SearchSuggestionProvider(
         ))
     }
 
-    override val shouldClearSuggestions: Boolean
-        // We do not want the suggestion of this provider to disappear and re-appear when text changes.
-        get() = false
-
     enum class Mode {
         SINGLE_SUGGESTION,
         MULTIPLE_SUGGESTIONS

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -76,12 +76,6 @@ class BookmarksStorageSuggestionProviderTest {
         assertEquals(20, suggestions.size)
     }
 
-    @Test
-    fun `Provider suggestion should get cleared when text changes`() {
-        val provider = BookmarksStorageSuggestionProvider(mock(), mock())
-        assertTrue(provider.shouldClearSuggestions)
-    }
-
     @SuppressWarnings
     class testableBookmarksStorage : BookmarksStorage {
         val bookmarkMap: HashMap<String, BookmarkNode> = hashMapOf()

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
@@ -20,7 +20,6 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -166,12 +165,6 @@ class ClipboardSuggestionProviderTest {
         suggestion.onSuggestionClicked!!.invoke()
 
         verify(useCase).invoke(eq("https://www.mozilla.org"), any())
-    }
-
-    @Test
-    fun `Provider suggestion should not get cleared when text changes`() {
-        val provider = ClipboardSuggestionProvider(testContext, mock())
-        assertFalse(provider.shouldClearSuggestions)
     }
 
     @Test

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
@@ -12,7 +12,6 @@ import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
@@ -50,12 +49,6 @@ class HistoryStorageSuggestionProviderTest {
 
         val suggestions = provider.onInputChanged("moz")
         assertEquals(20, suggestions.size)
-    }
-
-    @Test
-    fun `Provider suggestion should not get cleared when text changes`() {
-        val provider = HistoryStorageSuggestionProvider(mock(), mock())
-        assertFalse(provider.shouldClearSuggestions)
     }
 
     @Test

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -21,7 +21,6 @@ import mozilla.components.support.test.robolectric.testContext
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -300,12 +299,6 @@ class SearchSuggestionProviderTest {
                 server.shutdown()
             }
         }
-    }
-
-    @Test
-    fun `Provider should not clear suggestions`() {
-        val provider = SearchSuggestionProvider(mock(), mock(), mock())
-        assertFalse(provider.shouldClearSuggestions)
     }
 
     @Test

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -124,10 +124,4 @@ class SessionSuggestionProviderTest {
 
         verify(useCase).invoke(session)
     }
-
-    @Test
-    fun `Provider suggestion should get cleared when text changes`() {
-        val provider = SessionSuggestionProvider(mock(), mock())
-        assertTrue(provider.shouldClearSuggestions)
-    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-awesomebar**, **feature-awesomebar**
+  * Deprecated `shouldClearSuggestions` in `SuggestionProvider`. The AwesomeBar now always clear the previous provider suggestions.
+  * Renamed `optionallyClearSuggestions` to `removeAllSuggestions` in `SuggestionProvider`.
+
 * **browser-menu**
   * Added `endOfMenuAlwaysVisible` property/parameter to `BrowserMenuBuilder` constructor and to `BrowserMenu.show` function.
     When is set to true makes sure the bottom of the menu is always visible, this allows use cases like [#3211](https://github.com/mozilla-mobile/android-components/issues/3211).
@@ -99,7 +103,7 @@ permalink: /changelog/
 
 * **feature-app-links**
   * Add a flag to allow the app to not detect an external app if the user has told android to use the browser as default.
-  * Turn off interception of web links. 
+  * Turn off interception of web links.
 
 # 0.55.0
 


### PR DESCRIPTION
Fixes #3288.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
