### PR TITLE
For mozilla-mobile/fenix#2945: Dispatchers.default is a deadlock footgun

### DIFF
--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngineManager.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.CoroutineContext
 class SearchEngineManager(
     private val providers: List<SearchEngineProvider> = listOf(
             AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())),
-    coroutineContext: CoroutineContext = Dispatchers.Default
+    coroutineContext: CoroutineContext = Dispatchers.IO
 ) {
     private var deferredSearchEngines: Deferred<SearchEngineList>? = null
     private val scope = CoroutineScope(coroutineContext)

--- a/docs/api/mozilla.components.browser.search/-search-engine-manager/-init-.md
+++ b/docs/api/mozilla.components.browser.search/-search-engine-manager/-init-.md
@@ -3,7 +3,7 @@
 # &lt;init&gt;
 
 `SearchEngineManager(providers: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`SearchEngineProvider`](../../mozilla.components.browser.search.provider/-search-engine-provider/index.md)`> = listOf(
-            AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())), coroutineContext: `[`CoroutineContext`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/-coroutine-context/index.html)` = Dispatchers.Default)`
+            AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())), coroutineContext: `[`CoroutineContext`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/-coroutine-context/index.html)` = Dispatchers.IO)`
 
 This class provides access to a centralized registry of search engines.
 

--- a/docs/api/mozilla.components.browser.search/-search-engine-manager/index.md
+++ b/docs/api/mozilla.components.browser.search/-search-engine-manager/index.md
@@ -11,7 +11,7 @@ This class provides access to a centralized registry of search engines.
 | Name | Summary |
 |---|---|
 | [&lt;init&gt;](-init-.md) | `SearchEngineManager(providers: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`SearchEngineProvider`](../../mozilla.components.browser.search.provider/-search-engine-provider/index.md)`> = listOf(
-            AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())), coroutineContext: `[`CoroutineContext`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/-coroutine-context/index.html)` = Dispatchers.Default)`<br>This class provides access to a centralized registry of search engines. |
+            AssetsSearchEngineProvider(LocaleSearchLocalizationProvider())), coroutineContext: `[`CoroutineContext`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/-coroutine-context/index.html)` = Dispatchers.IO)`<br>This class provides access to a centralized registry of search engines. |
 
 ### Properties
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 
 * **feature-pwa**
   * Added preliminary support for pinning websites to the home screen.
+  
+* **browser-search**
+  * Loading search engines should no longer deadlock on devices with 1-2 CPUs
 
 # 2.0.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -87,7 +87,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     // Search
     val searchEngineManager by lazy {
         SearchEngineManager().apply {
-            CoroutineScope(Dispatchers.Default).launch {
+            CoroutineScope(Dispatchers.IO).launch {
                 loadAsync(applicationContext).await()
             }
         }


### PR DESCRIPTION
Lesson Learned: Always make sure you or the library method you're using specifies a dispatcher when using Kotlin Coroutines. The default dispatcher is almost always the wrong answer. I believe the default thread pool size still equals # of CPUs plus one. Using the default dispatcher when the IO dispatcher is needed will result in deadlocks, livelocks, and ANRs which only appear on cheaper devices with fewer CPUs. It's very common that these issues do not become noticeable until an app is deployed to production.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
