### PR TITLE
Clean up toolbar feature code

### DIFF
--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
@@ -5,8 +5,8 @@
 package mozilla.components.feature.toolbar
 
 import androidx.annotation.ColorInt
-import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.base.feature.BackHandler
@@ -45,9 +45,7 @@ class ToolbarFeature(
      *
      * @return true if the event was handled, otherwise false.
      */
-    override fun onBackPressed(): Boolean {
-        return toolbar.onBackPressed()
-    }
+    override fun onBackPressed(): Boolean = toolbar.onBackPressed()
 
     /**
      * Stop feature: App is in the background.

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarInteractor.kt
@@ -25,10 +25,10 @@ class ToolbarInteractor(
      */
     fun start() {
         toolbar.setOnUrlCommitListener { text ->
-            if (text.isUrl()) {
-                loadUrlUseCase.invoke(text.toNormalizedUrl())
-            } else {
-                searchUseCase?.invoke(text) ?: loadUrlUseCase.invoke(text)
+            when {
+                text.isUrl() -> loadUrlUseCase.invoke(text.toNormalizedUrl())
+                searchUseCase != null -> searchUseCase.invoke(text)
+                else -> loadUrlUseCase.invoke(text)
             }
             true
         }


### PR DESCRIPTION
Some minor clean up for feature-toolbar.

- Instead of having a list of `Any` in `ToolbarAutocompleteFeature`, just have two similar for loops. Overall it's less code and doesn't deal with casting.
- Simplify `URLRenderer.updateUrl` and keep the order consistent between the when statement and the enum.