### PR TITLE
Deprecate View.isVisible in favour of Android KTX

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -17,6 +17,7 @@ import android.widget.ImageButton
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.inputmethod.EditorInfoCompat
+import androidx.core.view.isVisible
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +36,6 @@ import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.view.forEach
-import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.ui.autocomplete.AutocompleteView
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import mozilla.components.ui.autocomplete.OnFilterListener
@@ -105,9 +105,9 @@ class BrowserToolbar @JvmOverloads constructor(
      * Set/Get whether a site security icon (usually a lock or globe icon) should be visible next to the URL.
      */
     var displaySiteSecurityIcon: Boolean
-        get() = displayToolbar.siteSecurityIconView.isVisible()
+        get() = displayToolbar.siteSecurityIconView.isVisible
         set(value) {
-            displayToolbar.siteSecurityIconView.visibility = if (value) View.VISIBLE else View.GONE
+            displayToolbar.siteSecurityIconView.isVisible = value
         }
 
     /**

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -15,6 +15,7 @@ import android.widget.ProgressBar
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -25,7 +26,6 @@ import mozilla.components.browser.toolbar.internal.measureActions
 import mozilla.components.browser.toolbar.internal.wrapAction
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
-import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.ui.icons.R.drawable.mozac_ic_globe
 import mozilla.components.ui.icons.R.drawable.mozac_ic_lock
 
@@ -189,7 +189,7 @@ internal class DisplayToolbar(
      */
     fun updateTitle(title: String) {
         titleView.text = title
-        titleView.visibility = if (title.isEmpty()) View.GONE else View.VISIBLE
+        titleView.isVisible = title.isNotEmpty()
     }
 
     /**
@@ -224,7 +224,7 @@ internal class DisplayToolbar(
      *
      */
     fun updateProgress(progress: Int) {
-        if (!progressView.isVisible() && progress > 0) {
+        if (!progressView.isVisible && progress > 0) {
             // Loading has just started, make visible and announce "loading" for accessibility.
             progressView.visibility = View.VISIBLE
             progressView.announceForAccessibility(context.getString(R.string.mozac_browser_toolbar_progress_loading))
@@ -315,12 +315,12 @@ internal class DisplayToolbar(
         val pageActionsWidth = measureActions(pageActions, size = height)
 
         // The url uses whatever space is left. Subtract the icon and (optionally) the menu
-        val menuWidth = if (menuView.isVisible()) height else 0
+        val menuWidth = if (menuView.isVisible) height else 0
         val urlWidth = (width - iconSize - browserActionsWidth - pageActionsWidth -
             menuWidth - navigationActionsWidth - 2 * urlBoxMargin)
         val urlWidthSpec = MeasureSpec.makeMeasureSpec(urlWidth, MeasureSpec.EXACTLY)
 
-        if (titleView.isVisible()) {
+        if (titleView.isVisible) {
             /* With a title view, the url and title split the rest of the space vertically. The
             title view and url should be centered as a singular unit in the middle third. */
             titleView.measure(urlWidthSpec, thirdFixedHeightSpec)
@@ -385,7 +385,7 @@ internal class DisplayToolbar(
         //   |   actions   |      |                                  |      |
         //   +-------------+------+----------------------------------+------+
 
-        val menuWidth = if (menuView.isVisible()) height else 0
+        val menuWidth = if (menuView.isVisible) height else 0
         menuView.layout(measuredWidth - menuView.measuredWidth, 0, measuredWidth, measuredHeight)
 
         // Now we add browser actions from the left side of the menu to the right (in reversed order):
@@ -431,7 +431,7 @@ internal class DisplayToolbar(
         //   | navigation  | icon | url       [ page    ] | browser  | menu |
         //   |   actions   |      |           [ actions ] | actions  |      |
         //   +-------------+------+-----------------------+----------+------+
-        val iconWidth = if (siteSecurityIconView.isVisible()) siteSecurityIconView.measuredWidth else 0
+        val iconWidth = if (siteSecurityIconView.isVisible) siteSecurityIconView.measuredWidth else 0
         val urlLeft = navigationActionsWidth + iconWidth + urlBoxMargin
 
         // If the titleView is visible, it will appear above the URL:
@@ -439,7 +439,7 @@ internal class DisplayToolbar(
         //   | navigation  | icon |  title       [ page    ] | browser  | menu |
         //   |   actions   |      |  url         [ actions ] | actions  |      |
         //   +-------------+------+-----------------------+----------+------+
-        if (titleView.isVisible()) {
+        if (titleView.isVisible) {
             val totalTextHeights = urlView.measuredHeight + titleView.measuredHeight
             val totalAvailablePadding = height - totalTextHeights
             val padding = totalAvailablePadding / MEASURED_HEIGHT_DENOMINATOR

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -15,6 +15,7 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
@@ -86,7 +87,7 @@ internal class EditToolbar(
         }
 
     internal fun updateClearViewVisibility(text: String) {
-        clearView.visibility = if (text.isBlank()) View.GONE else View.VISIBLE
+        clearView.isVisible = text.isNotBlank()
     }
 
     private val clearView = ImageView(context).apply {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -15,6 +15,7 @@ import android.view.accessibility.AccessibilityManager
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import androidx.core.view.inputmethod.EditorInfoCompat
+import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar.Companion.ACTION_PADDING_DP
@@ -24,7 +25,6 @@ import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.ktx.android.view.isGone
-import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -292,11 +292,11 @@ class BrowserToolbarTest {
         toolbar.editMode()
 
         assertTrue(toolbar.displayToolbar.isGone())
-        assertTrue(toolbar.editToolbar.isVisible())
+        assertTrue(toolbar.editToolbar.isVisible)
 
         toolbar.onUrlEntered("https://www.mozilla.org")
 
-        assertTrue(toolbar.displayToolbar.isVisible())
+        assertTrue(toolbar.displayToolbar.isVisible)
         assertTrue(toolbar.editToolbar.isGone())
     }
 
@@ -307,12 +307,12 @@ class BrowserToolbarTest {
         toolbar.editMode()
 
         assertTrue(toolbar.displayToolbar.isGone())
-        assertTrue(toolbar.editToolbar.isVisible())
+        assertTrue(toolbar.editToolbar.isVisible)
 
         toolbar.onUrlEntered("https://www.mozilla.org")
 
         assertTrue(toolbar.displayToolbar.isGone())
-        assertTrue(toolbar.editToolbar.isVisible())
+        assertTrue(toolbar.editToolbar.isVisible)
     }
 
     @Test
@@ -822,7 +822,7 @@ class BrowserToolbarTest {
     @Test
     fun `displaySiteSecurityIcon getter and setter`() {
         val toolbar = BrowserToolbar(testContext)
-        assertEquals(toolbar.displayToolbar.siteSecurityIconView.isVisible(), toolbar.displaySiteSecurityIcon)
+        assertEquals(toolbar.displayToolbar.siteSecurityIconView.isVisible, toolbar.displaySiteSecurityIcon)
 
         toolbar.displaySiteSecurityIcon = false
         assertEquals(View.GONE, toolbar.displayToolbar.siteSecurityIconView.visibility)

--- a/components/feature/prompts/build.gradle
+++ b/components/feature/prompts/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':concept-engine')
     implementation project(':support-ktx')
 
+    implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.google_material
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/TextPromptDialogFragmentTest.kt
@@ -8,11 +8,11 @@ import android.content.DialogInterface.BUTTON_POSITIVE
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.ext.appCompatContext
 import mozilla.components.feature.prompts.R.id
-import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.support.test.mock
+import mozilla.ext.appCompatContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -53,7 +53,7 @@ class TextPromptDialogFragmentTest {
         assertEquals(fragment.title, "title")
         assertEquals(inputLabel.text, "label")
         assertEquals(inputValue.text.toString(), "defaultValue")
-        assertTrue(checkBox.isVisible())
+        assertTrue(checkBox.isVisible)
 
         checkBox.isChecked = true
         assertTrue(fragment.userSelectionNoMoreDialogs)
@@ -77,7 +77,7 @@ class TextPromptDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(id.no_more_dialogs_check_box)
 
-        assertFalse(checkBox.isVisible())
+        assertFalse(checkBox.isVisible)
     }
 
     @Test

--- a/components/feature/readerview/build.gradle
+++ b/components/feature/readerview/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':ui-icons')
 
+    implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenter.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenter.kt
@@ -6,9 +6,9 @@
 
 package mozilla.components.feature.readerview.internal
 
+import androidx.core.view.isVisible
 import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
-import mozilla.components.support.ktx.android.view.isVisible
 
 /**
  * Presenter implementation that will update the view whenever the feature is started.
@@ -33,7 +33,7 @@ internal class ReaderViewControlsPresenter(
      * Checks whether or not the ReaderView controls are visible.
      */
     fun areControlsVisible(): Boolean {
-        return view.asView().isVisible()
+        return view.asView().isVisible
     }
 
     /**

--- a/components/feature/sitepermissions/build.gradle
+++ b/components/feature/sitepermissions/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
     implementation Dependencies.kotlin_coroutines
 
+    implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.androidx_constraintlayout
 

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
@@ -8,11 +8,11 @@ import android.view.Gravity.TOP
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.CheckBox
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature.PromptsStyling
-import mozilla.components.support.ktx.android.view.isVisible
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
@@ -44,7 +44,7 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertTrue("Checkbox should be displayed", checkBox.isVisible())
+        assertTrue("Checkbox should be displayed", checkBox.isVisible)
         assertFalse("Checkbox shouldn't be checked", checkBox.isChecked)
         assertFalse("User selection property should be false", fragment.userSelectionCheckBox)
     }
@@ -68,7 +68,7 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertTrue("Checkbox should be displayed", checkBox.isVisible())
+        assertTrue("Checkbox should be displayed", checkBox.isVisible)
         assertFalse("Checkbox shouldn't be checked", checkBox.isChecked)
         assertFalse("User selection property should be false", fragment.userSelectionCheckBox)
     }
@@ -92,7 +92,7 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertTrue("Checkbox should be displayed", checkBox.isVisible())
+        assertTrue("Checkbox should be displayed", checkBox.isVisible)
         assertTrue("Checkbox should be checked", checkBox.isChecked)
         assertTrue("User selection property should be true", fragment.userSelectionCheckBox)
     }
@@ -116,7 +116,7 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertFalse("Checkbox shouldn't be displayed", checkBox.isVisible())
+        assertFalse("Checkbox shouldn't be displayed", checkBox.isVisible)
         assertFalse("User selection property should be false", fragment.userSelectionCheckBox)
     }
 
@@ -281,7 +281,7 @@ class SitePermissionsDialogFragmentTest {
 
         val checkBox = dialog.findViewById<CheckBox>(R.id.do_not_ask_again)
 
-        assertFalse("Checkbox shouldn't be displayed", checkBox.isVisible())
+        assertFalse("Checkbox shouldn't be displayed", checkBox.isVisible)
         assertTrue("User selection property should be true", fragment.userSelectionCheckBox)
     }
 

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -30,6 +30,7 @@ val View.isLTR: Boolean
 
 /**
  * Returns true if this view's visibility is set to View.VISIBLE.
+ * @deprecated Use Android KTX instead.
  */
 fun View.isVisible(): Boolean {
     return visibility == View.VISIBLE


### PR DESCRIPTION
The Android KTX version also has a setter that I used where appropriate. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
