### PR TITLE
Closes #3573: Adds SendTabUseCases in a component 

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -72,6 +72,10 @@ projects:
     path: components/feature/search
     description: 'Feature implementation connecting an engine implementation with the search module.'
     publish: true
+  feature-sendtab:
+    path: components/feature/sendtab
+    description: 'Feature of use cases for sending tabs between devices in an FxA Account.'
+    publish: true
   feature-session:
     path: components/feature/session
     description: 'Feature implementation connecting an engine implementation with the session module.'

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ _Combined components to implement feature-specific use cases._
 
 * 🔴 [**Search**](components/feature/search/README.md) - A component that connects an (concept) engine implementation with the browser search module.
 
+* 🔴 [**SendTab**](components/feature/sendtab/README.md) - A component for sending tabs to other devices with a registered FxA Account.
+
 * ⚪ [**Session**](components/feature/session/README.md) - A component that connects an (concept) engine implementation with the browser session and storage modules.
 
 * 🔴 [**Sync**](components/feature/sync/README.md) -A component that provides synchronization orchestration for groups of (concept) SyncableStore objects.

--- a/components/feature/sendtab/README.md
+++ b/components/feature/sendtab/README.md
@@ -1,0 +1,40 @@
+# [Android Components](../../../README.md) > Feature > SendTab
+
+Feature component for sending tabs to other devices with a registered FxA Account.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-sendtab:{latest-version}"
+```
+
+## Usage
+
+In order to make use of the send tab features here, it's required to have an an FxA Account setup.
+See the [service-firefox-accounts](../../service/firefox-accounts/README.md) for more information how to set this up.
+
+```kotlin
+
+val sendTabUseCases = SendTabUseCases(accountManager)
+
+// Send to a particular device
+sendTabUseCases.sendToDeviceAsync("1234", TabData("Mozilla", "https://mozilla.org"))
+
+// Send to all devices
+sendTabUseCases.sendToAllAsync(TabData("Mozilla", "https://mozilla.org"))
+
+// Send multiple tabs to devices works too..
+sendTabUseCases.sendToDeviceAsync("1234", listof(tab1, tab2))
+sendTabUseCases.sendToAllAsync(listof(tab1, tab2))
+
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/sendtab/build.gradle
+++ b/components/feature/sendtab/build.gradle
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/proguard/androidx-annotations.pro'
+    }
+}
+
+dependencies {
+    implementation project(':service-firefox-accounts')
+    implementation project(':support-ktx')
+    implementation project(':support-base')
+
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_coroutines
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/feature/sendtab/proguard-rules.pro
+++ b/components/feature/sendtab/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/sendtab/src/main/AndroidManifest.xml
+++ b/components/feature/sendtab/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.sendtab" />

--- a/components/feature/sendtab/src/main/java/mozilla/components/feature/sendtab/SendTabUseCases.kt
+++ b/components/feature/sendtab/src/main/java/mozilla/components/feature/sendtab/SendTabUseCases.kt
@@ -1,0 +1,176 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.sendtab
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.plus
+import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.DeviceEventOutgoing.SendTab
+import mozilla.components.concept.sync.TabData
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.ktx.kotlin.crossProduct
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Contains use cases for sending tabs to devices related to the firefox-accounts.
+ *
+ * @param accountManager The AccountManager on which we want to retrieve our devices.
+ * @param coroutineContext The Coroutine Context on which we want to do the actual sending.
+ * By default, we want to do this on the IO dispatcher since it involves making network requests to
+ * the Sync servers.
+ */
+class SendTabUseCases(
+    accountManager: FxaAccountManager,
+    coroutineContext: CoroutineContext = Dispatchers.IO
+) {
+    private var job: Job = SupervisorJob()
+    private val scope = CoroutineScope(coroutineContext) + job
+
+    class SendToDeviceUseCase internal constructor(
+        private val accountManager: FxaAccountManager,
+        private val scope: CoroutineScope
+    ) {
+        /**
+         * Sends the tab to provided deviceId if possible.
+         *
+         * @param deviceId The deviceId to send the tab.
+         * @param tab The tab to send.
+         * @return a deferred boolean if the result was successful or not.
+         */
+        operator fun invoke(deviceId: String, tab: TabData) =
+            scope.async { send(deviceId, tab) }
+
+        /**
+         * Sends the tabs to provided deviceId if possible.
+         *
+         * @param deviceId The deviceId to send the tab.
+         * @param tabs The list of tabs to send.
+         * @return a deferred boolean as true if the combined result was successful or not.
+         */
+        operator fun invoke(deviceId: String, tabs: List<TabData>): Deferred<Boolean> {
+            return scope.async {
+                tabs.map { tab ->
+                    send(deviceId, tab)
+                }.fold(true) { acc, result ->
+                    acc and result
+                }
+            }
+        }
+
+        private suspend fun send(deviceId: String, tab: TabData): Boolean {
+            filterSendTabDevices(accountManager) { constellation, devices ->
+                val device = devices.firstOrNull {
+                    it.id == deviceId
+                }
+                device?.let {
+                    return constellation.sendEventToDeviceAsync(
+                        device.id,
+                        SendTab(tab.title, tab.url)
+                    ).await()
+                }
+            }
+
+            return false
+        }
+    }
+
+    class SendToAllUseCase internal constructor(
+        private val accountManager: FxaAccountManager,
+        private val scope: CoroutineScope
+    ) {
+
+        /**
+         * Sends the tab to all send-tab compatible devices.
+         *
+         * @param tab The tab to send.
+         * @return a deferred boolean as true if the combined result was successful or not.
+         */
+        operator fun invoke(tab: TabData): Deferred<Boolean> {
+            return scope.async {
+                sendToAll { devices ->
+                    devices.map { device ->
+                        device to tab
+                    }
+                }
+            }
+        }
+
+        /**
+         * Sends the tabs to all the send-tab compatible devices.
+         *
+         * @param tabs a collection of tabs to send.
+         * @return a deferred boolean as true if the combined result was successful or not.
+         */
+        operator fun invoke(tabs: Collection<TabData>): Deferred<Boolean> {
+            return scope.async {
+                sendToAll { devices ->
+                    devices.crossProduct(tabs) { device, tab ->
+                        device to tab
+                    }
+                }
+            }
+        }
+
+        private suspend inline fun sendToAll(
+            block: (Collection<Device>) -> List<Pair<Device, TabData>>
+        ): Boolean {
+            // Filter devices to send tab capable ones.
+            filterSendTabDevices(accountManager) { constellation, devices ->
+                // Get a list of device-tab combinations that we want to send.
+                return block(devices).map { (device, tab) ->
+                    // Send the tab!
+                    constellation.sendEventToDeviceAsync(
+                        device.id,
+                        SendTab(tab.title, tab.url)
+                    ).await()
+                }.fold(true) { acc, result ->
+                    // Collect the results and reduce them into one final result.
+                    acc and result
+                }
+            }
+            return false
+        }
+    }
+
+    val sendToDeviceAsync: SendToDeviceUseCase by lazy {
+        SendToDeviceUseCase(
+            accountManager,
+            scope
+        )
+    }
+
+    val sendToAllAsync: SendToAllUseCase by lazy {
+        SendToAllUseCase(
+            accountManager,
+            scope
+        )
+    }
+}
+
+@VisibleForTesting
+internal inline fun filterSendTabDevices(
+    accountManager: FxaAccountManager,
+    block: (DeviceConstellation, Collection<Device>) -> Unit
+) {
+    val constellation = accountManager.authenticatedAccount()?.deviceConstellation() ?: return
+
+    constellation.state()?.let { state ->
+        state.otherDevices.filter {
+            it.capabilities.contains(DeviceCapability.SEND_TAB)
+        }.let { devices ->
+            block(constellation, devices)
+        }
+    }
+}

--- a/components/feature/sendtab/src/test/java/mozilla/components/feature/sendtab/SendTabUseCasesTest.kt
+++ b/components/feature/sendtab/src/test/java/mozilla/components/feature/sendtab/SendTabUseCasesTest.kt
@@ -1,0 +1,301 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.sendtab
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.concept.sync.ConstellationState
+import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.TabData
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+class SendTabUseCasesTest {
+
+    private val manager: FxaAccountManager = mock()
+    private val account: OAuthAccount = mock()
+    private val constellation: DeviceConstellation = mock()
+    private val state: ConstellationState = mock()
+
+    @Before
+    fun setup() {
+        `when`(manager.authenticatedAccount()).thenReturn(account)
+        `when`(account.deviceConstellation()).thenReturn(constellation)
+        `when`(constellation.state()).thenReturn(state)
+    }
+
+    @Test
+    fun `SendTabUseCase - tab is sent to capable device`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = generateDevice()
+
+        `when`(state.otherDevices).thenReturn(listOf(device))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(true))
+
+        useCases.sendToDeviceAsync(device.id, TabData("Title", "http://example.com"))
+
+        verify(constellation).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabUseCase - tabs are sent to capable device`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = generateDevice()
+        val tab = TabData("Title", "http://example.com")
+
+        `when`(state.otherDevices).thenReturn(listOf(device))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(true))
+
+        useCases.sendToDeviceAsync(device.id, listOf(tab, tab))
+
+        verify(constellation, times(2)).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabUseCase - tabs are NOT sent to incapable devices`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = mock()
+        val tab = TabData("Title", "http://example.com")
+
+        useCases.sendToDeviceAsync("123", listOf(tab, tab))
+
+        verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+        `when`(device.id).thenReturn("123")
+        `when`(state.otherDevices).thenReturn(listOf(device))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(false))
+
+        useCases.sendToDeviceAsync("123", listOf(tab, tab))
+
+        verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabUseCase - device id does not match when sending single tab`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = generateDevice("123")
+        val tab = TabData("Title", "http://example.com")
+
+        useCases.sendToDeviceAsync("123", tab)
+
+        verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+        `when`(state.otherDevices).thenReturn(listOf(device))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(false))
+
+        useCases.sendToDeviceAsync("456", tab)
+
+        verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+        useCases.sendToDeviceAsync("123", tab)
+
+        verify(constellation).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabUseCase - device id does not match when sending tabs`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = generateDevice("123")
+        val tab = TabData("Title", "http://example.com")
+
+        useCases.sendToDeviceAsync("123", listOf(tab))
+
+        verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+        `when`(state.otherDevices).thenReturn(listOf(device))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(false))
+
+        useCases.sendToDeviceAsync("456", listOf(tab))
+
+        verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+        useCases.sendToDeviceAsync("123", listOf(tab))
+
+        verify(constellation).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabToAllUseCase - tab is sent to capable devices`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = generateDevice()
+        val device2: Device = generateDevice()
+
+        `when`(state.otherDevices).thenReturn(listOf(device, device2))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(false))
+
+        val tab = TabData("Mozilla", "https://mozilla.org")
+
+        useCases.sendToAllAsync(tab)
+
+        verify(constellation, times(2)).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabToAllUseCase - tabs is sent to capable devices`() = runBlockingTest {
+        val useCases = SendTabUseCases(manager, coroutineContext)
+        val device: Device = generateDevice()
+        val device2: Device = generateDevice()
+
+        `when`(state.otherDevices).thenReturn(listOf(device, device2))
+        `when`(constellation.sendEventToDeviceAsync(any(), any()))
+            .thenReturn(CompletableDeferred(false))
+
+        val tab = TabData("Mozilla", "https://mozilla.org")
+        val tab2 = TabData("Firefox", "https://firefox.com")
+
+        useCases.sendToAllAsync(listOf(tab, tab2))
+
+        verify(constellation, times(4)).sendEventToDeviceAsync(any(), any())
+    }
+
+    @Test
+    fun `SendTabToAllUseCase - tab is NOT sent to incapable devices`() {
+        val useCases = SendTabUseCases(manager)
+        val tab = TabData("Mozilla", "https://mozilla.org")
+        val device: Device = mock()
+        val device2: Device = mock()
+
+        runBlocking {
+            useCases.sendToAllAsync(tab)
+
+            verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+            `when`(device.id).thenReturn("123")
+            `when`(device2.id).thenReturn("456")
+            `when`(state.otherDevices).thenReturn(listOf(device, device2))
+
+            useCases.sendToAllAsync(tab)
+
+            verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+        }
+    }
+
+    @Test
+    fun `SendTabToAllUseCase - tabs are NOT sent to capable devices`() {
+        val useCases = SendTabUseCases(manager)
+        val tab = TabData("Mozilla", "https://mozilla.org")
+        val tab2 = TabData("Firefox", "https://firefox.com")
+        val device: Device = mock()
+        val device2: Device = mock()
+
+        runBlocking {
+            useCases.sendToAllAsync(tab)
+
+            verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+            `when`(device.id).thenReturn("123")
+            `when`(device2.id).thenReturn("456")
+            `when`(state.otherDevices).thenReturn(listOf(device, device2))
+
+            useCases.sendToAllAsync(listOf(tab, tab2))
+
+            verify(constellation, never()).sendEventToDeviceAsync(eq("123"), any())
+            verify(constellation, never()).sendEventToDeviceAsync(eq("456"), any())
+        }
+    }
+
+    @Test
+    fun `SendTabUseCase - result is false if any send tab action fails`() {
+        val useCases = SendTabUseCases(manager)
+        val device: Device = mock()
+        val tab = TabData("Title", "http://example.com")
+
+        runBlocking {
+            useCases.sendToDeviceAsync("123", listOf(tab, tab))
+
+            verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+
+            `when`(device.id).thenReturn("123")
+            `when`(state.otherDevices).thenReturn(listOf(device))
+            `when`(constellation.sendEventToDeviceAsync(any(), any()))
+                .thenReturn(CompletableDeferred(true))
+                .thenReturn(CompletableDeferred(true))
+
+            val result = useCases.sendToDeviceAsync("123", listOf(tab, tab))
+
+            verify(constellation, never()).sendEventToDeviceAsync(any(), any())
+            Assert.assertFalse(result.await())
+        }
+    }
+
+    @Test
+    fun `filter devices returns capable devices`() {
+        var executed = false
+        runBlocking {
+            `when`(state.otherDevices).thenReturn(listOf(generateDevice(), generateDevice()))
+            filterSendTabDevices(manager) { _, _ ->
+                executed = true
+            }
+
+            Assert.assertTrue(executed)
+        }
+    }
+
+    @Test
+    fun `filter devices does NOT provide for incapable devices`() {
+        val device: Device = mock()
+        val device2: Device = mock()
+
+        runBlocking {
+            `when`(device.id).thenReturn("123")
+            `when`(device2.id).thenReturn("456")
+            `when`(state.otherDevices).thenReturn(listOf(device, device2))
+
+            filterSendTabDevices(manager) { _, filteredDevices ->
+                Assert.assertTrue(filteredDevices.isEmpty())
+            }
+
+            val accountManager: FxaAccountManager = mock()
+            val account: OAuthAccount = mock()
+            val constellation: DeviceConstellation = mock()
+            val state: ConstellationState = mock()
+            `when`(accountManager.authenticatedAccount()).thenReturn(account)
+            `when`(account.deviceConstellation()).thenReturn(constellation)
+            `when`(constellation.state()).thenReturn(state)
+
+            filterSendTabDevices(mock()) { _, _ ->
+                Assert.fail()
+            }
+        }
+    }
+
+    private fun generateDevice(id: String = UUID.randomUUID().toString()): Device {
+        return Device(
+            id = id,
+            displayName = id,
+            deviceType = DeviceType.MOBILE,
+            isCurrentDevice = false,
+            lastAccessTime = null,
+            capabilities = listOf(DeviceCapability.SEND_TAB),
+            subscriptionExpired = false,
+            subscription = null
+        )
+    }
+}

--- a/components/feature/sendtab/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/sendtab/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/Collection.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/Collection.kt
@@ -1,0 +1,28 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.support.ktx.kotlin
+
+/**
+ * Performs a cartesian product of all the elements in two collections and returns each pair to
+ * the [block] function.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * val numbers = listOf(1, 2, 3)
+ * val letters = listOf('a', 'b', 'c')
+ * numbers.crossProduct(letters) { number, letter ->
+ *   // Each combination of (1, a), (1, b), (1, c), (2, a), (2, b), etc.
+ * }
+ * ```
+ */
+inline fun <T, U, R> Collection<T>.crossProduct(
+    other: Collection<U>,
+    block: (T, U) -> R
+) = flatMap { first ->
+    other.map { second -> first to second }.map { block(it.first, it.second) }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/CollectionKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/CollectionKtTest.kt
@@ -1,0 +1,72 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.support.ktx.kotlin
+
+import org.junit.Assert
+import org.junit.Test
+
+class CollectionKtTest {
+
+    @Test
+    fun `cross product of each element is called exactly`() {
+        val numbers = listOf(1, 2, 3)
+        val letters = listOf('a', 'b', 'c')
+        var counter = 0
+        numbers.crossProduct(letters) { _, _ ->
+            counter++
+        }
+
+        Assert.assertEquals(numbers.size * letters.size, counter)
+    }
+
+    @Test
+    fun `cross product of each element is of the same type`() {
+        val numbers = listOf(1, 2, 3)
+        val letters = listOf('a', 'b', 'c')
+        numbers.crossProduct(letters) { number, letter ->
+            Assert.assertEquals(Int::class, number::class)
+            Assert.assertEquals(Char::class, letter::class)
+        }
+    }
+
+    @Test
+    fun `cross product of each pair is in order`() {
+        val numbers = listOf(1, 2, 3)
+        val letters = listOf('a', 'b', 'c')
+        val assertions = arrayOf(
+            1 to 'a',
+            1 to 'b',
+            1 to 'c',
+            2 to 'a',
+            2 to 'b',
+            2 to 'c',
+            3 to 'a',
+            3 to 'b',
+            3 to 'c'
+        )
+        var position = 0
+        numbers.crossProduct(letters) { number, letter ->
+            Assert.assertEquals(assertions[position].first, number)
+            Assert.assertEquals(assertions[position].second, letter)
+            position++
+        }
+    }
+
+    @Suppress("USELESS_IS_CHECK")
+    @Test
+    fun `cross product result is list of return type`() {
+        val numbers = listOf(1, 2, 3)
+        val letters = listOf('a', 'b', 'c')
+        val result = numbers.crossProduct(letters) { number, letter ->
+            number to letter
+        }
+        Assert.assertTrue(result is List)
+        Assert.assertEquals(Pair::class, result[0]::class)
+        Assert.assertEquals(Int::class, result[0].first::class)
+        Assert.assertEquals(Char::class, result[0].second::class)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,26 @@ permalink: /changelog/
 * **feature-customtabs**
   * `CustomTabsToolbarFeature` now optionally takes `Window` as a parameter. It will update the status bar color to match the toolbar color.
 
+* **feature-sendtab**
+  * 🆕 New component for send tab use cases.
+
+  ```kotlin
+    val sendTabUseCases = SendTabUseCases(accountManager)
+
+    // Send to a particular device
+    sendTabUseCases.sendToDeviceAsync("1234", TabData("Mozilla", "https://mozilla.org"))
+
+    // Send to all devices
+    sendTabUseCases.sendToAllAsync(TabData("Mozilla", "https://mozilla.org"))
+
+    // Send multiple tabs to devices works too..
+    sendTabUseCases.sendToDeviceAsync("1234", listof(tab1, tab2))
+    sendTabUseCases.sendToAllAsync(listof(tab1, tab2))
+  ```
+
+* **support-ktx**
+  * Added `Collection.crossProduct` to retrieve the cartesian product of two `Collections`.
+
 # 5.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v4.0.0...v5.0.0)


### PR DESCRIPTION
This PR adds a new component `feature-sendtab` with use cases that make sending a tab easier. Providing an AccountManager is the only dependency, and if the account is in the correct state, tabs will be sent.

An additional helper extension was also added to `support-ktx` for retrieving the cartesian product of two collections.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
