### PR TITLE
Point default experiments Kinto endpoint to prod server

### DIFF
--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/Configuration.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/Configuration.kt
@@ -14,5 +14,5 @@ import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
  */
 data class Configuration(
     val httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() },
-    val kintoEndpoint: String = ExperimentsUpdater.KINTO_ENDPOINT_DEV
+    val kintoEndpoint: String = ExperimentsUpdater.KINTO_ENDPOINT_PROD
 )

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivityTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivityTest.kt
@@ -110,9 +110,9 @@ class ExperimentsDebugActivityTest {
 
         activity.create().start().resume()
 
-        // Right now we default to the dev instance, so make sure that we are on the default if no
-        // extra is used
-        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_DEV, Experiments.updater.source.baseUrl)
+        // We default to the prod instance, so make sure that we are on the default if no extra is
+        // used.
+        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_PROD, Experiments.updater.source.baseUrl)
 
         // Destroy the activity so we can create a new one with the command added to the intent
         activity.pause().stop().destroy()
@@ -128,24 +128,24 @@ class ExperimentsDebugActivityTest {
         // Destroy the activity so we can create a new one with a new command added to the intent
         activity.pause().stop().destroy()
 
-        intent.putExtra(ExperimentsDebugActivity.SET_KINTO_INSTANCE_EXTRA_KEY, "prod")
-        activity = Robolectric.buildActivity(ExperimentsDebugActivity::class.java, intent)
-
-        activity.create().start().resume()
-
-        // Make sure we changed to the 'production' instance
-        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_PROD, Experiments.updater.source.baseUrl)
-
-        // Destroy the activity so we can create a new one with a new command added to the intent
-        activity.pause().stop().destroy()
-
         intent.putExtra(ExperimentsDebugActivity.SET_KINTO_INSTANCE_EXTRA_KEY, "dev")
         activity = Robolectric.buildActivity(ExperimentsDebugActivity::class.java, intent)
 
         activity.create().start().resume()
 
-        // Make sure we changed to the 'developer' instance
+        // Make sure we changed to the 'dev' instance
         assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_DEV, Experiments.updater.source.baseUrl)
+
+        // Destroy the activity so we can create a new one with a new command added to the intent
+        activity.pause().stop().destroy()
+
+        intent.putExtra(ExperimentsDebugActivity.SET_KINTO_INSTANCE_EXTRA_KEY, "prod")
+        activity = Robolectric.buildActivity(ExperimentsDebugActivity::class.java, intent)
+
+        activity.create().start().resume()
+
+        // Make sure we changed to the 'developer' instance
+        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_PROD, Experiments.updater.source.baseUrl)
     }
 
     @Test
@@ -161,9 +161,9 @@ class ExperimentsDebugActivityTest {
 
         activity.create().start().resume()
 
-        // Right now we default to the dev instance, so make sure that we are on the default if no
+        // Right now we default to the prod instance, so make sure that we are on the default if no
         // extra is used
-        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_DEV, Experiments.updater.source.baseUrl)
+        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_PROD, Experiments.updater.source.baseUrl)
 
         // Destroy the activity so we can create a new one with the command added to the intent
         activity.pause().stop().destroy()
@@ -173,8 +173,8 @@ class ExperimentsDebugActivityTest {
 
         activity.create().start().resume()
 
-        // Make sure we stayed on the 'developer' instance
-        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_DEV, Experiments.updater.source.baseUrl)
+        // Make sure we stayed on the 'production' instance
+        assertEquals(ExperimentsUpdater.KINTO_ENDPOINT_PROD, Experiments.updater.source.baseUrl)
     }
 
     @Test


### PR DESCRIPTION
The current default endpoint for the experiments library is the Kinto dev server, it should be the prod server instead.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
