### PR TITLE
Merge day! GeckoView 68 release.

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -16,7 +16,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Release Version.
      */
-    const val release_version = "67.0.20190613202504"
+    const val release_version = "68.0.20190711090008"
 }
 
 @Suppress("MaxLineLength")

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -11,7 +11,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Beta Version.
      */
-    const val beta_version = "68.0.20190612114833"
+    const val beta_version = "69.0.20190711090037"
 
     /**
      * GeckoView Release Version.

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "69.0.20190708095055"
+    const val nightly_version = "70.0.20190711095112"
 
     /**
      * GeckoView Beta Version.

--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation project(':concept-engine')
     implementation project(':concept-fetch')
     implementation project(':support-ktx')
-    implementation project(path: ':support-utils')
+    implementation project(':support-utils')
+
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import org.mozilla.geckoview.GeckoResult
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Wait for a GeckoResult to be complete in a co-routine.
+ */
+suspend fun <T> GeckoResult<T>.await() = suspendCoroutine<T?> { continuation ->
+    then({
+        continuation.resume(it)
+        GeckoResult<Void>()
+    }, {
+        continuation.resumeWithException(it)
+        GeckoResult<Void>()
+    })
+}
+
+/**
+ * Create a GeckoResult from a co-routine.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun <T> CoroutineScope.launchGeckoResult(
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> T
+) = GeckoResult<T>().apply {
+    launch(context, start) {
+        try {
+            val value = block()
+            complete(value)
+        } catch (exception: Throwable) {
+            completeExceptionally(exception)
+        }
+    }
+}

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
@@ -46,7 +46,7 @@ internal class GeckoMedia(
 private class MediaDelegate(
     private val media: Media
 ) : MediaElement.Delegate {
-    @Suppress("ComplexMethod")
+
     override fun onPlaybackStateChange(mediaElement: MediaElement, mediaState: Int) {
         when (mediaState) {
             MEDIA_STATE_PLAY -> media.playbackState = Media.PlaybackState.PLAY

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
@@ -22,13 +22,11 @@ internal class GeckoMediaDelegate(
     private val mediaMap: MutableMap<MediaElement, Media> = mutableMapOf()
 
     override fun onMediaAdd(session: GeckoSession, element: MediaElement) {
-        engineSession.notifyObservers {
-            val media = GeckoMedia(element)
-
-            mediaMap[element] = media
-
-            onMediaAdded(media)
+        val media = GeckoMedia(element).also {
+            mediaMap[element] = it
         }
+
+        engineSession.notifyObservers { onMediaAdded(media) }
     }
 
     override fun onMediaRemove(session: GeckoSession, element: MediaElement) {

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -4,24 +4,21 @@
 
 package mozilla.components.browser.engine.gecko.permission
 
-import mozilla.components.concept.engine.permission.Permission
-import mozilla.components.concept.engine.permission.PermissionRequest
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_APPLICATION
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_BROWSER
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_CAMERA
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_MICROPHONE
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_OTHER
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_SCREEN
-import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_WINDOW
 import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.Manifest.permission.CAMERA
 import android.Manifest.permission.RECORD_AUDIO
+import mozilla.components.concept.engine.permission.Permission
+import mozilla.components.concept.engine.permission.PermissionRequest
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_AUDIOCAPTURE
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_CAMERA
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_MICROPHONE
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_OTHER
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_SCREEN
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
 /**
  * Gecko-based implementation of [PermissionRequest].
@@ -118,26 +115,27 @@ sealed class GeckoPermissionRequest constructor(
         }
 
         companion object {
-            @Suppress("ComplexMethod", "SwitchIntDef")
-            fun mapPermission(mediaSource: MediaSource): Permission {
+            fun mapPermission(mediaSource: MediaSource): Permission =
                 if (mediaSource.type == MediaSource.TYPE_AUDIO) {
-                    return when (mediaSource.source) {
-                        SOURCE_AUDIOCAPTURE -> Permission.ContentAudioCapture(mediaSource.id, mediaSource.name)
-                        SOURCE_MICROPHONE -> Permission.ContentAudioMicrophone(mediaSource.id, mediaSource.name)
-                        SOURCE_OTHER -> Permission.ContentAudioOther(mediaSource.id, mediaSource.name)
-                        else -> Permission.Generic(mediaSource.id, mediaSource.name)
-                    }
+                    mapAudioPermission(mediaSource)
                 } else {
-                    return when (mediaSource.source) {
-                        SOURCE_CAMERA -> Permission.ContentVideoCamera(mediaSource.id, mediaSource.name)
-                        SOURCE_APPLICATION -> Permission.ContentVideoApplication(mediaSource.id, mediaSource.name)
-                        SOURCE_BROWSER -> Permission.ContentVideoBrowser(mediaSource.id, mediaSource.name)
-                        SOURCE_SCREEN -> Permission.ContentVideoScreen(mediaSource.id, mediaSource.name)
-                        SOURCE_WINDOW -> Permission.ContentVideoWindow(mediaSource.id, mediaSource.name)
-                        SOURCE_OTHER -> Permission.ContentVideoOther(mediaSource.id, mediaSource.name)
-                        else -> Permission.Generic(mediaSource.id, mediaSource.name)
-                    }
+                    mapVideoPermission(mediaSource)
                 }
+
+            @Suppress("SwitchIntDef")
+            private fun mapAudioPermission(mediaSource: MediaSource) = when (mediaSource.source) {
+                SOURCE_AUDIOCAPTURE -> Permission.ContentAudioCapture(mediaSource.id, mediaSource.name)
+                SOURCE_MICROPHONE -> Permission.ContentAudioMicrophone(mediaSource.id, mediaSource.name)
+                SOURCE_OTHER -> Permission.ContentAudioOther(mediaSource.id, mediaSource.name)
+                else -> Permission.Generic(mediaSource.id, mediaSource.name)
+            }
+
+            @Suppress("ComplexMethod", "SwitchIntDef")
+            private fun mapVideoPermission(mediaSource: MediaSource) = when (mediaSource.source) {
+                SOURCE_CAMERA -> Permission.ContentVideoCamera(mediaSource.id, mediaSource.name)
+                SOURCE_SCREEN -> Permission.ContentVideoScreen(mediaSource.id, mediaSource.name)
+                SOURCE_OTHER -> Permission.ContentVideoOther(mediaSource.id, mediaSource.name)
+                else -> Permission.Generic(mediaSource.id, mediaSource.name)
             }
         }
     }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -132,6 +132,8 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
 
         val isMultipleFilesSelection = selectionType == GeckoSession.PromptDelegate.FILE_TYPE_MULTIPLE
 
+        val captureMode = PromptRequest.File.FacingMode.NONE
+
         val onSelectSingle: (Context, Uri) -> Unit = { context, uri ->
             callback.confirm(context, uri.toFileUri(context))
         }
@@ -145,6 +147,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
                 PromptRequest.File(
                     mimeTypes ?: emptyArray(),
                     isMultipleFilesSelection,
+                    captureMode,
                     onSelectSingle,
                     onSelectMultiple,
                     onDismiss

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -408,7 +408,7 @@ class GeckoEngineTest {
 
         println(version)
 
-        assertTrue(version.major >= 68)
-        assertTrue(version.isAtLeast(68, 0, 0))
+        assertTrue(version.major >= 69)
+        assertTrue(version.isAtLeast(69, 0, 0))
     }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -15,7 +15,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
@@ -96,8 +96,8 @@ class GeckoEngineViewTest {
 
         engineView.render(engineSession)
 
-        verify(geckoView, Mockito.never()).releaseSession()
-        verify(engineSession, Mockito.never()).unregister(any())
+        verify(geckoView, never()).releaseSession()
+        verify(engineSession, never()).unregister(any())
 
         engineView.release()
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoResultTest.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoResult
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class GeckoResultTest {
+
+    @Test
+    fun awaitWithResult() = runBlockingTest {
+        val result = GeckoResult.fromValue(42).await()
+        assertEquals(42, result)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun awaitWithException() = runBlockingTest {
+        GeckoResult.fromException<Unit>(IllegalStateException()).await()
+    }
+
+    @Test
+    fun fromResult() = runBlockingTest {
+        val result = launchGeckoResult { 42 }
+
+        result.then {
+            assertEquals(42, it)
+            GeckoResult.fromValue(null)
+        }.await()
+    }
+
+    @Test
+    fun fromException() = runBlockingTest {
+        val result = launchGeckoResult { throw IllegalStateException() }
+
+        result.then({
+            assertTrue("Invalid branch", false)
+            GeckoResult.fromValue(null)
+        }, {
+            assertTrue(it is IllegalStateException)
+            GeckoResult.fromValue(null)
+        }).await()
+    }
+}

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
@@ -67,4 +67,21 @@ class GeckoMediaTest {
 
         assertTrue(media.controller is GeckoMediaController)
     }
+
+    @Test
+    fun `GeckoMedia observer is notified when its playback state changes`() {
+        val mediaElement: MediaElement = mock()
+
+        val media = GeckoMedia(mediaElement)
+
+        val captor = argumentCaptor<MediaElement.Delegate>()
+        verify(mediaElement).delegate = captor.capture()
+        val delegate = captor.value
+
+        val observer: Media.Observer = mock()
+        media.register(observer)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PLAYING)
+        verify(observer).onPlaybackStateChanged(media, Media.PlaybackState.PLAYING)
+    }
 }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -114,26 +114,17 @@ class GeckoPermissionRequestTest {
 
         val videoCamera = MockMediaSource("videoCamera", "videoCamera",
                 MediaSource.SOURCE_CAMERA, MediaSource.TYPE_VIDEO)
-        val videoBrowser = MockMediaSource("videoBrowser", "videoBrowser",
-                MediaSource.SOURCE_BROWSER, MediaSource.TYPE_VIDEO)
-        val videoApplication = MockMediaSource("videoApplication", "videoApplication",
-                MediaSource.SOURCE_APPLICATION, MediaSource.TYPE_VIDEO)
         val videoScreen = MockMediaSource("videoScreen", "videoScreen",
                 MediaSource.SOURCE_SCREEN, MediaSource.TYPE_VIDEO)
-        val videoWindow = MockMediaSource("videoWindow", "videoWindow",
-                MediaSource.SOURCE_WINDOW, MediaSource.TYPE_VIDEO)
         val videoOther = MockMediaSource("videoOther", "videoOther",
                 MediaSource.SOURCE_OTHER, MediaSource.TYPE_VIDEO)
 
         val audioSources = listOf(audioCapture, audioMicrophone, audioOther)
-        val videoSources = listOf(videoApplication, videoBrowser, videoCamera, videoOther, videoScreen, videoWindow)
+        val videoSources = listOf(videoCamera, videoOther, videoScreen)
 
         val mappedPermissions = listOf(
                 Permission.ContentVideoCamera("videoCamera", "videoCamera"),
-                Permission.ContentVideoBrowser("videoBrowser", "videoBrowser"),
-                Permission.ContentVideoApplication("videoApplication", "videoApplication"),
                 Permission.ContentVideoScreen("videoScreen", "videoScreen"),
-                Permission.ContentVideoWindow("videoWindow", "videoWindow"),
                 Permission.ContentVideoOther("videoOther", "videoOther"),
                 Permission.ContentAudioMicrophone("audioMicrophone", "audioMicrophone"),
                 Permission.ContentAudioCapture("audioCapture", "audioCapture"),

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -774,7 +774,6 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onColorPrompt must provide a Color PromptRequest`() {
-
         val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.engine.gecko.prompt
+package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
-import mozilla.components.browser.engine.gecko.webextension.GeckoPort
-import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -84,7 +84,7 @@ class GeckoWebExtension(
         }
 
         val geckoSession = (session as GeckoEngineSession).geckoSession
-        geckoSession.setMessageDelegate(messageDelegate, name)
+        geckoSession.setMessageDelegate(nativeExtension, messageDelegate, name)
     }
 
     /**
@@ -92,7 +92,7 @@ class GeckoWebExtension(
      */
     override fun hasContentMessageHandler(session: EngineSession, name: String): Boolean {
         val geckoSession = (session as GeckoEngineSession).geckoSession
-        return geckoSession.getMessageDelegate(name) != null
+        return geckoSession.getMessageDelegate(nativeExtension, name) != null
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -86,7 +86,7 @@ class GeckoWebExtensionTest {
         val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
-        verify(geckoSession).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+        verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
 
         // Verify messages are forwarded to message handler and return value passed on
         val message: Any = mock()

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -11,6 +11,7 @@ android {
     defaultConfig {
         minSdkVersion config.minSdkVersion
         targetSdkVersion config.targetSdkVersion
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -18,6 +19,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/proguard/androidx-annotations.pro'
     }
 }
 
@@ -39,6 +44,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_mockwebserver
+    testImplementation Dependencies.testing_coroutines
     testImplementation project(':support-test')
     testImplementation project(':tooling-fetch-tests')
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -5,13 +5,12 @@
 package mozilla.components.browser.engine.gecko
 
 import android.annotation.SuppressLint
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
 import mozilla.components.browser.errorpages.ErrorType
@@ -28,7 +27,6 @@ import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
 import mozilla.components.support.utils.DownloadUtils
-import mozilla.components.support.utils.ThreadUtils
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoResult
@@ -37,7 +35,7 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate
 import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.WebRequestError
-import java.lang.IllegalStateException
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Gecko-based EngineSession implementation.
@@ -58,7 +56,10 @@ class GeckoEngineSession(
 
     internal lateinit var geckoSession: GeckoSession
     internal var currentUrl: String? = null
+    internal var scrollY: Int = 0
     internal var job: Job = Job()
+    private var lastSessionState: GeckoSession.SessionState? = null
+    private var stateBeforeCrash: GeckoSession.SessionState? = null
 
     /**
      * See [EngineSession.settings]
@@ -69,6 +70,9 @@ class GeckoEngineSession(
         override var userAgentString: String?
             get() = geckoSession.settings.userAgentOverride
             set(value) { geckoSession.settings.userAgentOverride = value }
+        override var suspendMediaWhenInactive: Boolean
+            get() = geckoSession.settings.suspendMediaWhenInactive
+            set(value) { geckoSession.settings.suspendMediaWhenInactive = value }
     }
 
     private var initialLoad = true
@@ -134,28 +138,9 @@ class GeckoEngineSession(
 
     /**
      * See [EngineSession.saveState]
-     *
-     * See https://bugzilla.mozilla.org/show_bug.cgi?id=1441810 for
-     * discussion on sync vs. async, where a decision was made that
-     * callers should provide synchronous wrappers, if needed. In case we're
-     * asking for the state when persisting, a separate (independent) thread
-     * is used so we're not blocking anything else. In case of calling this
-     * method from onPause or similar, we also want a synchronous response.
      */
-    override fun saveState(): EngineSessionState = runBlocking {
-        val state = CompletableDeferred<GeckoEngineSessionState>()
-
-        ThreadUtils.postToBackgroundThread {
-            geckoSession.saveState().then({ sessionState ->
-                state.complete(GeckoEngineSessionState(sessionState))
-                GeckoResult<Void>()
-            }, { throwable ->
-                state.completeExceptionally(throwable)
-                GeckoResult<Void>()
-            })
-        }
-
-        state.await()
+    override fun saveState(): EngineSessionState {
+        return GeckoEngineSessionState(lastSessionState)
     }
 
     /**
@@ -268,17 +253,28 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.recoverFromCrash]
+     */
+    @Synchronized
+    override fun recoverFromCrash(): Boolean {
+        val state = stateBeforeCrash
+
+        return if (state != null) {
+            geckoSession.restoreState(state)
+            stateBeforeCrash = null
+            true
+        } else {
+            false
+        }
+    }
+
+    /**
      * See [EngineSession.close].
      */
     override fun close() {
         super.close()
         job.cancel()
         geckoSession.close()
-    }
-
-    override fun recoverFromCrash(): Boolean {
-        // No-op: Functionality requires GeckoView 68.0
-        return false
     }
 
     /**
@@ -320,7 +316,22 @@ class GeckoEngineSession(
                     is InterceptionResponse.Url -> loadUrl(url)
                 }
             }
-            return GeckoResult.fromValue(if (response != null) AllowOrDeny.DENY else AllowOrDeny.ALLOW)
+
+            return if (response != null) {
+                GeckoResult.fromValue(AllowOrDeny.DENY)
+            } else {
+                notifyObservers {
+                    // As the name LoadRequest.isRedirect may imply this flag is about http redirects. The flag
+                    // is "True if and only if the request was triggered by an HTTP redirect."
+                    onLoadRequest(
+                        url = request.uri,
+                        triggeredByRedirect = request.isRedirect,
+                        triggeredByWebContent = requestFromWebContent
+                    )
+                }
+
+                GeckoResult.fromValue(AllowOrDeny.ALLOW)
+            }
         }
 
         override fun onCanGoForward(session: GeckoSession, canGoForward: Boolean) {
@@ -392,6 +403,10 @@ class GeckoEngineSession(
                 onProgress(PROGRESS_STOP)
                 onLoadingStateChange(false)
             }
+        }
+
+        override fun onSessionStateChange(session: GeckoSession, sessionState: GeckoSession.SessionState) {
+            lastSessionState = sessionState
         }
     }
 
@@ -479,8 +494,12 @@ class GeckoEngineSession(
         }
 
         override fun onCrash(session: GeckoSession) {
+            stateBeforeCrash = lastSessionState
+
             geckoSession.close()
             createGeckoSession()
+
+            notifyObservers { onCrashStateChange(crashed = true) }
         }
 
         override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) {
@@ -561,6 +580,12 @@ class GeckoEngineSession(
         }
     }
 
+    private fun createScrollDelegate() = object : GeckoSession.ScrollDelegate {
+        override fun onScrollChanged(session: GeckoSession, scrollX: Int, scrollY: Int) {
+            this@GeckoEngineSession.scrollY = scrollY
+        }
+    }
+
     @Suppress("ComplexMethod")
     fun handleLongClick(elementSrc: String?, elementType: Int, uri: String? = null): HitResult? {
         return when (elementType) {
@@ -603,12 +628,9 @@ class GeckoEngineSession(
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
         defaultSettings?.requestInterceptor?.let { settings.requestInterceptor = it }
         defaultSettings?.historyTrackingDelegate?.let { settings.historyTrackingDelegate = it }
-        defaultSettings?.testingModeEnabled?.let {
-            geckoSession.settings.fullAccessibilityTree = it
-        }
-        defaultSettings?.userAgentString?.let {
-            geckoSession.settings.userAgentOverride = it
-        }
+        defaultSettings?.testingModeEnabled?.let { geckoSession.settings.fullAccessibilityTree = it }
+        defaultSettings?.userAgentString?.let { geckoSession.settings.userAgentOverride = it }
+        defaultSettings?.suspendMediaWhenInactive?.let { geckoSession.settings.suspendMediaWhenInactive = it }
 
         geckoSession.open(runtime)
 
@@ -619,6 +641,8 @@ class GeckoEngineSession(
         geckoSession.permissionDelegate = createPermissionDelegate()
         geckoSession.promptDelegate = GeckoPromptDelegate(this)
         geckoSession.historyDelegate = createHistoryDelegate()
+        geckoSession.mediaDelegate = GeckoMediaDelegate(this)
+        geckoSession.scrollDelegate = createScrollDelegate()
     }
 
     companion object {
@@ -631,7 +655,7 @@ class GeckoEngineSession(
          * Provides an ErrorType corresponding to the error code provided.
          */
         @Suppress("ComplexMethod")
-        internal fun geckoErrorToErrorType(@WebRequestError.Error errorCode: Int) =
+        internal fun geckoErrorToErrorType(errorCode: Int) =
             when (errorCode) {
                 WebRequestError.ERROR_UNKNOWN -> ErrorType.UNKNOWN
                 WebRequestError.ERROR_SECURITY_SSL -> ErrorType.ERROR_SECURITY_SSL

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionState.kt
@@ -26,7 +26,10 @@ class GeckoEngineSessionState internal constructor(
     companion object {
         fun fromJSON(json: JSONObject): GeckoEngineSessionState = try {
             val state = json.getString(GECKO_STATE_KEY)
-            GeckoEngineSessionState(GeckoSession.SessionState(state))
+
+            GeckoEngineSessionState(
+                GeckoSession.SessionState.fromString(state)
+            )
         } catch (e: JSONException) {
             GeckoEngineSessionState(null)
         }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -8,9 +8,11 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
 import android.widget.FrameLayout
+import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.concept.engine.permission.PermissionRequest
 import org.mozilla.geckoview.GeckoResult
 
 /**
@@ -21,6 +23,7 @@ class GeckoEngineView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), EngineView {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var currentGeckoView = object : NestedGeckoView(context) {
         override fun onDetachedFromWindow() {
             // We are releasing the session before GeckoView gets detached from the window. Otherwise
@@ -33,8 +36,24 @@ class GeckoEngineView @JvmOverloads constructor(
         // Explicitly mark this view as important for autofill. The default "auto" doesn't seem to trigger any
         // autofill behavior for us here.
         @Suppress("WrongConstant")
-        ViewCompat.setImportantForAutofill(this, 0x1 /* View.IMPORTANT_FOR_AUTOFILL_YES */)
+        ViewCompat.setImportantForAutofill(this, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES)
     }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val observer = object : EngineSession.Observer {
+        override fun onCrashStateChange(crashed: Boolean) {
+            if (crashed) {
+                // When crashing the previous GeckoSession is no longer usable. Internally GeckoEngineSession will
+                // create a new instance. This means we will need to tell GeckoView about this new GeckoSession:
+                currentSession?.let { currentGeckoView.setSession(it.geckoSession) }
+            }
+        }
+        override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
+        override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal var currentSession: GeckoEngineSession? = null
 
     init {
         // Currently this is just a FrameLayout with a single GeckoView instance. Eventually this
@@ -45,8 +64,15 @@ class GeckoEngineView @JvmOverloads constructor(
     /**
      * Render the content of the given session.
      */
+    @Synchronized
     override fun render(session: EngineSession) {
         val internalSession = session as GeckoEngineSession
+
+        currentSession?.apply { unregister(observer) }
+
+        currentSession = session.apply {
+            register(observer)
+        }
 
         if (currentGeckoView.session != internalSession.geckoSession) {
             currentGeckoView.session?.let {
@@ -61,10 +87,26 @@ class GeckoEngineView @JvmOverloads constructor(
 
     @Synchronized
     override fun release() {
+        currentSession?.apply { unregister(observer) }
+
+        currentSession = null
+
         currentGeckoView.releaseSession()
     }
 
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+
+        release()
+    }
+
+    override fun canScrollVerticallyUp() = currentSession?.let { it.scrollY > 0 } != false
+
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
+
+    override fun setVerticalClipping(clippingHeight: Int) {
+        currentGeckoView.setVerticalClipping(clippingHeight)
+    }
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         val geckoResult = currentGeckoView.capturePixels()
@@ -75,9 +117,5 @@ class GeckoEngineView @JvmOverloads constructor(
             onFinish(null)
             GeckoResult<Void>()
         })
-    }
-
-    override fun setVerticalClipping(clippingHeight: Int) {
-        // no-op: requires GeckoView 68.0
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/integration/LocaleSettingUpdater.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/integration/LocaleSettingUpdater.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.integration
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.os.LocaleListCompat as LocaleList
+import org.mozilla.geckoview.GeckoRuntime
+
+/**
+ * Class to set the locales setting for geckoview, updating from the locale of the device.
+ */
+class LocaleSettingUpdater(
+    private val context: Context,
+    private val runtime: GeckoRuntime
+) : SettingUpdater<Array<String>>() {
+
+    override var value: Array<String> = findValue()
+        set(value) {
+            runtime.settings.locales = value
+            field = value
+        }
+
+    private val localeChangedReceiver by lazy {
+        object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent?) {
+                updateValue()
+            }
+        }
+    }
+
+    override fun registerForUpdates() {
+        context.registerReceiver(localeChangedReceiver, IntentFilter(Intent.ACTION_LOCALE_CHANGED))
+    }
+
+    override fun unregisterForUpdates() {
+        context.unregisterReceiver(localeChangedReceiver)
+    }
+
+    override fun findValue(): Array<String> {
+        val localeList = LocaleList.getAdjustedDefault()
+        return arrayOfNulls<Unit>(localeList.size())
+            .mapIndexedNotNull { i, _ -> localeList.get(i).toLanguageTag() }
+            .toTypedArray()
+    }
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/integration/SettingUpdater.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/integration/SettingUpdater.kt
@@ -1,0 +1,41 @@
+package mozilla.components.browser.engine.gecko.integration
+
+abstract class SettingUpdater<T> {
+    /**
+     * Toggle the automatic tracking of a setting derived from the device state.
+     */
+    var enabled: Boolean = false
+        set(value) {
+            if (value) {
+                updateValue()
+                registerForUpdates()
+            } else {
+                unregisterForUpdates()
+            }
+            field = value
+        }
+
+    /**
+     * The setter for this property should change the GeckoView setting.
+     */
+    abstract var value: T
+
+    internal fun updateValue() {
+        value = findValue()
+    }
+
+    /**
+     * Register for updates from the device state. This is setting specific.
+     */
+    abstract fun registerForUpdates()
+
+    /**
+     * Unregister for updates from the device state.
+     */
+    abstract fun unregisterForUpdates()
+
+    /**
+     * Find the value of the setting from the device state. This is setting specific.
+     */
+    abstract fun findValue(): T
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMedia.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.concept.engine.media.Media
+import org.mozilla.geckoview.MediaElement
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_ABORT
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_EMPTIED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_ENDED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_PAUSE
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_PLAY
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_PLAYING
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_SEEKED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_SEEKING
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_STALLED
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_SUSPEND
+import org.mozilla.geckoview.MediaElement.MEDIA_STATE_WAITING
+
+/**
+ * [Media] (`concept-engine`) implementation for GeckoView.
+ */
+internal class GeckoMedia(
+    internal val mediaElement: MediaElement
+) : Media() {
+    override val controller: Controller = GeckoMediaController(mediaElement)
+
+    init {
+        mediaElement.delegate = MediaDelegate(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is GeckoMedia) {
+            return false
+        }
+
+        return mediaElement == other.mediaElement
+    }
+
+    override fun hashCode(): Int {
+        return mediaElement.hashCode()
+    }
+}
+
+private class MediaDelegate(
+    private val media: Media
+) : MediaElement.Delegate {
+    @Suppress("ComplexMethod")
+    override fun onPlaybackStateChange(mediaElement: MediaElement, mediaState: Int) {
+        when (mediaState) {
+            MEDIA_STATE_PLAY -> media.playbackState = Media.PlaybackState.PLAY
+            MEDIA_STATE_PLAYING -> media.playbackState = Media.PlaybackState.PLAYING
+            MEDIA_STATE_PAUSE -> media.playbackState = Media.PlaybackState.PAUSE
+            MEDIA_STATE_ENDED -> media.playbackState = Media.PlaybackState.ENDED
+            MEDIA_STATE_SEEKING -> media.playbackState = Media.PlaybackState.SEEKING
+            MEDIA_STATE_SEEKED -> media.playbackState = Media.PlaybackState.SEEKED
+            MEDIA_STATE_STALLED -> media.playbackState = Media.PlaybackState.STALLED
+            MEDIA_STATE_SUSPEND -> media.playbackState = Media.PlaybackState.SUSPENDED
+            MEDIA_STATE_WAITING -> media.playbackState = Media.PlaybackState.WAITING
+            MEDIA_STATE_ABORT -> media.playbackState = Media.PlaybackState.ABORT
+            MEDIA_STATE_EMPTIED -> media.playbackState = Media.PlaybackState.EMPTIED
+        }
+    }
+
+    override fun onReadyStateChange(mediaElement: MediaElement, readyState: Int) = Unit
+    override fun onMetadataChange(mediaElement: MediaElement, metaData: MediaElement.Metadata) = Unit
+    override fun onLoadProgress(mediaElement: MediaElement, progressInfo: MediaElement.LoadProgressInfo) = Unit
+    override fun onVolumeChange(mediaElement: MediaElement, volume: Double, muted: Boolean) = Unit
+    override fun onTimeChange(mediaElement: MediaElement, time: Double) = Unit
+    override fun onPlaybackRateChange(mediaElement: MediaElement, rate: Double) = Unit
+    override fun onFullscreenChange(mediaElement: MediaElement, fullscreen: Boolean) = Unit
+    override fun onError(mediaElement: MediaElement, errorCode: Int) = Unit
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaController.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaController.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.concept.engine.media.Media
+import org.mozilla.geckoview.MediaElement
+
+/**
+ * [Media.Controller] (`concept-engine`) implementation for GeckoView.
+ */
+internal class GeckoMediaController(
+    private val mediaElement: MediaElement
+) : Media.Controller {
+    override fun pause() {
+        mediaElement.pause()
+    }
+
+    override fun play() {
+        mediaElement.play()
+    }
+
+    override fun seek(time: Double) {
+        mediaElement.seek(time)
+    }
+
+    override fun setMuted(muted: Boolean) {
+        mediaElement.setMuted(muted)
+    }
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegate.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.concept.engine.media.RecordingDevice
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.MediaElement
+import org.mozilla.geckoview.GeckoSession.MediaDelegate.RecordingDevice as GeckoRecordingDevice
+
+/**
+ * [GeckoSession.MediaDelegate] implementation for wrapping [MediaElement] instances in [GeckoMedia] ([Media]) and
+ * forwarding them to the [EngineSession.Observer].
+ */
+internal class GeckoMediaDelegate(
+    private val engineSession: GeckoEngineSession
+) : GeckoSession.MediaDelegate {
+    private val mediaMap: MutableMap<MediaElement, Media> = mutableMapOf()
+
+    override fun onMediaAdd(session: GeckoSession, element: MediaElement) {
+        engineSession.notifyObservers {
+            val media = GeckoMedia(element)
+
+            mediaMap[element] = media
+
+            onMediaAdded(media)
+        }
+    }
+
+    override fun onMediaRemove(session: GeckoSession, element: MediaElement) {
+        mediaMap[element]?.let { media ->
+            engineSession.notifyObservers { onMediaRemoved(media) }
+        }
+    }
+
+    override fun onRecordingStatusChanged(
+        session: GeckoSession,
+        devices: Array<out GeckoRecordingDevice>
+    ) {
+        val genericDevices = devices.map { it.toRecordingDevice() }
+        engineSession.notifyObservers {
+            onRecordingStateChanged(genericDevices)
+        }
+    }
+}
+
+private fun GeckoRecordingDevice.toRecordingDevice(): RecordingDevice {
+    val type = when (type) {
+        GeckoRecordingDevice.Type.CAMERA -> RecordingDevice.Type.CAMERA
+        GeckoRecordingDevice.Type.MICROPHONE -> RecordingDevice.Type.MICROPHONE
+        else -> throw IllegalStateException("Unknown device type: $type")
+    }
+
+    val status = when (status) {
+        GeckoRecordingDevice.Status.INACTIVE -> RecordingDevice.Status.INACTIVE
+        GeckoRecordingDevice.Status.RECORDING -> RecordingDevice.Status.RECORDING
+        else -> throw IllegalStateException("Unknown device status: $status")
+    }
+
+    return RecordingDevice(type, status)
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/mediaquery/PreferredColorScheme.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/mediaquery/PreferredColorScheme.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.browser.engine.gecko.mediaquery
+
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import org.mozilla.geckoview.GeckoRuntimeSettings
+
+internal fun PreferredColorScheme.Companion.from(geckoValue: Int) =
+        when (geckoValue) {
+            GeckoRuntimeSettings.COLOR_SCHEME_DARK -> PreferredColorScheme.Dark
+            GeckoRuntimeSettings.COLOR_SCHEME_LIGHT -> PreferredColorScheme.Light
+            GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM -> PreferredColorScheme.System
+            else -> PreferredColorScheme.System
+        }
+
+internal fun PreferredColorScheme.toGeckoValue() =
+    when (this) {
+        is PreferredColorScheme.Dark -> GeckoRuntimeSettings.COLOR_SCHEME_DARK
+        is PreferredColorScheme.Light -> GeckoRuntimeSettings.COLOR_SCHEME_LIGHT
+        is PreferredColorScheme.System -> GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM
+    }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -1,8 +1,12 @@
 package mozilla.components.browser.engine.gecko.webextension
 
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.WebExtension as GeckoNativeWebExtension
 
 /**
@@ -12,19 +16,103 @@ import org.mozilla.geckoview.WebExtension as GeckoNativeWebExtension
 class GeckoWebExtension(
     id: String,
     url: String,
-    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(url, id)
+    allowContentMessaging: Boolean = true,
+    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
+        url,
+        id,
+        createWebExtensionFlags(allowContentMessaging)
+    )
 ) : WebExtension(id, url) {
 
-    // Not supported in beta
-    override fun registerContentMessageHandler(
-        session: EngineSession,
-        name: String,
-        messageHandler: MessageHandler
-    ) = Unit
+    /**
+     * See [WebExtension.registerBackgroundMessageHandler].
+     */
+    override fun registerBackgroundMessageHandler(name: String, messageHandler: MessageHandler) {
+        val portDelegate = object : GeckoNativeWebExtension.PortDelegate {
 
-    // Not supported in beta
-    override fun registerBackgroundMessageHandler(name: String, messageHandler: MessageHandler) = Unit
+            override fun onPortMessage(message: Any, port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortMessage(message, GeckoPort(port))
+            }
 
-    // Not supported in beta
-    override fun hasContentMessageHandler(session: EngineSession, name: String): Boolean = false
+            override fun onDisconnect(port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortDisconnected(GeckoPort(port))
+            }
+        }
+
+        val messageDelegate = object : GeckoNativeWebExtension.MessageDelegate {
+
+            override fun onConnect(port: GeckoNativeWebExtension.Port) {
+                port.setDelegate(portDelegate)
+                messageHandler.onPortConnected(GeckoPort(port))
+            }
+
+            override fun onMessage(message: Any, sender: GeckoNativeWebExtension.MessageSender): GeckoResult<Any>? {
+                val response = messageHandler.onMessage(message, null)
+                return response?.let { GeckoResult.fromValue(it) }
+            }
+        }
+
+        nativeExtension.setMessageDelegate(messageDelegate, name)
+    }
+
+    /**
+     * See [WebExtension.registerContentMessageHandler].
+     */
+    override fun registerContentMessageHandler(session: EngineSession, name: String, messageHandler: MessageHandler) {
+        val portDelegate = object : GeckoNativeWebExtension.PortDelegate {
+
+            override fun onPortMessage(message: Any, port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortMessage(message, GeckoPort(port, session))
+            }
+
+            override fun onDisconnect(port: GeckoNativeWebExtension.Port) {
+                messageHandler.onPortDisconnected(GeckoPort(port, session))
+            }
+        }
+
+        val messageDelegate = object : GeckoNativeWebExtension.MessageDelegate {
+
+            override fun onConnect(port: GeckoNativeWebExtension.Port) {
+                port.setDelegate(portDelegate)
+                messageHandler.onPortConnected(GeckoPort(port, session))
+            }
+
+            override fun onMessage(message: Any, sender: GeckoNativeWebExtension.MessageSender): GeckoResult<Any>? {
+                val response = messageHandler.onMessage(message, session)
+                return response?.let { GeckoResult.fromValue(it) }
+            }
+        }
+
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        geckoSession.setMessageDelegate(messageDelegate, name)
+    }
+
+    /**
+     * See [WebExtension.hasContentMessageHandler].
+     */
+    override fun hasContentMessageHandler(session: EngineSession, name: String): Boolean {
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        return geckoSession.getMessageDelegate(name) != null
+    }
+}
+
+/**
+ * Gecko-based implementation of [Port], wrapping the native port provided by GeckoView.
+ */
+class GeckoPort(
+    internal val nativePort: GeckoNativeWebExtension.Port,
+    engineSession: EngineSession? = null
+) : Port(engineSession) {
+
+    override fun postMessage(message: Any) {
+        nativePort.postMessage(message as JSONObject)
+    }
+}
+
+private fun createWebExtensionFlags(allowContentMessaging: Boolean): Long {
+    return if (allowContentMessaging) {
+        GeckoNativeWebExtension.Flags.ALLOW_CONTENT_MESSAGING
+    } else {
+        GeckoNativeWebExtension.Flags.NONE
+    }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionStateTest.kt
@@ -5,19 +5,25 @@
 package mozilla.components.browser.engine.gecko
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
 import org.mozilla.geckoview.GeckoSession
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineSessionStateTest {
+
     @Test
     fun toJSON() {
-        val state = GeckoEngineSessionState(GeckoSession.SessionState("<state>"))
+        val geckoState: GeckoSession.SessionState = mock()
+        doReturn("<state>").`when`(geckoState).toString()
+
+        val state = GeckoEngineSessionState(geckoState)
 
         val json = state.toJSON()
 
@@ -29,12 +35,12 @@ class GeckoEngineSessionStateTest {
     @Test
     fun fromJSON() {
         val json = JSONObject().apply {
-            put("GECKO_STATE", "<state>")
+            put("GECKO_STATE", "{ 'foo': 'bar' }")
         }
 
         val state = GeckoEngineSessionState.fromJSON(json)
 
-        assertEquals("<state>", state.actualState.toString())
+        assertEquals("""{"foo":"bar"}""", state.actualState.toString())
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -8,6 +8,7 @@ import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertNotNull
@@ -15,34 +16,32 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
-import org.robolectric.Robolectric
+import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineViewTest {
 
     private val context: Context
-        get() = Robolectric.buildActivity(Activity::class.java).get()
+        get() = buildActivity(Activity::class.java).get()
 
     @Test
     fun render() {
         val engineView = GeckoEngineView(context)
-        val engineSession = mock(GeckoEngineSession::class.java)
-        val geckoSession = mock(GeckoSession::class.java)
-        val geckoView = mock(NestedGeckoView::class.java)
+        val engineSession = mock<GeckoEngineSession>()
+        val geckoSession = mock<GeckoSession>()
+        val geckoView = mock<NestedGeckoView>()
 
-        `when`(engineSession.geckoSession).thenReturn(geckoSession)
+        whenever(engineSession.geckoSession).thenReturn(geckoSession)
         engineView.currentGeckoView = geckoView
 
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
 
-        `when`(geckoView.session).thenReturn(geckoSession)
+        whenever(geckoView.session).thenReturn(geckoSession)
         engineView.render(engineSession)
         verify(geckoView, times(1)).setSession(geckoSession)
     }
@@ -50,11 +49,11 @@ class GeckoEngineViewTest {
     @Test
     fun captureThumbnail() {
         val engineView = GeckoEngineView(context)
-        val mockGeckoView = mock(NestedGeckoView::class.java)
+        val mockGeckoView = mock<NestedGeckoView>()
         var thumbnail: Bitmap? = null
 
         var geckoResult = GeckoResult<Bitmap>()
-        `when`(mockGeckoView.capturePixels()).thenReturn(geckoResult)
+        whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
         engineView.currentGeckoView = mockGeckoView
 
         engineView.captureThumbnail {
@@ -65,7 +64,7 @@ class GeckoEngineViewTest {
         assertNotNull(thumbnail)
 
         geckoResult = GeckoResult()
-        `when`(mockGeckoView.capturePixels()).thenReturn(geckoResult)
+        whenever(mockGeckoView.capturePixels()).thenReturn(geckoResult)
 
         engineView.captureThumbnail {
             thumbnail = it
@@ -76,12 +75,13 @@ class GeckoEngineViewTest {
     }
 
     @Test
-    fun `setVerticalClipping is a no-op`() {
+    fun `setVerticalClipping is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
         engineView.currentGeckoView = mock()
 
         engineView.setVerticalClipping(42)
-        Mockito.verifyNoMoreInteractions(engineView.currentGeckoView)
+
+        verify(engineView.currentGeckoView).setVerticalClipping(42)
     }
 
     @Test
@@ -97,9 +97,11 @@ class GeckoEngineViewTest {
         engineView.render(engineSession)
 
         verify(geckoView, Mockito.never()).releaseSession()
+        verify(engineSession, Mockito.never()).unregister(any())
 
         engineView.release()
 
         verify(geckoView).releaseSession()
+        verify(engineSession).unregister(any())
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -24,13 +24,13 @@ import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.robolectric.Robolectric
+import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
 class NestedGeckoViewTest {
 
     private val context: Context
-        get() = Robolectric.buildActivity(Activity::class.java).get()
+        get() = buildActivity(Activity::class.java).get()
 
     @Test
     fun `NestedGeckoView must delegate NestedScrollingChild implementation to childHelper`() {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt
@@ -4,14 +4,16 @@
 
 package mozilla.components.browser.engine.gecko.fetch
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import mozilla.components.tooling.fetch.tests.FetchTestCases
 import okhttp3.Headers
-import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
@@ -22,11 +24,8 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
-import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebRequest
 import org.mozilla.geckoview.WebRequestError
@@ -44,9 +43,10 @@ import java.util.concurrent.TimeoutException
  * provided in instrumented tests.
  */
 @RunWith(AndroidJUnit4::class)
-class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.FetchTestCases() {
+class GeckoViewFetchUnitTestCases : FetchTestCases() {
+
     override fun createNewClient(): Client {
-        val client = GeckoViewFetchClient(ApplicationProvider.getApplicationContext(), mock(GeckoRuntime::class.java))
+        val client = GeckoViewFetchClient(testContext, mock())
         geckoWebExecutor?.let { client.executor = it }
         return client
     }
@@ -70,8 +70,8 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test
     override fun get200WithDefaultHeaders() {
-        val server = mock(MockWebServer::class.java)
-        `when`(server.url(any())).thenReturn(mock(HttpUrl::class.java))
+        val server = mock<MockWebServer>()
+        whenever(server.url(any())).thenReturn(mock())
         val host = server.url("/").host()
         val port = server.url("/").port()
         val headerMap = mapOf(
@@ -149,10 +149,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
         mockRequest()
         mockResponse(200)
 
-        val geckoResult = mock(GeckoResult::class.java)
-        `when`(geckoResult.poll(anyLong())).thenThrow(TimeoutException::class.java)
+        val geckoResult = mock<GeckoResult<*>>()
+        whenever(geckoResult.poll(anyLong())).thenThrow(TimeoutException::class.java)
         @Suppress("UNCHECKED_CAST")
-        `when`(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
+        whenever(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
 
         super.get200WithReadTimeout()
     }
@@ -176,10 +176,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get302FollowRedirects() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.redirect).thenReturn(Request.Redirect.FOLLOW)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.redirect).thenReturn(Request.Redirect.FOLLOW)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_NONE))
@@ -189,10 +189,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get302FollowRedirectsDisabled() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.redirect).thenReturn(Request.Redirect.MANUAL)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.redirect).thenReturn(Request.Redirect.MANUAL)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_NO_REDIRECTS))
@@ -223,14 +223,14 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     fun pollReturningNull() {
         mockResponse(200)
 
-        val geckoResult = mock(GeckoResult::class.java)
-        `when`(geckoResult.poll(anyLong())).thenReturn(null)
+        val geckoResult = mock<GeckoResult<*>>()
+        whenever(geckoResult.poll(anyLong())).thenReturn(null)
         @Suppress("UNCHECKED_CAST")
-        `when`(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
+        whenever(geckoWebExecutor!!.fetch(any(), anyInt())).thenReturn(geckoResult as GeckoResult<WebResponse>)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
         createNewClient().fetch(request)
     }
 
@@ -238,10 +238,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get200WithCookiePolicy() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.cookiePolicy).thenReturn(Request.CookiePolicy.OMIT)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.cookiePolicy).thenReturn(Request.CookiePolicy.OMIT)
         createNewClient().fetch(request)
 
         verify(geckoWebExecutor)!!.fetch(any(), eq(GeckoWebExecutor.FETCH_FLAGS_ANONYMOUS))
@@ -249,9 +249,9 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test
     override fun get200WithContentTypeCharset() {
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
 
         mockResponse(200,
                 headerMap = mapOf("Content-Type" to "text/html; charset=ISO-8859-1"),
@@ -266,10 +266,10 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
     override fun get200WithCacheControl() {
         mockResponse(200)
 
-        val request = mock(Request::class.java)
-        `when`(request.url).thenReturn("https://mozilla.org")
-        `when`(request.method).thenReturn(Request.Method.GET)
-        `when`(request.useCaches).thenReturn(false)
+        val request = mock<Request>()
+        whenever(request.url).thenReturn("https://mozilla.org")
+        whenever(request.method).thenReturn(Request.Method.GET)
+        whenever(request.useCaches).thenReturn(false)
         createNewClient().fetch(request)
 
         val captor = ArgumentCaptor.forClass(WebRequest::class.java)
@@ -280,31 +280,31 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
     @Test(expected = IOException::class)
     override fun getThrowsIOExceptionWhenHostNotReachable() {
-        val executor = mock(GeckoWebExecutor::class.java)
-        `when`(executor.fetch(any(), anyInt())).thenAnswer { throw WebRequestError(0, 0) }
+        val executor = mock<GeckoWebExecutor>()
+        whenever(executor.fetch(any(), anyInt())).thenAnswer { throw WebRequestError(0, 0) }
         geckoWebExecutor = executor
 
         createNewClient().fetch(Request(""))
     }
 
     private fun mockRequest(headerMap: Map<String, String>? = null, body: String? = null, method: String = "GET") {
-        val server = mock(MockWebServer::class.java)
-        `when`(server.url(any())).thenReturn(mock(HttpUrl::class.java))
-        val request = mock(RecordedRequest::class.java)
-        `when`(request.method).thenReturn(method)
+        val server = mock<MockWebServer>()
+        whenever(server.url(any())).thenReturn(mock())
+        val request = mock<RecordedRequest>()
+        whenever(request.method).thenReturn(method)
 
         headerMap?.let {
-            `when`(request.headers).thenReturn(Headers.of(headerMap))
-            `when`(request.getHeader(any())).thenAnswer { inv -> it[inv.getArgument(0)] }
+            whenever(request.headers).thenReturn(Headers.of(headerMap))
+            whenever(request.getHeader(any())).thenAnswer { inv -> it[inv.getArgument(0)] }
         }
 
         body?.let {
             val buffer = okio.Buffer()
             buffer.write(body.toByteArray())
-            `when`(request.body).thenReturn(buffer)
+            whenever(request.body).thenReturn(buffer)
         }
 
-        `when`(server.takeRequest()).thenReturn(request)
+        whenever(server.takeRequest()).thenReturn(request)
         mockWebServer = server
     }
 
@@ -314,7 +314,7 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
         body: String? = null,
         charset: Charset = Charsets.UTF_8
     ) {
-        val executor = mock(GeckoWebExecutor::class.java)
+        val executor = mock<GeckoWebExecutor>()
         val builder = WebResponse.Builder("").statusCode(statusCode)
         headerMap?.let {
             headerMap.forEach { (k, v) -> builder.addHeader(k, v) }
@@ -326,7 +326,7 @@ class GeckoViewFetchUnitTestCases : mozilla.components.tooling.fetch.tests.Fetch
 
         val response = builder.build()
 
-        `when`(executor.fetch(any(), anyInt())).thenReturn(GeckoResult.fromValue(response))
+        whenever(executor.fetch(any(), anyInt())).thenReturn(GeckoResult.fromValue(response))
         geckoWebExecutor = executor
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/integration/SettingUpdaterTest.kt
@@ -1,0 +1,68 @@
+package mozilla.components.browser.engine.gecko.integration
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SettingUpdaterTest {
+
+    @Test
+    fun `test updateValue`() {
+        val subject = DummySettingUpdater("current", "new")
+        assertEquals("current", subject.value)
+
+        subject.updateValue()
+        assertEquals("new", subject.value)
+    }
+
+    @Test
+    fun `test enabled updates value`() {
+        val subject = DummySettingUpdater("current", "new")
+        assertEquals("current", subject.value)
+
+        subject.enabled = true
+        assertEquals("new", subject.value)
+
+        // disabling doesn't update the value.
+        subject.nextValue = "disabled"
+        subject.enabled = false
+        assertEquals("new", subject.value)
+    }
+
+    @Test
+    fun `test registering and deregistering for updates`() {
+        val subject = DummySettingUpdater("current", "new")
+        assertFalse("Initialized not registering for updates", subject.registered)
+
+        subject.updateValue()
+        assertFalse("updateValue not registering for updates", subject.registered)
+
+        subject.enabled = true
+        assertTrue("enabled = true registering for updates", subject.registered)
+
+        subject.enabled = false
+        assertFalse("enabled = false deregistering for updates", subject.registered)
+    }
+}
+
+class DummySettingUpdater(
+    override var value: String = "",
+    var nextValue: String
+) : SettingUpdater<String>() {
+
+    var registered = false
+
+    override fun registerForUpdates() {
+        registered = true
+    }
+
+    override fun unregisterForUpdates() {
+        registered = false
+    }
+
+    override fun findValue() = nextValue
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaControllerTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaControllerTest.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.support.test.mock
+import org.junit.Test
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mozilla.geckoview.MediaElement
+
+class GeckoMediaControllerTest {
+    @Test
+    fun `Pause is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.pause()
+
+        verify(mediaElement).pause()
+    }
+
+    @Test
+    fun `Play is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.play()
+
+        verify(mediaElement).play()
+    }
+
+    @Test
+    fun `Seek is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.seek(1337.42)
+
+        verify(mediaElement).seek(1337.42)
+    }
+
+    @Test
+    fun `SetMuted is forwarded to media element`() {
+        val mediaElement: MediaElement = mock()
+
+        val controller = GeckoMediaController(mediaElement)
+        controller.setMuted(true)
+
+        verify(mediaElement).setMuted(true)
+        verifyNoMoreInteractions(mediaElement)
+
+        controller.setMuted(false)
+        verify(mediaElement).setMuted(false)
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaDelegateTest.kt
@@ -1,0 +1,128 @@
+package mozilla.components.browser.engine.gecko.media
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.concept.engine.media.RecordingDevice
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.MediaElement
+import org.mozilla.geckoview.MockRecordingDevice
+
+@RunWith(AndroidJUnit4::class)
+class GeckoMediaDelegateTest {
+
+    @Test
+    fun `Added MediaElement is wrapped in GeckoMedia and forwarded to observer`() {
+        val engineSession = GeckoEngineSession(mock())
+
+        var observedMedia: Media? = null
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onMediaAdded(media: Media) {
+                observedMedia = media
+            }
+        })
+
+        val mediaElement: MediaElement = mock()
+        engineSession.geckoSession.mediaDelegate!!.onMediaAdd(mock(), mediaElement)
+
+        assertNotNull(observedMedia!!)
+
+        observedMedia!!.controller.play()
+        verify(mediaElement).play()
+    }
+
+    @Test
+    fun `WHEN MediaElement is removed THEN previously added GeckoMedia is used to notify observer`() {
+        val engineSession = GeckoEngineSession(mock())
+
+        var addedMedia: Media? = null
+        var removedMedia: Media? = null
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onMediaAdded(media: Media) {
+                addedMedia = media
+            }
+
+            override fun onMediaRemoved(media: Media) {
+                removedMedia = media
+            }
+        })
+
+        val mediaElement: MediaElement = mock()
+        engineSession.geckoSession.mediaDelegate!!.onMediaAdd(mock(), mediaElement)
+        engineSession.geckoSession.mediaDelegate!!.onMediaRemove(mock(), mediaElement)
+
+        assertNotNull(addedMedia!!)
+        assertNotNull(removedMedia!!)
+        assertEquals(addedMedia, removedMedia)
+    }
+
+    @Test
+    fun `WHEN unknown media is removed THEN observer is not notified`() {
+        val engineSession = GeckoEngineSession(mock())
+
+        var onMediaRemovedExecuted = false
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onMediaRemoved(media: Media) {
+                onMediaRemovedExecuted = true
+            }
+        })
+
+        val mediaElement: MediaElement = mock()
+        engineSession.geckoSession.mediaDelegate!!.onMediaRemove(mock(), mediaElement)
+
+        assertFalse(onMediaRemovedExecuted)
+    }
+
+    @Test
+    fun `WHEN recording state changes THEN observers are notified`() {
+        val engineSession = GeckoEngineSession(mock())
+
+        var observedDevices: List<RecordingDevice> = listOf()
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onRecordingStateChanged(devices: List<RecordingDevice>) {
+                observedDevices = devices
+            }
+        })
+
+        assertTrue(observedDevices.isEmpty())
+
+        engineSession.geckoSession.mediaDelegate!!.onRecordingStatusChanged(mock(), arrayOf(
+            MockRecordingDevice(
+                GeckoSession.MediaDelegate.RecordingDevice.Type.CAMERA,
+                GeckoSession.MediaDelegate.RecordingDevice.Status.RECORDING)
+        ))
+
+        assertEquals(1, observedDevices.size)
+        assertEquals(RecordingDevice(RecordingDevice.Type.CAMERA, RecordingDevice.Status.RECORDING), observedDevices[0])
+
+        engineSession.geckoSession.mediaDelegate!!.onRecordingStatusChanged(mock(), arrayOf(
+            MockRecordingDevice(
+                GeckoSession.MediaDelegate.RecordingDevice.Type.CAMERA,
+                GeckoSession.MediaDelegate.RecordingDevice.Status.RECORDING),
+            MockRecordingDevice(
+                GeckoSession.MediaDelegate.RecordingDevice.Type.MICROPHONE,
+                GeckoSession.MediaDelegate.RecordingDevice.Status.INACTIVE)
+        ))
+
+        assertEquals(2, observedDevices.size)
+        assertEquals(RecordingDevice(RecordingDevice.Type.CAMERA, RecordingDevice.Status.RECORDING), observedDevices[0])
+        assertEquals(RecordingDevice(RecordingDevice.Type.MICROPHONE, RecordingDevice.Status.INACTIVE), observedDevices[1])
+
+        engineSession.geckoSession.mediaDelegate!!.onRecordingStatusChanged(mock(), emptyArray())
+
+        assertTrue(observedDevices.isEmpty())
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/media/GeckoMediaTest.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.media
+
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.MediaElement
+
+class GeckoMediaTest {
+    @Test
+    fun `Playback state is updated from MediaDelegate`() {
+        val mediaElement: MediaElement = mock()
+
+        val media = GeckoMedia(mediaElement)
+
+        val captor = argumentCaptor<MediaElement.Delegate>()
+        verify(mediaElement).delegate = captor.capture()
+
+        val delegate = captor.value
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PLAYING)
+        assertEquals(Media.PlaybackState.PLAYING, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_SEEKING)
+        assertEquals(Media.PlaybackState.SEEKING, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_WAITING)
+        assertEquals(Media.PlaybackState.WAITING, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PAUSE)
+        assertEquals(Media.PlaybackState.PAUSE, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_PLAY)
+        assertEquals(Media.PlaybackState.PLAY, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_SEEKED)
+        assertEquals(Media.PlaybackState.SEEKED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_STALLED)
+        assertEquals(Media.PlaybackState.STALLED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_SUSPEND)
+        assertEquals(Media.PlaybackState.SUSPENDED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_ABORT)
+        assertEquals(Media.PlaybackState.ABORT, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_EMPTIED)
+        assertEquals(Media.PlaybackState.EMPTIED, media.playbackState)
+
+        delegate.onPlaybackStateChange(mediaElement, MediaElement.MEDIA_STATE_ENDED)
+        assertEquals(Media.PlaybackState.ENDED, media.playbackState)
+    }
+
+    @Test
+    fun `GeckoMedia exposes GeckoMediaController`() {
+        val mediaElement: MediaElement = mock()
+
+        val media = GeckoMedia(mediaElement)
+
+        assertTrue(media.controller is GeckoMediaController)
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -8,6 +8,7 @@ import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.support.test.mock
+import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,7 +18,6 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
-import org.robolectric.util.ReflectionHelpers.setField
 
 @RunWith(AndroidJUnit4::class)
 class GeckoPermissionRequestTest {
@@ -45,7 +45,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
+        val request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.grant()
         verify(callback).grant()
     }
@@ -55,7 +55,7 @@ class GeckoPermissionRequestTest {
         val callback: GeckoSession.PermissionDelegate.Callback = mock()
         val uri = "https://mozilla.org"
 
-        var request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
+        val request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         request.reject()
         verify(callback).reject()
     }
@@ -78,7 +78,7 @@ class GeckoPermissionRequestTest {
                 Permission.Generic("unknown app permission")
         )
 
-        var request = GeckoPermissionRequest.App(permissions, callback)
+        val request = GeckoPermissionRequest.App(permissions, callback)
         assertEquals(mappedPermissions, request.permissions)
     }
 
@@ -140,7 +140,7 @@ class GeckoPermissionRequestTest {
                 Permission.ContentAudioOther("audioOther", "audioOther")
         )
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         assertEquals(uri, request.uri)
         assertEquals(mappedPermissions.size, request.permissions.size)
         assertTrue(request.permissions.containsAll(mappedPermissions))
@@ -159,7 +159,7 @@ class GeckoPermissionRequestTest {
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         request.grant(request.permissions)
         verify(callback).grant(videoCamera, audioMicrophone)
     }
@@ -177,17 +177,17 @@ class GeckoPermissionRequestTest {
         val audioSources = listOf(audioMicrophone)
         val videoSources = listOf(videoCamera)
 
-        var request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
+        val request = GeckoPermissionRequest.Media(uri, videoSources, audioSources, callback)
         request.reject()
         verify(callback).reject()
     }
 
     class MockMediaSource(id: String, name: String, source: Int, type: Int) : MediaSource() {
         init {
-            setField(this, "id", id)
-            setField(this, "name", name)
-            setField(this, "source", source)
-            setField(this, "type", type)
+            ReflectionUtils.setField(this, "id", id)
+            ReflectionUtils.setField(this, "name", name)
+            ReflectionUtils.setField(this, "source", source)
+            ReflectionUtils.setField(this, "type", type)
         }
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -26,10 +26,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
-import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_CROSS_ORIGIN_SUB_RESOURCE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.AuthOptions.AUTH_FLAG_HOST
@@ -48,6 +46,8 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_MONTH
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_TIME
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DATETIME_TYPE_WEEK
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.TextCallback
+import org.robolectric.Shadows.shadowOf
+import java.io.FileInputStream
 import java.security.InvalidParameterException
 import java.util.Calendar
 import java.util.Calendar.YEAR
@@ -60,7 +60,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_SINGLE must provide a SingleChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = MultipleChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -90,7 +90,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_MULTIPLE must provide a MultipleChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = SingleChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -120,7 +120,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onChoicePrompt called with CHOICE_TYPE_MENU must provide a MenuChoice PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var promptRequestSingleChoice: PromptRequest = PromptRequest.MenuChoice(arrayOf()) {}
         var confirmWasCalled = false
 
@@ -168,7 +168,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onAlert must provide an alert PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var alertRequest: PromptRequest? = null
         var dismissWasCalled = false
         var setCheckboxValueWasCalled = false
@@ -212,7 +212,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `hitting default values`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         val gecko = GeckoPromptDelegate(mockSession)
         gecko.onDateTimePrompt(mock(), null, DATETIME_TYPE_DATE, null, null, null, mock())
         gecko.onDateTimePrompt(mock(), null, DATETIME_TYPE_WEEK, null, null, null, mock())
@@ -232,7 +232,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_DATE must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         var onClearPicker = false
@@ -268,7 +268,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_DATE with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -310,7 +310,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_MONTH must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         val callback = object : TextCallback {
@@ -338,7 +338,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_MONTH with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -380,7 +380,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_WEEK must provide a date PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
         val callback = object : TextCallback {
@@ -408,7 +408,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_WEEK with date parameters must format dates correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -450,7 +450,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_TIME must provide a TimeSelection PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
 
@@ -479,7 +479,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_TIME with time parameters must format time correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -521,7 +521,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt called with DATETIME_TYPE_DATETIME_LOCAL must provide a TimeSelection PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var dateRequest: PromptRequest? = null
         var confirmCalled = false
 
@@ -543,7 +543,7 @@ class GeckoPromptDelegateTest {
         })
         promptDelegate.onDateTimePrompt(
             mock(), "title",
-            GeckoSession.PromptDelegate.DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
+            DATETIME_TYPE_DATETIME_LOCAL, "", "", "", callback
         )
         assertTrue(dateRequest is PromptRequest.TimeSelection)
         (dateRequest as PromptRequest.TimeSelection).onConfirm(Date())
@@ -553,7 +553,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onDateTimePrompt DATETIME_TYPE_DATETIME_LOCAL with date parameters must format time correctly`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var timeSelectionRequest: PromptRequest.TimeSelection? = null
         var geckoDate: String? = null
         val callback = object : TextCallback {
@@ -625,11 +625,16 @@ class GeckoPromptDelegateTest {
     fun `Calling onFilePrompt must provide a FilePicker PromptRequest`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onSingleFileSelectedWasCalled = false
         var onMultipleFilesSelectedWasCalled = false
         var onDismissWasCalled = false
+        val mockUri: Uri = mock()
+        val mockFileInput: FileInputStream = mock()
+        val shadowContentResolver = shadowOf(context.contentResolver)
+
+        shadowContentResolver.registerInputStream(mockUri, mockFileInput)
 
         val callback = object : GeckoSession.PromptDelegate.FileCallback {
             override fun dismiss() {
@@ -662,10 +667,10 @@ class GeckoPromptDelegateTest {
 
         val filePickerRequest = request as PromptRequest.File
 
-        filePickerRequest.onSingleFileSelected(context, mock())
+        filePickerRequest.onSingleFileSelected(context, mockUri)
         assertTrue(onSingleFileSelectedWasCalled)
 
-        filePickerRequest.onMultipleFilesSelected(context, emptyArray())
+        filePickerRequest.onMultipleFilesSelected(context, arrayOf(mockUri))
         assertTrue(onMultipleFilesSelectedWasCalled)
 
         filePickerRequest.onDismiss()
@@ -684,7 +689,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `Calling onAuthPrompt must provide an Authentication PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false
         var onConfirmOnlyPasswordWasCalled = false
@@ -770,12 +775,12 @@ class GeckoPromptDelegateTest {
     @Test
     fun `Calling onColorPrompt must provide a Color PromptRequest`() {
 
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var onConfirmWasCalled = false
         var onDismissWasCalled = false
 
-        val geckoCallback = object : GeckoSession.PromptDelegate.TextCallback {
+        val geckoCallback = object : TextCallback {
 
             override fun confirm(text: String?) {
                 onConfirmWasCalled = true
@@ -824,13 +829,13 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onTextPrompt must provide an TextPrompt PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest? = null
         var dismissWasCalled = false
         var confirmWasCalled = false
         var setCheckboxValueWasCalled = false
 
-        val callback = object : GeckoSession.PromptDelegate.TextCallback {
+        val callback = object : TextCallback {
 
             override fun confirm(text: String?) {
                 confirmWasCalled = true
@@ -875,7 +880,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onPopupRequest must provide a Popup PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest.Popup? = null
         var onAllowWasCalled = false
         var onDenyWasCalled = false
@@ -916,7 +921,7 @@ class GeckoPromptDelegateTest {
 
     @Test
     fun `onButtonPrompt must provide a Confirm PromptRequest`() {
-        val mockSession = GeckoEngineSession(Mockito.mock(GeckoRuntime::class.java))
+        val mockSession = GeckoEngineSession(mock())
         var request: PromptRequest.Confirm? = null
         var onPositiveButtonWasCalled = false
         var onNegativeButtonWasCalled = false

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -5,29 +5,122 @@
 package mozilla.components.browser.engine.gecko.prompt
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.webextension.GeckoPort
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.json.JSONObject
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.WebExtension
 
 @RunWith(AndroidJUnit4::class)
 class GeckoWebExtensionTest {
 
-    // There is not much to test here in beta. All functionality is in nightly only.
     @Test
-    fun `create gecko web extension`() {
-        val session: EngineSession = mock()
-        val contentMessageHandler: MessageHandler = mock()
-        val backgroundMessageHandler: MessageHandler = mock()
-        val appName = "mozac-test"
+    fun `register background message handler`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val portCaptor = argumentCaptor<Port>()
+        val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
-        val ext = GeckoWebExtension(appName, "url")
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
 
-        ext.registerBackgroundMessageHandler(appName, backgroundMessageHandler)
-        ext.registerContentMessageHandler(session, appName, contentMessageHandler)
-        assertFalse(ext.hasContentMessageHandler(session, appName))
+        verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Verify messages are forwarded to message handler
+        val message: Any = mock()
+        val sender: WebExtension.MessageSender = mock()
+        whenever(messageHandler.onMessage(eq(message), eq(null))).thenReturn("result")
+        assertNotNull(messageDelegateCaptor.value.onMessage(message, sender))
+        verify(messageHandler).onMessage(eq(message), eq(null))
+
+        whenever(messageHandler.onMessage(eq(message), eq(null))).thenReturn(null)
+        assertNull(messageDelegateCaptor.value.onMessage(message, sender))
+        verify(messageHandler, times(2)).onMessage(eq(message), eq(null))
+
+        // Verify connected port is forwarded to message handler
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        verify(messageHandler).onPortConnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+
+        // Verify port messages are forwarded to message handler
+        verify(port).setDelegate(portDelegateCaptor.capture())
+        val portDelegate = portDelegateCaptor.value
+        val portMessage: JSONObject = mock()
+        portDelegate.onPortMessage(portMessage, port)
+        verify(messageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+
+        // Verify disconnected port is forwarded to message handler
+        portDelegate.onDisconnect(port)
+        verify(messageHandler).onPortDisconnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+    }
+
+    @Test
+    fun `register content message handler`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val session: GeckoEngineSession = mock()
+        val geckoSession: GeckoSession = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val portCaptor = argumentCaptor<Port>()
+        val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
+
+        whenever(session.geckoSession).thenReturn(geckoSession)
+
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
+        extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
+        verify(geckoSession).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Verify messages are forwarded to message handler and return value passed on
+        val message: Any = mock()
+        val sender: WebExtension.MessageSender = mock()
+        whenever(messageHandler.onMessage(eq(message), eq(session))).thenReturn("result")
+        assertNotNull(messageDelegateCaptor.value.onMessage(message, sender))
+        verify(messageHandler).onMessage(eq(message), eq(session))
+
+        whenever(messageHandler.onMessage(eq(message), eq(session))).thenReturn(null)
+        assertNull(messageDelegateCaptor.value.onMessage(message, sender))
+        verify(messageHandler, times(2)).onMessage(eq(message), eq(session))
+
+        // Verify connected port is forwarded to message handler
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        verify(messageHandler).onPortConnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+
+        // Verify port messages are forwarded to message handler
+        verify(port).setDelegate(portDelegateCaptor.capture())
+        val portDelegate = portDelegateCaptor.value
+        val portMessage: JSONObject = mock()
+        portDelegate.onPortMessage(portMessage, port)
+        verify(messageHandler).onPortMessage(eq(portMessage), portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+
+        // Verify disconnected port is forwarded to message handler
+        portDelegate.onDisconnect(port)
+        verify(messageHandler).onPortDisconnected(portCaptor.capture())
+        assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertSame(session, (portCaptor.value as GeckoPort).engineSession)
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/test/ReflectionUtils.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/test/ReflectionUtils.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.test
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+
+object ReflectionUtils {
+    fun <T : Any> setField(instance: T, fieldName: String, value: Any?) {
+        val originField = instance.javaClass.getField(fieldName)
+
+        val modifiersField = Field::class.java.getDeclaredField("modifiers")
+        modifiersField.isAccessible = true
+        modifiersField.setInt(originField, originField.modifiers and Modifier.FINAL.inv())
+
+        originField.set(instance, value)
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/org/mozilla/geckoview/MockRecordingDevice.kt
+++ b/components/browser/engine-gecko/src/test/java/org/mozilla/geckoview/MockRecordingDevice.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.geckoview
+
+import mozilla.components.test.ReflectionUtils
+
+internal class MockRecordingDevice(
+    type: Long,
+    status: Long
+) : GeckoSession.MediaDelegate.RecordingDevice() {
+    init {
+        ReflectionUtils.setField(this, "type", type)
+        ReflectionUtils.setField(this, "status", status)
+    }
+}

--- a/components/browser/engine-gecko/src/test/java/org/mozilla/geckoview/MockWebResponseInfo.kt
+++ b/components/browser/engine-gecko/src/test/java/org/mozilla/geckoview/MockWebResponseInfo.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.geckoview
 
-import org.robolectric.util.ReflectionHelpers.setField
+import mozilla.components.test.ReflectionUtils
 
 class MockWebResponseInfo(
     uri: String,
@@ -13,9 +13,9 @@ class MockWebResponseInfo(
     filename: String?
 ) : GeckoSession.WebResponseInfo() {
     init {
-        setField(this, "uri", uri)
-        setField(this, "contentType", contentType)
-        setField(this, "filename", filename)
-        setField(this, "contentLength", contentLength)
+        ReflectionUtils.setField(this, "uri", uri)
+        ReflectionUtils.setField(this, "contentType", contentType)
+        ReflectionUtils.setField(this, "filename", filename)
+        ReflectionUtils.setField(this, "contentLength", contentLength)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
+  * **Merge day!**
+    * `browser-engine-gecko-release`: GeckoView 68.0
+    * `browser-engine-gecko-beta`: GeckoView 69.0
+    * `browser-engine-gecko-nightly`: GeckoView 70.0
+
 * **feature-media**
   * Added `MediaNotificationFeature` - a feature implementation to show an ongoing notification (keeping the app process alive) while web content is playing media.
 


### PR DESCRIPTION
It's merge day again! 🎉 

Closes #3616.

Copied the code over as follows:
* browser-engine-gecko-beta (68) -> browser-engine-gecko-release (68)
* browser-engine-gecko-nightly (69) -> browser-engine-gecko-beta (69)
* browser-engine-gecko-nightly -> 70

Only manual change was a small API change in Nightly that happened around the merge day period.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
