### PR TITLE
Issue #3481 - Support Q in browser components

### DIFF
--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt
@@ -1,7 +1,6 @@
 package mozilla.components.browser.domains
 
 import android.content.Context
-import android.preference.PreferenceManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
 import mozilla.components.browser.domains.autocomplete.BaseDomainAutocompleteProvider
@@ -9,7 +8,6 @@ import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvide
 import mozilla.components.browser.domains.autocomplete.DomainList
 import mozilla.components.browser.domains.autocomplete.DomainsLoader
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -18,14 +16,6 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class BaseDomainAutocompleteProviderTest {
-
-    @After
-    fun tearDown() {
-        PreferenceManager.getDefaultSharedPreferences(testContext)
-            .edit()
-            .clear()
-            .apply()
-    }
 
     @Test
     fun `empty provider with DEFAULT list returns nothing`() {

--- a/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
+++ b/components/browser/domains/src/test/java/mozilla/components/browser/domains/DomainAutoCompleteProviderTest.kt
@@ -6,12 +6,10 @@
 
 package mozilla.components.browser.domains
 
-import android.preference.PreferenceManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.domains.DomainAutoCompleteProvider.AutocompleteSource.CUSTOM_LIST
 import mozilla.components.browser.domains.DomainAutoCompleteProvider.AutocompleteSource.DEFAULT_LIST
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -23,14 +21,6 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class DomainAutoCompleteProviderTest {
-
-    @After
-    fun tearDown() {
-        PreferenceManager.getDefaultSharedPreferences(testContext)
-            .edit()
-            .clear()
-            .apply()
-    }
 
     @Test
     fun autocompletionWithShippedDomains() {

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/ParseSearchPluginsTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/ParseSearchPluginsTest.kt
@@ -44,7 +44,7 @@ class ParseSearchPluginsTest(private val searchEngineIdentifier: String) {
     companion object {
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
-        fun searchPlugins(): Collection<Array<Any>> = basePath.list()
+        fun searchPlugins(): Collection<Array<Any>> = basePath.list().orEmpty()
             .mapNotNull { it as Any }
             .map { arrayOf(it) }
 

--- a/samples/dataprotect/src/main/java/org/mozilla/samples/dataprotect/MainActivity.kt
+++ b/samples/dataprotect/src/main/java/org/mozilla/samples/dataprotect/MainActivity.kt
@@ -6,7 +6,6 @@ package org.mozilla.samples.dataprotect
 
 import android.content.SharedPreferences
 import android.os.Bundle
-import android.preference.PreferenceManager
 import android.util.Base64
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
@@ -36,7 +35,7 @@ class MainActivity : AppCompatActivity() {
         keystore.generateKey()
 
         // setup protected data key/value pairs
-        val prefs = PreferenceManager.getDefaultSharedPreferences(this).apply {
+        val prefs = getSharedPreferences(SAMPLE_PREFS_KEY, MODE_PRIVATE).apply {
             prepareProtectedData(this)
         }
 
@@ -77,5 +76,9 @@ class MainActivity : AppCompatActivity() {
     private fun updateToggleButton() {
         val res = if (listAdapter.unlocked) R.string.btn_toggle_lock else R.string.btn_toggle_unlock
         toggleBtn.setText(res)
+    }
+
+    companion object {
+        private const val SAMPLE_PREFS_KEY = "protectedData"
     }
 }


### PR DESCRIPTION
- Removed useless teardown functions in browser-domains tests
- Fall back to empty list when `File.list()` returns null
- Don't use deprecated `getDefaultSharedPreferences` in sample-dataprotect