### PR TITLE
Fix null checks before Android Q

### DIFF
--- a/components/browser/domains/src/main/java/mozilla/components/browser/domains/Domains.kt
+++ b/components/browser/domains/src/main/java/mozilla/components/browser/domains/Domains.kt
@@ -5,6 +5,8 @@
 package mozilla.components.browser.domains
 
 import android.content.Context
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES
 import android.os.LocaleList
 import android.text.TextUtils
 import java.io.IOException
@@ -46,9 +48,9 @@ object Domains {
         val availableDomains = LinkedHashSet<String>()
         val assetManager = context.assets
         val domains = try {
-            assetManager.list("domains")
+            assetManager.list("domains") ?: emptyArray<String>()
         } catch (e: IOException) {
-            arrayOf<String>()
+            emptyArray<String>()
         }
         availableDomains.addAll(domains)
         return availableDomains
@@ -57,7 +59,7 @@ object Domains {
     private fun loadDomainsForLanguage(context: Context, domains: MutableSet<String>, country: String) {
         val assetManager = context.assets
         val languageDomains = try {
-            assetManager.open("domains/" + country).bufferedReader().readLines()
+            assetManager.open("domains/$country").bufferedReader().readLines()
         } catch (e: IOException) {
             emptyList<String>()
         }
@@ -68,7 +70,7 @@ object Domains {
         val countries = java.util.LinkedHashSet<String>()
         val addIfNotEmpty = { c: String -> if (!TextUtils.isEmpty(c)) countries.add(c.toLowerCase(Locale.US)) }
 
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        if (SDK_INT >= VERSION_CODES.N) {
             val list = LocaleList.getDefault()
             for (i in 0 until list.size()) {
                 addIfNotEmpty(list.get(i).country)

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -437,7 +437,7 @@ class SystemEngineView @JvmOverloads constructor(
                 session.notifyObservers {
                     onPromptRequest(
                         PromptRequest.TextPrompt(
-                            title ?: "",
+                            title,
                             message ?: "",
                             defaultValue ?: "",
                             areDialogsBeingAbused(),

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/IconMessage.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/IconMessage.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.icons.extension
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.org.json.tryGetString
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -88,7 +89,7 @@ private fun JSONObject.toIconResource(): IconRequest.Resource? {
         val type = typeMap[getString("type")]
             ?: return null
         val sizes = optJSONArray("sizes").toResourceSizes()
-        val mimeType = optString("mimeType", null)
+        val mimeType = tryGetString("mimeType")
 
         return IconRequest.Resource(url, type, sizes, if (mimeType.isNullOrEmpty()) null else mimeType)
     } catch (e: JSONException) {

--- a/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt
@@ -205,8 +205,9 @@ class AssetsSearchEngineProvider(
     private fun applyOverridesIfNeeded(config: JSONObject, jsonSearchEngineIdentifiers: JSONArray): List<String> {
         val overrides = config.getJSONObject("regionOverrides")
         val searchEngineIdentifiers = mutableListOf<String>()
-        val regionOverrides = if (localizationProvider.region != null && overrides.has(localizationProvider.region)) {
-            overrides.getJSONObject(localizationProvider.region)
+        val region = localizationProvider.region
+        val regionOverrides = if (region != null && overrides.has(region)) {
+            overrides.getJSONObject(region)
         } else {
             null
         }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
@@ -49,13 +49,13 @@ class WebAppManifestParser {
                 shortName = shortName,
                 startUrl = json.getString("start_url"),
                 display = getDisplayMode(json),
-                backgroundColor = parseColor(json.optString("background_color", null)),
-                description = json.optString("description", null),
+                backgroundColor = parseColor(json.tryGetString("background_color")),
+                description = json.tryGetString("description"),
                 icons = parseIcons(json),
-                scope = json.optString("scope", null),
-                themeColor = parseColor(json.optString("theme_color", null)),
+                scope = json.tryGetString("scope"),
+                themeColor = parseColor(json.tryGetString("theme_color")),
                 dir = parseTextDirection(json),
-                lang = json.optString("lang", null),
+                lang = json.tryGetString("lang"),
                 orientation = parseOrientation(json)
             ))
         } catch (e: JSONException) {
@@ -107,17 +107,15 @@ private fun parseIcons(json: JSONObject): List<WebAppManifest.Icon> {
 }
 
 private fun parseIconSizes(json: JSONObject): List<Size> {
-    val sizes = json.optString("sizes") ?: return emptyList()
+    val sizes = json.tryGetString("sizes") ?: return emptyList()
 
     return sizes
         .split(whitespace)
         .mapNotNull { Size.parse(it) }
 }
 
-private fun parsePurposes(json: JSONObject): Set<WebAppManifest.Icon.Purpose> {
-    val purposes = json.optString("purpose") ?: return emptySet()
-
-    return purposes
+private fun parsePurposes(json: JSONObject): Set<WebAppManifest.Icon.Purpose> =
+    json.tryGetString("purpose").orEmpty()
         .split(whitespace)
         .mapNotNull {
             when (it.toLowerCase()) {
@@ -129,7 +127,6 @@ private fun parsePurposes(json: JSONObject): Set<WebAppManifest.Icon.Purpose> {
         }
         .toSet()
         .ifEmpty { setOf(WebAppManifest.Icon.Purpose.ANY) }
-}
 
 private fun parseTextDirection(json: JSONObject): WebAppManifest.TextDirection {
     return when (json.optString("dir")) {

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/MultiButtonDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/MultiButtonDialogFragment.kt
@@ -29,11 +29,11 @@ internal class MultiButtonDialogFragment : PromptDialogFragment() {
      */
     internal val hasShownManyDialogs: Boolean by lazy { safeArguments.getBoolean(KEY_MANY_ALERTS) }
 
-    internal val positiveButtonTitle: String by lazy { safeArguments.getString(KEY_POSITIVE_BUTTON_TITLE) }
+    internal val positiveButtonTitle: String? by lazy { safeArguments.getString(KEY_POSITIVE_BUTTON_TITLE) }
 
-    internal val negativeButtonTitle: String by lazy { safeArguments.getString(KEY_NEGATIVE_BUTTON_TITLE) }
+    internal val negativeButtonTitle: String? by lazy { safeArguments.getString(KEY_NEGATIVE_BUTTON_TITLE) }
 
-    internal val neutralButtonTitle: String by lazy { safeArguments.getString(KEY_NEUTRAL_BUTTON_TITLE) }
+    internal val neutralButtonTitle: String? by lazy { safeArguments.getString(KEY_NEUTRAL_BUTTON_TITLE) }
 
     /**
      * Stores the user's decision from the checkbox
@@ -74,18 +74,17 @@ internal class MultiButtonDialogFragment : PromptDialogFragment() {
     }
 
     private fun AlertDialog.Builder.setupButtons(): AlertDialog.Builder {
-        if (positiveButtonTitle.isNotEmpty()) {
+        if (!positiveButtonTitle.isNullOrBlank()) {
             setPositiveButton(positiveButtonTitle) { _, _ ->
                 feature?.onConfirm(sessionId, userSelectionNoMoreDialogs to ButtonType.POSITIVE)
             }
         }
-
-        if (negativeButtonTitle.isNotEmpty()) {
+        if (!negativeButtonTitle.isNullOrBlank()) {
             setNegativeButton(negativeButtonTitle) { _, _ ->
                 feature?.onConfirm(sessionId, userSelectionNoMoreDialogs to ButtonType.NEGATIVE)
             }
         }
-        if (neutralButtonTitle.isNotEmpty()) {
+        if (!neutralButtonTitle.isNullOrBlank()) {
             setNeutralButton(neutralButtonTitle) { _, _ ->
                 feature?.onConfirm(sessionId, userSelectionNoMoreDialogs to ButtonType.NEUTRAL)
             }

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TextPromptDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/TextPromptDialogFragment.kt
@@ -39,13 +39,13 @@ internal class TextPromptDialogFragment : PromptDialogFragment(), TextWatcher {
      * Contains the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt#Parameters">default()</a>
      * value provided by this [sessionId].
      */
-    internal val defaultInputValue: String by lazy { safeArguments.getString(KEY_DEFAULT_INPUT_VALUE) }
+    internal val defaultInputValue: String? by lazy { safeArguments.getString(KEY_DEFAULT_INPUT_VALUE) }
 
     /**
      * Contains the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt#Parameters">message</a>
      * value provided by this [sessionId].
      */
-    internal val labelInput: String by lazy { safeArguments.getString(KEY_LABEL_INPUT) }
+    internal val labelInput: String? by lazy { safeArguments.getString(KEY_LABEL_INPUT) }
 
     /**
      * Stores the user's decision from the checkbox

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -26,19 +26,13 @@ import mozilla.components.support.ktx.R
  * attribute. E.g. "2.0".
  */
 val Context.appVersionName: String?
-    get() {
-        val packageInfo = packageManager.getPackageInfo(packageName, 0)
-        return packageInfo.versionName
-    }
+    get() = packageManager.getPackageInfo(packageName, 0).versionName
 
 /**
  * Returns the name (label) of the application or the package name as a fallback.
  */
 val Context.appName: String
-    get() {
-        return packageManager.getApplicationLabel(applicationInfo)?.toString()
-            ?: packageName
-    }
+    get() = packageManager.getApplicationLabel(applicationInfo).toString()
 
 /**
  * Returns whether or not the operating system is under low memory conditions.

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -42,8 +42,8 @@ fun String.isGeoLocation() = re.geoish.matches(this)
  */
 fun String.toDate(format: String, locale: Locale = Locale.ROOT): Date {
     val formatter = SimpleDateFormat(format, locale)
-    return if (!this.isEmpty()) {
-        formatter.parse(this)
+    return if (isNotEmpty()) {
+        formatter.parse(this) ?: Date()
     } else {
         Date()
     }

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -151,7 +151,7 @@ object DownloadUtils {
                 val encodedFileName = m.group(ENCODED_FILE_NAME_GROUP)
                 val encoding = m.group(ENCODING_GROUP)
 
-                if (encodedFileName != null) {
+                if (encodedFileName != null && encoding != null) {
                     return decodeHeaderField(encodedFileName, encoding)
                 }
 

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
@@ -75,7 +75,7 @@ class SafeIntent(val unsafe: Intent) {
 
     fun <T : Parcelable> getParcelableArrayListExtra(name: String): ArrayList<T>? {
         return safeAccess {
-            val value: ArrayList<T> = unsafe.getParcelableArrayListExtra(name)
+            val value: ArrayList<T>? = unsafe.getParcelableArrayListExtra(name)
             value
         }
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -48,7 +48,7 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         super.onBackPressed()
     }
 
-    override fun onCreateView(parent: View?, name: String?, context: Context, attrs: AttributeSet?): View? =
+    override fun onCreateView(parent: View?, name: String, context: Context, attrs: AttributeSet): View? =
         when (name) {
             EngineView::class.java.name -> components.engine.createView(context, attrs).asView()
             TabsTray::class.java.name -> BrowserTabsTray(context, attrs)


### PR DESCRIPTION
SDK 29 adds many more `@Nullable` and `@NotNull` checks, which causes parts of our code to break since they assume nullability one way or another. I pulled some of the fixes I needed to get compling to work into their own branch here.