### PR TITLE
Closes #3743: Adding TrackingProtectionPolicy.CookiePolicy.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -161,6 +161,7 @@ class GeckoEngine(
             set(value) {
                 value?.let {
                     runtime.settings.contentBlocking.categories = it.categories
+                    runtime.settings.contentBlocking.cookieBehavior = it.cookiePolicy.id
                     defaultSettings?.trackingProtectionPolicy = value
                 }
             }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -874,6 +874,17 @@ class GeckoEngineSessionTest {
 
         assertEquals(TrackingProtectionPolicy.all().categories, ContentBlocking.CB_STRICT)
         assertEquals(TrackingProtectionPolicy.recommended().categories, ContentBlocking.CB_DEFAULT)
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL.id, ContentBlocking.COOKIE_ACCEPT_ALL)
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS.id,
+            ContentBlocking.COOKIE_ACCEPT_NON_TRACKERS
+        )
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_NONE.id, ContentBlocking.COOKIE_ACCEPT_NONE)
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_ONLY_FIRST_PARTY.id,
+            ContentBlocking.COOKIE_ACCEPT_FIRST_PARTY
+        )
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_VISITED.id, ContentBlocking.COOKIE_ACCEPT_VISITED)
     }
 
     @Test

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
 import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.support.test.any
@@ -148,6 +149,7 @@ class GeckoEngineTest {
                 TrackingProtectionPolicy.SAFE_BROWSING_PHISHING
         ).categories, contentBlockingSettings.categories)
         assertEquals(defaultSettings.trackingProtectionPolicy, TrackingProtectionPolicy.all())
+        assertEquals(contentBlockingSettings.cookieBehavior, CookiePolicy.ACCEPT_NON_TRACKERS.id)
 
         try {
             engine.settings.domStorageEnabled
@@ -209,11 +211,24 @@ class GeckoEngineTest {
             TrackingProtectionPolicy.SAFE_BROWSING_MALWARE,
             TrackingProtectionPolicy.SAFE_BROWSING_PHISHING
         ).categories, contentBlockingSettings.categories)
+        assertEquals(contentBlockingSettings.cookieBehavior, CookiePolicy.ACCEPT_NON_TRACKERS.id)
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
         assertFalse(engine.settings.allowAutoplayMedia)
         assertTrue(engine.settings.suspendMediaWhenInactive)
+
+        engine.settings.trackingProtectionPolicy =
+            TrackingProtectionPolicy.select(
+                TrackingProtectionPolicy.AD,
+                cookiePolicy = CookiePolicy.ACCEPT_ONLY_FIRST_PARTY
+            )
+
+        assertEquals(CookiePolicy.ACCEPT_ONLY_FIRST_PARTY.id, contentBlockingSettings.cookieBehavior)
+
+        engine.settings.trackingProtectionPolicy = TrackingProtectionPolicy.none()
+
+        assertEquals(CookiePolicy.ACCEPT_ALL.id, contentBlockingSettings.cookieBehavior)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -161,6 +161,7 @@ class GeckoEngine(
             set(value) {
                 value?.let {
                     runtime.settings.contentBlocking.categories = it.categories
+                    runtime.settings.contentBlocking.cookieBehavior = it.cookiePolicy.id
                     defaultSettings?.trackingProtectionPolicy = value
                 }
             }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -874,6 +874,17 @@ class GeckoEngineSessionTest {
 
         assertEquals(TrackingProtectionPolicy.all().categories, ContentBlocking.CB_STRICT)
         assertEquals(TrackingProtectionPolicy.recommended().categories, ContentBlocking.CB_DEFAULT)
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL.id, ContentBlocking.COOKIE_ACCEPT_ALL)
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS.id,
+            ContentBlocking.COOKIE_ACCEPT_NON_TRACKERS
+        )
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_NONE.id, ContentBlocking.COOKIE_ACCEPT_NONE)
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_ONLY_FIRST_PARTY.id,
+            ContentBlocking.COOKIE_ACCEPT_FIRST_PARTY
+        )
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_VISITED.id, ContentBlocking.COOKIE_ACCEPT_VISITED)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
 import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.support.test.any
@@ -148,6 +149,7 @@ class GeckoEngineTest {
                 TrackingProtectionPolicy.SAFE_BROWSING_PHISHING
         ).categories, contentBlockingSettings.categories)
         assertEquals(defaultSettings.trackingProtectionPolicy, TrackingProtectionPolicy.all())
+        assertEquals(contentBlockingSettings.cookieBehavior, CookiePolicy.ACCEPT_NON_TRACKERS.id)
 
         try {
             engine.settings.domStorageEnabled
@@ -209,11 +211,22 @@ class GeckoEngineTest {
             TrackingProtectionPolicy.SAFE_BROWSING_MALWARE,
             TrackingProtectionPolicy.SAFE_BROWSING_PHISHING
         ).categories, contentBlockingSettings.categories)
+
+        assertEquals(CookiePolicy.ACCEPT_NON_TRACKERS.id, contentBlockingSettings.cookieBehavior)
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
         assertFalse(engine.settings.allowAutoplayMedia)
         assertTrue(engine.settings.suspendMediaWhenInactive)
+
+        engine.settings.trackingProtectionPolicy =
+            TrackingProtectionPolicy.select(TrackingProtectionPolicy.AD, cookiePolicy = CookiePolicy.ACCEPT_ONLY_FIRST_PARTY)
+
+        assertEquals(CookiePolicy.ACCEPT_ONLY_FIRST_PARTY.id, contentBlockingSettings.cookieBehavior)
+
+        engine.settings.trackingProtectionPolicy = TrackingProtectionPolicy.none()
+
+        assertEquals(CookiePolicy.ACCEPT_ALL.id, contentBlockingSettings.cookieBehavior)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -161,6 +161,7 @@ class GeckoEngine(
             set(value) {
                 value?.let {
                     runtime.settings.contentBlocking.categories = it.categories
+                    runtime.settings.contentBlocking.cookieBehavior = it.cookiePolicy.id
                     defaultSettings?.trackingProtectionPolicy = value
                 }
             }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -849,6 +849,17 @@ class GeckoEngineSessionTest {
 
         assertEquals(TrackingProtectionPolicy.all().categories, ContentBlocking.CB_STRICT)
         assertEquals(TrackingProtectionPolicy.recommended().categories, ContentBlocking.CB_DEFAULT)
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL.id, ContentBlocking.COOKIE_ACCEPT_ALL)
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS.id,
+            ContentBlocking.COOKIE_ACCEPT_NON_TRACKERS
+        )
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_NONE.id, ContentBlocking.COOKIE_ACCEPT_NONE)
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_ONLY_FIRST_PARTY.id,
+            ContentBlocking.COOKIE_ACCEPT_FIRST_PARTY
+        )
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_VISITED.id, ContentBlocking.COOKIE_ACCEPT_VISITED)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
 import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.support.test.any
@@ -148,6 +149,7 @@ class GeckoEngineTest {
                 TrackingProtectionPolicy.SAFE_BROWSING_PHISHING
         ).categories, contentBlockingSettings.categories)
         assertEquals(defaultSettings.trackingProtectionPolicy, TrackingProtectionPolicy.all())
+        assertEquals(contentBlockingSettings.cookieBehavior, CookiePolicy.ACCEPT_NON_TRACKERS.id)
 
         try {
             engine.settings.domStorageEnabled
@@ -209,11 +211,27 @@ class GeckoEngineTest {
             TrackingProtectionPolicy.SAFE_BROWSING_MALWARE,
             TrackingProtectionPolicy.SAFE_BROWSING_PHISHING
         ).categories, contentBlockingSettings.categories)
+        assertEquals(contentBlockingSettings.cookieBehavior, CookiePolicy.ACCEPT_NON_TRACKERS.id)
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
         assertFalse(engine.settings.allowAutoplayMedia)
         assertTrue(engine.settings.suspendMediaWhenInactive)
+
+        engine.settings.trackingProtectionPolicy =
+            TrackingProtectionPolicy.select(
+                TrackingProtectionPolicy.AD,
+                cookiePolicy = CookiePolicy.ACCEPT_ONLY_FIRST_PARTY
+            )
+
+        assertEquals(
+            TrackingProtectionPolicy.CookiePolicy.ACCEPT_ONLY_FIRST_PARTY.id,
+            contentBlockingSettings.cookieBehavior
+        )
+
+        engine.settings.trackingProtectionPolicy = TrackingProtectionPolicy.none()
+
+        assertEquals(TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL.id, contentBlockingSettings.cookieBehavior)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,11 @@ permalink: /changelog/
   * See component's [README](https://github.com/mozilla-mobile/android-components/blob/master/components/service/firefox-accounts/README.md) for detailed description of the new API.
   * As part of these changes, token caching issue has been fixed. See [#3579](https://github.com/mozilla-mobile/android-components/pull/3579) for details.
 
+* **concept-engine**, **browser-engine-gecko(-beta/nightly)**.
+  * Added `TrackingProtectionPolicy.CookiePolicy` to indicate how cookies should behave for a given `TrackingProtectionPolicy`.
+  * Now `TrackingProtectionPolicy.select` allows you to specify a `TrackingProtectionPolicy.CookiePolicy`, if not specified, `TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS` will be used.
+  * Behavior change: Now `TrackingProtectionPolicy.none()` will get assigned a `TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL`, and both `TrackingProtectionPolicy.all()` and `TrackingProtectionPolicy.recommended()` will have a `TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS`.
+
 # 3.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v2.0.0...v3.0.0)


### PR DESCRIPTION
As GeckoView is [enabling by default  ETP(Enhanced Tracking Protection)](https://github.com/mozilla-mobile/fenix/issues/1749#issuecomment-509517270) by default we are following the same steps.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
