### PR TITLE
For #3274: Removes setSelectAllOnFocus from EditToolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -55,7 +55,6 @@ internal class EditToolbar(
         inputType = InputType.TYPE_TEXT_VARIATION_URI or InputType.TYPE_CLASS_TEXT
 
         setPadding(resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_padding))
-        setSelectAllOnFocus(true)
 
         setOnCommitListener {
             // We emit the fact before notifying the listener because otherwise the listener may cause a focus


### PR DESCRIPTION
This is a small follow-up PR to #3447 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
