### PR TITLE
Warmup engine when PWA is launched

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/AbstractWebAppShellActivity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/AbstractWebAppShellActivity.kt
@@ -46,6 +46,8 @@ abstract class AbstractWebAppShellActivity : AppCompatActivity() {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun applyConfiguration(manifest: WebAppManifest) {
+        engine.speculativeConnect(manifest.startUrl)
+
         if (manifest.display == WebAppManifest.DisplayMode.FULLSCREEN) {
             enterToImmersiveMode()
         }


### PR DESCRIPTION
Call `engine.speculativeConnect` to load web page alongside the engine. Custom Tabs does this to speed up startup.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
