### PR TITLE
Closes #3567: BrowserStore/SessionManager: Make result of "nearby" tab selection match.

### DIFF
--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -978,8 +978,8 @@ class SessionManagerTest {
         manager.select(child)
         manager.remove(child, selectParentIfExists = true)
 
-        assertEquals(session2, manager.selectedSession)
-        assertEquals("https://getpocket.com", manager.selectedSessionOrThrow.url)
+        assertEquals(session1, manager.selectedSession)
+        assertEquals("https://www.firefox.com", manager.selectedSessionOrThrow.url)
     }
 
     @Test
@@ -1009,12 +1009,12 @@ class SessionManagerTest {
         assertEquals(session4, manager.selectedSession)
 
         manager.remove(session4)
-        assertEquals(session2, manager.selectedSession)
-
-        manager.remove(session2)
         assertEquals(session9, manager.selectedSession)
 
         manager.remove(session9)
+        assertEquals(session2, manager.selectedSession)
+
+        manager.remove(session2)
         assertNull(manager.selectedSession)
     }
 


### PR DESCRIPTION
This is a bit crazy. But `browser-session` is going away eventually....

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
