### PR TITLE
Bump version of application-services libraries to 0.34.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val jna = "5.2.0"
     const val disklrucache = "2.0.2"
 
-    const val mozilla_appservices = "0.31.2"
+    const val mozilla_appservices = "0.34.0"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -268,7 +268,7 @@ class PlacesHistoryStorageTest {
         // Empty search.
         assertEquals(4, history.getSuggestions("", 100).size)
 
-        val search2 = history.getSuggestions("Mozilla", 100)
+        val search2 = history.getSuggestions("Mozilla", 100).sortedByDescending { it.url }
         assertEquals(2, search2.size)
         assertEquals("http://www.mozilla.org/", search2[0].id)
         assertEquals("http://www.mozilla.org/", search2[0].url)
@@ -277,15 +277,16 @@ class PlacesHistoryStorageTest {
         assertEquals("http://www.firefox.com/", search2[1].url)
         assertEquals("Mozilla Firefox", search2[1].title)
 
-        val search3 = history.getSuggestions("Mo", 100)
+        val search3 = history.getSuggestions("Mo", 100).sortedByDescending { it.url }
         assertEquals(3, search3.size)
-        assertEquals("http://www.moscow.ru/", search3[0].id)
-        assertEquals("http://www.moscow.ru/", search3[0].url)
-        assertEquals("Moscow City", search3[0].title)
 
-        assertEquals("http://www.mozilla.org/", search3[1].id)
-        assertEquals("http://www.mozilla.org/", search3[1].url)
-        assertEquals("Mozilla", search3[1].title)
+        assertEquals("http://www.mozilla.org/", search3[0].id)
+        assertEquals("http://www.mozilla.org/", search3[0].url)
+        assertEquals("Mozilla", search3[0].title)
+
+        assertEquals("http://www.moscow.ru/", search3[1].id)
+        assertEquals("http://www.moscow.ru/", search3[1].url)
+        assertEquals("Moscow City", search3[1].title)
 
         assertEquals("http://www.firefox.com/", search3[2].id)
         assertEquals("http://www.firefox.com/", search3[2].url)


### PR DESCRIPTION
Only real change here is that we return results in a slightly different order. Note that the order was never guaranteed, so this shouldn't matter.

CC @grigoryk 