### PR TITLE
Closes #3630: Bump application-services to 0.31.3

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val jna = "5.2.0"
     const val disklrucache = "2.0.2"
 
-    const val mozilla_appservices = "0.31.2"
+    const val mozilla_appservices = "0.31.3"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"


### PR DESCRIPTION
For your consideration, as described in https://github.com/mozilla-mobile/android-components/issues/3630

I targeted this PR at the `releases/0.56` branch but I don't really know if that's the right approach, please correct as appropriate. /cc @grigoryk.