### PR TITLE
Ensure experiments record enrollment/unenrollment in Glean

### DIFF
--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
@@ -187,6 +187,10 @@ open class ExperimentsInternalAPI internal constructor() {
     private fun stopActiveExperiment() {
         assert(activeExperiment != null) { "Should have an active experiment" }
 
+        activeExperiment?.let {
+            Glean.setExperimentInactive(it.experiment.id)
+        }
+
         ActiveExperiment.clear(context)
         activeExperiment = null
     }


### PR DESCRIPTION
The enrollment call to `Glean.setExperimentActive` was already here, just adding the unenrollment call to `Glean.setExperimentInactive`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
