### PR TITLE
GeckoEngineSession now receives an elapsed time for page load

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -396,12 +396,13 @@ class GeckoEngineSession(
             }
         }
 
-        override fun onPageStop(session: GeckoSession, success: Boolean) {
+        override fun onPageStop(session: GeckoSession, success: Boolean, elapsed: Int) {
             // by the time we reach here, any new request will come from web content.
             // If it comes from the chrome, loadUrl(url) or loadData(string) will set it to
             // false.
             requestFromWebContent = true
             notifyObservers {
+                onElapsedLoadTimeMS(elapsed)
                 onProgress(PROGRESS_STOP)
                 onLoadingStateChange(false)
             }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -151,7 +151,7 @@ class GeckoEngineSessionTest {
         assertEquals(GeckoEngineSession.PROGRESS_START, observedProgress)
         assertEquals(true, observedLoadingState)
 
-        progressDelegate.value.onPageStop(mock(), true)
+        progressDelegate.value.onPageStop(mock(), true, 0)
         assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
         assertEquals(false, observedLoadingState)
 
@@ -161,7 +161,7 @@ class GeckoEngineSessionTest {
         assertEquals(GeckoEngineSession.PROGRESS_START, observedProgress)
         assertEquals(true, observedLoadingState)
 
-        progressDelegate.value.onPageStop(mock(), false)
+        progressDelegate.value.onPageStop(mock(), false, 0)
         assertEquals(GeckoEngineSession.PROGRESS_STOP, observedProgress)
         assertEquals(false, observedLoadingState)
 
@@ -1727,7 +1727,7 @@ class GeckoEngineSessionTest {
             observedUrl = null
             navigationDelegate.value.onLoadRequest(
                 mock(), mockLoadRequest(fakeUrl, triggeredByRedirect = true))
-            progressDelegate.value.onPageStop(mock(), true)
+            progressDelegate.value.onPageStop(mock(), true, 0)
             assertNotNull(observedTriggeredByWebContent)
             assertEquals(expectedTriggeredByWebContent, observedTriggeredByWebContent!!)
             assertNotNull(observedUrl)

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -67,6 +67,7 @@ class Session(
         fun onUrlChanged(session: Session, url: String) = Unit
         fun onTitleChanged(session: Session, title: String) = Unit
         fun onProgress(session: Session, progress: Int) = Unit
+        fun onElapsedLoadTimeMS(session: Session, progress: Int) = Unit
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
         fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) = Unit
         fun onLoadRequest(
@@ -195,6 +196,13 @@ class Session(
         if (notifyObservers(old, new) { onProgress(this@Session, new) }) {
             store?.syncDispatch(UpdateProgressAction(id, new))
         }
+    }
+
+    /**
+     * The elapsed time of the load.
+     */
+    var elapsedLoadTimeMS: Int by Delegates.observable(-1) {
+        _, old, new -> notifyObservers(old, new) { onElapsedLoadTimeMS(this@Session, new) }
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -48,6 +48,10 @@ internal class EngineObserver(
         }
     }
 
+    override fun onElapsedLoadTimeMS(elapsed: Int) {
+        session.elapsedLoadTimeMS = elapsed
+    }
+
     override fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {
         if (triggeredByRedirect || triggeredByWebContent) {
             session.searchTerms = ""

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -34,6 +34,7 @@ abstract class EngineSession(
         fun onLocationChange(url: String) = Unit
         fun onTitleChange(title: String) = Unit
         fun onProgress(progress: Int) = Unit
+        fun onElapsedLoadTimeMS(elapsed: Int) = Unit
         fun onLoadingStateChange(loading: Boolean) = Unit
         fun onNavigationStateChange(canGoBack: Boolean? = null, canGoForward: Boolean? = null) = Unit
         fun onSecurityChange(secure: Boolean, host: String? = null, issuer: String? = null) = Unit


### PR DESCRIPTION
This patch brings ac up-to-date with changes to GV nightly
that expose a document request's elapsed load time. This
patch receives the elapsed time from GV and then calls
observers to notify them.
