### PR TITLE
PublicSuffixListData: Handle empty labels.

### DIFF
--- a/components/lib/publicsuffixlist/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
+++ b/components/lib/publicsuffixlist/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
@@ -22,12 +22,18 @@ internal class PublicSuffixListData(
         return exceptions.binarySearch(labels, labelIndex)
     }
 
+    @Suppress("ReturnCount")
     fun getPublicSuffixOffset(domain: String): PublicSuffixOffset? {
         if (domain.isEmpty()) {
             return null
         }
 
         val domainLabels = IDN.toUnicode(domain).split('.')
+        if (domainLabels.find { it.isEmpty() } != null) {
+            // At least one of the labels is empty: Bail out.
+            return null
+        }
+
         val rule = findMatchingRule(domainLabels)
 
         if (domainLabels.size == rule.size && rule[0][0] != PublicSuffixListData.EXCEPTION_MARKER) {

--- a/components/lib/publicsuffixlist/src/test/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListTest.kt
+++ b/components/lib/publicsuffixlist/src/test/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListTest.kt
@@ -369,4 +369,33 @@ class PublicSuffixListTest {
         assertFalse(publicSuffixList.isPublicSuffix("ork").await())
         assertFalse(publicSuffixList.isPublicSuffix("us.com.uk").await())
     }
+
+    /**
+     * Test cases inspired by Guava tests:
+     * https://github.com/google/guava/blob/master/guava-tests/test/com/google/common/net/InternetDomainNameTest.java
+     */
+    @Test
+    fun `Verify getPublicSuffix can handle obscure and invalid input`() = runBlocking {
+        assertEquals("cOM", publicSuffixList.getPublicSuffix("f-_-o.cOM").await())
+        assertEquals("com", publicSuffixList.getPublicSuffix("f11-1.com").await())
+        assertNull(publicSuffixList.getPublicSuffix("www").await())
+        assertEquals("a23", publicSuffixList.getPublicSuffix("abc.a23").await())
+        assertEquals("com", publicSuffixList.getPublicSuffix("a\u0394b.com").await())
+        assertNull(publicSuffixList.getPublicSuffix("").await())
+        assertNull(publicSuffixList.getPublicSuffix(" ").await())
+        assertNull(publicSuffixList.getPublicSuffix(".").await())
+        assertNull(publicSuffixList.getPublicSuffix("..").await())
+        assertNull(publicSuffixList.getPublicSuffix("...").await())
+        assertNull(publicSuffixList.getPublicSuffix("woo.com.").await())
+        assertNull(publicSuffixList.getPublicSuffix("::1").await())
+        assertNull(publicSuffixList.getPublicSuffix("13").await())
+
+        // The following input returns an empty string which does not seem correct:
+        // https://github.com/mozilla-mobile/android-components/issues/3541
+        assertEquals("", publicSuffixList.getPublicSuffix("foo.net.us\uFF61ocm").await())
+
+        // Technically that may be correct; but it doesn't make sense to return part of an IP as public suffix:
+        // https://github.com/mozilla-mobile/android-components/issues/3540
+        assertEquals("1", publicSuffixList.getPublicSuffix("127.0.0.1").await())
+    }
 }


### PR DESCRIPTION
This is a fix for this Fenix crash:
https://github.com/mozilla-mobile/fenix/issues/3625

Of course adding the test cases I found two other weird things. But they are not crashes and seem less critical: #3541, #3540