### PR TITLE
Issue #2747 - Split intent processors 

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/intent/IntentExtensions.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/intent/IntentExtensions.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.intent
+
+import android.content.Intent
+import mozilla.components.support.utils.SafeIntent
+
+const val EXTRA_SESSION_ID = "activeSessionId"
+
+/**
+ * Retrieves [mozilla.components.browser.session.Session] ID from the intent.
+ *
+ * @return The session ID previously added with [putSessionId],
+ * or null if no ID was found.
+ */
+fun Intent.getSessionId(): String? = getStringExtra(EXTRA_SESSION_ID)
+
+/**
+ * Retrieves [mozilla.components.browser.session.Session] ID from the intent.
+ *
+ * @return The session ID previously added with [putSessionId],
+ * or null if no ID was found.
+ */
+fun SafeIntent.getSessionId(): String? = getStringExtra(EXTRA_SESSION_ID)
+
+/**
+ * Add [mozilla.components.browser.session.Session] ID to the intent.
+ *
+ * @param sessionId The session ID data value.
+ *
+ * @return Returns the same Intent object, for chaining multiple calls
+ * into a single statement.
+ *
+ * @see [getSessionId]
+ */
+fun Intent.putSessionId(sessionId: String?): Intent {
+    return putExtra(EXTRA_SESSION_ID, sessionId)
+}

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/intent/IntentProcessor.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/intent/IntentProcessor.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.intent
+
+import android.content.Intent
+
+/**
+ * Processor for Android intents which should trigger session-related actions.
+ */
+interface IntentProcessor {
+
+    /**
+     * Returns true if this intent processor will handle the intent.
+     */
+    fun matches(intent: Intent): Boolean
+
+    /**
+     * Processes the given [Intent].
+     *
+     * @param intent The intent to process.
+     * @return True if the intent was processed, otherwise false.
+     */
+    suspend fun process(intent: Intent): Boolean
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/intent/IntentExtensionsTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/intent/IntentExtensionsTest.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.session.intent
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.utils.toSafeIntent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+
+@RunWith(AndroidJUnit4::class)
+class IntentExtensionsTest {
+
+    @Test
+    fun `getSessionId should call getStringExtra`() {
+        val id = "mock-session-id"
+        val intent: Intent = mock()
+        val safeIntent: SafeIntent = mock()
+
+        `when`(intent.getStringExtra(EXTRA_SESSION_ID)).thenReturn(id)
+        `when`(safeIntent.getStringExtra(EXTRA_SESSION_ID)).thenReturn(id)
+
+        assertEquals(id, intent.getSessionId())
+        assertEquals(id, safeIntent.getSessionId())
+    }
+
+    @Test
+    fun `putSessionId should put string extra`() {
+        val id = "mock-session-id"
+        val intent = Intent()
+
+        assertEquals(intent, intent.putSessionId(id))
+
+        assertEquals(id, intent.getSessionId())
+        assertEquals(id, intent.toSafeIntent().getSessionId())
+    }
+}

--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':browser-session')
     implementation project(':browser-toolbar')
     implementation project(':concept-engine')
+    implementation project(':feature-session')
     implementation project(':support-base')
     implementation project(':support-ktx')
     implementation project(':support-utils')
@@ -40,6 +41,7 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.kotlin_coroutines_test
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs
+
+import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.util.DisplayMetrics
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.intent.IntentProcessor
+import mozilla.components.browser.session.intent.putSessionId
+import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.utils.SafeIntent
+
+/**
+ * Processor for intents which trigger actions related to custom tabs.
+ */
+class CustomTabIntentProcessor(
+    private val sessionManager: SessionManager,
+    private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase,
+    private val displayMetrics: DisplayMetrics
+) : IntentProcessor {
+
+    override fun matches(intent: Intent): Boolean {
+        val safeIntent = SafeIntent(intent)
+        return safeIntent.action == ACTION_VIEW && CustomTabConfig.isCustomTabIntent(safeIntent)
+    }
+
+    override suspend fun process(intent: Intent): Boolean {
+        val safeIntent = SafeIntent(intent)
+        val url = safeIntent.dataString
+
+        return if (!url.isNullOrEmpty() && matches(intent)) {
+            val session = Session(url, private = false, source = Session.Source.CUSTOM_TAB)
+            session.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
+
+            sessionManager.add(session)
+            loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external())
+            intent.putSessionId(session.id)
+
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/AbstractCustomTabsServiceTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/AbstractCustomTabsServiceTest.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.session.tab
+package mozilla.components.feature.customtabs
 
 import android.net.Uri
 import android.os.Bundle
@@ -12,7 +12,6 @@ import android.support.customtabs.ICustomTabsService
 import androidx.browser.customtabs.CustomTabsService
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.engine.Engine
-import mozilla.components.feature.customtabs.AbstractCustomTabsService
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs
+
+import android.content.Intent
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.Session.Source
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.intent.EXTRA_SESSION_ID
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class CustomTabIntentProcessorTest {
+
+    private val sessionManager = mock<SessionManager>()
+    private val session = mock<Session>()
+    private val engineSession = mock<EngineSession>()
+
+    @Before
+    fun setup() {
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+    }
+
+    @Test
+    fun processCustomTabIntentWithDefaultHandlers() = runBlockingTest {
+        val engine = mock<Engine>()
+        val sessionManager = spy(SessionManager(engine))
+        doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
+        val useCases = SessionUseCases(sessionManager)
+
+        val handler =
+            CustomTabIntentProcessor(sessionManager, useCases.loadUrl, testContext.resources.displayMetrics)
+
+        val intent = mock<Intent>()
+        whenever(intent.action).thenReturn(Intent.ACTION_VIEW)
+        whenever(intent.hasExtra(CustomTabsIntent.EXTRA_SESSION)).thenReturn(true)
+        whenever(intent.dataString).thenReturn("http://mozilla.org")
+        whenever(intent.putExtra(any<String>(), any<String>())).thenReturn(intent)
+
+        handler.process(intent)
+        verify(sessionManager).add(anySession(), eq(false), eq(null), eq(null))
+        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
+        verify(intent).putExtra(eq(EXTRA_SESSION_ID), any<String>())
+
+        val customTabSession = sessionManager.all[0]
+        assertNotNull(customTabSession)
+        assertEquals("http://mozilla.org", customTabSession.url)
+        assertEquals(Source.CUSTOM_TAB, customTabSession.source)
+        assertNotNull(customTabSession.customTabConfig)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> anySession(): T {
+        any<T>()
+        return null as T
+    }
+}

--- a/components/feature/intent/build.gradle
+++ b/components/feature/intent/build.gradle
@@ -26,6 +26,7 @@ android {
 dependencies {
     implementation project(':concept-engine')
     implementation project(':browser-session')
+    implementation project(':feature-customtabs')
     implementation project(':feature-search')
     implementation project(':feature-session')
     implementation project(':support-utils')
@@ -39,6 +40,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.kotlin_coroutines
+    testImplementation Dependencies.kotlin_coroutines_test
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -6,16 +6,12 @@ package mozilla.components.feature.intent
 
 import android.content.Context
 import android.content.Intent
-import android.text.TextUtils
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.Session.Source
+import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.tab.CustomTabConfig
-import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
+import mozilla.components.browser.session.intent.EXTRA_SESSION_ID
+import mozilla.components.feature.customtabs.CustomTabIntentProcessor
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.support.utils.SafeIntent
-import mozilla.components.support.utils.WebURLFinder
 
 typealias IntentHandler = (Intent) -> Boolean
 
@@ -30,6 +26,8 @@ typealias IntentHandler = (Intent) -> Boolean
  * @property openNewTab Whether a processed intent should open a new tab or
  * open URLs in the currently selected tab.
  * @property isPrivate Whether a processed intent should open a new tab as private
+ *
+ * @deprecated Use individual intent processors instead.
  */
 class IntentProcessor(
     private val sessionUseCases: SessionUseCases,
@@ -40,70 +38,29 @@ class IntentProcessor(
     private val openNewTab: Boolean = true,
     private val isPrivate: Boolean = false
 ) {
-    private val defaultActionViewHandler = { intent: Intent ->
-        val safeIntent = SafeIntent(intent)
-        val url = safeIntent.dataString ?: ""
 
-        when {
-            TextUtils.isEmpty(url) -> false
+    private val defaultHandlers by lazy {
+        val tabIntentProcessor = TabIntentProcessor(
+            sessionManager,
+            sessionUseCases.loadUrl,
+            if (isPrivate) searchUseCases.newPrivateTabSearch else searchUseCases.newTabSearch,
+            openNewTab,
+            isPrivate
+        )
+        val customTabIntentProcessor = CustomTabIntentProcessor(
+            sessionManager,
+            sessionUseCases.loadUrl,
+            context.resources.displayMetrics
+        )
+        val viewHandlers = listOf(customTabIntentProcessor, tabIntentProcessor)
 
-            CustomTabConfig.isCustomTabIntent(safeIntent) -> {
-                val session = Session(url, false, Source.CUSTOM_TAB).apply {
-                    val displayMetrics = context.resources.displayMetrics
-                    this.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
-                }
-                sessionManager.add(session)
-                sessionUseCases.loadUrl(url, session, LoadUrlFlags.external())
-                intent.putExtra(ACTIVE_SESSION_ID, session.id)
-                true
+        mutableMapOf<String, IntentHandler>(
+            Intent.ACTION_VIEW to { intent ->
+                runBlocking { viewHandlers.any { it.process(intent) } }
+            },
+            Intent.ACTION_SEND to { intent ->
+                runBlocking { tabIntentProcessor.process(intent) }
             }
-
-            else -> {
-                val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
-                sessionUseCases.loadUrl(url, session, LoadUrlFlags.external())
-                true
-            }
-        }
-    }
-
-    private val defaultActionSendHandler = { intent: Intent ->
-        val safeIntent = SafeIntent(intent)
-        val extraText = safeIntent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
-
-        when {
-            TextUtils.isEmpty(extraText.trim()) -> false
-
-            else -> {
-                WebURLFinder(extraText).bestWebURL()?.let { url ->
-                    sessionUseCases.loadUrl(
-                        url,
-                        createSession(
-                            url,
-                            private = isPrivate,
-                            source = Source.ACTION_SEND
-                        ),
-                        LoadUrlFlags.external()
-                    )
-                } ?: run {
-                    searchUseCases.newTabSearch(extraText, Source.ACTION_SEND, openNewTab)
-                }
-                true
-            }
-        }
-    }
-
-    private fun createSession(url: String, private: Boolean = false, source: Source): Session {
-        return if (openNewTab) {
-            Session(url, private, source).also { sessionManager.add(it, selected = true) }
-        } else {
-            sessionManager.selectedSession ?: Session(url, private, source)
-        }
-    }
-
-    private val defaultHandlers: MutableMap<String, IntentHandler> by lazy {
-        mutableMapOf(
-            Intent.ACTION_VIEW to defaultActionViewHandler,
-            Intent.ACTION_SEND to defaultActionSendHandler
         )
     }
 
@@ -141,6 +98,6 @@ class IntentProcessor(
     }
 
     companion object {
-        const val ACTIVE_SESSION_ID = "activeSessionId"
+        const val ACTIVE_SESSION_ID = EXTRA_SESSION_ID
     }
 }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/TabIntentProcessor.kt
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.intent
+
+import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.ACTION_VIEW
+import android.content.Intent.EXTRA_TEXT
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.Session.Source
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.intent.IntentProcessor
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
+import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.utils.WebURLFinder
+
+/**
+ * Processor for intents which should trigger session-related actions.
+ *
+ * @property sessionManager The application's [SessionManager].
+ * @property loadUrlUseCase A reference to [SessionUseCases.DefaultLoadUrlUseCase] used to load URLs.
+ * @property newTabSearchUseCase A reference to [SearchUseCases.NewTabSearchUseCase] to be used for
+ * ACTION_SEND intents if the provided text is not a URL.
+ * @property openNewTab Whether a processed intent should open a new tab or
+ * open URLs in the currently selected tab.
+ * @property isPrivate Whether a processed intent should open a new tab as private
+ */
+class TabIntentProcessor(
+    private val sessionManager: SessionManager,
+    private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase,
+    private val newTabSearchUseCase: SearchUseCases.NewTabSearchUseCase,
+    private val openNewTab: Boolean = true,
+    private val isPrivate: Boolean = false
+) : IntentProcessor {
+
+    /**
+     * Loads a URL from a view intent in a new session.
+     */
+    private fun processViewIntent(intent: SafeIntent): Boolean {
+        val url = intent.dataString
+
+        return if (url.isNullOrEmpty()) {
+            false
+        } else {
+            val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
+            loadUrlUseCase(url, session, LoadUrlFlags.external())
+            true
+        }
+    }
+
+    /**
+     * Processes a send intent and tries to load [EXTRA_TEXT] as a URL.
+     * If its not a URL, a search is run instead.
+     */
+    private fun processSendIntent(intent: SafeIntent): Boolean {
+        val extraText = intent.getStringExtra(EXTRA_TEXT)
+
+        return if (extraText.isNullOrBlank()) {
+            false
+        } else {
+            val url = WebURLFinder(extraText).bestWebURL()
+            if (url != null) {
+                val session = createSession(url, private = isPrivate, source = Source.ACTION_SEND)
+                loadUrlUseCase(url, session, LoadUrlFlags.external())
+            } else {
+                newTabSearchUseCase(extraText, Source.ACTION_SEND, openNewTab)
+            }
+            true
+        }
+    }
+
+    private fun createSession(url: String, private: Boolean = false, source: Source): Session {
+        return if (openNewTab) {
+            Session(url, private, source).also { sessionManager.add(it, selected = true) }
+        } else {
+            sessionManager.selectedSession ?: Session(url, private, source)
+        }
+    }
+
+    override fun matches(intent: Intent): Boolean {
+        val safeIntent = SafeIntent(intent)
+        return safeIntent.action == ACTION_VIEW || safeIntent.action == ACTION_SEND
+    }
+
+    /**
+     * Processes the given intent by invoking the registered handler.
+     *
+     * @param intent the intent to process
+     * @return true if the intent was processed, otherwise false.
+     */
+    override suspend fun process(intent: Intent): Boolean {
+        val safeIntent = SafeIntent(intent)
+        return when (safeIntent.action) {
+            ACTION_VIEW -> processViewIntent(safeIntent)
+            ACTION_SEND -> processSendIntent(safeIntent)
+            else -> false
+        }
+    }
+}

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/TabIntentProcessorTest.kt
@@ -5,8 +5,9 @@
 package mozilla.components.feature.intent
 
 import android.content.Intent
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
@@ -24,19 +25,17 @@ import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyZeroInteractions
 
 @RunWith(AndroidJUnit4::class)
-class IntentProcessorTest {
+@ExperimentalCoroutinesApi
+class TabIntentProcessorTest {
 
     private val sessionManager = mock<SessionManager>()
     private val session = mock<Session>()
@@ -52,12 +51,12 @@ class IntentProcessorTest {
     }
 
     @Test
-    fun processWithDefaultHandlers() {
+    fun processViewIntent() = runBlockingTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         val useCases = SessionUseCases(sessionManager)
         val handler =
-            IntentProcessor(useCases, sessionManager, searchUseCases, testContext)
+            TabIntentProcessor(sessionManager, useCases.loadUrl, searchUseCases.newTabSearch)
         val intent = mock<Intent>()
         whenever(intent.action).thenReturn(Intent.ACTION_VIEW)
 
@@ -79,13 +78,11 @@ class IntentProcessorTest {
     }
 
     @Test
-    fun processWithDefaultHandlersUsingSelectedSession() {
-        val handler = IntentProcessor(
-            sessionUseCases,
+    fun processViewIntentUsingSelectedSession() = runBlockingTest {
+        val handler = TabIntentProcessor(
             sessionManager,
-            searchUseCases,
-            testContext,
-            useDefaultHandlers = true,
+            sessionUseCases.loadUrl,
+            searchUseCases.newTabSearch,
             openNewTab = false
         )
         val intent = mock<Intent>()
@@ -97,16 +94,14 @@ class IntentProcessorTest {
     }
 
     @Test
-    fun processWithDefaultHandlersHavingNoSelectedSession() {
+    fun processViewIntentHavingNoSelectedSession() = runBlockingTest {
         whenever(sessionManager.selectedSession).thenReturn(null)
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
 
-        val handler = IntentProcessor(
-            sessionUseCases,
+        val handler = TabIntentProcessor(
             sessionManager,
-            searchUseCases,
-            testContext,
-            useDefaultHandlers = true,
+            sessionUseCases.loadUrl,
+            searchUseCases.newTabSearch,
             openNewTab = false
         )
         val intent = mock<Intent>()
@@ -118,81 +113,10 @@ class IntentProcessorTest {
     }
 
     @Test
-    fun processWithoutDefaultHandlers() {
-        val handler = IntentProcessor(
-            sessionUseCases,
-            sessionManager,
-            searchUseCases,
-            testContext,
-            useDefaultHandlers = false
-        )
-        val intent = mock<Intent>()
-        whenever(intent.action).thenReturn(Intent.ACTION_VIEW)
-        whenever(intent.dataString).thenReturn("http://mozilla.org")
-
-        handler.process(intent)
-        verifyZeroInteractions(engineSession)
-    }
-
-    @Test
-    fun processWithCustomHandlers() {
-        val handler = IntentProcessor(
-            sessionUseCases,
-            sessionManager,
-            searchUseCases,
-            testContext,
-            useDefaultHandlers = false
-        )
-        val intent = mock<Intent>()
-        whenever(intent.action).thenReturn(Intent.ACTION_SEND)
-
-        var handlerInvoked = false
-        handler.registerHandler(Intent.ACTION_SEND) {
-            handlerInvoked = true
-            true
-        }
-
-        handler.process(intent)
-        assertTrue(handlerInvoked)
-
-        handlerInvoked = false
-        handler.unregisterHandler(Intent.ACTION_SEND)
-
-        handler.process(intent)
-        assertFalse(handlerInvoked)
-    }
-
-    @Test
-    fun processCustomTabIntentWithDefaultHandlers() {
-        val engine = mock<Engine>()
-        val sessionManager = spy(SessionManager(engine))
-        doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
-        val useCases = SessionUseCases(sessionManager)
-
-        val handler = IntentProcessor(useCases, sessionManager, searchUseCases, testContext)
-
-        val intent = mock<Intent>()
-        whenever(intent.action).thenReturn(Intent.ACTION_VIEW)
-        whenever(intent.hasExtra(CustomTabsIntent.EXTRA_SESSION)).thenReturn(true)
-        whenever(intent.dataString).thenReturn("http://mozilla.org")
-        whenever(intent.putExtra(any(), any<String>())).thenReturn(intent)
-
-        handler.process(intent)
-        verify(sessionManager).add(anySession(), eq(false), eq(null), eq(null))
-        verify(engineSession).loadUrl("http://mozilla.org", LoadUrlFlags.external())
-
-        val customTabSession = sessionManager.all[0]
-        assertNotNull(customTabSession)
-        assertEquals("http://mozilla.org", customTabSession.url)
-        assertEquals(Source.CUSTOM_TAB, customTabSession.source)
-        assertNotNull(customTabSession.customTabConfig)
-    }
-
-    @Test
-    fun `load URL on ACTION_SEND if text contains URL`() {
+    fun `load URL on ACTION_SEND if text contains URL`() = runBlockingTest {
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
 
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, testContext)
+        val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
 
         val intent = mock<Intent>()
         whenever(intent.action).thenReturn(Intent.ACTION_SEND)
@@ -219,7 +143,7 @@ class IntentProcessorTest {
     }
 
     @Test
-    fun `perform search on ACTION_SEND if text (no URL) provided`() {
+    fun `perform search on ACTION_SEND if text (no URL) provided`() = runBlockingTest {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession())
@@ -230,7 +154,7 @@ class IntentProcessorTest {
         val searchTerms = "mozilla android"
         val searchUrl = "http://search-url.com?$searchTerms"
 
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, testContext)
+        val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
 
         val intent = mock<Intent>()
         whenever(intent.action).thenReturn(Intent.ACTION_SEND)
@@ -247,8 +171,8 @@ class IntentProcessorTest {
     }
 
     @Test
-    fun `processor handles ACTION_SEND with empty text`() {
-        val handler = IntentProcessor(sessionUseCases, sessionManager, searchUseCases, testContext)
+    fun `processor handles ACTION_SEND with empty text`() = runBlockingTest {
+        val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
 
         val intent = mock<Intent>()
         whenever(intent.action).thenReturn(Intent.ACTION_SEND)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -11,10 +11,10 @@ import android.util.AttributeSet
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import mozilla.components.browser.session.intent.getSessionId
 import mozilla.components.browser.tabstray.BrowserTabsTray
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.tabstray.TabsTray
-import mozilla.components.feature.intent.IntentProcessor
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.samples.browser.ext.components
@@ -29,7 +29,7 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         setContentView(R.layout.activity_main)
 
         if (savedInstanceState == null) {
-            val sessionId = SafeIntent(intent).getStringExtra(IntentProcessor.ACTIVE_SESSION_ID)
+            val sessionId = SafeIntent(intent).getSessionId()
             supportFragmentManager?.beginTransaction()?.apply {
                 replace(R.id.container, createBrowserFragment(sessionId))
                 commit()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -27,7 +27,8 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
-import mozilla.components.feature.intent.IntentProcessor
+import mozilla.components.feature.customtabs.CustomTabIntentProcessor
+import mozilla.components.feature.intent.TabIntentProcessor
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.notification.MediaNotificationFeature
 import mozilla.components.feature.media.state.MediaStateMachine
@@ -112,13 +113,11 @@ open class DefaultComponents(private val applicationContext: Context) {
     val webAppUseCases by lazy { WebAppUseCases(applicationContext, sessionManager) }
 
     // Intent
-    val sessionIntentProcessor by lazy {
-        IntentProcessor(
-            sessionUseCases,
-            sessionManager,
-            searchUseCases,
-            applicationContext
-        )
+    val tabIntentProcessor by lazy {
+        TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
+    }
+    val customTabIntentProcessor by lazy {
+        CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources.displayMetrics)
     }
 
     // Menu


### PR DESCRIPTION
This PR separates the `IntentProcessor` class into different classes with a shared interface. In the future we plan to add intent processors for progressive web apps and private mode, in addition to the existing standard browsing and custom tab intent processors. 

I've kept the legacy version to preserve backwards compatibility. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
