### PR TITLE
Add helper for one-time OnGlobalLayoutListener

### DIFF
--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -25,6 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -98,17 +99,18 @@ class BrowserMenuTest {
             SimpleBrowserMenuItem("Hello") {},
             SimpleBrowserMenuItem("World") {})
 
-        val adapter = spy(BrowserMenuAdapter(testContext, items))
-        val menu = BrowserMenu(adapter)
+        val adapter = BrowserMenuAdapter(testContext, items)
+        val menu = spy(BrowserMenu(adapter))
+        doNothing().`when`(menu).scrollOnceToTheBottom(any())
 
         val anchor = Button(testContext)
         val popup = menu.show(anchor, endOfMenuAlwaysVisible = true)
-        val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
 
+        val recyclerView: RecyclerView = popup.contentView.findViewById(R.id.mozac_browser_menu_recyclerView)
         val layoutManager = recyclerView.layoutManager as LinearLayoutManager
 
         assertFalse(layoutManager.stackFromEnd)
-        assertNotNull(menu.scrollOnceToTheBottomWasCalled)
+        verify(menu).scrollOnceToTheBottom(any())
     }
 
     @Test

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -9,6 +9,7 @@ import android.graphics.Rect
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
 import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
@@ -97,6 +98,19 @@ fun View.setPadding(padding: Padding) {
             padding.bottom.dpToPx(displayMetrics)
         )
     }
+}
+
+/**
+ * Registers a one-time callback to be invoked when the global layout state
+ * or the visibility of views within the view tree changes.
+ */
+inline fun View.onNextGlobalLayout(crossinline callback: () -> Unit) {
+    var listener: ViewTreeObserver.OnGlobalLayoutListener? = null
+    listener = ViewTreeObserver.OnGlobalLayoutListener {
+        viewTreeObserver.removeOnGlobalLayoutListener(listener)
+        callback()
+    }
+    viewTreeObserver.addOnGlobalLayoutListener(listener)
 }
 
 private class ShowKeyboard(

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
@@ -18,7 +18,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
 import org.robolectric.shadows.ShadowLooper
 
 @RunWith(AndroidJUnit4::class)
@@ -95,5 +98,36 @@ class ViewTest {
         assertEquals(200, outRect.top)
         assertEquals(250, outRect.right)
         assertEquals(450, outRect.bottom)
+    }
+
+    @Test
+    fun `called after next layout`() {
+        val view = View(testContext)
+
+        var callbackInvoked = false
+        view.onNextGlobalLayout {
+            callbackInvoked = true
+        }
+
+        assertFalse(callbackInvoked)
+
+        view.viewTreeObserver.dispatchOnGlobalLayout()
+
+        assertTrue(callbackInvoked)
+    }
+
+    @Test
+    fun `remove listener after next layout`() {
+        val view = spy(View(testContext))
+        val viewTreeObserver = spy(view.viewTreeObserver)
+        doReturn(viewTreeObserver).`when`(view).viewTreeObserver
+
+        view.onNextGlobalLayout {}
+
+        verify(viewTreeObserver, never()).removeOnGlobalLayoutListener(any())
+
+        viewTreeObserver.dispatchOnGlobalLayout()
+
+        verify(viewTreeObserver).removeOnGlobalLayoutListener(any())
     }
 }

--- a/components/ui/tabcounter/build.gradle
+++ b/components/ui/tabcounter/build.gradle
@@ -22,6 +22,7 @@ android {
 }
 
 dependencies {
+    implementation project(':support-ktx')
     implementation project(':support-utils')
 
     implementation Dependencies.kotlin_stdlib

--- a/components/ui/tabcounter/src/main/java/mozilla/components/ui/tabcounter/TabCounter.kt
+++ b/components/ui/tabcounter/src/main/java/mozilla/components/ui/tabcounter/TabCounter.kt
@@ -10,12 +10,12 @@ import android.content.Context
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
-import android.view.ViewTreeObserver
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
+import mozilla.components.support.ktx.android.view.onNextGlobalLayout
 import mozilla.components.support.utils.DrawableUtils
 import java.text.NumberFormat
 
@@ -251,16 +251,13 @@ open class TabCounter @JvmOverloads constructor(
 
         if (newRatio != currentTextRatio) {
             currentTextRatio = newRatio
-            text.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
-                override fun onGlobalLayout() {
-                    text.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                    val sizeInPixel = (box.width * newRatio).toInt()
-                    if (sizeInPixel > 0) {
-                        // Only apply the size when we calculate a valid value.
-                        text.setTextSize(TypedValue.COMPLEX_UNIT_PX, sizeInPixel.toFloat())
-                    }
+            text.onNextGlobalLayout {
+                val sizeInPixel = (box.width * newRatio).toInt()
+                if (sizeInPixel > 0) {
+                    // Only apply the size when we calculate a valid value.
+                    text.setTextSize(TypedValue.COMPLEX_UNIT_PX, sizeInPixel.toFloat())
                 }
-            })
+            }
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,6 +52,9 @@ permalink: /changelog/
   * `Tab.restore()` now returns a `Session` instead of a `SessionManager.Snapshot`
   * `TabCollection.restore()` and `TabCollection.restoreSubset()` now return a `List<Session>` instead of a `SessionManager.Snapshot`
 
+* **support-ktx**
+  * Added `onNextGlobalLayout` to add a `ViewTreeObserver.OnGlobalLayoutListener` that is only called once.
+
 # 3.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v2.0.0...v3.0.0)


### PR DESCRIPTION
This is a pattern used in a few places in A-C and Fenix, so I think it makes sense to put it in a helper to improve readability. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
