### PR TITLE
Closes #3666: Expose useWideViewPort for SystemEngine

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -319,6 +319,7 @@ class SystemEngineSession(
                 webFontsEnabled = it.webFontsEnabled
                 displayZoomControls = it.displayZoomControls
                 loadWithOverviewMode = it.loadWithOverviewMode
+                useWideViewPort = it.useWideViewPort
                 trackingProtectionPolicy = it.trackingProtectionPolicy
                 historyTrackingDelegate = it.historyTrackingDelegate
                 requestInterceptor = it.requestInterceptor

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -281,6 +281,7 @@ class SystemEngineSession(
             override var userAgentString by WebSetting(s::getUserAgentString, s::setUserAgentString)
             override var displayZoomControls by WebSetting(s::getDisplayZoomControls, s::setDisplayZoomControls)
             override var loadWithOverviewMode by WebSetting(s::getLoadWithOverviewMode, s::setLoadWithOverviewMode)
+            override var useWideViewPort by WebSetting(s::getUseWideViewPort, s::setUseWideViewPort)
             override var supportMultipleWindows by WebSetting(s::supportMultipleWindows, s::setSupportMultipleWindows)
             override var allowFileAccessFromFileURLs by WebSetting(
                     s::getAllowFileAccessFromFileURLs, s::setAllowFileAccessFromFileURLs)

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -49,7 +49,7 @@ class SystemEngineSession(
     @Volatile internal var trackingProtectionPolicy: TrackingProtectionPolicy? = null
     @Volatile internal var webFontsEnabled = true
     @Volatile internal var currentUrl = ""
-    @Volatile internal var useWideViewPort: Boolean? = null
+    @Volatile internal var useWideViewPort: Boolean? = null // See [toggleDesktopMode]
     @Volatile internal var fullScreenCallback: WebChromeClient.CustomViewCallback? = null
 
     // This is public for FFTV which needs access to the WebView instance. We can mark it internal once
@@ -348,11 +348,15 @@ class SystemEngineSession(
 
     /**
      * See [EngineSession.toggleDesktopMode]
+     *
+     * Precondition:
+     * If settings.useWideViewPort = true, then webSettings.useWideViewPort is always on
+     * If settings.useWideViewPort = false or null, then webSettings.useWideViewPort can be on/off
      */
     override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         val webSettings = webView.settings
         webSettings.userAgentString = toggleDesktopUA(webSettings.userAgentString, enable)
-        webSettings.useWideViewPort = settings.useWideViewPort ?: enable
+        webSettings.useWideViewPort = if (settings.useWideViewPort == true) true else enable
 
         notifyObservers { onDesktopModeChange(enable) }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -306,9 +306,9 @@ class SystemEngineSessionTest {
         engineSession.settings.loadWithOverviewMode = true
         verify(webViewSettings).loadWithOverviewMode = true
 
-        assertFalse(engineSession.settings.useWideViewPort)
-        engineSession.settings.useWideViewPort = true
-        verify(webViewSettings).useWideViewPort = true
+        assertNull(engineSession.settings.useWideViewPort)
+        engineSession.settings.useWideViewPort = false
+        verify(webViewSettings).useWideViewPort = false
 
         assertTrue(engineSession.settings.allowContentAccess)
         engineSession.settings.allowContentAccess = false
@@ -372,6 +372,7 @@ class SystemEngineSessionTest {
                 javaScriptCanOpenWindowsAutomatically = true,
                 displayZoomControls = true,
                 loadWithOverviewMode = true,
+                useWideViewPort = true,
                 supportMultipleWindows = true)
         val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
 
@@ -390,6 +391,7 @@ class SystemEngineSessionTest {
         verify(webViewSettings).javaScriptCanOpenWindowsAutomatically = true
         verify(webViewSettings).displayZoomControls = true
         verify(webViewSettings).loadWithOverviewMode = true
+        verify(webViewSettings).useWideViewPort = true
         verify(webViewSettings).setSupportMultipleWindows(true)
         verify(engineSession).enableTrackingProtection(EngineSession.TrackingProtectionPolicy.all())
         assertFalse(engineSession.webFontsEnabled)
@@ -637,8 +639,7 @@ class SystemEngineSessionTest {
     @Test
     fun desktopMode() {
         val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
-        val defaultSettings = DefaultSettings()
-        val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
+        val engineSession = spy(SystemEngineSession(testContext))
         val webView = mock<WebView>()
         val webViewSettings = mock<WebSettings>()
         var desktopMode = false
@@ -662,6 +663,22 @@ class SystemEngineSessionTest {
 
         engineSession.toggleDesktopMode(true, true)
         verify(webView).reload()
+    }
+
+    @Test
+    fun desktopModeWithProvidedWideViewPort() {
+        val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
+        val defaultSettings = DefaultSettings(useWideViewPort = true)
+        val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
+        val webView = mock<WebView>()
+        val webViewSettings = mock<WebSettings>()
+
+        engineSession.webView = webView
+        whenever(webView.settings).thenReturn(webViewSettings)
+        whenever(webViewSettings.userAgentString).thenReturn(userAgentMobile)
+
+        engineSession.toggleDesktopMode(false)
+        verify(webViewSettings).useWideViewPort = true
     }
 
     @Test

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -306,6 +306,10 @@ class SystemEngineSessionTest {
         engineSession.settings.loadWithOverviewMode = true
         verify(webViewSettings).loadWithOverviewMode = true
 
+        assertFalse(engineSession.settings.useWideViewPort)
+        engineSession.settings.useWideViewPort = true
+        verify(webViewSettings).useWideViewPort = true
+
         assertTrue(engineSession.settings.allowContentAccess)
         engineSession.settings.allowContentAccess = false
         verify(webViewSettings).allowContentAccess = false

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -666,12 +666,19 @@ class SystemEngineSessionTest {
     }
 
     @Test
-    fun desktopModeWithProvidedWideViewPort() {
+    fun desktopModeWithProvidedTrueWideViewPort() {
         val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
         val defaultSettings = DefaultSettings(useWideViewPort = true)
         val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
         val webView = mock<WebView>()
         val webViewSettings = mock<WebSettings>()
+        var desktopMode = false
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onDesktopModeChange(enabled: Boolean) {
+                desktopMode = enabled
+            }
+        })
 
         engineSession.webView = webView
         whenever(webView.settings).thenReturn(webViewSettings)
@@ -679,6 +686,37 @@ class SystemEngineSessionTest {
 
         engineSession.toggleDesktopMode(false)
         verify(webViewSettings).useWideViewPort = true
+        verify(engineSession).toggleDesktopUA(userAgentMobile, false)
+        assertFalse(desktopMode)
+    }
+
+    @Test
+    fun desktopModeWithProvidedFalseWideViewPort() {
+        val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
+        val defaultSettings = DefaultSettings(useWideViewPort = false)
+        val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
+        val webView = mock<WebView>()
+        val webViewSettings = mock<WebSettings>()
+        var desktopMode = false
+        engineSession.register(object : EngineSession.Observer {
+            override fun onDesktopModeChange(enabled: Boolean) {
+                desktopMode = enabled
+            }
+        })
+
+        engineSession.webView = webView
+        whenever(webView.settings).thenReturn(webViewSettings)
+        whenever(webViewSettings.userAgentString).thenReturn(userAgentMobile)
+
+        engineSession.toggleDesktopMode(true)
+        verify(webViewSettings).useWideViewPort = true
+        verify(engineSession).toggleDesktopUA(userAgentMobile, true)
+        assertTrue(desktopMode)
+
+        engineSession.toggleDesktopMode(false)
+        verify(webViewSettings).useWideViewPort = false
+        verify(engineSession).toggleDesktopUA(userAgentMobile, false)
+        assertFalse(desktopMode)
     }
 
     @Test

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -637,7 +637,8 @@ class SystemEngineSessionTest {
     @Test
     fun desktopMode() {
         val userAgentMobile = "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 Mobile Safari/537.36"
-        val engineSession = spy(SystemEngineSession(testContext))
+        val defaultSettings = DefaultSettings()
+        val engineSession = spy(SystemEngineSession(testContext, defaultSettings))
         val webView = mock<WebView>()
         val webViewSettings = mock<WebSettings>()
         var desktopMode = false

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -84,6 +84,13 @@ abstract class Settings {
     open var loadWithOverviewMode: Boolean by UnsupportedSetting()
 
     /**
+     * Setting to control whether to support the viewport HTML meta tag or if a wide viewport
+     * should be used. If not null, this value overrides useWideViePort webSettings in
+     * [EngineSession.toggleDesktopMode].
+     */
+    open var useWideViewPort: Boolean by UnsupportedSetting()
+
+    /**
      * Setting to control whether or not file access is allowed.
      */
     open var allowFileAccess: Boolean by UnsupportedSetting()
@@ -175,6 +182,7 @@ data class DefaultSettings(
     override var javaScriptCanOpenWindowsAutomatically: Boolean = false,
     override var displayZoomControls: Boolean = true,
     override var loadWithOverviewMode: Boolean = false,
+    override var useWideViewPort: Boolean = false,
     override var allowFileAccess: Boolean = true,
     override var allowFileAccessFromFileURLs: Boolean = false,
     override var allowUniversalAccessFromFileURLs: Boolean = false,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -88,7 +88,7 @@ abstract class Settings {
      * should be used. If not null, this value overrides useWideViePort webSettings in
      * [EngineSession.toggleDesktopMode].
      */
-    open var useWideViewPort: Boolean by UnsupportedSetting()
+    open var useWideViewPort: Boolean? by UnsupportedSetting()
 
     /**
      * Setting to control whether or not file access is allowed.
@@ -182,7 +182,7 @@ data class DefaultSettings(
     override var javaScriptCanOpenWindowsAutomatically: Boolean = false,
     override var displayZoomControls: Boolean = true,
     override var loadWithOverviewMode: Boolean = false,
-    override var useWideViewPort: Boolean = false,
+    override var useWideViewPort: Boolean? = null,
     override var allowFileAccess: Boolean = true,
     override var allowFileAccessFromFileURLs: Boolean = false,
     override var allowUniversalAccessFromFileURLs: Boolean = false,

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -50,7 +50,7 @@ class SettingsTest {
             { settings.loadWithOverviewMode },
             { settings.loadWithOverviewMode = false },
             { settings.useWideViewPort },
-            { settings.useWideViewPort = false },
+            { settings.useWideViewPort = null },
             { settings.allowFileAccess },
             { settings.allowFileAccess = false },
             { settings.allowContentAccess },
@@ -103,7 +103,7 @@ class SettingsTest {
         assertTrue(settings.automaticFontSizeAdjustment)
         assertTrue(settings.automaticLanguageAdjustment)
         assertFalse(settings.loadWithOverviewMode)
-        assertFalse(settings.useWideViewPort)
+        assertNull(settings.useWideViewPort)
         assertTrue(settings.allowContentAccess)
         assertTrue(settings.allowFileAccess)
         assertFalse(settings.allowFileAccessFromFileURLs)
@@ -165,7 +165,7 @@ class SettingsTest {
         assertTrue(defaultSettings.javaScriptCanOpenWindowsAutomatically)
         assertFalse(defaultSettings.displayZoomControls)
         assertTrue(defaultSettings.loadWithOverviewMode)
-        assertTrue(defaultSettings.useWideViewPort)
+        assertEquals(defaultSettings.useWideViewPort, true)
         assertFalse(defaultSettings.allowContentAccess)
         assertFalse(defaultSettings.allowFileAccess)
         assertTrue(defaultSettings.allowFileAccessFromFileURLs)

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -49,6 +49,8 @@ class SettingsTest {
             { settings.displayZoomControls = false },
             { settings.loadWithOverviewMode },
             { settings.loadWithOverviewMode = false },
+            { settings.useWideViewPort },
+            { settings.useWideViewPort = false },
             { settings.allowFileAccess },
             { settings.allowFileAccess = false },
             { settings.allowContentAccess },
@@ -101,6 +103,7 @@ class SettingsTest {
         assertTrue(settings.automaticFontSizeAdjustment)
         assertTrue(settings.automaticLanguageAdjustment)
         assertFalse(settings.loadWithOverviewMode)
+        assertFalse(settings.useWideViewPort)
         assertTrue(settings.allowContentAccess)
         assertTrue(settings.allowFileAccess)
         assertFalse(settings.allowFileAccessFromFileURLs)
@@ -133,6 +136,7 @@ class SettingsTest {
             javaScriptCanOpenWindowsAutomatically = true,
             displayZoomControls = false,
             loadWithOverviewMode = true,
+            useWideViewPort = true,
             allowContentAccess = false,
             allowFileAccess = false,
             allowFileAccessFromFileURLs = true,
@@ -161,6 +165,7 @@ class SettingsTest {
         assertTrue(defaultSettings.javaScriptCanOpenWindowsAutomatically)
         assertFalse(defaultSettings.displayZoomControls)
         assertTrue(defaultSettings.loadWithOverviewMode)
+        assertTrue(defaultSettings.useWideViewPort)
         assertFalse(defaultSettings.allowContentAccess)
         assertFalse(defaultSettings.allowFileAccess)
         assertTrue(defaultSettings.allowFileAccessFromFileURLs)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ permalink: /changelog/
   * Now `TrackingProtectionPolicy.select` allows you to specify a `TrackingProtectionPolicy.CookiePolicy`, if not specified, `TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS` will be used.
   * Behavior change: Now `TrackingProtectionPolicy.none()` will get assigned a `TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL`, and both `TrackingProtectionPolicy.all()` and `TrackingProtectionPolicy.recommended()` will have a `TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS`.
 
+* **concept-engine**, **browser-engine-system**
+  * Added `useWideViewPort` in `Settings` to support the viewport HTML meta tag or if a wide viewport should be used. (Only affects `SystemEngineSession`)
+
 # 3.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v2.0.0...v3.0.0)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
