### PR TITLE
For #1514: Better follow app bar specs

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -16,7 +16,6 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import androidx.core.view.setPadding
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.R
@@ -75,8 +74,9 @@ internal class DisplayToolbar(
         set(value) { menuView.menuBuilder = value }
 
     internal val siteSecurityIconView = AppCompatImageView(context).apply {
-        setPadding(resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_icon_padding))
-
+        val paddingHorizontal = resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_icon_horizontal_padding)
+        val paddingVertical = resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_menu_padding)
+        setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, paddingVertical)
         setImageResource(mozac_ic_globe)
 
         // Avoiding text behind the icon being selectable. If the listener is not set
@@ -306,11 +306,18 @@ internal class DisplayToolbar(
         // The icon and menu fill the whole height and have a square shape
         val iconSize = height
         val squareSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
-        siteSecurityIconView.measure(squareSpec, squareSpec)
+        val securityWidth = resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_button_width)
+        val startEndPadding = siteSecurityIconView.paddingStart + siteSecurityIconView.paddingEnd
+        val securityIconWidthSpec = MeasureSpec.makeMeasureSpec(securityWidth + startEndPadding, MeasureSpec.EXACTLY)
+        siteSecurityIconView.measure(securityIconWidthSpec, securityIconWidthSpec)
         menuView.measure(squareSpec, squareSpec)
 
         // Measure all actions and use the available height for determining the size (square shape)
-        val navigationActionsWidth = measureActions(navigationActions, size = height)
+        val navigationActionsWidth = measureActions(
+                navigationActions,
+                size = resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_button_width)
+        )
+
         val browserActionsWidth = measureActions(browserActions, size = height)
         val pageActionsWidth = measureActions(pageActions, size = height)
 
@@ -357,12 +364,11 @@ internal class DisplayToolbar(
             .asSequence()
             .mapNotNull { it.view }
             .fold(0) { usedWidth, view ->
-                val viewLeft = usedWidth
+                val viewLeft = usedWidth + resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_left_padding_navigation)
                 val viewRight = viewLeft + view.measuredWidth
-
                 view.layout(viewLeft, 0, viewRight, measuredHeight)
 
-                usedWidth + view.measuredWidth
+                viewLeft + view.measuredWidth
             }
 
         // The icon is always on the far left side of the toolbar. We cam lay it out even if it's

--- a/components/browser/toolbar/src/main/res/values/dimens.xml
+++ b/components/browser/toolbar/src/main/res/values/dimens.xml
@@ -8,8 +8,10 @@
     <!-- DisplayToolbar -->
     <dimen name="mozac_browser_toolbar_progress_bar_height">3dp</dimen>
     <dimen name="mozac_browser_toolbar_url_fading_edge_size">24dp</dimen>
-    <dimen name="mozac_browser_toolbar_icon_padding">16dp</dimen>
+    <dimen name="mozac_browser_toolbar_icon_horizontal_padding">8dp</dimen>
     <dimen name="mozac_browser_toolbar_menu_padding">16dp</dimen>
+    <dimen name="mozac_browser_toolbar_button_width">24dp</dimen>
+    <dimen name="mozac_browser_toolbar_left_padding_navigation">16dp</dimen>
 
     <!-- EditToolbar -->
     <dimen name="mozac_browser_toolbar_url_padding">8dp</dimen>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -88,8 +88,8 @@ class DisplayToolbarTest {
 
         val iconView = extractIconView(displayToolbar)
 
-        assertEquals(56, iconView.measuredWidth)
-        assertEquals(56, iconView.measuredHeight)
+        assertEquals(40, iconView.measuredWidth)
+        assertEquals(40, iconView.measuredHeight)
     }
 
     @Test
@@ -347,8 +347,8 @@ class DisplayToolbarTest {
 
         val view = extractActionView(displayToolbar, "Back")!!
 
-        assertEquals(56, view.measuredWidth)
-        assertEquals(56, view.measuredHeight)
+        assertEquals(24, view.measuredWidth)
+        assertEquals(24, view.measuredHeight)
     }
 
     @Test
@@ -476,11 +476,11 @@ class DisplayToolbarTest {
         val forwardView = extractActionView(displayToolbar, "Forward")!!
         val backView = extractActionView(displayToolbar, "Back")!!
 
-        assertEquals(56, forwardView.measuredWidth)
-        assertEquals(56, forwardView.measuredHeight)
+        assertEquals(24, forwardView.measuredWidth)
+        assertEquals(24, forwardView.measuredHeight)
 
         assertEquals(500, backView.measuredWidth)
-        assertEquals(56, backView.measuredHeight)
+        assertEquals(24, backView.measuredHeight)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-toolbar**
+  * Updated `DisplayToolbar` to better match UX specs
+
 * **browser-awesomebar**
   * Updated `DefaultSuggestionViewHolder` to have a style more consistent with Fenix mocks.
   


### PR DESCRIPTION
### Before

<img width="355" alt="Screen Shot 2019-07-01 at 10 38 45 AM" src="https://user-images.githubusercontent.com/4400286/60456403-07fc2e80-9bee-11e9-84a4-c5fd18426795.png">

### After
<img width="355" alt="Screen Shot 2019-07-01 at 10 43 27 AM" src="https://user-images.githubusercontent.com/4400286/60456395-06cb0180-9bee-11e9-8673-c98986f3ea84.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
