### PR TITLE
Issue #3481 - Use setPrimaryClip 

### DIFF
--- a/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/provider/AssetsSearchEngineProvider.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.search.provider.filter.SearchEngineFilter
 import mozilla.components.browser.search.provider.localization.SearchLocalizationProvider
 import mozilla.components.support.ktx.android.content.res.readJSONObject
 import mozilla.components.support.ktx.android.org.json.toList
+import mozilla.components.support.ktx.android.org.json.tryGetString
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -173,7 +174,7 @@ class AssetsSearchEngineProvider(
 
     private fun getStringFromBlock(key: String, blocks: Array<JSONObject>): String? =
             getValueFromBlock(blocks) {
-                it.optString(key, null)
+                it.tryGetString(key)
             }
 
     private fun getArrayFromBlock(key: String, blocks: Array<JSONObject>): JSONArray? =

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
@@ -125,7 +125,7 @@ private fun parseIcons(json: JSONObject): List<WebAppManifest.Icon> {
             WebAppManifest.Icon(
                 src = obj.getString("src"),
                 sizes = parseIconSizes(obj),
-                type = obj.optString("type", null),
+                type = obj.tryGetString("type"),
                 purpose = parsePurposes(obj)
             )
         }

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProviderTest.kt
@@ -39,7 +39,7 @@ class ClipboardSuggestionProviderTest {
 
     @Test
     fun `provider returns empty list by default`() = runBlocking {
-        clipboardManager.primaryClip = null
+        clipboardManager.clearPrimaryClip()
 
         val provider = ClipboardSuggestionProvider(testContext, mock())
 
@@ -51,10 +51,13 @@ class ClipboardSuggestionProviderTest {
 
     @Test
     fun `provider returns empty list for non plain text clip`() {
-        clipboardManager.primaryClip = ClipData.newHtmlText(
-            "Label",
-            "Hello mozilla.org",
-            "<b>This is HTML on mozilla.org</b>")
+        clipboardManager.setPrimaryClip(
+            ClipData.newHtmlText(
+                "Label",
+                "Hello mozilla.org",
+                "<b>This is HTML on mozilla.org</b>"
+            )
+        )
 
         assertNull(getSuggestion())
     }
@@ -91,7 +94,7 @@ class ClipboardSuggestionProviderTest {
 
     @Test
     fun `provider return suggestion on input start`() {
-        clipboardManager.primaryClip = ClipData.newPlainText("Test label", "https://www.mozilla.org")
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("Test label", "https://www.mozilla.org"))
 
         val provider = ClipboardSuggestionProvider(testContext, mock())
         val suggestions = runBlocking { provider.onInputStarted() }
@@ -115,7 +118,7 @@ class ClipboardSuggestionProviderTest {
 
     @Test
     fun `provider should allow customization of title and icon on suggestion`() {
-        clipboardManager.primaryClip = ClipData.newPlainText("Test label", "http://mozilla.org")
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("Test label", "http://mozilla.org"))
         val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
         val provider = ClipboardSuggestionProvider(
             testContext,
@@ -140,9 +143,12 @@ class ClipboardSuggestionProviderTest {
 
     @Test
     fun `clicking suggestion loads url`() = runBlocking {
-        clipboardManager.primaryClip = ClipData.newPlainText(
-            "Label",
-            "Hello Mozilla, https://www.mozilla.org")
+        clipboardManager.setPrimaryClip(
+            ClipData.newPlainText(
+                "Label",
+                "Hello Mozilla, https://www.mozilla.org"
+            )
+        )
 
         val selectedEngineSession: EngineSession = mock()
         val selectedSession: Session = mock()
@@ -176,9 +182,12 @@ class ClipboardSuggestionProviderTest {
 
     @Test
     fun `provider returns empty list for non-empty text if empty text required`() = runBlocking {
-        clipboardManager.primaryClip = ClipData.newPlainText(
+        clipboardManager.setPrimaryClip(
+            ClipData.newPlainText(
                 "Label",
-                "Hello Mozilla, https://www.mozilla.org")
+                "Hello Mozilla, https://www.mozilla.org"
+            )
+        )
 
         val provider = ClipboardSuggestionProvider(testContext, mock(), requireEmptyText = true)
         val suggestions = provider.onInputChanged("Hello")
@@ -199,7 +208,7 @@ class ClipboardSuggestionProviderTest {
     }
 
     private fun getSuggestionWithClipboard(text: String): AwesomeBar.Suggestion? {
-        clipboardManager.primaryClip = ClipData.newPlainText("Test label", text)
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("Test label", text))
         return getSuggestion()
     }
 

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -194,7 +194,7 @@ data class ContextMenuCandidate(
             action = { _, hitResult ->
                 val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 val clip = ClipData.newPlainText(hitResult.getLink(), hitResult.getLink())
-                clipboardManager.primaryClip = clip
+                clipboardManager.setPrimaryClip(clip)
 
                 snackbarDelegate.show(
                     snackBarParentView = snackBarParentView,
@@ -218,7 +218,7 @@ data class ContextMenuCandidate(
             action = { _, hitResult ->
                 val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 val clip = ClipData.newPlainText(hitResult.getLink(), hitResult.src)
-                clipboardManager.primaryClip = clip
+                clipboardManager.setPrimaryClip(clip)
 
                 snackbarDelegate.show(
                     snackBarParentView = snackBarParentView,


### PR DESCRIPTION
Android Q changes setPrimaryClip to be NotNull, but getPrimaryClip remains Nullable.
Kotlin no longer exposes a setter as a result.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
