### PR TITLE
Closes #3207 - Generate PWA launcher icons

### DIFF
--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.kotlin_reflect
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
     testImplementation Dependencies.testing_robolectric

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/IconRequest.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/IconRequest.kt
@@ -27,7 +27,8 @@ data class IconRequest(
      */
     enum class Size(@DimenRes val dimen: Int) {
         DEFAULT(R.dimen.mozac_browser_icons_size_default),
-        LAUNCHER(R.dimen.mozac_browser_icons_size_launcher)
+        LAUNCHER(R.dimen.mozac_browser_icons_size_launcher),
+        LAUNCHER_ADAPTIVE(R.dimen.mozac_browser_icons_size_launcher_adaptive)
     }
 
     /**

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/WebAppManifest.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/extension/WebAppManifest.kt
@@ -4,13 +4,21 @@
 
 package mozilla.components.browser.icons.extension
 
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.icons.IconRequest.Resource.Type.MANIFEST_ICON
+import mozilla.components.browser.icons.IconRequest.Size.LAUNCHER
+import mozilla.components.browser.icons.IconRequest.Size.LAUNCHER_ADAPTIVE
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.manifest.WebAppManifest.Icon.Purpose
 
+/**
+ * Creates an [IconRequest] for retrieving the icon specified in the manifest.
+ */
 fun WebAppManifest.toIconRequest() = IconRequest(
     url = startUrl,
-    size = IconRequest.Size.LAUNCHER,
+    size = if (SDK_INT >= Build.VERSION_CODES.O) LAUNCHER_ADAPTIVE else LAUNCHER,
     resources = icons.mapNotNull { it.toIconResource() }
 )
 
@@ -19,7 +27,7 @@ private fun WebAppManifest.Icon.toIconResource(): IconRequest.Resource? {
 
     return IconRequest.Resource(
         url = src,
-        type = IconRequest.Resource.Type.MANIFEST_ICON,
+        type = MANIFEST_ICON,
         sizes = sizes,
         mimeType = type,
         maskable = Purpose.MASKABLE in purpose

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/DefaultIconGenerator.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/generator/DefaultIconGenerator.kt
@@ -22,13 +22,14 @@ import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.icons.R
 import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
+import kotlin.math.abs
 
 /**
  * [IconGenerator] implementation that will generate an icon with a background color, rounded corners and a letter
  * representing the URL.
  */
 class DefaultIconGenerator(
-    @DimenRes private val cornerRadiusDimen: Int = R.dimen.mozac_browser_icons_generator_default_corner_radius,
+    @DimenRes private val cornerRadiusDimen: Int? = R.dimen.mozac_browser_icons_generator_default_corner_radius,
     @ColorRes private val textColorRes: Int = R.color.mozac_browser_icons_generator_default_text_color,
     @ArrayRes private val backgroundColorsRes: Int = R.array.mozac_browser_icons_photon_palette
 ) : IconGenerator {
@@ -47,7 +48,7 @@ class DefaultIconGenerator(
         paint.color = backgroundColor
 
         val sizeRect = RectF(0f, 0f, size, size)
-        val cornerRadius = context.resources.getDimension(cornerRadiusDimen)
+        val cornerRadius = cornerRadiusDimen?.let { context.resources.getDimension(it) } ?: 0f
         canvas.drawRoundRect(sizeRect, cornerRadius, cornerRadius, paint)
 
         val character = getRepresentativeCharacter(request.url)
@@ -75,7 +76,8 @@ class DefaultIconGenerator(
         return Icon(
             bitmap = bitmap,
             color = backgroundColor,
-            source = Icon.Source.GENERATOR
+            source = Icon.Source.GENERATOR,
+            maskable = cornerRadius == 0f
         )
     }
 
@@ -90,7 +92,7 @@ class DefaultIconGenerator(
             backgroundColors.getColor(0, 0)
         } else {
             val snippet = getRepresentativeSnippet(url)
-            val index = Math.abs(snippet.hashCode() % backgroundColors.length())
+            val index = abs(snippet.hashCode() % backgroundColors.length())
 
             backgroundColors.getColor(index, 0)
         }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessor.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.processor
+
+import android.content.Context
+import android.graphics.Paint
+import android.graphics.Paint.ANTI_ALIAS_FLAG
+import android.graphics.Rect
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
+import mozilla.components.browser.icons.DesiredSize
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import kotlin.math.max
+
+/**
+ * [IconProcessor] implementation that builds maskable icons.
+ */
+class AdaptiveIconProcessor : IconProcessor {
+
+    /**
+     * Creates an adaptive icon using the base icon.
+     * On older devices, non-maskable icons are not transformed.
+     */
+    @Suppress("LongMethod")
+    override fun process(
+        context: Context,
+        request: IconRequest,
+        resource: IconRequest.Resource?,
+        icon: Icon,
+        desiredSize: DesiredSize
+    ): Icon {
+        if (!icon.maskable && SDK_INT < Build.VERSION_CODES.O) {
+            return icon
+        }
+
+        val originalBitmap = icon.bitmap
+
+        val paddingRatio = if (icon.maskable) {
+            MASKABLE_ICON_PADDING_RATIO
+        } else {
+            TRANSPARENT_ICON_PADDING_RATIO
+        }
+        val maskedIconSize = max(originalBitmap.width, originalBitmap.height)
+        val padding = (paddingRatio * maskedIconSize).toInt()
+
+        // The actual size of the icon asset, before masking, in pixels.
+        val rawIconSize = 2 * padding + maskedIconSize
+        val maskBounds = Rect(0, 0, maskedIconSize, maskedIconSize).apply {
+            offset(padding, padding)
+        }
+
+        val paint = Paint(ANTI_ALIAS_FLAG).apply { isFilterBitmap = true }
+
+        val paddedBitmap = createBitmap(rawIconSize, rawIconSize).applyCanvas {
+            icon.color?.also { drawColor(it) }
+            drawBitmap(originalBitmap, null, maskBounds, paint)
+        }
+
+        return icon.copy(bitmap = paddedBitmap, maskable = true).also { originalBitmap.recycle() }
+    }
+
+    companion object {
+        private const val MASKABLE_ICON_SAFE_ZONE = 4 / 5f
+        private const val ADAPTIVE_ICON_SAFE_ZONE = 66 / 108f
+        private const val TRANSPARENT_ICON_SAFE_ZONE = 192 / 176f
+        private const val MASKABLE_ICON_PADDING_RATIO =
+            ((MASKABLE_ICON_SAFE_ZONE / ADAPTIVE_ICON_SAFE_ZONE) - 1) / 2
+        private const val TRANSPARENT_ICON_PADDING_RATIO =
+            ((TRANSPARENT_ICON_SAFE_ZONE / ADAPTIVE_ICON_SAFE_ZONE) - 1) / 2
+    }
+}

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/ResizingProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/ResizingProcessor.kt
@@ -50,7 +50,6 @@ class ResizingProcessor(
             }
         }
 
-        originalBitmap.recycle()
         return icon.copy(bitmap = resizedBitmap ?: return null)
     }
 

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
@@ -33,9 +33,9 @@ private const val WEBP_QUALITY = 90
 /**
  * Caching bitmaps and resource URLs on disk.
  */
-internal class DiskCache :
+class IconDiskCache :
     DiskIconLoader.LoaderDiskCache, DiskIconPreparer.PreparerDiskCache, DiskIconProcessor.ProcessorDiskCache {
-    private val logger = Logger("Icons/DiskCache")
+    private val logger = Logger("Icons/IconDiskCache")
     private var iconResourcesCache: DiskLruCache? = null
     private var iconDataCache: DiskLruCache? = null
     private val iconResourcesCacheWriteLock = Any()

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconMemoryCache.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconMemoryCache.kt
@@ -19,7 +19,7 @@ private const val MAXIMUM_CACHE_URLS = 1000
 // https://github.com/mozilla-mobile/android-components/issues/2764
 private const val MAXIMUM_CACHE_BITMAP_BYTES = 1024 * 1024 * 25 // 25 MB
 
-internal class MemoryCache : ProcessorMemoryCache, LoaderMemoryCache, MemoryIconPreparer.PreparerMemoryCache {
+class IconMemoryCache : ProcessorMemoryCache, LoaderMemoryCache, MemoryIconPreparer.PreparerMemoryCache {
     private val iconResourcesCache = LruCache<String, List<IconRequest.Resource>>(MAXIMUM_CACHE_URLS)
     private val iconBitmapCache = object : LruCache<String, Bitmap>(MAXIMUM_CACHE_BITMAP_BYTES) {
         override fun sizeOf(key: String, value: Bitmap): Int {

--- a/components/browser/icons/src/main/res/values/dimens.xml
+++ b/components/browser/icons/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
 <resources>
     <dimen name="mozac_browser_icons_size_default">32dp</dimen>
     <dimen name="mozac_browser_icons_size_launcher">48dp</dimen>
+    <dimen name="mozac_browser_icons_size_launcher_adaptive">102dp</dimen>
 
     <dimen name="mozac_browser_icons_maximum_size">64dp</dimen>
     <dimen name="mozac_browser_icons_generator_default_corner_radius">2dp</dimen>

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/pipeline/IconResourceComparatorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/pipeline/IconResourceComparatorTest.kt
@@ -299,4 +299,33 @@ class IconResourceComparatorTest {
             urls
         )
     }
+
+    @Test
+    fun `compare proxx-app icons`() {
+        val resources = listOf(
+            IconRequest.Resource(
+                url = "https://proxx.app/assets/icon-05a70868.png",
+                type = IconRequest.Resource.Type.MANIFEST_ICON,
+                sizes = listOf(Size(1024, 1024)),
+                mimeType = "image/png"
+            ),
+            IconRequest.Resource(
+                url = "https://proxx.app/assets/icon-maskable-7a2eb399.png",
+                type = IconRequest.Resource.Type.MANIFEST_ICON,
+                sizes = listOf(Size(1024, 1024)),
+                mimeType = "image/png",
+                maskable = true
+            )
+        )
+
+        val urls = resources.sortedWith(IconResourceComparator).map { it.url }
+
+        assertEquals(
+            listOf(
+                "https://proxx.app/assets/icon-maskable-7a2eb399.png",
+                "https://proxx.app/assets/icon-05a70868.png"
+            ),
+            urls
+        )
+    }
 }

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessorTest.kt
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.processor
+
+import android.os.Build
+import androidx.core.graphics.createBitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.icons.Icon
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.util.ReflectionHelpers.setStaticField
+import kotlin.reflect.jvm.javaField
+
+@RunWith(AndroidJUnit4::class)
+class AdaptiveIconProcessorTest {
+
+    @Before
+    fun setup() {
+        setSdkInt(0)
+    }
+
+    @After
+    fun teardown() = setSdkInt(0)
+
+    @Test
+    fun `process returns non-maskable icons on legacy devices`() {
+        val icon = Icon(mock(), source = Icon.Source.GENERATOR, maskable = false)
+
+        assertEquals(
+            icon,
+            AdaptiveIconProcessor().process(mock(), mock(), mock(), icon, mock())
+        )
+    }
+
+    @Test
+    fun `process adds padding to legacy icons`() {
+        setSdkInt(Build.VERSION_CODES.O)
+        val bitmap = spy(createBitmap(128, 128))
+
+        val icon = AdaptiveIconProcessor().process(
+            mock(),
+            mock(),
+            mock(),
+            Icon(bitmap, source = Icon.Source.DISK, maskable = false),
+            mock()
+        )
+
+        assertEquals(228, icon.bitmap.width)
+        assertEquals(228, icon.bitmap.height)
+
+        assertEquals(Icon.Source.DISK, icon.source)
+        assertTrue(icon.maskable)
+        verify(bitmap).recycle()
+    }
+
+    @Test
+    fun `process adjusts the size of maskable icons`() {
+        val bitmap = createBitmap(256, 256)
+
+        val icon = AdaptiveIconProcessor().process(
+            mock(),
+            mock(),
+            mock(),
+            Icon(bitmap, source = Icon.Source.INLINE, maskable = true),
+            mock()
+        )
+
+        assertEquals(334, icon.bitmap.width)
+        assertEquals(334, icon.bitmap.height)
+
+        assertEquals(Icon.Source.INLINE, icon.source)
+        assertTrue(icon.maskable)
+    }
+
+    private fun setSdkInt(sdkVersion: Int) {
+        setStaticField(Build.VERSION::SDK_INT.javaField, sdkVersion)
+    }
+}

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/ColorProcessorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/ColorProcessorTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.icons.processor
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.Icon
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
@@ -16,9 +17,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doReturn
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ColorProcessorTest {
     @Test
     fun `test extracting color`() {

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/ResizingProcessorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/ResizingProcessorTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.util.DisplayMetrics
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.DesiredSize
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
@@ -22,9 +23,8 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ResizingProcessorTest {
     private lateinit var processor: ResizingProcessor
 
@@ -41,7 +41,6 @@ class ResizingProcessorTest {
         assertEquals(icon.bitmap, resized?.bitmap)
 
         verify(processor, never()).resize(any(), anyInt())
-        verify(icon.bitmap, never()).recycle()
     }
 
     @Test
@@ -55,7 +54,6 @@ class ResizingProcessorTest {
         assertEquals(smallerIcon, resized?.bitmap)
 
         verify(processor).resize(icon.bitmap, 64)
-        verify(icon.bitmap).recycle()
     }
 
     @Test
@@ -69,7 +67,6 @@ class ResizingProcessorTest {
         assertEquals(largerIcon, resized?.bitmap)
 
         verify(processor).resize(icon.bitmap, 64)
-        verify(icon.bitmap).recycle()
     }
 
     @Test
@@ -81,8 +78,6 @@ class ResizingProcessorTest {
 
         assertNotEquals(icon.bitmap, resized?.bitmap)
         assertNull(resized)
-
-        verify(icon.bitmap).recycle()
     }
 
     @Test
@@ -98,7 +93,6 @@ class ResizingProcessorTest {
         assertNotNull(resized)
 
         verify(processor).resize(icon.bitmap, 30)
-        verify(icon.bitmap).recycle()
     }
 
     private fun process(

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconDiskCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconDiskCacheTest.kt
@@ -20,11 +20,11 @@ import org.mockito.Mockito.`when`
 import java.io.OutputStream
 
 @RunWith(AndroidJUnit4::class)
-class DiskCacheTest {
+class IconDiskCacheTest {
 
     @Test
     fun `Writing and reading resources`() {
-        val cache = DiskCache()
+        val cache = IconDiskCache()
 
         val resources = listOf(
             IconRequest.Resource(
@@ -56,7 +56,7 @@ class DiskCacheTest {
 
     @Test
     fun `Writing and reading bitmap bytes`() {
-        val cache = DiskCache()
+        val cache = IconDiskCache()
 
         val resource = IconRequest.Resource(
             url = "https://www.mozilla.org/icon64.png",

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconMemoryCacheTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconMemoryCacheTest.kt
@@ -19,11 +19,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class MemoryCacheTest {
+class IconMemoryCacheTest {
 
     @Test
     fun `Verify memory components interaction`() {
-        val cache = MemoryCache()
+        val cache = IconMemoryCache()
 
         val preparer = MemoryIconPreparer(cache)
         val loader = MemoryIconLoader(cache)

--- a/components/feature/pwa/build.gradle
+++ b/components/feature/pwa/build.gradle
@@ -29,8 +29,10 @@ android {
 }
 
 dependencies {
+    implementation project(':browser-icons')
     implementation project(':browser-session')
     implementation project(':concept-engine')
+    implementation project(':concept-fetch')
     implementation project(':support-base')
     implementation project(':support-ktx')
 

--- a/components/feature/pwa/src/main/AndroidManifest.xml
+++ b/components/feature/pwa/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mozilla.components.feature.pwa">
 
+    <uses-permission
+        android:name="com.android.launcher.permission.INSTALL_SHORTCUT"
+        android:maxSdkVersion="26" />
+
     <application>
 
         <activity android:name=".WebAppLauncherActivity"

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.pwa
 import android.content.Context
 import androidx.core.content.pm.ShortcutManagerCompat
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.fetch.Client
 
 /**
  * These use cases allow for adding a web app or web site to the homescreen.
@@ -14,6 +15,7 @@ import mozilla.components.browser.session.SessionManager
 class WebAppUseCases(
     private val applicationContext: Context,
     sessionManager: SessionManager,
+    httpClient: Client,
     supportWebApps: Boolean = true
 ) {
 
@@ -32,11 +34,13 @@ class WebAppUseCases(
     class AddToHomescreenUseCase internal constructor(
         private val applicationContext: Context,
         private val sessionManager: SessionManager,
+        httpClient: Client,
         supportWebApps: Boolean
     ) {
         private val shortcutManager = WebAppShortcutManager(
-            ManifestStorage(applicationContext),
-            supportWebApps
+            applicationContext,
+            httpClient,
+            supportWebApps = supportWebApps
         )
 
         suspend operator fun invoke() {
@@ -45,5 +49,7 @@ class WebAppUseCases(
         }
     }
 
-    val addToHomescreen by lazy { AddToHomescreenUseCase(applicationContext, sessionManager, supportWebApps) }
+    val addToHomescreen by lazy {
+        AddToHomescreenUseCase(applicationContext, sessionManager, httpClient, supportWebApps)
+    }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -110,7 +110,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     val searchUseCases by lazy { SearchUseCases(applicationContext, searchEngineManager, sessionManager) }
     val defaultSearchUseCase by lazy { { searchTerms: String -> searchUseCases.defaultSearch.invoke(searchTerms) } }
 
-    val webAppUseCases by lazy { WebAppUseCases(applicationContext, sessionManager) }
+    val webAppUseCases by lazy { WebAppUseCases(applicationContext, sessionManager, client) }
 
     // Intent
     val tabIntentProcessor by lazy {


### PR DESCRIPTION
The [issue](https://github.com/mozilla-mobile/android-components/issues/3207) describes a lot about the different icons.

- On Oreo+, use a maskable icon if possible (adjusted to correct size)
- On Oreo+, if the icon is not maskable, add lots of padding and use the icon color as a background
- On Nougat-, don't do anything to non-maskable icons.
- On Nougat-, maskable icons are automatically reformatted by the support library.

I'm currently leaning to moving the `AdaptiveIconProcessor` into feature-pwa and using the manifest theme color as the background instead.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
