### PR TITLE
Add putCompoundDrawablesRelative support function

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/TextView.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/TextView.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to other public APIs.
+
+package mozilla.components.support.ktx.android.view
+
+import android.graphics.drawable.Drawable
+import android.widget.TextView
+
+/**
+ * Sets the [Drawable]s (if any) to appear to the start of, above, to the end of,
+ * and below the text. Use `null` if you do not want a Drawable there.
+ * The Drawables must already have had [Drawable.setBounds] called.
+ *
+ * Calling this method will overwrite any Drawables previously set using
+ * [TextView.setCompoundDrawables] or related methods.
+ */
+inline fun TextView.putCompoundDrawablesRelative(
+    start: Drawable? = null,
+    top: Drawable? = null,
+    end: Drawable? = null,
+    bottom: Drawable? = null
+) = setCompoundDrawablesRelative(start, top, end, bottom)
+
+/**
+ *
+ * Sets the [Drawable]s (if any) to appear to the start of, above, to the end of,
+ * and below the text. Use `null` if you do not want a Drawable there.
+ * The Drawables' bounds will be set to their intrinsic bounds.
+ *
+ * Calling this method will overwrite any Drawables previously set using
+ * [TextView.setCompoundDrawables] or related methods.
+ */
+inline fun TextView.putCompoundDrawablesRelativeWithIntrinsicBounds(
+    start: Drawable? = null,
+    top: Drawable? = null,
+    end: Drawable? = null,
+    bottom: Drawable? = null
+) = setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom)

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/TextViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/TextViewTest.kt
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.view
+
+import android.graphics.drawable.Drawable
+import android.widget.EditText
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class TextViewTest {
+
+    @Test
+    fun `putCompoundDrawablesRelative defaults to all null`() {
+        val view = TextView(testContext)
+
+        view.putCompoundDrawablesRelative()
+
+        assertArrayEquals(
+            arrayOf<Drawable?>(null, null, null, null),
+            view.compoundDrawablesRelative
+        )
+    }
+
+    @Test
+    fun `putCompoundDrawablesRelativeWithIntrinsicBounds defaults to all null`() {
+        val view = TextView(testContext)
+
+        view.putCompoundDrawablesRelativeWithIntrinsicBounds()
+
+        assertArrayEquals(
+            arrayOf<Drawable?>(null, null, null, null),
+            view.compoundDrawablesRelative
+        )
+    }
+
+    @Test
+    fun `putCompoundDrawablesRelative should set drawableStart and drawableEnd`() {
+        val view = EditText(testContext)
+        val drawable: Drawable = mock()
+
+        view.putCompoundDrawablesRelative(start = drawable)
+
+        assertArrayEquals(
+            arrayOf(drawable, null, null, null),
+            view.compoundDrawablesRelative
+        )
+
+        view.putCompoundDrawablesRelative(end = drawable)
+
+        assertArrayEquals(
+            arrayOf(null, null, drawable, null),
+            view.compoundDrawablesRelative
+        )
+    }
+
+    @Test
+    fun `putCompoundDrawablesRelativeWithIntrinsicBounds should set drawableStart and drawableEnd`() {
+        val view = EditText(testContext)
+        val drawable: Drawable = mock()
+
+        view.putCompoundDrawablesRelativeWithIntrinsicBounds(start = drawable)
+
+        assertArrayEquals(
+            arrayOf(drawable, null, null, null),
+            view.compoundDrawablesRelative
+        )
+
+        view.putCompoundDrawablesRelativeWithIntrinsicBounds(end = drawable)
+
+        assertArrayEquals(
+            arrayOf(null, null, drawable, null),
+            view.compoundDrawablesRelative
+        )
+    }
+
+    @Test
+    fun `putCompoundDrawablesRelative should call setCompoundDrawablesRelative`() {
+        val view: TextView = mock()
+        val drawable: Drawable = mock()
+
+        view.putCompoundDrawablesRelative(top = drawable)
+
+        verify(view).setCompoundDrawablesRelative(null, drawable, null, null)
+
+        view.putCompoundDrawablesRelativeWithIntrinsicBounds(bottom = drawable)
+
+        verify(view).setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, drawable)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,9 @@ permalink: /changelog/
 * **feature-downloads**
   * Added `FetchDownloadManager`, an alternate download manager that uses a fetch `Client` instead of the native Android `DownloadManager`.
 
+* **support-ktx**
+  * Added `putCompoundDrawablesRelative` and `putCompoundDrawablesRelativeWithIntrinsicBounds`, aliases of `setCompoundDrawablesRelative` that use Kotlin named and default arguments.
+
 # 2.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v1.0.0...v2.0.0)


### PR DESCRIPTION
Adds new alias for [`setCompoundDrawablesRelative`](https://developer.android.com/reference/kotlin/android/widget/TextView?hl=en#setcompounddrawablesrelative) that lets you use named arguments.

While we don't use this function in Android Components, Fenix and Focus both use `setCompoundDrawables` functions and could use this to slightly avoid boilerplate and make the code more readable. 

```kt
view.setCompoundDrawablesRelative(drawable, null, null, null) // Before
view.putCompoundDrawablesRelative(start = drawable) // After
```

`setCompoundDrawablesRelativeWithIntrinsicBounds` also has an equivalent alias. 

I intentionally omitted aliases for setCompoundDrawables, since you usually want to use the relative versions to support RTL languages.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
