### PR TITLE
Publish browser-state component [ci skip]

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -167,7 +167,7 @@ projects:
   browser-state:
     path: components/browser/state
     description: 'Component responsible for maintaining the centralized state of a browser engine.'
-    publish: false
+    publish: true
   browser-storage-memory:
     path: components/browser/storage-memory
     description: 'A memory-backed implementation of core data storage.'


### PR DESCRIPTION
We need to publish browser-state now that `SessionManager` is using it (see https://github.com/mozilla-mobile/android-components/pull/3543)