### PR TITLE
Save 1min in release end to end time by running dummy task in smaller docker images

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -330,7 +330,7 @@ class TaskBuilder(object):
         )
 
     def _craft_dummy_task(
-        self, name, description,  dependencies=None, routes=[], scopes=[],
+        self, name, description,  dependencies=None, routes=None, scopes=None,
     ):
         payload = {
             "maxRunTime": 600,

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -310,7 +310,7 @@ class TaskBuilder(object):
             "maxRunTime": 7200,
             "image": "mozillamobile/android-components:1.19",
             "command": [
-                "/bin/bash",
+                "/bin/sh",
                 "--login",
                 "-cx",
                 command

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -73,11 +73,10 @@ class TaskBuilder(object):
         )
 
     def craft_barrier_task(self, dependencies):
-        return self._craft_build_ish_task(
+        return self._craft_dummy_task(
             name='Android Components - Barrier task to wait on other tasks to complete',
             description='Dummy tasks that ensures all other tasks are correctly done before publishing them',
             dependencies=dependencies,
-            command="exit 0"
         )
 
     def craft_detekt_task(self):
@@ -317,6 +316,31 @@ class TaskBuilder(object):
                 command
             ],
             "artifacts": artifacts,
+        }
+
+        return self._craft_default_task_definition(
+            self.build_worker_type,
+            'aws-provisioner-v1',
+            dependencies,
+            routes,
+            scopes,
+            name,
+            description,
+            payload
+        )
+
+    def _craft_dummy_task(
+        self, name, description, command, dependencies=None, routes=None, scopes=[],
+    ):
+        payload = {
+            "maxRunTime": 600,
+            "image": "alpine",
+            "command": [
+                "/bin/bash",
+                "--login",
+                "-cx",
+                "echo \"Dummy task\""
+            ],
         }
 
         return self._craft_default_task_definition(

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -330,7 +330,7 @@ class TaskBuilder(object):
         )
 
     def _craft_dummy_task(
-        self, name, description, command, dependencies=None, routes=None, scopes=[],
+        self, name, description,  dependencies=None, routes=[], scopes=[],
     ):
         payload = {
             "maxRunTime": 600,

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -336,7 +336,7 @@ class TaskBuilder(object):
             "maxRunTime": 600,
             "image": "alpine",
             "command": [
-                "/bin/bash",
+                "/bin/sh",
                 "--login",
                 "-cx",
                 "echo \"Dummy task\""

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -310,7 +310,7 @@ class TaskBuilder(object):
             "maxRunTime": 7200,
             "image": "mozillamobile/android-components:1.19",
             "command": [
-                "/bin/sh",
+                "/bin/bash",
                 "--login",
                 "-cx",
                 command


### PR DESCRIPTION
Based on https://github.com/mozilla-mobile/android-components/pull/3084. See only https://github.com/mozilla-mobile/android-components/pull/3649/commits/08533592e5be48a919c2b58d267e27fe01d0ac80. 
 
In releases (both github and snapshots) we have a barrier task to wait for all builds to succeed before enabling signing and beetmove-ing. However, the current implementation assumes the task as being a build task that exits right away. Even so, downloading the android-components image takes ~1min for ~6-8 Gb of data. Instead, we could use a minimal docker image and avoid checking out the repository as its completely useless. We could save at least 1 minute (and more as the android-components docker images grows over time) in end-to-end release time with this.

Testing results:
* barrier task that downloads `a-c` docker image + clones repository - `62.463 seconds` [here](https://tools.taskcluster.net/groups/YyQwihouTI2fzsXz41uWpQ/tasks/C_2wJD5kSDC8iseXT6jn6g/details)
* barrier task that runs in minimal docker image available - `1.718 seconds` [here](https://tools.taskcluster.net/groups/ZFQJJ7oXQsmIOHLF36o30Q/tasks/R-Lon16FRSWypDU-_tZJmQ/details)

Full staging release to test this change is https://tools.taskcluster.net/groups/ZFQJJ7oXQsmIOHLF36o30Q. 