### PR TITLE
Fixes #3705 - Fix conflicting authorities

### DIFF
--- a/components/feature/prompts/src/main/AndroidManifest.xml
+++ b/components/feature/prompts/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     package="mozilla.components.feature.prompts">
     <application>
         <provider
-            android:authorities="mozilla.components.feature.prompts.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:name="androidx.core.content.FileProvider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/MimeType.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/MimeType.kt
@@ -52,7 +52,7 @@ internal sealed class MimeType(
                 return null
             }
 
-            val photoUri = getUri(context, FILE_PROVIDER_AUTHORITY, photoFile)
+            val photoUri = getUri(context, "${context.packageName}.fileprovider", photoFile)
 
             return intent.apply { putExtra(EXTRA_OUTPUT, photoUri) }.addCaptureHint(request.captureMode)
         }
@@ -121,7 +121,6 @@ internal sealed class MimeType(
         const val USE_FRONT_CAMERA = "android.intent.extra.USE_FRONT_CAMERA"
         const val LENS_FACING_BACK = "android.intent.extras.LENS_FACING_BACK"
         const val USE_BACK_CAMERA = "android.intent.extra.USE_BACK_CAMERA"
-        const val FILE_PROVIDER_AUTHORITY = "mozilla.components.feature.prompts.fileprovider"
     }
 }
 


### PR DESCRIPTION
(Oops)

Removes hardcoded authority in feature-prompts so that two apps that use the library can be installed at the same time.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
