### PR TITLE
Closes #3559: Add actions for removing tabs to browser-state

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -187,6 +187,9 @@ class SessionManager(
      */
     fun removeSessions() {
         delegate.removeSessions()
+        store?.syncDispatch(
+            TabListAction.RemoveAllTabsAction
+        )
     }
 
     /**
@@ -194,6 +197,12 @@ class SessionManager(
      */
     fun removeAll() {
         delegate.removeAll()
+        store?.syncDispatch(
+            TabListAction.RemoveAllTabsAction
+        )
+        store?.syncDispatch(
+            CustomTabListAction.RemoveAllCustomTabsAction
+        )
     }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -58,6 +58,49 @@ class SessionManagerMigrationTest {
     }
 
     @Test
+    fun `Remove all regular sessions`() {
+        val store = BrowserStore()
+
+        val sessionManager = SessionManager(engine = mock(), store = store)
+        sessionManager.add(Session("https://www.mozilla.org"))
+        sessionManager.add(Session("https://www.firefox.com"))
+        sessionManager.add(Session("https://www.getpocket.com").apply { customTabConfig = mock() })
+
+        assertEquals(2, sessionManager.sessions.size)
+        assertEquals(3, sessionManager.all.size)
+        assertEquals(2, store.state.tabs.size)
+        assertEquals(1, store.state.customTabs.size)
+
+        sessionManager.removeSessions()
+
+        assertEquals(0, sessionManager.sessions.size)
+        assertEquals(1, sessionManager.all.size)
+        assertEquals(0, store.state.tabs.size)
+        assertEquals(1, store.state.customTabs.size)
+    }
+
+    @Test
+    fun `Remove all custom tab and regular sessions`() {
+        val store = BrowserStore()
+
+        val sessionManager = SessionManager(engine = mock(), store = store)
+        sessionManager.add(Session("https://www.mozilla.org"))
+        sessionManager.add(Session("https://www.firefox.com").apply {
+            customTabConfig = mock()
+        })
+
+        assertEquals(2, sessionManager.all.size)
+        assertEquals(1, store.state.tabs.size)
+        assertEquals(1, store.state.customTabs.size)
+
+        sessionManager.removeAll()
+
+        assertTrue(sessionManager.sessions.isEmpty())
+        assertTrue(store.state.tabs.isEmpty())
+        assertTrue(store.state.customTabs.isEmpty())
+    }
+
+    @Test
     fun `Selecting session`() {
         val store = BrowserStore()
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -39,6 +39,21 @@ sealed class TabListAction : BrowserAction() {
      * Restores state from a (partial) previous state.
      */
     data class RestoreAction(val tabs: List<TabSessionState>, val selectedTabId: String? = null) : TabListAction()
+
+    /**
+     * Removes both private and normal [TabSessionState]s.
+     */
+    object RemoveAllTabsAction : TabListAction()
+
+    /**
+     * Removes all private [TabSessionState]s.
+     */
+    object RemoveAllPrivateTabsAction : TabListAction()
+
+    /**
+     * Removes all non-private [TabSessionState]s.
+     */
+    object RemoveAllNormalTabsAction : TabListAction()
 }
 
 /**
@@ -54,6 +69,11 @@ sealed class CustomTabListAction : BrowserAction() {
      * Removes an existing [CustomTabSessionState] to [BrowserState.customTabs].
      */
     data class RemoveCustomTabAction(val tabId: String) : CustomTabListAction()
+
+    /**
+     * Removes all custom tabs [TabSessionState]s.
+     */
+    object RemoveAllCustomTabsAction : CustomTabListAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/CustomTabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/CustomTabListReducer.kt
@@ -20,6 +20,10 @@ internal object CustomTabListReducer {
                 val tab = state.findCustomTab(action.tabId) ?: return state
                 state.copy(customTabs = state.customTabs - tab)
             }
+
+            is CustomTabListAction.RemoveAllCustomTabsAction -> {
+                state.copy(customTabs = emptyList())
+            }
         }
     }
 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/CustomTabListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/CustomTabListActionTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.state.action
 
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createCustomTab
+import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
 import org.junit.Assert.assertEquals
@@ -59,5 +60,22 @@ class CustomTabListActionTest {
         assertEquals(2, store.state.customTabs.size)
         assertEquals(customTab1, store.state.customTabs[0])
         assertEquals(customTab2, store.state.customTabs[1])
+    }
+
+    @Test
+    fun `RemoveAllCustomTabsAction - Removes all custom tabs (but not regular tabs)`() {
+        val customTab1 = createCustomTab("https://www.mozilla.org")
+        val customTab2 = createCustomTab("https://www.firefox.com")
+        val regularTab = createTab(url = "https://www.mozilla.org")
+
+        val state = BrowserState(customTabs = listOf(customTab1, customTab2), tabs = listOf(regularTab))
+        val store = BrowserStore(state)
+
+        assertEquals(2, store.state.customTabs.size)
+        assertEquals(1, store.state.tabs.size)
+
+        store.dispatch(CustomTabListAction.RemoveAllCustomTabsAction).joinBlocking()
+        assertEquals(0, store.state.customTabs.size)
+        assertEquals(1, store.state.tabs.size)
     }
 }


### PR DESCRIPTION
Decided to implement all cases here since we also have `TabsUseCases.RemoveAllTabsOfTypeUseCase` so having independent action will come in handy:

- `TabsListAction.RemoveAllTabsAction`: Remove all tabs (private and non-private; maps to current `removeSessions` in SessionManager)
- `TabsListAction.RemoveAllPrivateTabsAction`: Remove all private tabs
- `TabsListAction.RemoveAllNormalTabsAction`: Remove all non-private (normal) tabs
- `CustomTabListAction.RemoveAllCustomTabsAction`: Remove all custom tabs

We probably want to deprecate `removeAll` in `SessionManager`, as it's not needed (except in tests), but I'd vote for doing that separately (in a follow-up). For now I've made it work by dispatching both `RemoveAllTabsAction` and `RemoveAllCustomTabsAction`.