### PR TITLE
Use Firebase Messaging as api gradle dependency

### DIFF
--- a/components/lib/push-firebase/build.gradle
+++ b/components/lib/push-firebase/build.gradle
@@ -25,8 +25,9 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
 
     implementation project(':concept-push')
+
     implementation Dependencies.firebase_core
-    implementation Dependencies.firebase_messaging
+    api Dependencies.firebase_messaging
 
     testImplementation project(':support-test')
 


### PR DESCRIPTION
Needed when consumers extended the abstract service, gradle can't see firebase messaging classes.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
