### PR TITLE
Closes #3582: IntentProcessor should set flags when loading URL

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -221,6 +221,7 @@ abstract class EngineSession(
 
             fun all() = LoadUrlFlags(ALL)
             fun none() = LoadUrlFlags(NONE)
+            fun external() = LoadUrlFlags(EXTERNAL)
             fun select(vararg types: Int) = LoadUrlFlags(types.sum())
         }
 

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -587,6 +587,7 @@ class EngineSessionTest {
     fun `load flags can be selected`() {
         assertEquals(LoadUrlFlags.NONE, LoadUrlFlags.none().value)
         assertEquals(LoadUrlFlags.ALL, LoadUrlFlags.all().value)
+        assertEquals(LoadUrlFlags.EXTERNAL, LoadUrlFlags.external().value)
 
         assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE).value))
         assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.BYPASS_PROXY).value))

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.utils.SafeIntent
@@ -52,14 +53,14 @@ class IntentProcessor(
                     this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
                 }
                 sessionManager.add(session)
-                sessionUseCases.loadUrl(url, session)
+                sessionUseCases.loadUrl(url, session, LoadUrlFlags.external())
                 intent.putExtra(ACTIVE_SESSION_ID, session.id)
                 true
             }
 
             else -> {
                 val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
-                sessionUseCases.loadUrl(url, session)
+                sessionUseCases.loadUrl(url, session, LoadUrlFlags.external())
                 true
             }
         }
@@ -80,7 +81,8 @@ class IntentProcessor(
                             url,
                             private = isPrivate,
                             source = Source.ACTION_SEND
-                        )
+                        ),
+                        LoadUrlFlags.external()
                     )
                 } ?: run {
                     searchUseCases.newTabSearch(extraText, Source.ACTION_SEND, openNewTab)

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.test.any
@@ -69,7 +70,7 @@ class IntentProcessorTest {
 
         whenever(intent.dataString).thenReturn("http://mozilla.org")
         handler.process(intent)
-        verify(engineSession).loadUrl("http://mozilla.org")
+        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
 
         val session = sessionManager.all[0]
         assertNotNull(session)
@@ -92,7 +93,7 @@ class IntentProcessorTest {
         whenever(intent.dataString).thenReturn("http://mozilla.org")
 
         handler.process(intent)
-        verify(engineSession).loadUrl("http://mozilla.org")
+        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
     }
 
     @Test
@@ -113,7 +114,7 @@ class IntentProcessorTest {
         whenever(intent.dataString).thenReturn("http://mozilla.org")
 
         handler.process(intent)
-        verify(engineSession).loadUrl("http://mozilla.org")
+        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
     }
 
     @Test
@@ -177,7 +178,7 @@ class IntentProcessorTest {
 
         handler.process(intent)
         verify(sessionManager).add(anySession(), eq(false), eq(null), eq(null))
-        verify(engineSession).loadUrl("http://mozilla.org")
+        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
 
         val customTabSession = sessionManager.all[0]
         assertNotNull(customTabSession)
@@ -197,23 +198,23 @@ class IntentProcessorTest {
 
         whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("http://mozilla.org")
         handler.process(intent)
-        verify(engineSession).loadUrl("http://mozilla.org")
+        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
 
         whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("see http://getpocket.com")
         handler.process(intent)
-        verify(engineSession).loadUrl("http://getpocket.com")
+        verify(engineSession).loadUrl("http://getpocket.com", LoadUrlFlags.external())
 
         whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("see http://mozilla.com and http://getpocket.com")
         handler.process(intent)
-        verify(engineSession).loadUrl("http://mozilla.com")
+        verify(engineSession).loadUrl("http://mozilla.com", LoadUrlFlags.external())
 
         whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("checkout the Tweet: http://tweets.mozilla.com")
         handler.process(intent)
-        verify(engineSession).loadUrl("http://tweets.mozilla.com")
+        verify(engineSession).loadUrl("http://tweets.mozilla.com", LoadUrlFlags.external())
 
         whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("checkout the Tweet: HTTP://tweets.mozilla.com")
         handler.process(intent)
-        verify(engineSession).loadUrl("http://tweets.mozilla.com")
+        verify(engineSession).loadUrl("http://tweets.mozilla.com", LoadUrlFlags.external())
     }
 
     @Test


### PR DESCRIPTION
Makes sure we're passing in the load flag "external" when loading URLs from intents. I've also created a shortcut for it as it seems a common enough use case.