### PR TITLE
Issue mozilla-mobile/fenix#1048 - Add historyList to Session

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.history.HistoryItem
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
@@ -412,6 +413,21 @@ class GeckoEngineSession(
 
     @Suppress("ComplexMethod")
     internal fun createHistoryDelegate() = object : GeckoSession.HistoryDelegate {
+        override fun onHistoryStateChange(
+            session: GeckoSession,
+            historyList: GeckoSession.HistoryDelegate.HistoryList
+        ) {
+            val list = historyList.mapIndexed { index, historyItem ->
+                HistoryItem(
+                    title = historyItem.title,
+                    uri = historyItem.uri,
+                    selected = index == historyList.currentIndex
+                )
+            }
+
+            notifyObservers { onHistoryStateChange(list) }
+        }
+
         @SuppressWarnings("ReturnCount")
         override fun onVisited(
             session: GeckoSession,

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.history.HistoryItem
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.manifest.WebAppManifestParser
 import mozilla.components.concept.engine.request.RequestInterceptor
@@ -414,6 +415,21 @@ class GeckoEngineSession(
 
     @Suppress("ComplexMethod")
     internal fun createHistoryDelegate() = object : GeckoSession.HistoryDelegate {
+        override fun onHistoryStateChange(
+            session: GeckoSession,
+            historyList: GeckoSession.HistoryDelegate.HistoryList
+        ) {
+            val list = historyList.mapIndexed { index, historyItem ->
+                HistoryItem(
+                    title = historyItem.title,
+                    uri = historyItem.uri,
+                    selected = index == historyList.currentIndex
+                )
+            }
+
+            notifyObservers { onHistoryStateChange(list) }
+        }
+
         @SuppressWarnings("ReturnCount")
         override fun onVisited(
             session: GeckoSession,

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -13,12 +13,13 @@ import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.browser.state.action.ContentAction.UpdateLoadingStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdateProgressAction
-import mozilla.components.browser.state.action.ContentAction.UpdateSecurityInfo
 import mozilla.components.browser.state.action.ContentAction.UpdateSearchTermsAction
+import mozilla.components.browser.state.action.ContentAction.UpdateSecurityInfo
 import mozilla.components.browser.state.action.ContentAction.UpdateTitleAction
 import mozilla.components.browser.state.action.ContentAction.UpdateUrlAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.history.HistoryItem
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.media.RecordingDevice
@@ -67,6 +68,7 @@ class Session(
         fun onProgress(session: Session, progress: Int) = Unit
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
         fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) = Unit
+        fun onHistoryStateChanged(session: Session, historyList: List<HistoryItem>) = Unit
         fun onLoadRequest(
             session: Session,
             url: String,
@@ -216,6 +218,13 @@ class Session(
      */
     var canGoForward: Boolean by Delegates.observable(false) { _, old, new ->
         notifyObservers(old, new) { onNavigationStateChanged(this@Session, canGoBack, new) }
+    }
+
+    /**
+     * Local session history, with the current page selected.
+     */
+    var historyList: List<HistoryItem> by Delegates.observable(emptyList()) { _, old, new ->
+        notifyObservers(old, new) { onHistoryStateChanged(this@Session, new) }
     }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -17,6 +17,7 @@ import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.history.HistoryItem
 import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.Media
@@ -175,6 +176,22 @@ class SessionTest {
         session.canGoForward = true
         assertEquals(true, session.canGoForward)
         verify(observer).onNavigationStateChanged(eq(session), eq(true), eq(true))
+
+        verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `observer is notified when history state changes`() {
+        val observer = mock(Session.Observer::class.java)
+
+        val session = Session("https://www.mozilla.org")
+        session.register(observer)
+
+        val history = listOf(HistoryItem("Mozilla", "https://www.mozilla.org", false))
+
+        session.historyList = history
+        assertEquals(history, session.historyList)
+        verify(observer).onHistoryStateChanged(session, history)
 
         verifyNoMoreInteractions(observer)
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import android.graphics.Bitmap
 import androidx.annotation.CallSuper
+import mozilla.components.concept.engine.history.HistoryItem
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.media.RecordingDevice
@@ -14,7 +15,6 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
-import java.lang.UnsupportedOperationException
 
 /**
  * Class representing a single engine session.
@@ -34,6 +34,7 @@ abstract class EngineSession(
         fun onProgress(progress: Int) = Unit
         fun onLoadingStateChange(loading: Boolean) = Unit
         fun onNavigationStateChange(canGoBack: Boolean? = null, canGoForward: Boolean? = null) = Unit
+        fun onHistoryStateChange(historyList: List<HistoryItem>) = Unit
         fun onSecurityChange(secure: Boolean, host: String? = null, issuer: String? = null) = Unit
         fun onTrackerBlockingEnabledChange(enabled: Boolean) = Unit
         fun onTrackerBlocked(url: String) = Unit

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryItem.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryItem.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.history
+
+/**
+ * A representation of an entry in browser history.
+ */
+data class HistoryItem(
+    val title: String,
+    val uri: String,
+    val selected: Boolean
+)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,15 +14,17 @@ permalink: /changelog/
 
 * **feature-pwa**
   * Added preliminary support for pinning websites to the home screen.
-  
+
 * **browser-search**
   * Loading search engines should no longer deadlock on devices with 1-2 CPUs
 
 * **concept-engine**, **browser-engine-gecko(-beta/nightly)**, **browser-engine-system**
   * Added `EngineView.release()` to manually release an `EngineSession` that is currently being rendered by the `EngineView`. Usually an app does not need to call `release()` manually since `EngineView` takes care of releasing the `EngineSession` on specific lifecycle events. However sometimes the app wants to release an `EngineSession` to immediately render it on another `EngineView`; e.g. when transforming a Custom Tab into a regular browser tab.
+  * Added `EngingeSession.onHistoryStateChange` to notify observers of updates to the local session history.
 
 * **browser-session**
   * ⚠️ **This is a breaking change**: Removed "default session" behavior from `SessionManager`. This feature was never used by any app except the sample browser.
+  * Add `historyList` property with the current session history.
 
 # 2.0.0
 
@@ -34,12 +36,12 @@ permalink: /changelog/
 
 
 * **browser-toolbar**
-  * Adds `focus()` which provides a hook for calling `editMode.focus()` to focus the edit mode `urlView` 
-  
+  * Adds `focus()` which provides a hook for calling `editMode.focus()` to focus the edit mode `urlView`
+
 * **browser-awesomebar**
   * Updated `DefaultSuggestionViewHolder` to have a style more consistent with Fenix mocks.
   * Fixed a bug with `InlineAutocompleteEditText` where the cursor would disappear if a user cleared an suggested URL.
-  
+
 * **lib-state**
   * A new component for maintaining application, screen or component state via a redux-style `Store`. This component provides the architectural foundation for the `browser-state` component (in development).
 
@@ -62,7 +64,7 @@ permalink: /changelog/
   sessionManager.getEngineSession().loadUrl(url, LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE))
 
   // Bypass cache and proxy
-  sessionUseCases.loadUrl.invoke(url, LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE, LoadUrlFlags.BYPASS_PROXY))  
+  sessionUseCases.loadUrl.invoke(url, LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE, LoadUrlFlags.BYPASS_PROXY))
   ```
 
 # 1.0.0
@@ -98,7 +100,7 @@ permalink: /changelog/
 * **browser-search**
   * Added `getProvidedDefaultSearchEngine` to `SearchEngineManager` to return the provided default search engine or the first
     search engine if the default is not set. This allows use cases like [#3344](https://github.com/mozilla-mobile/android-components/issues/3344).
-  
+
 * **feature-tab-collections**
   * Behavior change: `TabCollection` instances returned by `TabCollectionStorage` are now ordered by the last time they have been updated (instead of the time they have been created).
 


### PR DESCRIPTION
Adds `historyList` property to Session, so that we can later use it to render a list of pages when the back/forward buttons are held.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
