### PR TITLE
Add deprecation blog post link to changelog entry. [ci-skip]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/v1.0.0/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v1.0.0/buildSrc/src/main/java/Config.kt)
 
-* 🛑 Removed deprecated components (See blog posting):
+* 🛑 Removed deprecated components (See [blog posting](https://mozac.org/2019/05/23/deprecation.html)):
   * feature-session-bundling
   * ui-progress
   * ui-doorhanger


### PR DESCRIPTION
Just making it easier to find in the future. :)