### PR TITLE
For #3274: Adds editModeFocus to BrowserToolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -504,6 +504,13 @@ class BrowserToolbar @JvmOverloads constructor(
     }
 
     /**
+     * Focuses the editToolbar if already in edit mode
+     */
+    fun focus() {
+        editToolbar.focus()
+    }
+
+    /**
      * Switches to URL editing mode.
      */
     override fun editMode() {
@@ -512,10 +519,9 @@ class BrowserToolbar @JvmOverloads constructor(
         val shouldAutoComplete = searchTerms.isEmpty()
 
         editToolbar.updateUrl(urlValue.toString(), shouldAutoComplete)
-
         updateState(State.EDIT)
-
         editToolbar.focus()
+        editToolbar.urlView.selectAll()
     }
 
     /**

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -71,6 +71,19 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `calling editModeFocus() focuses the editToolbar`() {
+        val toolbar = BrowserToolbar(testContext)
+        toolbar.editToolbar = spy(toolbar.editToolbar)
+
+        verify(toolbar.editToolbar, never()).focus()
+
+        toolbar.editMode()
+        toolbar.focus()
+
+        verify(toolbar.editToolbar, times(2)).focus()
+    }
+
+    @Test
     fun `calling displayMode() makes display toolbar visible`() {
         val toolbar = BrowserToolbar(testContext)
         toolbar.editMode()
@@ -113,30 +126,28 @@ class BrowserToolbarTest {
     fun `displayUrl will be forwarded to display toolbar immediately`() {
         val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
-        val ediToolbar = mock(EditToolbar::class.java)
+        val editToolbar = mock(EditToolbar::class.java)
 
         toolbar.displayToolbar = displayToolbar
-        toolbar.editToolbar = ediToolbar
+        toolbar.editToolbar = editToolbar
 
         toolbar.url = "https://www.mozilla.org"
 
         verify(displayToolbar).updateUrl("https://www.mozilla.org")
-        verify(ediToolbar, never()).updateUrl(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())
+        verify(editToolbar, never()).updateUrl(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())
     }
 
     @Test
     fun `last URL will be forwarded to edit toolbar when switching mode`() {
         val toolbar = BrowserToolbar(testContext)
-
-        val ediToolbar = mock(EditToolbar::class.java)
-        toolbar.editToolbar = ediToolbar
+        toolbar.editToolbar = spy(toolbar.editToolbar)
 
         toolbar.url = "https://www.mozilla.org"
-        verify(ediToolbar, never()).updateUrl("https://www.mozilla.org", true)
+        verify(toolbar.editToolbar, never()).updateUrl("https://www.mozilla.org", true)
 
         toolbar.editMode()
 
-        verify(ediToolbar).updateUrl("https://www.mozilla.org", true)
+        verify(toolbar.editToolbar).updateUrl("https://www.mozilla.org", true)
     }
 
     @Test
@@ -417,22 +428,21 @@ class BrowserToolbarTest {
     fun `URL update does not override search terms in edit mode`() {
         val toolbar = BrowserToolbar(testContext)
         val displayToolbar = mock(DisplayToolbar::class.java)
-        val editToolbar = mock(EditToolbar::class.java)
 
         toolbar.displayToolbar = displayToolbar
-        toolbar.editToolbar = editToolbar
+        toolbar.editToolbar = spy(toolbar.editToolbar)
 
         toolbar.setSearchTerms("mozilla android")
         toolbar.url = "https://www.mozilla.com"
         toolbar.editMode()
         verify(displayToolbar).updateUrl("https://www.mozilla.com")
-        verify(editToolbar).updateUrl("mozilla android", false)
+        verify(toolbar.editToolbar).updateUrl("mozilla android", false)
 
         toolbar.setSearchTerms("")
         toolbar.url = "https://www.mozilla.org"
         toolbar.editMode()
         verify(displayToolbar).updateUrl("https://www.mozilla.org")
-        verify(editToolbar).updateUrl("https://www.mozilla.org", true)
+        verify(toolbar.editToolbar).updateUrl("https://www.mozilla.org", true)
     }
 
     @Test
@@ -467,19 +477,18 @@ class BrowserToolbarTest {
     fun `search terms (if set) are forwarded to edit toolbar instead of URL`() {
         val toolbar = BrowserToolbar(testContext)
 
-        val ediToolbar = mock(EditToolbar::class.java)
-        toolbar.editToolbar = ediToolbar
+        toolbar.editToolbar = spy(toolbar.editToolbar)
 
         toolbar.url = "https://www.mozilla.org"
         toolbar.setSearchTerms("Mozilla Firefox")
 
-        verify(ediToolbar, never()).updateUrl("https://www.mozilla.org")
-        verify(ediToolbar, never()).updateUrl("Mozilla Firefox")
+        verify(toolbar.editToolbar, never()).updateUrl("https://www.mozilla.org")
+        verify(toolbar.editToolbar, never()).updateUrl("Mozilla Firefox")
 
         toolbar.editMode()
 
-        verify(ediToolbar, never()).updateUrl("https://www.mozilla.org")
-        verify(ediToolbar).updateUrl("Mozilla Firefox")
+        verify(toolbar.editToolbar, never()).updateUrl("https://www.mozilla.org")
+        verify(toolbar.editToolbar).updateUrl("Mozilla Firefox")
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+
+* **browser-toolbar**
+  * Adds `focus()` which provides a hook for calling `editMode.focus()` to focus the edit mode `urlView` 
+  
 * **browser-awesomebar**
   * Updated `DefaultSuggestionViewHolder` to have a style more consistent with Fenix mocks.
   
@@ -73,7 +77,7 @@ permalink: /changelog/
 * **browser-search**
   * Added `getProvidedDefaultSearchEngine` to `SearchEngineManager` to return the provided default search engine or the first
     search engine if the default is not set. This allows use cases like [#3344](https://github.com/mozilla-mobile/android-components/issues/3344).
-
+  
 * **feature-tab-collections**
   * Behavior change: `TabCollection` instances returned by `TabCollectionStorage` are now ordered by the last time they have been updated (instead of the time they have been created).
 


### PR DESCRIPTION
I ended up implementing `editModeFocus`. This function is necessary because in Fenix, we use calling `editMode` (while already set to `state editing` to clear the search field or properly set it to the search terms). Because of that, having a separate function helps us explicitly focus the the editToolbar.urlView.

@pocmo let me know if you have any concerns with this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
