### PR TITLE
Closes #3521: Expose GeckoView load flags for loadUrl calls

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -89,9 +89,9 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.loadUrl]
      */
-    override fun loadUrl(url: String) {
+    override fun loadUrl(url: String, flags: LoadUrlFlags) {
         requestFromWebContent = false
-        geckoSession.loadUri(url)
+        geckoSession.loadUri(url, flags.value)
     }
 
     /**

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.UnsupportedSettingException
@@ -302,8 +303,10 @@ class GeckoEngineSessionTest {
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.loadUrl("http://mozilla.org")
+        verify(geckoSession).loadUri("http://mozilla.org", GeckoSession.LOAD_FLAGS_NONE)
 
-        verify(geckoSession).loadUri("http://mozilla.org")
+        engineSession.loadUrl("http://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+        verify(geckoSession).loadUri("http://www.mozilla.org", GeckoSession.LOAD_FLAGS_EXTERNAL)
     }
 
     @Test
@@ -988,7 +991,7 @@ class GeckoEngineSessionTest {
         navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about"))
 
         assertEquals("sample:about", interceptorCalledWithUri)
-        verify(geckoSession).loadUri("https://mozilla.org")
+        verify(geckoSession).loadUri("https://mozilla.org", GeckoSession.LOAD_FLAGS_NONE)
     }
 
     @Test
@@ -1693,7 +1696,7 @@ class GeckoEngineSessionTest {
 
         // loadUrl(url: String)
         engineSession.loadUrl(fakeUrl)
-        verify(geckoSession).loadUri(fakeUrl)
+        verify(geckoSession).loadUri(fakeUrl, GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         // subsequent page loads _are_ from web content
@@ -1759,6 +1762,15 @@ class GeckoEngineSessionTest {
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
 
         verify(observer, never()).onLoadRequest(eq("sample:about"), anyBoolean(), anyBoolean())
+    }
+
+    @Test
+    fun loadFlagsAreAligned() {
+        assertEquals(LoadUrlFlags.BYPASS_CACHE, GeckoSession.LOAD_FLAGS_BYPASS_CACHE)
+        assertEquals(LoadUrlFlags.BYPASS_PROXY, GeckoSession.LOAD_FLAGS_BYPASS_PROXY)
+        assertEquals(LoadUrlFlags.EXTERNAL, GeckoSession.LOAD_FLAGS_EXTERNAL)
+        assertEquals(LoadUrlFlags.ALLOW_POPUPS, GeckoSession.LOAD_FLAGS_ALLOW_POPUPS)
+        assertEquals(LoadUrlFlags.BYPASS_CLASSIFIER, GeckoSession.LOAD_FLAGS_BYPASS_CLASSIFIER)
     }
 
     private fun mockGeckoSession(): GeckoSession {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -90,9 +90,9 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.loadUrl]
      */
-    override fun loadUrl(url: String) {
+    override fun loadUrl(url: String, flags: LoadUrlFlags) {
         requestFromWebContent = false
-        geckoSession.loadUri(url)
+        geckoSession.loadUri(url, flags.value)
     }
 
     /**

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -85,9 +85,9 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.loadUrl]
      */
-    override fun loadUrl(url: String) {
+    override fun loadUrl(url: String, flags: LoadUrlFlags) {
         requestFromWebContent = false
-        geckoSession.loadUri(url)
+        geckoSession.loadUri(url, flags.value)
     }
 
     /**

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.UnsupportedSettingException
@@ -306,8 +307,10 @@ class GeckoEngineSessionTest {
                 geckoSessionProvider = geckoSessionProvider)
 
         engineSession.loadUrl("http://mozilla.org")
+        verify(geckoSession).loadUri("http://mozilla.org", GeckoSession.LOAD_FLAGS_NONE)
 
-        verify(geckoSession).loadUri("http://mozilla.org")
+        engineSession.loadUrl("http://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+        verify(geckoSession).loadUri("http://www.mozilla.org", GeckoSession.LOAD_FLAGS_EXTERNAL)
     }
 
     @Test
@@ -1000,7 +1003,7 @@ class GeckoEngineSessionTest {
         navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about"))
 
         assertEquals("sample:about", interceptorCalledWithUri)
-        verify(geckoSession).loadUri("https://mozilla.org")
+        verify(geckoSession).loadUri("https://mozilla.org", GeckoSession.LOAD_FLAGS_NONE)
     }
 
     @Test
@@ -1575,6 +1578,15 @@ class GeckoEngineSessionTest {
         assertFalse(engineSession.recoverFromCrash())
 
         verify(engineSession.geckoSession, never()).restoreState(any())
+    }
+
+    @Test
+    fun loadFlagsAreAligned() {
+        assertEquals(LoadUrlFlags.BYPASS_CACHE, GeckoSession.LOAD_FLAGS_BYPASS_CACHE)
+        assertEquals(LoadUrlFlags.BYPASS_PROXY, GeckoSession.LOAD_FLAGS_BYPASS_PROXY)
+        assertEquals(LoadUrlFlags.EXTERNAL, GeckoSession.LOAD_FLAGS_EXTERNAL)
+        assertEquals(LoadUrlFlags.ALLOW_POPUPS, GeckoSession.LOAD_FLAGS_ALLOW_POPUPS)
+        assertEquals(LoadUrlFlags.BYPASS_CLASSIFIER, GeckoSession.LOAD_FLAGS_BYPASS_CLASSIFIER)
     }
 
     private fun mockGeckoSession(): GeckoSession {

--- a/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSession.kt
+++ b/components/browser/engine-servo/src/main/java/mozilla/components/browser/engine/servo/ServoEngineSession.kt
@@ -74,7 +74,7 @@ class ServoEngineSession(
         }
     }
 
-    override fun loadUrl(url: String) {
+    override fun loadUrl(url: String, flags: LoadUrlFlags) {
         val view = view
         if (view != null) {
             view.loadUri(Uri.parse(url))

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
@@ -62,9 +63,10 @@ class SystemEngineSession(
     }
 
     /**
-     * See [EngineSession.loadUrl]
+     * See [EngineSession.loadUrl]. Note that [LoadUrlFlags] are ignored in this engine
+     * implementation.
      */
-    override fun loadUrl(url: String) {
+    override fun loadUrl(url: String, flags: LoadUrlFlags) {
         if (!url.isEmpty()) {
             currentUrl = url
             webView.loadUrl(url, additionalHeaders)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -61,7 +61,7 @@ class EngineObserverTest {
                 notifyObservers { onLoadingStateChange(true) }
                 notifyObservers { onNavigationStateChange(true, true) }
             }
-            override fun loadUrl(url: String) {
+            override fun loadUrl(url: String, flags: LoadUrlFlags) {
                 notifyObservers { onLocationChange(url) }
                 notifyObservers { onProgress(100) }
                 notifyObservers { onLoadingStateChange(true) }
@@ -103,7 +103,7 @@ class EngineObserverTest {
             override fun saveState(): EngineSessionState = mock()
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun recoverFromCrash(): Boolean { return false }
-            override fun loadUrl(url: String) {
+            override fun loadUrl(url: String, flags: LoadUrlFlags) {
                 if (url.startsWith("https://")) {
                     notifyObservers { onSecurityChange(true, "host", "issuer") }
                 } else {
@@ -141,7 +141,7 @@ class EngineObserverTest {
 
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
             override fun saveState(): EngineSessionState = mock()
-            override fun loadUrl(url: String) {}
+            override fun loadUrl(url: String, flags: LoadUrlFlags) {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -143,9 +143,9 @@ abstract class EngineSession(
             const val SAFE_BROWSING_ALL =
                 SAFE_BROWSING_MALWARE + SAFE_BROWSING_UNWANTED + SAFE_BROWSING_HARMFUL + SAFE_BROWSING_PHISHING
 
-            internal const val RECOMMENDED: Int = AD + ANALYTICS + SOCIAL + TEST + SAFE_BROWSING_ALL
+            internal const val RECOMMENDED = AD + ANALYTICS + SOCIAL + TEST + SAFE_BROWSING_ALL
 
-            internal const val ALL: Int = RECOMMENDED + CRYPTOMINING + FINGERPRINTING + CONTENT
+            internal const val ALL = RECOMMENDED + CRYPTOMINING + FINGERPRINTING + CONTENT
 
             fun none() = TrackingProtectionPolicy(NONE)
 
@@ -207,9 +207,42 @@ abstract class EngineSession(
     }
 
     /**
-     * Loads the given URL.
+     * Describes a combination of flags provided to the engine when loading a URL.
      */
-    abstract fun loadUrl(url: String)
+    class LoadUrlFlags internal constructor(val value: Int) {
+        companion object {
+            const val NONE: Int = 0
+            const val BYPASS_CACHE: Int = 1 shl 0
+            const val BYPASS_PROXY: Int = 1 shl 1
+            const val EXTERNAL: Int = 1 shl 2
+            const val ALLOW_POPUPS: Int = 1 shl 3
+            const val BYPASS_CLASSIFIER: Int = 1 shl 4
+            internal const val ALL = BYPASS_CACHE + BYPASS_PROXY + EXTERNAL + ALLOW_POPUPS + BYPASS_CLASSIFIER
+
+            fun all() = LoadUrlFlags(ALL)
+            fun none() = LoadUrlFlags(NONE)
+            fun select(vararg types: Int) = LoadUrlFlags(types.sum())
+        }
+
+        fun contains(flag: Int) = (value and flag) != 0
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is LoadUrlFlags) return false
+            if (value != other.value) return false
+            return true
+        }
+
+        override fun hashCode() = value
+    }
+
+    /**
+     * Loads the given URL.
+     *
+     * @param url the url to load.
+     * @param flags the [LoadUrlFlags] to use when loading the provider url.
+     */
+    abstract fun loadUrl(url: String, flags: LoadUrlFlags = LoadUrlFlags.none())
 
     /**
      * Loads the data with the given mimeType.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.engine
 
 import android.graphics.Bitmap
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
@@ -583,6 +584,25 @@ class EngineSessionTest {
     }
 
     @Test
+    fun `load flags can be selected`() {
+        assertEquals(LoadUrlFlags.NONE, LoadUrlFlags.none().value)
+        assertEquals(LoadUrlFlags.ALL, LoadUrlFlags.all().value)
+
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE).value))
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY).value))
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.EXTERNAL).value))
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.ALLOW_POPUPS).value))
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.BYPASS_CLASSIFIER).value))
+
+        val flags = LoadUrlFlags.select(LoadUrlFlags.EXTERNAL)
+        assertTrue(flags.contains(LoadUrlFlags.EXTERNAL))
+        assertFalse(flags.contains(LoadUrlFlags.ALLOW_POPUPS))
+        assertFalse(flags.contains(LoadUrlFlags.BYPASS_CACHE))
+        assertFalse(flags.contains(LoadUrlFlags.BYPASS_CLASSIFIER))
+        assertFalse(flags.contains(LoadUrlFlags.BYPASS_PROXY))
+    }
+
+    @Test
     fun `engine observer has default methods`() {
         val defaultObserver = object : EngineSession.Observer {}
 
@@ -632,7 +652,7 @@ open class DummyEngineSession : EngineSession() {
 
     override fun saveState(): EngineSessionState { return mock() }
 
-    override fun loadUrl(url: String) {}
+    override fun loadUrl(url: String, flags: LoadUrlFlags) {}
 
     override fun loadData(data: String, mimeType: String, encoding: String) {}
 

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
@@ -160,12 +160,12 @@ class ClipboardSuggestionProviderTest {
 
         val suggestion = suggestions.first()
 
-        verify(useCase, never()).invoke(any(), any())
+        verify(useCase, never()).invoke(any(), any(), any())
 
         assertNotNull(suggestion.onSuggestionClicked)
         suggestion.onSuggestionClicked!!.invoke()
 
-        verify(useCase).invoke(eq("https://www.mozilla.org"), any())
+        verify(useCase).invoke(eq("https://www.mozilla.org"), any(), any())
     }
 
     @Test

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.session
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine.BrowsingData
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 
 /**
  * Contains use cases related to the session feature.
@@ -27,7 +28,7 @@ class SessionUseCases(
      * Contract for use cases that load a provided URL.
      */
     interface LoadUrlUseCase {
-        fun invoke(url: String)
+        fun invoke(url: String, flags: LoadUrlFlags = LoadUrlFlags.none())
     }
 
     class DefaultLoadUrlUseCase internal constructor(
@@ -41,9 +42,10 @@ class SessionUseCases(
          * [onNoSession].
          *
          * @param url The URL to be loaded using the selected session.
+         * @param flags The [LoadUrlFlags] to use when loading the provided url.
          */
-        override fun invoke(url: String) {
-            invoke(url, sessionManager.selectedSession)
+        override operator fun invoke(url: String, flags: LoadUrlFlags) {
+            this.invoke(url, sessionManager.selectedSession, flags)
         }
 
         /**
@@ -53,10 +55,15 @@ class SessionUseCases(
          *
          * @param url The URL to be loaded using the provided session.
          * @param session the session for which the URL should be loaded.
+         * @param flags The [LoadUrlFlags] to use when loading the provided url.
          */
-        operator fun invoke(url: String, session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(
+            url: String,
+            session: Session? = sessionManager.selectedSession,
+            flags: LoadUrlFlags = LoadUrlFlags.none()
+        ) {
             val loadSession = session ?: onNoSession.invoke(url)
-            sessionManager.getOrCreateEngineSession(loadSession).loadUrl(url)
+            sessionManager.getOrCreateEngineSession(loadSession).loadUrl(url, flags)
         }
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.Engine.BrowsingData
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -41,8 +42,16 @@ class SessionUseCasesTest {
         useCases.loadUrl("http://mozilla.org")
         verify(selectedEngineSession).loadUrl("http://mozilla.org")
 
+        useCases.loadUrl("http://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+        verify(selectedEngineSession).loadUrl("http://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+
         useCases.loadUrl("http://getpocket.com", selectedSession)
         verify(selectedEngineSession).loadUrl("http://getpocket.com")
+
+        useCases.loadUrl.invoke("http://www.getpocket.com", selectedSession,
+                LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY))
+        verify(selectedEngineSession).loadUrl("http://www.getpocket.com",
+                LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY))
     }
 
     @Test

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.tabs
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.feature.session.SessionUseCases.LoadUrlUseCase
 
 /**
@@ -49,9 +50,10 @@ class TabsUseCases(
          * Adds a new tab and loads the provided URL.
          *
          * @param url The URL to be loaded in the new tab.
+         * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
-        override fun invoke(url: String) {
-            this.invoke(url, true, true, null)
+        override fun invoke(url: String, flags: LoadUrlFlags) {
+            this.invoke(url, true, true, null, flags)
         }
 
         /**
@@ -61,18 +63,20 @@ class TabsUseCases(
          * @param selectTab True (default) if the new tab should be selected immediately.
          * @param startLoading True (default) if the new tab should start loading immediately.
          * @param parent the parent session to use for the newly created session.
+         * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
         operator fun invoke(
             url: String,
             selectTab: Boolean = true,
             startLoading: Boolean = true,
-            parent: Session? = null
+            parent: Session? = null,
+            flags: LoadUrlFlags = LoadUrlFlags.none()
         ): Session {
             val session = Session(url, false, Source.NEW_TAB)
             sessionManager.add(session, selected = selectTab, parent = parent)
 
             if (startLoading) {
-                sessionManager.getOrCreateEngineSession(session).loadUrl(url)
+                sessionManager.getOrCreateEngineSession(session).loadUrl(url, flags)
             }
 
             return session
@@ -87,9 +91,10 @@ class TabsUseCases(
          * Adds a new private tab and loads the provided URL.
          *
          * @param url The URL to be loaded in the new private tab.
+         * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
-        override fun invoke(url: String) {
-            this.invoke(url, true, true, null)
+        override fun invoke(url: String, flags: LoadUrlFlags) {
+            this.invoke(url, true, true, null, flags)
         }
 
         /**
@@ -99,18 +104,20 @@ class TabsUseCases(
          * @param selectTab True (default) if the new tab should be selected immediately.
          * @param startLoading True (default) if the new tab should start loading immediately.
          * @param parent the parent session to use for the newly created session.
+         * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
         operator fun invoke(
             url: String,
             selectTab: Boolean = true,
             startLoading: Boolean = true,
-            parent: Session? = null
+            parent: Session? = null,
+            flags: LoadUrlFlags = LoadUrlFlags.none()
         ): Session {
             val session = Session(url, true, Source.NEW_TAB)
             sessionManager.add(session, selected = selectTab, parent = parent)
 
             if (startLoading) {
-                sessionManager.getOrCreateEngineSession(session).loadUrl(url)
+                sessionManager.getOrCreateEngineSession(session).loadUrl(url, flags)
             }
 
             return session

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -100,6 +101,18 @@ class TabsUseCasesTest {
     }
 
     @Test
+    fun `AddNewTabUseCase forwards load flags to engine`() {
+        val sessionManager = spy(SessionManager(mock()))
+        val engineSession: EngineSession = mock()
+        doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(any())
+
+        val useCases = TabsUseCases(sessionManager)
+
+        useCases.addTab.invoke("https://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+        verify(engineSession).loadUrl("https://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+    }
+
+    @Test
     fun `AddNewPrivateTabUseCase will not load URL if flag is set to false`() {
         val sessionManager = spy(SessionManager(mock()))
         val engineSession: EngineSession = mock()
@@ -110,6 +123,18 @@ class TabsUseCasesTest {
         useCases.addPrivateTab("https://www.mozilla.org", startLoading = false)
 
         verify(engineSession, never()).loadUrl("https://www.mozilla.org")
+    }
+
+    @Test
+    fun `AddNewPrivateTabUseCase forwards load flags to engine`() {
+        val sessionManager = spy(SessionManager(mock()))
+        val engineSession: EngineSession = mock()
+        doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(any())
+
+        val useCases = TabsUseCases(sessionManager)
+
+        useCases.addPrivateTab.invoke("https://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
+        verify(engineSession).loadUrl("https://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
     }
 
     @Test

--- a/components/feature/toolbar/build.gradle
+++ b/components/feature/toolbar/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':feature-session')
     implementation project(':browser-session')
     implementation project(':browser-domains')
+    implementation project(':concept-engine')
     implementation project(':concept-toolbar')
     implementation project(':concept-storage')
     implementation project(':lib-publicsuffixlist')

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -7,6 +7,7 @@
 package mozilla.components.feature.toolbar
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
@@ -79,7 +80,7 @@ class ToolbarInteractorTest {
     fun `provide custom use case for loading url`() {
         var useCaseInvokedWithUrl = ""
         val loadUrlUseCase = object : SessionUseCases.LoadUrlUseCase {
-            override fun invoke(url: String) {
+            override fun invoke(url: String, flags: EngineSession.LoadUrlFlags) {
                 useCaseInvokedWithUrl = url
             }
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,17 @@ permalink: /changelog/
 * **browser-icons**
   * The component now ships with the [tippy-top-sites](https://github.com/mozilla/tippy-top-sites) top 200 list for looking up icon resources.
 
+* **concept-engine**, **browser-engine-gecko(-beta/nightly)**, **feature-session**, **feature-tabs**
+  * Added to support for specifying additional flags when loading URLs. This can be done using the engine session directly, as well as via use cases:
+  ```kotlin
+  // Bypass cache
+  sessionManager.getEngineSession().loadUrl(url, LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE))
+
+  // Bypass cache and proxy
+  sessionUseCases.loadUrl.invoke(url, LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE, LoadUrlFlags.BYPASS_PROXY))
+  
+  ```
+
 # 1.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v0.56.0...v1.0.0)


### PR DESCRIPTION
This allows specifying Gecko load flags (similar to other Gecko flags e.g. for clear data and tracking protection) and should also keep the API backward compatible. 