### PR TITLE
Closes #3643: Add localization comment to mozac_lib_crash_notification_action_report.

### DIFF
--- a/components/lib/crash/src/main/res/values/strings.xml
+++ b/components/lib/crash/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <!-- Name of the "notification channel" used for displaying a notification when the app crashed and we can't show a prompt. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_lib_crash_channel">Crashes</string>
 
+    <!-- Label of a notification action/button that will send the crash report to Mozilla. -->
     <string name="mozac_lib_crash_notification_action_report">Report</string>
 
 </resources>


### PR DESCRIPTION
Looking at the translations it seems like it wasn't clear what this string is used for.

https://github.com/mozilla-mobile/android-components/pull/3635