### PR TITLE
Use operator keyword in UseCases

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -82,7 +82,7 @@ class AppLinksFeature(
             return
         }
 
-        val redirect = useCases.interceptedAppLinkRedirect.invoke(url)
+        val redirect = useCases.interceptedAppLinkRedirect(url)
 
         if (redirect.isRedirect()) {
             handleRedirect(redirect, session)
@@ -98,7 +98,7 @@ class AppLinksFeature(
         }
 
         val doOpenApp = {
-            useCases.openAppLink.invoke(redirect)
+            useCases.openAppLink(redirect)
         }
 
         if (!session.private || fragmentManager == null) {

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -77,7 +77,7 @@ class AppLinksUseCases(
         private val ignoreDefaultBrowser: Boolean = false,
         private val includeInstallAppFallback: Boolean = false
     ) {
-        fun invoke(url: String): AppLinkRedirect {
+        operator fun invoke(url: String): AppLinkRedirect {
             val intents = createBrowsableIntents(url)
             val appIntent = if (includeHttpAppLinks) {
                 intents.firstOrNull { getNonBrowserActivities(it).isNotEmpty() }
@@ -153,7 +153,7 @@ class AppLinksUseCases(
     class OpenAppLinkRedirect internal constructor(
         private val context: Context
     ) {
-        fun invoke(redirect: AppLinkRedirect) {
+        operator fun invoke(redirect: AppLinkRedirect) {
             val intent = redirect.appIntent ?: return
             context.startActivity(intent)
         }

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -59,7 +59,7 @@ class AppLinksUseCasesTest {
         val context = createContext()
         val subject = AppLinksUseCases(context, emptySet())
 
-        val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
+        val redirect = subject.interceptedAppLinkRedirect(appUrl)
         assertFalse(redirect.isRedirect())
     }
 
@@ -69,11 +69,11 @@ class AppLinksUseCasesTest {
         val subject = AppLinksUseCases(context, emptySet())
 
         // We will not redirect to it when we click on it.
-        val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
+        val redirect = subject.interceptedAppLinkRedirect(appUrl)
         assertFalse(redirect.isRedirect())
 
         // But we do from a context menu.
-        val menuRedirect = subject.appLinkRedirect.invoke(appUrl)
+        val menuRedirect = subject.appLinkRedirect(appUrl)
         assertTrue(menuRedirect.isRedirect())
     }
 
@@ -82,7 +82,7 @@ class AppLinksUseCasesTest {
         val context = createContext(appUrl to browserPackage)
         val subject = AppLinksUseCases(context, setOf(browserPackage))
 
-        val redirect = subject.interceptedAppLinkRedirect.invoke(appUrl)
+        val redirect = subject.interceptedAppLinkRedirect(appUrl)
         assertFalse(redirect.isRedirect())
     }
 
@@ -91,7 +91,7 @@ class AppLinksUseCasesTest {
         val context = createContext(appUrl to appPackage, appUrl to browserPackage)
         val subject = AppLinksUseCases(context, setOf(browserPackage))
 
-        val redirect = subject.appLinkRedirect.invoke(appUrl)
+        val redirect = subject.appLinkRedirect(appUrl)
         assertTrue(redirect.isRedirect())
     }
 
@@ -110,7 +110,7 @@ class AppLinksUseCasesTest {
         val context = createContext(uri to appPackage, appUrl to browserPackage)
         val subject = AppLinksUseCases(context, setOf(browserPackage))
 
-        val redirect = subject.interceptedAppLinkRedirect.invoke(uri)
+        val redirect = subject.interceptedAppLinkRedirect(uri)
         assertTrue(redirect.hasExternalApp())
         assertNotNull(redirect.appIntent)
 
@@ -124,7 +124,7 @@ class AppLinksUseCasesTest {
 
         val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
 
-        val redirect = subject.interceptedAppLinkRedirect.invoke(uri)
+        val redirect = subject.interceptedAppLinkRedirect(uri)
         assertFalse(redirect.hasExternalApp())
         assertFalse(redirect.hasFallback())
         assertNull(redirect.webUrl)
@@ -137,7 +137,7 @@ class AppLinksUseCasesTest {
 
         val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;S.browser_fallback_url=http%3A%2F%2Fzxing.org;end"
 
-        val redirect = subject.interceptedAppLinkRedirect.invoke(uri)
+        val redirect = subject.interceptedAppLinkRedirect(uri)
         assertFalse(redirect.hasExternalApp())
         assertTrue(redirect.hasFallback())
 
@@ -151,7 +151,7 @@ class AppLinksUseCasesTest {
         val redirect = AppLinkRedirect(appIntent, appUrl, false)
         val subject = AppLinksUseCases(context, setOf(browserPackage))
 
-        subject.openAppLink.invoke(redirect)
+        subject.openAppLink(redirect)
 
         verify(context).startActivity(any())
     }

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -40,7 +40,7 @@ class SessionSuggestionProvider(
                         title = session.title,
                         description = session.url,
                         icon = icons.loadLambda(session.url),
-                        onSuggestionClicked = { selectTabUseCase.invoke(session) }
+                        onSuggestionClicked = { selectTabUseCase(session) }
                     )
                 )
             }

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -66,7 +66,7 @@ data class ContextMenuCandidate(
             label = context.getString(R.string.mozac_feature_contextmenu_open_link_in_new_tab),
             showFor = { session, hitResult -> hitResult.isLink() && !session.private },
             action = { parent, hitResult ->
-                val session = tabsUseCases.addTab.invoke(
+                val session = tabsUseCases.addTab(
                     hitResult.getLink(), selectTab = false, startLoading = true, parent = parent)
 
                 snackbarDelegate.show(
@@ -75,7 +75,7 @@ data class ContextMenuCandidate(
                     duration = Snackbar.LENGTH_LONG,
                     action = R.string.mozac_feature_contextmenu_snackbar_action_switch
                 ) {
-                    tabsUseCases.selectTab.invoke(session)
+                    tabsUseCases.selectTab(session)
                 }
             }
         )
@@ -93,7 +93,7 @@ data class ContextMenuCandidate(
             label = context.getString(R.string.mozac_feature_contextmenu_open_link_in_private_tab),
             showFor = { _, hitResult -> hitResult.isLink() },
             action = { parent, hitResult ->
-                val session = tabsUseCases.addPrivateTab.invoke(
+                val session = tabsUseCases.addPrivateTab(
                     hitResult.getLink(), selectTab = false, startLoading = true, parent = parent)
 
                 snackbarDelegate.show(
@@ -102,7 +102,7 @@ data class ContextMenuCandidate(
                     Snackbar.LENGTH_LONG,
                     R.string.mozac_feature_contextmenu_snackbar_action_switch
                 ) {
-                    tabsUseCases.selectTab.invoke(session)
+                    tabsUseCases.selectTab(session)
                 }
             }
         )
@@ -121,10 +121,10 @@ data class ContextMenuCandidate(
             showFor = { _, hitResult -> hitResult.isImage() },
             action = { parent, hitResult ->
                 val session = if (parent.private) {
-                    tabsUseCases.addPrivateTab.invoke(
+                    tabsUseCases.addPrivateTab(
                         hitResult.src, selectTab = false, startLoading = true, parent = parent)
                 } else {
-                    tabsUseCases.addTab.invoke(
+                    tabsUseCases.addTab(
                         hitResult.src, selectTab = false, startLoading = true, parent = parent)
                 }
 
@@ -134,7 +134,7 @@ data class ContextMenuCandidate(
                     duration = Snackbar.LENGTH_LONG,
                     action = R.string.mozac_feature_contextmenu_snackbar_action_switch
                 ) {
-                    tabsUseCases.selectTab.invoke(session)
+                    tabsUseCases.selectTab(session)
                 }
             }
         )

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -52,14 +52,14 @@ class IntentProcessor(
                     this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
                 }
                 sessionManager.add(session)
-                sessionUseCases.loadUrl.invoke(url, session)
+                sessionUseCases.loadUrl(url, session)
                 intent.putExtra(ACTIVE_SESSION_ID, session.id)
                 true
             }
 
             else -> {
                 val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
-                sessionUseCases.loadUrl.invoke(url, session)
+                sessionUseCases.loadUrl(url, session)
                 true
             }
         }
@@ -74,7 +74,7 @@ class IntentProcessor(
 
             else -> {
                 WebURLFinder(extraText).bestWebURL()?.let { url ->
-                    sessionUseCases.loadUrl.invoke(
+                    sessionUseCases.loadUrl(
                         url,
                         createSession(
                             url,
@@ -83,7 +83,7 @@ class IntentProcessor(
                         )
                     )
                 } ?: run {
-                    searchUseCases.newTabSearch.invoke(extraText, Source.ACTION_SEND, openNewTab)
+                    searchUseCases.newTabSearch(extraText, Source.ACTION_SEND, openNewTab)
                 }
                 true
             }

--- a/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
+++ b/components/feature/search/src/main/java/mozilla/components/feature/search/SearchUseCases.kt
@@ -50,7 +50,7 @@ class SearchUseCases(
          * is provided.
          * @param searchEngine Search Engine to use, or the default search engine if none is provided
          */
-        fun invoke(
+        operator fun invoke(
             searchTerms: String,
             session: Session? = sessionManager.selectedSession,
             searchEngine: SearchEngine? = null
@@ -92,7 +92,7 @@ class SearchUseCases(
          * @param source the source of the new session.
          * @param searchEngine Search Engine to use, or the default search engine if none is provided
          */
-        fun invoke(
+        operator fun invoke(
             searchTerms: String,
             source: Session.Source,
             selected: Boolean = true,

--- a/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
+++ b/components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt
@@ -52,7 +52,7 @@ class SearchUseCasesTest {
         whenever(searchEngineManager.getDefaultSearchEngine(testContext)).thenReturn(searchEngine)
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.defaultSearch.invoke(searchTerms, session)
+        useCases.defaultSearch(searchTerms, session)
 
         assertEquals(searchTerms, session.searchTerms)
         verify(engineSession).loadUrl(searchUrl)
@@ -68,7 +68,7 @@ class SearchUseCasesTest {
         whenever(searchEngineManager.getDefaultSearchEngine(testContext)).thenReturn(searchEngine)
         whenever(sessionManager.getOrCreateEngineSession(any())).thenReturn(engineSession)
 
-        useCases.newTabSearch.invoke(searchTerms, Session.Source.NEW_TAB)
+        useCases.newTabSearch(searchTerms, Session.Source.NEW_TAB)
         verify(engineSession).loadUrl(searchUrl)
     }
 
@@ -87,7 +87,7 @@ class SearchUseCasesTest {
             Session(url).also { createdSession = it }
         }
 
-        searchUseCases.defaultSearch.invoke("test")
+        searchUseCases.defaultSearch("test")
 
         assertEquals("https://search.example.com", sessionCreatedForUrl)
         assertNotNull(createdSession)

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/FullScreenFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/FullScreenFeature.kt
@@ -39,7 +39,7 @@ open class FullScreenFeature(
     override fun onBackPressed(): Boolean {
         activeSession?.let {
             if (it.fullScreenMode) {
-                sessionUseCases.exitFullscreen.invoke(it)
+                sessionUseCases.exitFullscreen(it)
                 return true
             }
         }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -38,7 +38,7 @@ class SessionFeature(
         } ?: sessionManager.selectedSession
 
         if (session?.canGoBack == true) {
-            sessionUseCases.goBack.invoke(session)
+            sessionUseCases.goBack(session)
             return true
         }
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -43,7 +43,7 @@ class SessionUseCases(
          * @param url The URL to be loaded using the selected session.
          */
         override fun invoke(url: String) {
-            this.invoke(url, sessionManager.selectedSession)
+            invoke(url, sessionManager.selectedSession)
         }
 
         /**
@@ -54,7 +54,7 @@ class SessionUseCases(
          * @param url The URL to be loaded using the provided session.
          * @param session the session for which the URL should be loaded.
          */
-        fun invoke(url: String, session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(url: String, session: Session? = sessionManager.selectedSession) {
             val loadSession = session ?: onNoSession.invoke(url)
             sessionManager.getOrCreateEngineSession(loadSession).loadUrl(url)
         }
@@ -68,7 +68,7 @@ class SessionUseCases(
          * Loads the provided data based on the mime type using the provided session (or the
          * currently selected session if none is provided).
          */
-        fun invoke(
+        operator fun invoke(
             data: String,
             mimeType: String,
             encoding: String = "UTF-8",
@@ -88,7 +88,7 @@ class SessionUseCases(
          *
          * @param session the session for which reload should be triggered.
          */
-        fun invoke(session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(session: Session? = sessionManager.selectedSession) {
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).reload()
             }
@@ -103,7 +103,7 @@ class SessionUseCases(
          *
          * @param session the session for which loading should be stopped.
          */
-        fun invoke(session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(session: Session? = sessionManager.selectedSession) {
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).stopLoading()
             }
@@ -116,7 +116,7 @@ class SessionUseCases(
         /**
          * Navigates back in the history of the currently selected session
          */
-        fun invoke(session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(session: Session? = sessionManager.selectedSession) {
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).goBack()
             }
@@ -129,7 +129,7 @@ class SessionUseCases(
         /**
          * Navigates forward in the history of the currently selected session
          */
-        fun invoke(session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(session: Session? = sessionManager.selectedSession) {
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).goForward()
             }
@@ -142,7 +142,7 @@ class SessionUseCases(
         /**
          * Requests the desktop version of the current session and reloads the page.
          */
-        fun invoke(enable: Boolean, session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(enable: Boolean, session: Session? = sessionManager.selectedSession) {
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).toggleDesktopMode(enable, true)
             }
@@ -155,7 +155,7 @@ class SessionUseCases(
         /**
          * Exits fullscreen mode of the current session.
          */
-        fun invoke(session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(session: Session? = sessionManager.selectedSession) {
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).exitFullScreenMode()
             }
@@ -168,7 +168,10 @@ class SessionUseCases(
         /**
          * Clears all user data sources available.
          */
-        fun invoke(session: Session? = sessionManager.selectedSession, data: BrowsingData = BrowsingData.all()) {
+        operator fun invoke(
+            session: Session? = sessionManager.selectedSession,
+            data: BrowsingData = BrowsingData.all()
+        ) {
             sessionManager.engine.clearData(data)
             if (session != null) {
                 sessionManager.getOrCreateEngineSession(session).clearData(data)

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SettingsUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SettingsUseCases.kt
@@ -37,7 +37,7 @@ class SettingsUseCases(
          *
          * @param value The new setting value
          */
-        fun invoke(value: T) {
+        operator fun invoke(value: T) {
             update(engineSettings, value)
             with(sessionManager) {
                 sessions.forEach {

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SwipeRefreshFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SwipeRefreshFeature.kt
@@ -53,7 +53,7 @@ class SwipeRefreshFeature(
      * Called when a swipe gesture triggers a refresh.
      */
     override fun onRefresh() {
-        reloadUrlUseCase.invoke(activeSession)
+        reloadUrlUseCase(activeSession)
     }
 
     /**

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -38,22 +38,22 @@ class SessionUseCasesTest {
 
     @Test
     fun loadUrl() {
-        useCases.loadUrl.invoke("http://mozilla.org")
+        useCases.loadUrl("http://mozilla.org")
         verify(selectedEngineSession).loadUrl("http://mozilla.org")
 
-        useCases.loadUrl.invoke("http://getpocket.com", selectedSession)
+        useCases.loadUrl("http://getpocket.com", selectedSession)
         verify(selectedEngineSession).loadUrl("http://getpocket.com")
     }
 
     @Test
     fun loadData() {
-        useCases.loadData.invoke("<html><body></body></html>", "text/html")
+        useCases.loadData("<html><body></body></html>", "text/html")
         verify(selectedEngineSession).loadData("<html><body></body></html>", "text/html", "UTF-8")
 
-        useCases.loadData.invoke("Should load in WebView", "text/plain", session = selectedSession)
+        useCases.loadData("Should load in WebView", "text/plain", session = selectedSession)
         verify(selectedEngineSession).loadData("Should load in WebView", "text/plain", "UTF-8")
 
-        useCases.loadData.invoke("ahr0cdovl21vemlsbgeub3jn==", "text/plain", "base64", selectedSession)
+        useCases.loadData("ahr0cdovl21vemlsbgeub3jn==", "text/plain", "base64", selectedSession)
         verify(selectedEngineSession).loadData("ahr0cdovl21vemlsbgeub3jn==", "text/plain", "base64")
     }
 
@@ -63,11 +63,11 @@ class SessionUseCasesTest {
         val session = mock<Session>()
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.reload.invoke(session)
+        useCases.reload(session)
         verify(engineSession).reload()
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.reload.invoke()
+        useCases.reload()
         verify(selectedEngineSession).reload()
     }
 
@@ -77,11 +77,11 @@ class SessionUseCasesTest {
         val session = mock<Session>()
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.stopLoading.invoke(session)
+        useCases.stopLoading(session)
         verify(engineSession).stopLoading()
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.stopLoading.invoke()
+        useCases.stopLoading()
         verify(selectedEngineSession).stopLoading()
     }
 
@@ -90,17 +90,17 @@ class SessionUseCasesTest {
         val engineSession = mock<EngineSession>()
         val session = mock<Session>()
 
-        useCases.goBack.invoke(null)
+        useCases.goBack(null)
         verify(engineSession, never()).goBack()
         verify(selectedEngineSession, never()).goBack()
 
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.goBack.invoke(session)
+        useCases.goBack(session)
         verify(engineSession).goBack()
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.goBack.invoke()
+        useCases.goBack()
         verify(selectedEngineSession).goBack()
     }
 
@@ -109,17 +109,17 @@ class SessionUseCasesTest {
         val engineSession = mock<EngineSession>()
         val session = mock<Session>()
 
-        useCases.goForward.invoke(null)
+        useCases.goForward(null)
         verify(engineSession, never()).goForward()
         verify(selectedEngineSession, never()).goForward()
 
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.goForward.invoke(session)
+        useCases.goForward(session)
         verify(engineSession).goForward()
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.goForward.invoke()
+        useCases.goForward()
         verify(selectedEngineSession).goForward()
     }
 
@@ -129,11 +129,11 @@ class SessionUseCasesTest {
         val session = mock<Session>()
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.requestDesktopSite.invoke(true, session)
+        useCases.requestDesktopSite(true, session)
         verify(engineSession).toggleDesktopMode(true, reload = true)
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.requestDesktopSite.invoke(true)
+        useCases.requestDesktopSite(true)
         verify(selectedEngineSession).toggleDesktopMode(true, reload = true)
     }
 
@@ -143,11 +143,11 @@ class SessionUseCasesTest {
         val session = mock<Session>()
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.exitFullscreen.invoke(session)
+        useCases.exitFullscreen(session)
         verify(engineSession).exitFullScreenMode()
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.exitFullscreen.invoke()
+        useCases.exitFullscreen()
         verify(selectedEngineSession).exitFullScreenMode()
     }
 
@@ -159,18 +159,18 @@ class SessionUseCasesTest {
         whenever(sessionManager.engine).thenReturn(engine)
         whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
 
-        useCases.clearData.invoke(session)
+        useCases.clearData(session)
         verify(engine).clearData()
         verify(engineSession).clearData()
 
-        useCases.clearData.invoke(data = BrowsingData.select(BrowsingData.COOKIES))
+        useCases.clearData(data = BrowsingData.select(BrowsingData.COOKIES))
         verify(engine).clearData(eq(BrowsingData.select(BrowsingData.COOKIES)), eq(null), any(), any())
 
-        useCases.clearData.invoke(session, data = BrowsingData.select(BrowsingData.COOKIES))
+        useCases.clearData(session, data = BrowsingData.select(BrowsingData.COOKIES))
         verify(engineSession).clearData(eq(BrowsingData.select(BrowsingData.COOKIES)), eq(null), any(), any())
 
         whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
-        useCases.clearData.invoke()
+        useCases.clearData()
         verify(selectedEngineSession).clearData()
     }
 
@@ -187,7 +187,7 @@ class SessionUseCasesTest {
             Session(url).also { createdSession = it }
         }
 
-        loadUseCase.invoke("https://www.example.com")
+        loadUseCase("https://www.example.com")
 
         assertEquals("https://www.example.com", sessionCreatedForUrl)
         assertNotNull(createdSession)
@@ -209,7 +209,7 @@ class SessionUseCasesTest {
             Session(url).also { createdSession = it }
         }
 
-        loadUseCase.invoke("Hello", mimeType = "plain/text", encoding = "UTF-8")
+        loadUseCase("Hello", mimeType = "plain/text", encoding = "UTF-8")
 
         assertEquals("about:blank", sessionCreatedForUrl)
         assertNotNull(createdSession)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
@@ -43,7 +43,7 @@ class SettingsUseCasesTest {
             }
         }
 
-        autoplaySetting.invoke(true)
+        autoplaySetting(true)
         verify(settings).allowAutoplayMedia = true
         verify(engineSessionA.settings).allowAutoplayMedia = true
         verify(engineSessionB.settings).allowAutoplayMedia = true
@@ -51,12 +51,12 @@ class SettingsUseCasesTest {
 
     @Test
     fun updateTrackingProtection() {
-        useCases.updateTrackingProtection.invoke(TrackingProtectionPolicy.none())
+        useCases.updateTrackingProtection(TrackingProtectionPolicy.none())
         verify(settings).trackingProtectionPolicy = TrackingProtectionPolicy.none()
         verify(engineSessionA).enableTrackingProtection(TrackingProtectionPolicy.none())
         verify(engineSessionB).enableTrackingProtection(TrackingProtectionPolicy.none())
 
-        useCases.updateTrackingProtection.invoke(TrackingProtectionPolicy.all())
+        useCases.updateTrackingProtection(TrackingProtectionPolicy.all())
         verify(settings).trackingProtectionPolicy = TrackingProtectionPolicy.all()
         verify(engineSessionA).enableTrackingProtection(TrackingProtectionPolicy.all())
         verify(engineSessionB).enableTrackingProtection(TrackingProtectionPolicy.all())

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -23,7 +23,7 @@ class TabsUseCases(
          *
          * @param session The session to select.
          */
-        fun invoke(session: Session) {
+        operator fun invoke(session: Session) {
             sessionManager.select(session)
         }
     }
@@ -36,7 +36,7 @@ class TabsUseCases(
          *
          * @param session The session to remove.
          */
-        fun invoke(session: Session) {
+        operator fun invoke(session: Session) {
             sessionManager.remove(session)
         }
     }
@@ -62,7 +62,7 @@ class TabsUseCases(
          * @param startLoading True (default) if the new tab should start loading immediately.
          * @param parent the parent session to use for the newly created session.
          */
-        fun invoke(
+        operator fun invoke(
             url: String,
             selectTab: Boolean = true,
             startLoading: Boolean = true,
@@ -100,7 +100,7 @@ class TabsUseCases(
          * @param startLoading True (default) if the new tab should start loading immediately.
          * @param parent the parent session to use for the newly created session.
          */
-        fun invoke(
+        operator fun invoke(
             url: String,
             selectTab: Boolean = true,
             startLoading: Boolean = true,
@@ -120,7 +120,7 @@ class TabsUseCases(
     class RemoveAllTabsUseCase internal constructor(
         private val sessionManager: SessionManager
     ) {
-        fun invoke() {
+        operator fun invoke() {
             sessionManager.removeSessions()
         }
     }
@@ -132,7 +132,7 @@ class TabsUseCases(
          * @param private pass true if only private tabs should be removed otherwise normal tabs will be removed
          */
 
-        fun invoke(private: Boolean) {
+        operator fun invoke(private: Boolean) {
             sessionManager.sessions.filter { it.private == private }.forEach {
                 sessionManager.remove(it)
             }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -30,7 +30,7 @@ class TabsUseCasesTest {
         val useCases = TabsUseCases(sessionManager)
 
         val session = Session("A")
-        useCases.selectTab.invoke(session)
+        useCases.selectTab(session)
 
         verify(sessionManager).select(session)
     }
@@ -41,7 +41,7 @@ class TabsUseCasesTest {
         val useCases = TabsUseCases(sessionManager)
 
         val session = Session("A")
-        useCases.removeTab.invoke(session)
+        useCases.removeTab(session)
 
         verify(sessionManager).remove(session)
     }
@@ -56,7 +56,7 @@ class TabsUseCasesTest {
 
         assertEquals(0, sessionManager.size)
 
-        useCases.addTab.invoke("https://www.mozilla.org")
+        useCases.addTab("https://www.mozilla.org")
 
         assertEquals(1, sessionManager.size)
         assertEquals("https://www.mozilla.org", sessionManager.selectedSessionOrThrow.url)
@@ -76,7 +76,7 @@ class TabsUseCasesTest {
 
         assertEquals(0, sessionManager.size)
 
-        useCases.addPrivateTab.invoke("https://www.mozilla.org")
+        useCases.addPrivateTab("https://www.mozilla.org")
 
         assertEquals(1, sessionManager.size)
         assertEquals("https://www.mozilla.org", sessionManager.selectedSessionOrThrow.url)
@@ -94,7 +94,7 @@ class TabsUseCasesTest {
 
         val useCases = TabsUseCases(sessionManager)
 
-        useCases.addTab.invoke("https://www.mozilla.org", startLoading = false)
+        useCases.addTab("https://www.mozilla.org", startLoading = false)
 
         verify(engineSession, never()).loadUrl("https://www.mozilla.org")
     }
@@ -107,7 +107,7 @@ class TabsUseCasesTest {
 
         val useCases = TabsUseCases(sessionManager)
 
-        useCases.addPrivateTab.invoke("https://www.mozilla.org", startLoading = false)
+        useCases.addPrivateTab("https://www.mozilla.org", startLoading = false)
 
         verify(engineSession, never()).loadUrl("https://www.mozilla.org")
     }
@@ -120,12 +120,12 @@ class TabsUseCasesTest {
 
         val useCases = TabsUseCases(sessionManager)
 
-        useCases.addPrivateTab.invoke("https://www.mozilla.org")
-        useCases.addTab.invoke("https://www.mozilla.org")
+        useCases.addPrivateTab("https://www.mozilla.org")
+        useCases.addTab("https://www.mozilla.org")
 
         assertEquals(2, sessionManager.size)
 
-        useCases.removeAllTabs.invoke()
+        useCases.removeAllTabs()
 
         assertEquals(0, sessionManager.size)
 
@@ -144,26 +144,26 @@ class TabsUseCasesTest {
         session1.customTabConfig = mock()
         sessionManager.add(session1)
 
-        useCases.addPrivateTab.invoke("https://www.mozilla.org")
-        useCases.addTab.invoke("https://www.mozilla.org")
+        useCases.addPrivateTab("https://www.mozilla.org")
+        useCases.addTab("https://www.mozilla.org")
 
         assertEquals(3, sessionManager.size)
 
-        useCases.removeAllTabsOfType.invoke(private = false)
+        useCases.removeAllTabsOfType(private = false)
 
         assertEquals(2, sessionManager.all.size)
 
-        useCases.addPrivateTab.invoke("https://www.mozilla.org")
-        useCases.addTab.invoke("https://www.mozilla.org")
-        useCases.addTab.invoke("https://www.mozilla.org")
+        useCases.addPrivateTab("https://www.mozilla.org")
+        useCases.addTab("https://www.mozilla.org")
+        useCases.addTab("https://www.mozilla.org")
 
         assertEquals(5, sessionManager.size)
 
-        useCases.removeAllTabsOfType.invoke(private = true)
+        useCases.removeAllTabsOfType(private = true)
 
         assertEquals(3, sessionManager.size)
 
-        useCases.removeAllTabsOfType.invoke(private = false)
+        useCases.removeAllTabsOfType(private = false)
         assertEquals(1, sessionManager.size)
 
         assertTrue(sessionManager.all[0].isCustomTabSession())

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -123,12 +123,12 @@ open class DefaultComponents(private val applicationContext: Context) {
                 },
                 BrowserMenuDivider(),
                 SimpleBrowserMenuItem("Clear Data") {
-                    sessionUseCases.clearData.invoke()
+                    sessionUseCases.clearData()
                 },
                 BrowserMenuCheckbox("Request desktop site", {
                     sessionManager.selectedSessionOrThrow.desktopMode
                 }) { checked ->
-                    sessionUseCases.requestDesktopSite.invoke(checked)
+                    sessionUseCases.requestDesktopSite(checked)
                 }
         )
     }
@@ -140,7 +140,7 @@ open class DefaultComponents(private val applicationContext: Context) {
                 contentDescription = "Forward",
                 isEnabled = { sessionManager.selectedSession?.canGoForward == true }
         ) {
-            sessionUseCases.goForward.invoke()
+            sessionUseCases.goForward()
         }
 
         val refresh = BrowserMenuItemToolbar.Button(
@@ -149,14 +149,14 @@ open class DefaultComponents(private val applicationContext: Context) {
                 contentDescription = "Refresh",
                 isEnabled = { sessionManager.selectedSession?.loading != true }
         ) {
-            sessionUseCases.reload.invoke()
+            sessionUseCases.reload()
         }
 
         val stop = BrowserMenuItemToolbar.Button(
                 mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
                 iconTintColorResource = R.color.photonBlue90,
                 contentDescription = "Stop") {
-            sessionUseCases.stopLoading.invoke()
+            sessionUseCases.stopLoading()
         }
 
         BrowserMenuItemToolbar(listOf(forward, refresh, stop))


### PR DESCRIPTION
`UseCases` represent functions for various tasks. Kotlin lets you invoke these classes like a function by adding `operator` to the `invoke()` functions already present in the classes.

This has no behavioural change, its just syntax sugar.

