### PR TITLE
Fixes #790. Add `isScreenReaderEnabled` ktx-extension.

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -15,6 +15,7 @@ import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.hardware.camera2.CameraManager
 import android.os.Process
+import android.view.accessibility.AccessibilityManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.core.content.getSystemService
@@ -95,6 +96,14 @@ fun Context.share(text: String, subject: String = getString(R.string.mozac_suppo
         false
     }
 }
+
+/**
+ * Check if TalkBack service is enabled.
+ *
+ * (via https://stackoverflow.com/a/12362545/512580)
+ */
+inline val Context.isScreenReaderEnabled: Boolean
+    get() = (getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).isTouchExplorationEnabled
 
 @VisibleForTesting
 internal var isMainProcess: Boolean? = null

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextKtTest.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.content
+
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowAccessibilityManager
+
+@RunWith(AndroidJUnit4::class)
+class ContextKtTest {
+
+    lateinit var accessibilityManager: ShadowAccessibilityManager
+
+    @Before
+    fun setUp() {
+        accessibilityManager = shadowOf(testContext
+            .getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager)
+    }
+
+    @Test
+    fun `screen reader enabled`() {
+        // Given
+        accessibilityManager.setTouchExplorationEnabled(true)
+
+        // When
+        val isEnabled = testContext.isScreenReaderEnabled
+
+        // Then
+        assertTrue(isEnabled)
+    }
+
+    @Test
+    fun `screen reader disabled`() {
+        // Given
+        accessibilityManager.setTouchExplorationEnabled(false)
+
+        // When
+        val isEnabled = testContext.isScreenReaderEnabled
+
+        // Then
+        assertFalse(isEnabled)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **lib-state**
   * A new component for maintaining application, screen or component state via a redux-style `Store`. This component provides the architectural foundation for the `browser-state` component (in development). 
 
+* **support-ktx**
+  * Added `Context.isScreenReaderEnabled` extension to check if TalkBack service is enabled.
+
 # 1.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.56.0...v1.0.0)


### PR DESCRIPTION
Added extension to check if TalkBack service is available.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
