### PR TITLE
Add glide-style icon loading function

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/CancelOnDetach.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/CancelOnDetach.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.utils
+
+import android.view.View
+import kotlinx.coroutines.Job
+
+/**
+ * Cancels the provided job when a view is detached from the window
+ */
+internal class CancelOnDetach(private val job: Job) : View.OnAttachStateChangeListener {
+
+    override fun onViewAttachedToWindow(v: View?) = Unit
+
+    override fun onViewDetachedFromWindow(v: View?) = job.cancel()
+}

--- a/components/browser/icons/src/main/res/values/tags.xml
+++ b/components/browser/icons/src/main/res/values/tags.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <item name="mozac_browser_icons_tag_job" type="id" />
+</resources>

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/CancelOnDetachTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/CancelOnDetachTest.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.icons.utils
+
+import android.view.View
+import kotlinx.coroutines.Job
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.verifyNoMoreInteractions
+
+class CancelOnDetachTest {
+
+    @Test
+    fun `onViewAttached does nothing`() {
+        val job: Job = mock()
+        val view: View = mock()
+
+        CancelOnDetach(job).onViewAttachedToWindow(view)
+
+        verifyNoMoreInteractions(job)
+        verifyNoMoreInteractions(view)
+    }
+
+    @Test
+    fun `onViewDetachedFromWindow cancels the job`() {
+        val job = Job()
+
+        CancelOnDetach(job).onViewDetachedFromWindow(mock())
+
+        assertTrue(job.isCancelled)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 * **All components**
   * Increased `compileSdkVersion` to 29 (Android Q)
 
+* **browser-icons**
+  * Added `BrowserIcons.loadIntoView` to automatically load an icon into an `ImageView`.
+
 * **support-ktx**
   * ⚠️ **This is a breaking behavior change**: `JSONArray.mapNotNull` is now an inline function, changing the behavior of the `return` keyword within its lambda.
 
@@ -80,6 +83,7 @@ permalink: /changelog/
 * **feature-prompts**
   * Improved file picker prompt by displaying the option to use the camera to capture images,
     microphone to record audio, or video camera to capture a video.
+  * The color picker has been redesigned based on Firefox for Android (Fennec).
 
 * **feature-pwa**
   * Added preliminary support for pinning websites to the home screen.
@@ -100,9 +104,6 @@ permalink: /changelog/
   * Deprecated `String.toUri()` in favour of Android Core KTX.
   * Deprecated `View.isGone` and `View.isInvisible` in favour of Android Core KTX.
   * Added `putCompoundDrawablesRelative` and `putCompoundDrawablesRelativeWithIntrinsicBounds`, aliases of `setCompoundDrawablesRelative` that use Kotlin named and default arguments.
-
-* **feature-prompts**
-  * The color picker has been redesigned based on Firefox for Android (Fennec).
 
 # 2.0.0
 


### PR DESCRIPTION
A lot of our code involves setting up coroutine scopes for the sole purpose of loading an icon from `BrowserIcons`, which already has its own scope. I've written a new helper that emulates the `Glide.load(url).into(view)` call which doesn't need a parent coroutine scope.

Loading is cancelled if the image view is detached, and loading for an image view is restarted if the function is called again with the same image view.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
