### PR TITLE
Ensure routes and scopes are arrays in dummy task.

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -332,6 +332,8 @@ class TaskBuilder(object):
     def _craft_dummy_task(
         self, name, description,  dependencies=None, routes=None, scopes=None,
     ):
+        routes = []
+        scopes = []
         payload = {
             "maxRunTime": 600,
             "image": "alpine",


### PR DESCRIPTION
Should fix: 

```
Traceback (most recent call last):
  File "automation/taskcluster/decision_task.py", line 377, in <module>
    full_task_graph = schedule_task_graph(ordered_groups_of_tasks)
  File "/build/android-components/automation/taskcluster/lib/tasks.py", line 405, in schedule_task_graph
    schedule_task(queue, task_id, task_definition)
  File "/build/android-components/automation/taskcluster/lib/tasks.py", line 393, in schedule_task
    result = queue.createTask(taskId, task)
  File "/usr/local/lib/python2.7/dist-packages/taskcluster/queue.py", line 169, in createTask
    return self._makeApiCall(self.funcinfo["createTask"], *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/taskcluster/client.py", line 262, in _makeApiCall
    response = self._makeHttpRequest(entry['method'], _route, payload)
  File "/usr/local/lib/python2.7/dist-packages/taskcluster/client.py", line 534, in _makeHttpRequest
    superExc=None
taskcluster.exceptions.TaskclusterRestFailure: 
Schema Validation Failed!
Rejecting Schema: https://schemas.taskcluster.net/queue/v1/create-task-request.json#
Errors:
  * data.routes should be array
  * data.scopes should be array
```