### PR TITLE
Closes #3496: Add new lib-push-amazon component

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -280,6 +280,10 @@ projects:
     path: components/lib/publicsuffixlist
     description: 'A library for reading and using the public suffix list.'
     publish: true
+  lib-push-amazon:
+    path: components/lib/push-amazon
+    description: 'An implementation of concept-push for the Amazon Device Messaging.'
+    publish: false
   lib-push-firebase:
     path: components/lib/push-firebase
     description: 'An implementation of concept-push for the Firebase Message Service.'

--- a/components/lib/push-amazon/README.md
+++ b/components/lib/push-amazon/README.md
@@ -1,0 +1,45 @@
+# [Android Components](../../../README.md) > Libraries > Push-Amazon
+
+A [concept-push](../../concept/push/README.md) implementation using [Amazon Device Messaging](https://developer.amazon.com/docs/adm/overview.html) (ADM).
+
+This implementation of `concept-push` uses [Amazon Device Messaging](https://developer.amazon.com/docs/adm/overview.html). It can be used by supported-Amazon Android devices.
+
+## Usage
+
+Add the push service for providing the encrypted messages:
+
+```kotlin
+class AmazonPush : AbstractAmazonPushService()
+```
+
+TBD
+
+The service can be started/stopped directly if required:
+```kotlin
+val service = AmazonPush()
+
+serivce.start()
+serivce.stop()
+```
+
+See `feature-push` for more details on how to use the service with Autopush.
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:lib-push-amazon:{latest-version}"
+```
+
+### Adding ADM Support
+
+TBD
+
+See the [concept-push documentation](../../concept/push/README.md) for generic examples of using the API of components implementing `concept-push`.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/lib/push-amazon/build.gradle
+++ b/components/lib/push-amazon/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+
+    implementation project(':concept-push')
+
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/lib/push-amazon/proguard-rules.pro
+++ b/components/lib/push-amazon/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/lib/push-amazon/src/main/AndroidManifest.xml
+++ b/components/lib/push-amazon/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.lib.push.amazon" />

--- a/components/lib/push-amazon/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/lib/push-amazon/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)


### PR DESCRIPTION
Creates an empty un-published component for adding Amazon Device Messaging support for (auto)push support.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
