### PR TITLE
Closes #3673 - Add custom download icon

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -209,7 +209,7 @@ abstract class AbstractFetchDownloadService(
         val channelId = ensureChannelExists(this)
 
         return NotificationCompat.Builder(this, channelId)
-            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setSmallIcon(R.drawable.mozac_feature_download_ic_download)
             .setContentTitle(getString(R.string.mozac_feature_downloads_ongoing_notification_title))
             .setContentText(getString(R.string.mozac_feature_downloads_ongoing_notification_text))
             .setCategory(NotificationCompat.CATEGORY_PROGRESS)

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<animation-list xmlns:android="http://schemas.android.com/apk/res/android" android:oneshot="false">
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim0" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim1" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim2" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim3" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim4" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim5" android:duration="200" />
+</animation-list>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim0.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim0.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#3FFF"/>
+</vector>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim1.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#3FFF"/>
+    <path
+        android:name="animated_fill"
+        android:pathData="M 0 0 L 24 0 L 24 4 L 0 4 Z"
+        android:fillColor="#FFF"/>
+</vector>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim2.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#3FFF"/>
+    <path
+        android:name="animated_fill"
+        android:pathData="M 0 0 L 24 0 L 24 6 L 0 6 Z"
+        android:fillColor="#FFF"/>
+</vector>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim3.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim3.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#3FFF"/>
+    <path
+        android:name="animated_fill"
+        android:pathData="M 0 0 L 24 0 L 24 8 L 0 8 Z"
+        android:fillColor="#FFF"/>
+</vector>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim4.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim4.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#3FFF"/>
+    <path
+        android:name="animated_fill"
+        android:pathData="M 0 0 L 24 0 L 24 10 L 0 10 Z"
+        android:fillColor="#FFF"/>
+</vector>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim5.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download_anim5.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#3FFF"/>
+    <path
+        android:name="animated_fill"
+        android:pathData="M 0 0 L 24 0 L 24 20 L 0 20 Z"
+        android:fillColor="#FFF"/>
+</vector>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-media**
   * Added `MediaNotificationFeature` - a feature implementation to show an ongoing notification (keeping the app process alive) while web content is playing media.
 
+* **feature-downloads**
+  * Added custom notification icon for `FetchDownloadManager`.
+
 # 3.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v2.0.0...v3.0.0)


### PR DESCRIPTION
Sadly animated vector drawables don't work with notifications, so I had to fall back to a frame based animation.

![Notification icon](https://user-images.githubusercontent.com/1782266/60999094-4d280b00-a328-11e9-8ae2-6af3e3de448d.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
