### PR TITLE
 For #1481. Use androidx runner in `service-glean`. 

### DIFF
--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -48,8 +48,7 @@ dependencies {
     implementation project(':lib-fetch-httpurlconnection')
 
     testImplementation Dependencies.androidx_test_core
-
-    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver

--- a/components/service/glean/gradle.properties
+++ b/components/service/glean/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
@@ -5,33 +5,29 @@
 package mozilla.components.service.glean
 
 import kotlinx.coroutines.runBlocking
-import org.junit.Test
-
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
+import org.junit.Test
 
 class DispatchersTest {
 
     @Test
-    fun `API scope runs off the main thread`() {
+    @Suppress("EXPERIMENTAL_API_USAGE")
+    fun `API scope runs off the main thread`() = runBlocking {
         val mainThread = Thread.currentThread()
         var threadCanary = false
-        @Suppress("EXPERIMENTAL_API_USAGE")
+
         Dispatchers.API.setTestingMode(false)
 
-        runBlocking {
-            @Suppress("EXPERIMENTAL_API_USAGE")
-            Dispatchers.API.launch {
-                assertNotSame(mainThread, Thread.currentThread())
-                // Use the canary bool to make sure this is getting called before
-                // the test completes.
-                assertEquals(false, threadCanary)
-                threadCanary = true
-            }!!.join()
-        }
+        Dispatchers.API.launch {
+            assertNotSame(mainThread, Thread.currentThread())
+            // Use the canary bool to make sure this is getting called before
+            // the test completes.
+            assertEquals(false, threadCanary)
+            threadCanary = true
+        }!!.join()
 
-        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.setTestingMode(true)
         assertEquals(true, threadCanary)
         assertSame(mainThread, Thread.currentThread())

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -29,6 +30,7 @@ import mozilla.components.service.glean.storages.StorageEngineManager
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.utils.getLanguageFromLocale
 import mozilla.components.service.glean.utils.getLocaleTag
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -44,7 +46,6 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -57,13 +58,12 @@ import mozilla.components.service.glean.private.TimeUnit as GleanTimeUnit
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GleanTest {
 
     @Before
     fun setup() {
-        WorkManagerTestInitHelper.initializeTestWorkManager(
-            ApplicationProvider.getApplicationContext())
+        WorkManagerTestInitHelper.initializeTestWorkManager(testContext)
 
         resetGlean()
     }
@@ -90,7 +90,7 @@ class GleanTest {
     fun `test path generation`() {
         val uuid = UUID.randomUUID()
         val path = Glean.makePath("test", uuid)
-        val applicationId = "mozilla-components-service-glean"
+        val applicationId = "mozilla-components-service-glean-test"
         // Make sure that the default applicationId matches the package name.
         assertEquals(applicationId, Glean.applicationId)
         assertEquals(path, "/submit/$applicationId/test/${Glean.SCHEMA_VERSION}/$uuid")

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -24,6 +24,7 @@ import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
+import mozilla.components.support.test.robolectric.testContext
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -119,7 +120,7 @@ internal fun collectAndCheckPingSchema(ping: PingType): JSONObject {
  * @param clearStores if true, clear the contents of all stores
  */
 internal fun resetGlean(
-    context: Context = ApplicationProvider.getApplicationContext(),
+    context: Context = testContext,
     config: Configuration = Configuration(),
     clearStores: Boolean = true
 ) {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -3,6 +3,7 @@ package mozilla.components.service.glean.debug
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.ResolveInfo
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.components.service.glean.Glean
@@ -21,7 +22,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import java.util.concurrent.TimeUnit
 
@@ -59,8 +59,7 @@ class GleanDebugActivityTest {
         assertNull(intent.extras)
 
         // Start the activity through our intent.
-        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
-        activity.create().start().resume()
+        launch<GleanDebugActivity>(intent)
 
         // Verify that the original configuration and the one after init took place
         // are the same.
@@ -78,8 +77,7 @@ class GleanDebugActivityTest {
         val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
             putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
         }
-        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
-        activity.create().start().resume()
+        launch<GleanDebugActivity>(intent)
 
         // Check that the configuration option was correctly flipped.
         assertTrue(Glean.configuration.logPings)
@@ -93,12 +91,13 @@ class GleanDebugActivityTest {
             putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
         }
         // Start the activity through our intent.
-        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
-        activity.create().start().resume()
+        val scenario = launch<GleanDebugActivity>(intent)
 
-        // Check that our main activity was launched.
-        assertEquals(testPackageName,
-            shadowOf(activity.get()).peekNextStartedActivityForResult().intent.`package`!!)
+        scenario.onActivity { activity ->
+            // Check that our main activity was launched.
+            assertEquals(testPackageName,
+                shadowOf(activity).peekNextStartedActivityForResult().intent.`package`!!)
+        }
     }
 
     @Test
@@ -126,8 +125,7 @@ class GleanDebugActivityTest {
         val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
             putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
         }
-        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
-        activity.create().start().resume()
+        launch<GleanDebugActivity>(intent)
 
         // Since we reset the serverEndpoint back to the default for untagged pings, we need to
         // override it here so that the local server we created to intercept the pings will
@@ -172,8 +170,7 @@ class GleanDebugActivityTest {
             putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
             putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, "inv@lid_id")
         }
-        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
-        activity.create().start().resume()
+        launch<GleanDebugActivity>(intent)
 
         // Since a bad tag ID results in resetting the endpoint to the default, verify that
         // has happened.
@@ -229,8 +226,7 @@ class GleanDebugActivityTest {
             putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
             putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, pingTag)
         }
-        val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
-        activity.create().start().resume()
+        launch<GleanDebugActivity>(intent)
 
         // This will trigger the call to `fetch()` in the TestPingTagClient which is where the
         // test assertions will occur

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -1,10 +1,8 @@
 package mozilla.components.service.glean.debug
 
-import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.ResolveInfo
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.components.service.glean.Glean
@@ -15,6 +13,7 @@ import mozilla.components.service.glean.private.BooleanMetricType
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -29,26 +28,24 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class GleanDebugActivityTest {
 
-    private val testPackageName = "mozilla.components.service.glean.test"
-
     @Before
     fun setup() {
         resetGlean()
 
-        WorkManagerTestInitHelper.initializeTestWorkManager(
-            ApplicationProvider.getApplicationContext())
+        WorkManagerTestInitHelper.initializeTestWorkManager(testContext)
 
         // This makes sure we have a "launch" intent in our package, otherwise
         // it will fail looking for it in `GleanDebugActivityTest`.
-        val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
-        val launchIntent = Intent(Intent.ACTION_MAIN)
-        launchIntent.setPackage(testPackageName)
-        launchIntent.addCategory(Intent.CATEGORY_LAUNCHER)
-        val resolveInfo = ResolveInfo()
-        resolveInfo.activityInfo = ActivityInfo()
-        resolveInfo.activityInfo.packageName = testPackageName
-        resolveInfo.activityInfo.name = "LauncherActivity"
-        @Suppress("DEPRECATION")
+        val pm = testContext.packageManager
+        val launchIntent = Intent(Intent.ACTION_MAIN).apply {
+            setPackage(testPackageName)
+            addCategory(Intent.CATEGORY_LAUNCHER)
+        }
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = ActivityInfo()
+            activityInfo.packageName = testPackageName
+            activityInfo.name = "LauncherActivity"
+        }
         shadowOf(pm).addResolveInfoForIntent(launchIntent, resolveInfo)
     }
 
@@ -58,8 +55,7 @@ class GleanDebugActivityTest {
         Glean.configuration = originalConfig
 
         // Build the intent that will call our debug activity, with no extra.
-        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
-            GleanDebugActivity::class.java)
+        val intent = Intent(testContext, GleanDebugActivity::class.java)
         assertNull(intent.extras)
 
         // Start the activity through our intent.
@@ -79,9 +75,9 @@ class GleanDebugActivityTest {
         assertFalse(originalConfig.logPings)
 
         // Set the extra values and start the intent.
-        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
-            GleanDebugActivity::class.java)
-        intent.putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
+        val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
+            putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
+        }
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
 
@@ -92,10 +88,10 @@ class GleanDebugActivityTest {
     @Test
     fun `the main activity is correctly started`() {
         // Build the intent that will call our debug activity, with no extra.
-        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
-            GleanDebugActivity::class.java)
-        // Add at least an option, otherwise the activity will be removed.
-        intent.putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
+        val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
+            // Add at least an option, otherwise the activity will be removed.
+            putExtra(GleanDebugActivity.LOG_PINGS_EXTRA_KEY, true)
+        }
         // Start the activity through our intent.
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
@@ -127,9 +123,9 @@ class GleanDebugActivityTest {
         assertTrue(booleanMetric.testHasValue())
 
         // Set the extra values and start the intent.
-        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
-        GleanDebugActivity::class.java)
-        intent.putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
+        val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
+            putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
+        }
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
 
@@ -172,10 +168,10 @@ class GleanDebugActivityTest {
         assertTrue(booleanMetric.testHasValue())
 
         // Set the extra values and start the intent.
-        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
-            GleanDebugActivity::class.java)
-        intent.putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
-        intent.putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, "inv@lid_id")
+        val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
+            putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
+            putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, "inv@lid_id")
+        }
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
 
@@ -229,10 +225,10 @@ class GleanDebugActivityTest {
         assertTrue(booleanMetric.testHasValue())
 
         // Set the extra values and start the intent.
-        val intent = Intent(ApplicationProvider.getApplicationContext<Context>(),
-            GleanDebugActivity::class.java)
-        intent.putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
-        intent.putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, pingTag)
+        val intent = Intent(testContext, GleanDebugActivity::class.java).apply {
+            putExtra(GleanDebugActivity.SEND_PING_EXTRA_KEY, "metrics")
+            putExtra(GleanDebugActivity.TAG_DEBUG_VIEW_EXTRA_KEY, pingTag)
+        }
         val activity = Robolectric.buildActivity(GleanDebugActivity::class.java, intent)
         activity.create().start().resume()
 
@@ -241,3 +237,5 @@ class GleanDebugActivityTest {
         triggerWorkManager()
     }
 }
+
+private const val testPackageName = "mozilla.components.service.glean.test"

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -1,35 +1,35 @@
 package mozilla.components.service.glean.debug
 
 import android.content.Context
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.TestPingTagClient
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.getMockWebServer
+import mozilla.components.service.glean.private.BooleanMetricType
+import mozilla.components.service.glean.private.Lifetime
+import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.triggerWorkManager
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import android.content.pm.ActivityInfo
-import android.content.pm.ResolveInfo
-import androidx.work.testing.WorkManagerTestInitHelper
-import mozilla.components.service.glean.private.BooleanMetricType
-import mozilla.components.service.glean.private.Lifetime
-import mozilla.components.service.glean.resetGlean
-import mozilla.components.service.glean.triggerWorkManager
-import mozilla.components.service.glean.TestPingTagClient
-import mozilla.components.service.glean.getMockWebServer
 import org.robolectric.Shadows.shadowOf
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GleanDebugActivityTest {
 
-    private val testPackageName = "mozilla.components.service.glean"
+    private val testPackageName = "mozilla.components.service.glean.test"
 
     @Before
     fun setup() {
@@ -144,7 +144,7 @@ class GleanDebugActivityTest {
         val request = server.takeRequest(10L, TimeUnit.SECONDS)
 
         assertTrue(
-            request.requestUrl.encodedPath().startsWith("/submit/mozilla-components-service-glean/metrics")
+            request.requestUrl.encodedPath().startsWith("/submit/mozilla-components-service-glean-test/metrics")
         )
 
         server.shutdown()
@@ -189,7 +189,7 @@ class GleanDebugActivityTest {
 
         assertTrue(
             "Request path must be correct",
-            request.requestUrl.encodedPath().startsWith("/submit/mozilla-components-service-glean/metrics")
+            request.requestUrl.encodedPath().startsWith("/submit/mozilla-components-service-glean-test/metrics")
         )
 
         assertNull(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
@@ -5,11 +5,14 @@
 package mozilla.components.service.glean.error
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.service.glean.error.ErrorRecording.ErrorType.InvalidLabel
+import mozilla.components.service.glean.error.ErrorRecording.ErrorType.InvalidValue
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringMetricType
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.storages.CountersStorageEngine
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.ext.combineWith
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -17,6 +20,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ErrorRecordingTest {
+
     @Before
     fun setup() {
         resetGlean()
@@ -37,28 +41,25 @@ class ErrorRecordingTest {
 
         ErrorRecording.recordError(
             stringMetric,
-            ErrorRecording.ErrorType.InvalidValue,
+            InvalidValue,
             "Invalid value",
             logger
         )
 
         ErrorRecording.recordError(
             stringMetric,
-            ErrorRecording.ErrorType.InvalidLabel,
+            InvalidLabel,
             "Invalid label",
             logger
         )
 
-        for (storeName in listOf("store1", "store2", "metrics")) {
-            for (errorType in listOf(
-                ErrorRecording.ErrorType.InvalidValue,
-                ErrorRecording.ErrorType.InvalidLabel
-            )) {
+        listOf("store1", "store2", "metrics")
+            .combineWith(listOf(InvalidValue, InvalidLabel))
+            .forEach { (storeName, errorType) ->
                 assertEquals(
                     1,
                     ErrorRecording.testGetNumRecordedErrors(stringMetric, errorType, storeName)
                 )
             }
-        }
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.error
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringMetricType
 import mozilla.components.service.glean.resetGlean
@@ -13,9 +14,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ErrorRecordingTest {
     @Before
     fun setup() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/HttpPingUploaderTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.net
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
@@ -22,7 +23,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
 import java.io.IOException
 import java.net.CookieHandler
 import java.net.CookieManager
@@ -30,7 +30,7 @@ import java.net.HttpCookie
 import java.net.URI
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class HttpPingUploaderTest {
     private val testPath: String = "/some/random/path/not/important"
     private val testPing: String = "{ 'ping': 'test' }"

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -6,27 +6,26 @@ package mozilla.components.service.glean.ping
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.storages.MockStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
 import org.json.JSONArray
 import org.json.JSONObject
-import org.junit.Test
-
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PingMakerTest {
     private val mockApplicationContext = mock(Context::class.java)
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/ping/PingMakerTest.kt
@@ -4,13 +4,12 @@
 
 package mozilla.components.service.glean.ping
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.storages.MockStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -20,14 +19,12 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
 import org.robolectric.annotation.Config
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
 @RunWith(AndroidJUnit4::class)
 class PingMakerTest {
-    private val mockApplicationContext = mock(Context::class.java)
 
     private val customPing = PingType(
         name = "test",
@@ -49,9 +46,9 @@ class PingMakerTest {
                 storageEngines = mapOf(
                     "engine2" to MockStorageEngine(JSONObject(mapOf("a.b" to "foo")))
                 ),
-                applicationContext = mockApplicationContext
+                applicationContext = testContext
             ),
-            mockApplicationContext
+            testContext
         )
 
         // Gather the data. We expect an empty ping with the "ping_info" information
@@ -79,9 +76,9 @@ class PingMakerTest {
                 storageEngines = mapOf(
                     "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
                 ),
-                applicationContext = mockApplicationContext
+                applicationContext = testContext
             ),
-            mockApplicationContext
+            testContext
         )
 
         // Gather the data. We expect an empty ping with the "ping_info" information
@@ -105,9 +102,9 @@ class PingMakerTest {
                 storageEngines = mapOf(
                     "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
                 ),
-                applicationContext = ApplicationProvider.getApplicationContext()
+                applicationContext = testContext
             ),
-            ApplicationProvider.getApplicationContext()
+            testContext
         )
 
         // Gather the data. We expect an empty ping with the "ping_info" information
@@ -132,9 +129,9 @@ class PingMakerTest {
                     "engine2" to MockStorageEngine(engine2Data),
                     "wontCollect" to MockStorageEngine(JSONObject(), "notThisPing")
                 ),
-                applicationContext = mockApplicationContext
+                applicationContext = testContext
             ),
-            mockApplicationContext
+            testContext
         )
 
         // Gather the data, this should have everything in the 'test' ping which is the default
@@ -160,9 +157,9 @@ class PingMakerTest {
                     "engine1" to MockStorageEngine(engine1Data),
                     "engine2" to MockStorageEngine(engine2Data)
                 ),
-                applicationContext = mockApplicationContext
+                applicationContext = testContext
             ),
-            mockApplicationContext
+            testContext
         )
 
         val noSuchPing = PingType(
@@ -179,7 +176,7 @@ class PingMakerTest {
     fun `seq number must be sequential`() {
         // NOTE: Using a "real" ApplicationContext here so that it will have
         // a working SharedPreferences implementation
-        val applicationContext = ApplicationProvider.getApplicationContext<Context>()
+        val applicationContext = testContext
         val maker = PingMaker(
             StorageEngineManager(
                 storageEngines = mapOf(

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/BooleanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/BooleanMetricTypeTest.kt
@@ -4,20 +4,19 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BooleanMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/CounterMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/CounterMetricTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
@@ -13,12 +14,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CounterMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/DatetimeMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/DatetimeMetricTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
@@ -13,13 +14,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
 import java.util.TimeZone
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DatetimeMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.glean.private
 
 import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.Glean
@@ -16,7 +17,6 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 // Declared here, since Kotlin can not declare nested enum classes.
 enum class clickKeys {
@@ -29,7 +29,7 @@ enum class testNameKeys {
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class EventMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.service.glean.private
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.GleanMetrics.Pings
 import mozilla.components.service.glean.collectAndCheckPingSchema
@@ -19,6 +18,9 @@ import mozilla.components.service.glean.storages.StringListsStorageEngine
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.storages.TimespansStorageEngine
 import mozilla.components.service.glean.storages.UuidsStorageEngine
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -27,15 +29,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class LabeledMetricTypeTest {
+
     private data class GenericMetricType(
         override val disabled: Boolean,
         override val category: String,
@@ -61,7 +62,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
+        val labeledCounterMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -81,9 +82,9 @@ class LabeledMetricTypeTest {
         val snapshot = CountersStorageEngine.getSnapshot(storeName = "metrics", clearStore = false)
 
         assertEquals(3, snapshot!!.size)
-        assertEquals(1, snapshot.get("telemetry.labeled_counter_metric/label1"))
-        assertEquals(2, snapshot.get("telemetry.labeled_counter_metric/label2"))
-        assertEquals(3, snapshot.get("telemetry.labeled_counter_metric"))
+        assertEquals(1, snapshot["telemetry.labeled_counter_metric/label1"])
+        assertEquals(2, snapshot["telemetry.labeled_counter_metric/label2"])
+        assertEquals(3, snapshot["telemetry.labeled_counter_metric"])
 
         val json = collectAndCheckPingSchema(Pings.metrics).getJSONObject("metrics")!!
         // Do the same checks again on the JSON structure
@@ -118,7 +119,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
+        val labeledCounterMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -138,10 +139,10 @@ class LabeledMetricTypeTest {
         val snapshot = CountersStorageEngine.getSnapshot(storeName = "metrics", clearStore = false)
 
         assertEquals(3, snapshot!!.size)
-        assertEquals(2, snapshot.get("telemetry.labeled_counter_metric/foo"))
-        assertEquals(1, snapshot.get("telemetry.labeled_counter_metric/bar"))
-        assertNull(snapshot.get("telemetry.labeled_counter_metric/baz"))
-        assertEquals(3, snapshot.get("telemetry.labeled_counter_metric/__other__"))
+        assertEquals(2, snapshot["telemetry.labeled_counter_metric/foo"])
+        assertEquals(1, snapshot["telemetry.labeled_counter_metric/bar"])
+        assertNull(snapshot["telemetry.labeled_counter_metric/baz"])
+        assertEquals(3, snapshot["telemetry.labeled_counter_metric/__other__"])
 
         val json = collectAndCheckPingSchema(Pings.metrics).getJSONObject("metrics")!!
         // Do the same checks again on the JSON structure
@@ -177,7 +178,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
+        val labeledCounterMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -195,11 +196,11 @@ class LabeledMetricTypeTest {
         val snapshot = CountersStorageEngine.getSnapshot(storeName = "metrics", clearStore = false)
 
         assertEquals(17, snapshot!!.size)
-        assertEquals(2, snapshot.get("telemetry.labeled_counter_metric/label_0"))
+        assertEquals(2, snapshot["telemetry.labeled_counter_metric/label_0"])
         for (i in 1..15) {
-            assertEquals(1, snapshot.get("telemetry.labeled_counter_metric/label_$i"))
+            assertEquals(1, snapshot["telemetry.labeled_counter_metric/label_$i"])
         }
-        assertEquals(5, snapshot.get("telemetry.labeled_counter_metric/__other__"))
+        assertEquals(5, snapshot["telemetry.labeled_counter_metric/__other__"])
 
         val json = collectAndCheckPingSchema(Pings.metrics).getJSONObject("metrics")!!
         // Do the same checks again on the JSON structure
@@ -237,7 +238,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
+        val labeledCounterMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -279,7 +280,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledCounterMetric = LabeledMetricType<CounterMetricType>(
+        val labeledCounterMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -333,7 +334,7 @@ class LabeledMetricTypeTest {
             timeUnit = TimeUnit.Nanosecond
         )
 
-        val labeledTimespanMetric = LabeledMetricType<TimespanMetricType>(
+        val labeledTimespanMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -362,7 +363,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledUuidMetric = LabeledMetricType<UuidMetricType>(
+        val labeledUuidMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -389,7 +390,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledStringListMetric = LabeledMetricType<StringListMetricType>(
+        val labeledStringListMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -414,7 +415,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledStringMetric = LabeledMetricType<StringMetricType>(
+        val labeledStringMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -441,7 +442,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledBooleanMetric = LabeledMetricType<BooleanMetricType>(
+        val labeledBooleanMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -466,7 +467,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("metrics")
         )
 
-        val labeledEventMetric = LabeledMetricType<EventMetricType<NoExtraKeys>>(
+        val labeledEventMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.Application,
@@ -487,17 +488,17 @@ class LabeledMetricTypeTest {
         )
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -512,7 +513,7 @@ class LabeledMetricTypeTest {
             sendInPings = listOf("store1")
         )
 
-        val labeledMetric = LabeledMetricType<GenericMetricType>(
+        val labeledMetric = LabeledMetricType(
             disabled = false,
             category = "telemetry",
             lifetime = Lifetime.User,
@@ -537,10 +538,10 @@ class LabeledMetricTypeTest {
         val snapshot = storageEngine.getSnapshot(storeName = "store1", clearStore = false)
 
         assertEquals(17, snapshot!!.size)
-        assertEquals(2, snapshot.get("telemetry.labeled_metric/label1"))
+        assertEquals(2, snapshot["telemetry.labeled_metric/label1"])
         for (i in 2..15) {
-            assertEquals(1, snapshot.get("telemetry.labeled_metric/label$i"))
+            assertEquals(1, snapshot["telemetry.labeled_metric/label$i"])
         }
-        assertEquals(1, snapshot.get("telemetry.labeled_metric/__other__"))
+        assertEquals(1, snapshot["telemetry.labeled_metric/__other__"])
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -7,8 +7,11 @@ package mozilla.components.service.glean.private
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.GleanMetrics.Pings
 import mozilla.components.service.glean.collectAndCheckPingSchema
+import mozilla.components.service.glean.error.ErrorRecording
+import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.storages.BooleansStorageEngine
 import mozilla.components.service.glean.storages.CountersStorageEngine
 import mozilla.components.service.glean.storages.MockGenericStorageEngine
@@ -16,15 +19,12 @@ import mozilla.components.service.glean.storages.StringListsStorageEngine
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.storages.TimespansStorageEngine
 import mozilla.components.service.glean.storages.UuidsStorageEngine
-import mozilla.components.service.glean.error.ErrorRecording
-import mozilla.components.service.glean.resetGlean
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import java.util.UUID
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
@@ -32,9 +32,9 @@ import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
-import org.robolectric.RobolectricTestRunner
+import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class LabeledMetricTypeTest {
     private data class GenericMetricType(
         override val disabled: Boolean,

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.checkPingSchema
 import mozilla.components.service.glean.getContextWithMockedInfo
@@ -21,10 +22,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PingTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringListMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringListMetricTypeTest.kt
@@ -4,21 +4,20 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class StringListMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringMetricTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
@@ -13,12 +14,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class StringMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
@@ -1,19 +1,18 @@
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.Assert.assertEquals
-import org.junit.Test
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TimespanMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -4,23 +4,22 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TimingDistributionMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/UuidMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/UuidMetricTypeTest.kt
@@ -4,22 +4,21 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.lang.NullPointerException
 import java.util.UUID
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class UuidMetricTypeTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -7,25 +7,26 @@ package mozilla.components.service.glean.scheduler
 import android.content.Context
 import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
-import mozilla.components.service.glean.getContextWithMockedInfo
 import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.private.Lifetime
-import mozilla.components.service.glean.resetGlean
-import mozilla.components.service.glean.private.StringMetricType
-import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.checkPingSchema
-import mozilla.components.service.glean.triggerWorkManager
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.getContextWithMockedInfo
 import mozilla.components.service.glean.getMockWebServer
 import mozilla.components.service.glean.getWorkerStatus
+import mozilla.components.service.glean.private.Lifetime
+import mozilla.components.service.glean.private.StringMetricType
+import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.triggerWorkManager
 import mozilla.components.service.glean.utils.getISOTimeString
 import mozilla.components.service.glean.utils.parseISOTimeString
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,11 +38,10 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class MetricsPingSchedulerTest {
     private fun <T> kotlinFriendlyAny(): T {
         // This is required to work around the Kotlin/ArgumentMatchers problem with using

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
@@ -1,35 +1,35 @@
 package mozilla.components.service.glean.scheduler
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.BackoffPolicy
 import androidx.work.NetworkType
 import androidx.work.WorkerParameters
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.resetGlean
-import org.junit.Assert
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.MockitoAnnotations
+import org.mockito.MockitoAnnotations.initMocks
 
 @RunWith(AndroidJUnit4::class)
 class PingUploadWorkerTest {
 
     @Mock
-    var workerParams: WorkerParameters? = null
+    lateinit var workerParams: WorkerParameters
 
-    private var pingUploadWorker: PingUploadWorker? = null
+    lateinit var pingUploadWorker: PingUploadWorker
 
     @Before
-    @Throws(Exception::class)
     fun setUp() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        MockitoAnnotations.initMocks(this)
-        resetGlean(context, config = Configuration().copy(logPings = true))
-        pingUploadWorker = PingUploadWorker(context, workerParams!!)
+        initMocks(this)
+
+        resetGlean(testContext, config = Configuration().copy(logPings = true))
+
+        pingUploadWorker = PingUploadWorker(testContext, workerParams)
     }
 
     @Test
@@ -40,14 +40,14 @@ class PingUploadWorkerTest {
         val workSpec = workRequest.workSpec
 
         // verify constraints
-        Assert.assertEquals(NetworkType.CONNECTED, workSpec.constraints.requiredNetworkType)
-        Assert.assertEquals(BackoffPolicy.EXPONENTIAL, workSpec.backoffPolicy)
-        Assert.assertTrue(workRequest.tags.contains(PingUploadWorker.PING_WORKER_TAG))
+        assertEquals(NetworkType.CONNECTED, workSpec.constraints.requiredNetworkType)
+        assertEquals(BackoffPolicy.EXPONENTIAL, workSpec.backoffPolicy)
+        assertTrue(workRequest.tags.contains(PingUploadWorker.PING_WORKER_TAG))
     }
 
     @Test
     fun testDoWorkSuccess() {
-        val result = pingUploadWorker!!.doWork()
-        Assert.assertTrue(result.toString().contains("Success"))
+        val result = pingUploadWorker.doWork()
+        assertTrue(result.toString().contains("Success"))
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
@@ -2,6 +2,7 @@ package mozilla.components.service.glean.scheduler
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.BackoffPolicy
 import androidx.work.NetworkType
 import androidx.work.WorkerParameters
@@ -13,9 +14,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PingUploadWorkerTest {
 
     @Mock

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/BooleansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/BooleansStorageEngineTest.kt
@@ -5,25 +5,25 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.BooleanMetricType
 import mozilla.components.service.glean.private.Lifetime
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 
 @RunWith(AndroidJUnit4::class)
 class BooleansStorageEngineTest {
 
     @Before
     fun setUp() {
-        BooleansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        BooleansStorageEngine.applicationContext = testContext
         BooleansStorageEngine.clearAllStores()
     }
 
@@ -39,17 +39,17 @@ class BooleansStorageEngineTest {
         val storageEngine = BooleansStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -63,7 +63,7 @@ class BooleansStorageEngineTest {
     fun `boolean serializer should correctly serialize booleans`() {
         run {
             val storageEngine = BooleansStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric = BooleanMetricType(
                 disabled = false,
@@ -91,7 +91,7 @@ class BooleansStorageEngineTest {
         // to the cache
         run {
             val storageEngine = BooleansStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             // Get the snapshot from "store1"
             val snapshot = storageEngine.getSnapshotAsJSON(storeName = "store1",

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/BooleansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/BooleansStorageEngineTest.kt
@@ -6,8 +6,9 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import mozilla.components.service.glean.private.Lifetime
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.BooleanMetricType
+import mozilla.components.service.glean.private.Lifetime
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -16,9 +17,8 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class BooleansStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
@@ -7,23 +7,23 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import mozilla.components.service.glean.private.Lifetime
-import mozilla.components.service.glean.private.CounterMetricType
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
+import mozilla.components.service.glean.private.CounterMetricType
+import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class CountersStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
@@ -6,13 +6,15 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.CounterMetricType
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -20,8 +22,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 
 @RunWith(AndroidJUnit4::class)
 class CountersStorageEngineTest {
@@ -44,17 +44,17 @@ class CountersStorageEngineTest {
         val storageEngine = CountersStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -68,7 +68,7 @@ class CountersStorageEngineTest {
     fun `counter serializer should correctly serialize counters`() {
         run {
             val storageEngine = CountersStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric = CounterMetricType(
                 disabled = false,
@@ -93,7 +93,7 @@ class CountersStorageEngineTest {
         // Re-instantiate storage engine to validate serialization from storage rather than cache
         run {
             val storageEngine = CountersStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             // Get the snapshot from "store1" and clear it.
             val snapshot = storageEngine.getSnapshotAsJSON(storeName = "store1", clearStore = true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
@@ -5,20 +5,20 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.DatetimeMetricType
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import java.util.Calendar
 import java.util.TimeZone
 
@@ -46,17 +46,17 @@ class DatetimesStorageEngineTest {
         val storageEngine = DatetimesStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -75,11 +75,11 @@ class DatetimesStorageEngineTest {
         val value = Calendar.getInstance()!!
         value.set(1993, 1, 23, 9, 5, 23)
         value.set(Calendar.MILLISECOND, 0)
-        value.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"))
+        value.timeZone = TimeZone.getTimeZone("America/Los_Angeles")
 
         run {
             val storageEngine = DatetimesStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric = DatetimeMetricType(
                 disabled = false,
@@ -104,7 +104,7 @@ class DatetimesStorageEngineTest {
         // to the cache
         run {
             val storageEngine = DatetimesStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             // Get the snapshot from "store1"
             val snapshot = storageEngine.getSnapshotAsJSON(storeName = "store1",

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
@@ -6,8 +6,9 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import mozilla.components.service.glean.private.Lifetime
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.DatetimeMetricType
+import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
@@ -18,11 +19,10 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
 import java.util.TimeZone
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DatetimesStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -5,28 +5,28 @@ package mozilla.components.service.glean.storages
 
 import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
+import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.checkPingSchema
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
-import mozilla.components.service.glean.private.Lifetime
-import mozilla.components.service.glean.private.EventMetricType
 import mozilla.components.service.glean.getContextWithMockedInfo
-import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.getMockWebServer
+import mozilla.components.service.glean.private.EventMetricType
+import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
 import org.json.JSONObject
 import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.TimeUnit
 
 // Declared here, since Kotlin can not declare nested enum classes
@@ -48,7 +48,7 @@ enum class TruncatedKeys {
     TruncatedExtra
 }
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class EventsStorageEngineTest {
     @Before
     fun setUp() {
@@ -287,7 +287,7 @@ class EventsStorageEngineTest {
             triggerWorkManager()
 
             val request = server.takeRequest(20L, TimeUnit.SECONDS)
-            val applicationId = "mozilla-components-service-glean"
+            val applicationId = "mozilla-components-service-glean-test"
             assert(request.path.startsWith("/submit/$applicationId/events/${Glean.SCHEMA_VERSION}/"))
             val eventsJsonData = request.body.readUtf8()
             val eventsJson = checkPingSchema(eventsJsonData)
@@ -385,7 +385,7 @@ class EventsStorageEngineTest {
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         assertEquals("POST", request.method)
-        val applicationId = "mozilla-components-service-glean"
+        val applicationId = "mozilla-components-service-glean-test"
         assert(
             request.path.startsWith("/submit/$applicationId/events/${Glean.SCHEMA_VERSION}/")
         )
@@ -446,7 +446,7 @@ class EventsStorageEngineTest {
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         assertEquals("POST", request.method)
-        val applicationId = "mozilla-components-service-glean"
+        val applicationId = "mozilla-components-service-glean-test"
         assert(
             request.path.startsWith("/submit/$applicationId/events/${Glean.SCHEMA_VERSION}/")
         )

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -4,7 +4,6 @@
 package mozilla.components.service.glean.storages
 
 import android.os.SystemClock
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.components.service.glean.Glean
@@ -18,8 +17,8 @@ import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONObject
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -50,6 +49,7 @@ enum class TruncatedKeys {
 
 @RunWith(AndroidJUnit4::class)
 class EventsStorageEngineTest {
+
     @Before
     fun setUp() {
         resetGlean()
@@ -57,7 +57,7 @@ class EventsStorageEngineTest {
         EventsStorageEngine.clearAllStores()
 
         // Initialize WorkManager using the WorkManagerTestInitHelper.
-        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
+        WorkManagerTestInitHelper.initializeTestWorkManager(testContext)
     }
 
     @Test
@@ -281,7 +281,7 @@ class EventsStorageEngineTest {
                 click.record(extra = mapOf(TestEventNumberKeys.TestEventNumber to "$i"))
             }
 
-            Assert.assertTrue(click.testHasValue())
+            assertTrue(click.testHasValue())
 
             // Trigger worker task to upload the pings in the background
             triggerWorkManager()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/ExperimentsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/ExperimentsStorageEngineTest.kt
@@ -3,16 +3,15 @@
 
 package mozilla.components.service.glean.storages
 
-import java.util.ArrayList
-
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import java.util.ArrayList
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ExperimentsStorageEngineTest {
     @Before
     fun setUp() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
@@ -6,23 +6,24 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.Lifetime
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
 class GenericStorageEngineTest {
+
     private data class GenericMetricType(
         override val disabled: Boolean,
         override val category: String,
@@ -37,7 +38,7 @@ class GenericStorageEngineTest {
         val dataPingLifetime = 3
 
         val storageEngine = MockGenericStorageEngine()
-        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        storageEngine.applicationContext = testContext
 
         val metric1 = GenericMetricType(
             disabled = false,
@@ -85,7 +86,7 @@ class GenericStorageEngineTest {
     @Test
     fun `metrics with empty 'category' must be properly recorded`() {
         val storageEngine = MockGenericStorageEngine()
-        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        storageEngine.applicationContext = testContext
 
         val metric = GenericMetricType(
             disabled = false,
@@ -118,10 +119,10 @@ class GenericStorageEngineTest {
         )
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
@@ -157,17 +158,17 @@ class GenericStorageEngineTest {
         )
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { brokenSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { brokenSample }
+        whenever(context.getSharedPreferences(
             eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -204,17 +205,17 @@ class GenericStorageEngineTest {
         )
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { brokenSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { brokenSample }
+        whenever(context.getSharedPreferences(
             eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -231,17 +232,17 @@ class GenericStorageEngineTest {
     @Test
     fun `unpersisting metrics must not fail if SharedPreferences throws`() {
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenThrow(NullPointerException())
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenThrow(NullPointerException())
+        whenever(context.getSharedPreferences(
             eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -267,17 +268,17 @@ class GenericStorageEngineTest {
         )
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(MockGenericStorageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${MockGenericStorageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -299,7 +300,7 @@ class GenericStorageEngineTest {
     @Test
     fun `snapshotting must only clear 'ping' lifetime`() {
         val storageEngine = MockGenericStorageEngine()
-        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        storageEngine.applicationContext = testContext
 
         val stores = listOf("store1", "store2")
 
@@ -370,7 +371,7 @@ class GenericStorageEngineTest {
         // for the SharedPreferences.
         run {
             val storageEngine = MockGenericStorageEngine()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric1 = GenericMetricType(
                 disabled = false,
@@ -410,7 +411,7 @@ class GenericStorageEngineTest {
         // Re-instantiate the engine: application lifetime probes should have been cleared.
         run {
             val storageEngine = MockGenericStorageEngine()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val snapshot = storageEngine.getSnapshot("store1", true)
             assertEquals(1, snapshot!!.size)
@@ -425,7 +426,7 @@ class GenericStorageEngineTest {
         // for the SharedPreferences.
         run {
             val storageEngine = MockGenericStorageEngine()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric1 = GenericMetricType(
                 disabled = false,
@@ -470,7 +471,7 @@ class GenericStorageEngineTest {
         // Re-instantiate the engine: ping lifetime metrics should be persisted.
         run {
             val storageEngine = MockGenericStorageEngine()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val snapshot = storageEngine.getSnapshot("store1", true)
             assertEquals(2, snapshot!!.size)
@@ -488,7 +489,7 @@ class GenericStorageEngineTest {
         // Now that the store was cleared, ping lifetime should have nothing persisted
         run {
             val storageEngine = MockGenericStorageEngine()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val snapshot = storageEngine.getSnapshot("store1", true)
             assertEquals(1, snapshot!!.size)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/GenericStorageEngineTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.CommonMetricData
 import mozilla.components.service.glean.private.Lifetime
 import org.junit.Assert.assertEquals
@@ -19,9 +20,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class GenericStorageEngineTest {
     private data class GenericMetricType(
         override val disabled: Boolean,

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/PingStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/PingStorageEngineTest.kt
@@ -4,26 +4,26 @@
 
 package mozilla.components.service.glean.storages
 
-import kotlinx.coroutines.runBlocking
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import java.io.File
-import java.io.FileReader
 import java.io.BufferedReader
+import java.io.File
 import java.io.FileOutputStream
+import java.io.FileReader
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PingStorageEngineTest {
     // Filenames and paths to test with, regenerated with each test.
     private lateinit var fileName1: UUID

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
@@ -4,8 +4,8 @@
 
 package mozilla.components.service.glean.storages
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -15,9 +15,10 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class StorageEngineManagerTest {
+
     @Test
     fun `collect() must return an empty object for empty or unknown stores`() {
-        val manager = StorageEngineManager(applicationContext = ApplicationProvider.getApplicationContext())
+        val manager = StorageEngineManager(applicationContext = testContext)
         val data = manager.collect("thisStoreNameDoesNotExist")
         assertNotNull(data)
         assertEquals("{}", data.toString())
@@ -28,10 +29,10 @@ class StorageEngineManagerTest {
         val manager = StorageEngineManager(storageEngines = mapOf(
             "engine1" to MockStorageEngine(JSONObject(mapOf("test" to "val"))),
             "engine2" to MockStorageEngine(JSONArray(listOf("a", "b", "c")))
-        ), applicationContext = ApplicationProvider.getApplicationContext())
+        ), applicationContext = testContext)
 
         val data = manager.collect("test")
-        assertEquals("{\"metrics\":{\"engine1\":{\"test\":\"val\"},\"engine2\":[\"a\",\"b\",\"c\"]}}",
+        assertEquals("""{"metrics":{"engine1":{"test":"val"},"engine2":["a","b","c"]}}""",
             data.toString())
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StorageEngineManagerTest.kt
@@ -5,15 +5,15 @@
 package mozilla.components.service.glean.storages
 
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class StorageEngineManagerTest {
     @Test
     fun `collect() must return an empty object for empty or unknown stores`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.Lifetime
@@ -22,9 +23,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class StringListsStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
@@ -6,13 +6,15 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringListMetricType
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert
@@ -22,7 +24,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito
 
 @RunWith(AndroidJUnit4::class)
 class StringListsStorageEngineTest {
@@ -218,17 +219,17 @@ class StringListsStorageEngineTest {
         val storageEngine = StringListsStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = Mockito.mock(Context::class.java)
-        val sharedPreferences = Mockito.mock(SharedPreferences::class.java)
-        Mockito.`when`(sharedPreferences.all).thenAnswer { persistedSample }
-        Mockito.`when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             ArgumentMatchers.eq(storageEngine::class.java.canonicalName),
             ArgumentMatchers.eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        Mockito.`when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             ArgumentMatchers.eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             ArgumentMatchers.eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -244,7 +245,7 @@ class StringListsStorageEngineTest {
     fun `string list serializer should correctly serialize lists`() {
         run {
             val storageEngine = StringListsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val storeNames = listOf("store1", "store2")
 
@@ -276,7 +277,7 @@ class StringListsStorageEngineTest {
         // to the cache
         run {
             val storageEngine = StringListsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             // Get snapshot from store1
             val json = storageEngine.getSnapshotAsJSON("store1", true)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -5,13 +5,15 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringMetricType
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -19,8 +21,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 
 @RunWith(AndroidJUnit4::class)
 class StringsStorageEngineTest {
@@ -42,17 +42,17 @@ class StringsStorageEngineTest {
         val storageEngine = StringsStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -66,7 +66,7 @@ class StringsStorageEngineTest {
     fun `string serializer should correctly serialize strings`() {
         run {
             val storageEngine = StringsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric = StringMetricType(
                 disabled = false,
@@ -94,7 +94,7 @@ class StringsStorageEngineTest {
         // to the cache
         run {
             val storageEngine = StringsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             // Get the snapshot from "store1"
             val snapshot = storageEngine.getSnapshotAsJSON(storeName = "store1",
@@ -127,7 +127,7 @@ class StringsStorageEngineTest {
         for (storeName in storeNames) {
             val snapshot = StringsStorageEngine.getSnapshot(storeName = storeName, clearStore = false)
             assertEquals(1, snapshot!!.size)
-            assertEquals("test_string_object", snapshot.get("telemetry.string_metric"))
+            assertEquals("test_string_object", snapshot["telemetry.string_metric"])
         }
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.Lifetime
@@ -20,9 +21,8 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class StringsStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -5,30 +5,31 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimespanMetricType
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.eq
-import org.mockito.Mockito.mock
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class TimespansStorageEngineTest {
+
     @Before
     fun setUp() {
         resetGlean()
-        TimespansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        TimespansStorageEngine.applicationContext = testContext
         TimespansStorageEngine.clearAllStores()
     }
 
@@ -49,17 +50,17 @@ class TimespansStorageEngineTest {
         val storageEngine = TimespansStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -6,25 +6,24 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimespanMetricType
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.After
-
-import org.junit.Before
-import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.eq
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TimespansStorageEngineTest {
     @Before
     fun setUp() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
@@ -7,26 +7,26 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
+import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimingDistributionMetricType
-import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.After
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class TimingDistributionsStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import mozilla.components.service.glean.error.ErrorRecording
@@ -15,6 +14,9 @@ import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimingDistributionMetricType
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.timing.TimingManager
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -24,7 +26,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito
 
 @RunWith(AndroidJUnit4::class)
 class TimingDistributionsStorageEngineTest {
@@ -93,31 +94,31 @@ class TimingDistributionsStorageEngineTest {
             "store1#telemetry.invalid_int" to -1,
             "store1#telemetry.invalid_list" to listOf("1", "2", "3"),
             "store1#telemetry.invalid_int_list" to "[1,2,3]",
-            "store1#telemetry.invalid_td_name" to "{\"category\":\"telemetry\",\"bucketCount\":100,\"range\":[0,60000,12],\"histogramType\":1,\"values\":{},\"sum\":0,\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_bucketCount" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":\"not an int!\",\"range\":[0,60000,12],\"histogramType\":1,\"values\":{},\"sum\":0,\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_range" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":100,\"range\":[0,60000,12],\"histogramType\":1,\"values\":{},\"sum\":0,\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_range2" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":100,\"range\":[\"not\",\"numeric\"],\"histogramType\":1,\"values\":{},\"sum\":0,\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_histogramType" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":100,\"range\":[0,60000,12],\"histogramType\":-1,\"values\":{},\"sum\":0,\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_values" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":100,\"range\":[0,60000,12],\"histogramType\":1,\"values\":{\"0\": \"nope\"},\"sum\":0,\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_sum" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":100,\"range\":[0,60000,12],\"histogramType\":1,\"values\":{},\"sum\":\"nope\",\"timeUnit\":2}",
-            "store1#telemetry.invalid_td_timeUnit" to "{\"category\":\"telemetry\",\"name\":\"test_timing_distribution\",\"bucketCount\":100,\"range\":[0,60000,12],\"histogramType\":1,\"values\":{},\"sum\":0,\"timeUnit\":-1}",
+            "store1#telemetry.invalid_td_name" to """{"category":"telemetry","bucketCount":100,"range":[0,60000,12],"histogramType":1,"values":{},"sum":0,"timeUnit":2}""",
+            "store1#telemetry.invalid_td_bucketCount" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":"not an int!","range":[0,60000,12],"histogramType":1,"values":{},"sum":0,"timeUnit":2}""",
+            "store1#telemetry.invalid_td_range" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":100,"range":[0,60000,12],"histogramType":1,"values":{},"sum":0,"timeUnit":2}""",
+            "store1#telemetry.invalid_td_range2" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":100,"range":["not","numeric"],"histogramType":1,"values":{},"sum":0,"timeUnit":2}""",
+            "store1#telemetry.invalid_td_histogramType" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":100,"range":[0,60000,12],"histogramType":-1,"values":{},"sum":0,"timeUnit":2}""",
+            "store1#telemetry.invalid_td_values" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":100,"range":[0,60000,12],"histogramType":1,"values":{"0": "nope"},"sum":0,"timeUnit":2}""",
+            "store1#telemetry.invalid_td_sum" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":100,"range":[0,60000,12],"histogramType":1,"values":{},"sum":"nope","timeUnit":2}""",
+            "store1#telemetry.invalid_td_timeUnit" to """{"category":"telemetry","name":"test_timing_distribution","bucketCount":100,"range":[0,60000,12],"histogramType":1,"values":{},"sum":0,"timeUnit":-1}""",
             "store1#telemetry.test_timing_distribution" to td.toJsonObject().toString()
         )
 
         val storageEngine = TimingDistributionsStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = Mockito.mock(Context::class.java)
-        val sharedPreferences = Mockito.mock(SharedPreferences::class.java)
-        Mockito.`when`(sharedPreferences.all).thenAnswer { persistedSample }
-        Mockito.`when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             ArgumentMatchers.eq(storageEngine::class.java.canonicalName),
             ArgumentMatchers.eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        Mockito.`when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             ArgumentMatchers.eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             ArgumentMatchers.eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -132,7 +133,7 @@ class TimingDistributionsStorageEngineTest {
     fun `serializer should correctly serialize timing distributions`() {
         run {
             val storageEngine = TimingDistributionsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val metric = TimingDistributionMetricType(
                 disabled = false,
@@ -168,7 +169,7 @@ class TimingDistributionsStorageEngineTest {
         // to the cache
         run {
             val storageEngine = TimingDistributionsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val td = TimingDistributionData(category = "telemetry", name = "test_timing_distribution")
             td.accumulate(1L)

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -5,10 +5,12 @@ package mozilla.components.service.glean.storages
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.UuidMetricType
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -16,8 +18,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
@@ -25,7 +25,7 @@ class UuidsStorageEngineTest {
 
     @Before
     fun setUp() {
-        UuidsStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        UuidsStorageEngine.applicationContext = testContext
         UuidsStorageEngine.clearAllStores()
     }
 
@@ -41,17 +41,17 @@ class UuidsStorageEngineTest {
         val storageEngine = UuidsStorageEngineImplementation()
 
         // Create a fake application context that will be used to load our data.
-        val context = mock(Context::class.java)
-        val sharedPreferences = mock(SharedPreferences::class.java)
-        `when`(sharedPreferences.all).thenAnswer { persistedSample }
-        `when`(context.getSharedPreferences(
+        val context = mock<Context>()
+        val sharedPreferences = mock<SharedPreferences>()
+        whenever(sharedPreferences.all).thenAnswer { persistedSample }
+        whenever(context.getSharedPreferences(
             eq(storageEngine::class.java.canonicalName),
             eq(Context.MODE_PRIVATE)
         )).thenReturn(sharedPreferences)
-        `when`(context.getSharedPreferences(
+        whenever(context.getSharedPreferences(
             eq("${storageEngine::class.java.canonicalName}.PingLifetime"),
             eq(Context.MODE_PRIVATE)
-        )).thenReturn(ApplicationProvider.getApplicationContext<Context>()
+        )).thenReturn(testContext
             .getSharedPreferences("${storageEngine::class.java.canonicalName}.PingLifetime",
                 Context.MODE_PRIVATE))
 
@@ -65,7 +65,7 @@ class UuidsStorageEngineTest {
     fun `UUID serializer correctly serializes UUID's`() {
         run {
             val storageEngine = UuidsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val testUUID = "ce2adeb8-843a-4232-87a5-a099ed1e7bb3"
 
@@ -93,7 +93,7 @@ class UuidsStorageEngineTest {
         // to the cache
         run {
             val storageEngine = UuidsStorageEngineImplementation()
-            storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+            storageEngine.applicationContext = testContext
 
             val testUUID = "ce2adeb8-843a-4232-87a5-a099ed1e7bb3"
 
@@ -204,7 +204,7 @@ class UuidsStorageEngineTest {
         val sampleUUID = "decaffde-caff-d3ca-ffd3-caffd3caffd3"
 
         val storageEngine = UuidsStorageEngineImplementation()
-        storageEngine.applicationContext = ApplicationProvider.getApplicationContext()
+        storageEngine.applicationContext = testContext
 
         val metric = UuidMetricType(
             disabled = false,
@@ -220,7 +220,7 @@ class UuidsStorageEngineTest {
         )
 
         // Check that the persisted shared prefs contains the expected data.
-        val storedData = ApplicationProvider.getApplicationContext<Context>()
+        val storedData = testContext
             .getSharedPreferences(storageEngine.javaClass.canonicalName, Context.MODE_PRIVATE)
             .all
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/UuidsStorageEngineTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.service.glean.storages
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.UuidMetricType
 import org.junit.Assert.assertEquals
@@ -17,10 +18,9 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class UuidsStorageEngineTest {
 
     @Before

--- a/components/service/glean/src/test/java/mozilla/ext/collections.kt
+++ b/components/service/glean/src/test/java/mozilla/ext/collections.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.ext
+
+/**
+ * Perforce cartesian product on two collections.
+ *
+ * For example result of
+ * ```
+ * listOf("a", "b").combineWith(listOf(1, 2))
+ * ```
+ *
+ * will be
+ * `[("a", 1), ("a", 2), ("b", 1), ("b", 2)]`
+ */
+fun <T, R> Iterable<T>.combineWith(other: Iterable<R>): Iterable<Pair<T, R>> =
+    flatMap { first ->
+        other.map { second ->
+            first to second
+        }
+    }

--- a/components/support/ktx/gradle.properties
+++ b/components/support/ktx/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/components/ui/tabcounter/gradle.properties
+++ b/components/ui/tabcounter/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove and enable globally
-android.enableUnitTestBinaryResources=false

--- a/samples/firefox-accounts/gradle.properties
+++ b/samples/firefox-accounts/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/samples/firefox-accounts/gradle.properties
+++ b/samples/firefox-accounts/gradle.properties
@@ -1,0 +1,2 @@
+# TODO remove
+android.enableUnitTestBinaryResources=false


### PR DESCRIPTION
### Issue #1481 

  - Use `AndroidJUnit4` as a test runner in `service-glean`.
  - Use `ActivityScenario` in `service-glean`, `lib-crash`.
  - Cleanup tests in this modules a little.

### Complexity

Easy (★☆☆)

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~