### PR TITLE
Fixes #1884 - Move intent code to feature-customtabs

### DIFF
--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -289,7 +289,14 @@ class SessionTest {
 
         assertNull(session.customTabConfig)
 
-        val customTabConfig = CustomTabConfig("id", null, null, true, null, true, listOf(), listOf())
+        val customTabConfig = CustomTabConfig(
+            "id",
+            toolbarColor = null,
+            closeButtonIcon = null,
+            enableUrlbarHiding = true,
+            actionButtonConfig = null,
+            showShareMenuItem = true
+        )
         session.customTabConfig = customTabConfig
 
         assertEquals(customTabConfig, session.customTabConfig)

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.annotation.ColorInt
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_ACTION_BUTTON_BUNDLE
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_CLOSE_BUTTON_ICON
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_DEFAULT_SHARE_MENU_ITEM
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_ENABLE_URLBAR_HIDING
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_EXIT_ANIMATION_BUNDLE
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_MENU_ITEMS
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_SESSION
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_TINT_ACTION_BUTTON
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_TOOLBAR_COLOR
+import androidx.browser.customtabs.CustomTabsIntent.KEY_DESCRIPTION
+import androidx.browser.customtabs.CustomTabsIntent.KEY_ICON
+import androidx.browser.customtabs.CustomTabsIntent.KEY_ID
+import androidx.browser.customtabs.CustomTabsIntent.KEY_MENU_ITEM_TITLE
+import androidx.browser.customtabs.CustomTabsIntent.KEY_PENDING_INTENT
+import androidx.browser.customtabs.CustomTabsIntent.NO_TITLE
+import androidx.browser.customtabs.CustomTabsIntent.SHOW_PAGE_TITLE
+import androidx.browser.customtabs.CustomTabsIntent.TOOLBAR_ACTION_BUTTON_ID
+import mozilla.components.browser.session.tab.CustomTabActionButtonConfig
+import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.browser.session.tab.CustomTabMenuItem
+import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.utils.toSafeBundle
+import mozilla.components.support.utils.toSafeIntent
+import java.util.UUID
+import kotlin.math.max
+
+/**
+ * Checks if the provided intent is a custom tab intent.
+ *
+ * @param intent the intent to check.
+ * @return true if the intent is a custom tab intent, otherwise false.
+ */
+fun isCustomTabIntent(intent: Intent) = isCustomTabIntent(intent.toSafeIntent())
+
+/**
+ * Checks if the provided intent is a custom tab intent.
+ *
+ * @param intent the intent to check, wrapped as a SafeIntent.
+ * @return true if the intent is a custom tab intent, otherwise false.
+ */
+fun isCustomTabIntent(safeIntent: SafeIntent) = safeIntent.hasExtra(EXTRA_SESSION)
+
+/**
+ * Creates a [CustomTabConfig] instance based on the provided intent.
+ *
+ * @param intent the intent, wrapped as a SafeIntent, which is processed to extract configuration data.
+ * @param resources needed in-order to verify that icons of a max size are only provided.
+ * @return the CustomTabConfig instance.
+ */
+fun createCustomTabConfigFromIntent(
+    intent: Intent,
+    resources: Resources
+): CustomTabConfig {
+    val safeIntent = intent.toSafeIntent()
+
+    return CustomTabConfig(
+        id = UUID.randomUUID().toString(),
+        toolbarColor = safeIntent.getColorExtra(EXTRA_TOOLBAR_COLOR),
+        closeButtonIcon = getCloseButtonIcon(safeIntent, resources),
+        enableUrlbarHiding = safeIntent.getBooleanExtra(EXTRA_ENABLE_URLBAR_HIDING, false),
+        actionButtonConfig = getActionButtonConfig(safeIntent),
+        showShareMenuItem = safeIntent.getBooleanExtra(EXTRA_DEFAULT_SHARE_MENU_ITEM, false),
+        menuItems = getMenuItems(safeIntent),
+        exitAnimations = safeIntent.getBundleExtra(EXTRA_EXIT_ANIMATION_BUNDLE)?.unsafe,
+        titleVisible = safeIntent.getIntExtra(EXTRA_TITLE_VISIBILITY_STATE, NO_TITLE) == SHOW_PAGE_TITLE
+    )
+}
+
+@ColorInt
+private fun SafeIntent.getColorExtra(name: String): Int? =
+    if (hasExtra(name)) getIntExtra(name, 0) else null
+
+private fun getCloseButtonIcon(intent: SafeIntent, resources: Resources): Bitmap? {
+    val icon = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
+    val maxSize = resources.getDimension(R.dimen.mozac_feature_customtabs_max_close_button_size)
+
+    return if (icon != null && max(icon.width, icon.height) <= maxSize) {
+        icon
+    } else {
+        null
+    }
+}
+
+private fun getActionButtonConfig(intent: SafeIntent): CustomTabActionButtonConfig? {
+    val actionButtonBundle = intent.getBundleExtra(EXTRA_ACTION_BUTTON_BUNDLE) ?: return null
+    val description = actionButtonBundle.getString(KEY_DESCRIPTION)
+    val icon = actionButtonBundle.getParcelable(KEY_ICON) as? Bitmap
+    val pendingIntent = actionButtonBundle.getParcelable(KEY_PENDING_INTENT) as? PendingIntent
+    val id = actionButtonBundle.getInt(KEY_ID, TOOLBAR_ACTION_BUTTON_ID)
+    val tint = intent.getBooleanExtra(EXTRA_TINT_ACTION_BUTTON, false)
+
+    return if (description != null && icon != null && pendingIntent != null) {
+        CustomTabActionButtonConfig(
+            id = id,
+            description = description,
+            icon = icon,
+            pendingIntent = pendingIntent,
+            tint = tint
+        )
+    } else {
+        null
+    }
+}
+
+private fun getMenuItems(intent: SafeIntent): List<CustomTabMenuItem> =
+    intent.getParcelableArrayListExtra<Parcelable>(EXTRA_MENU_ITEMS).orEmpty()
+        .mapNotNull { menuItemBundle ->
+            val bundle = (menuItemBundle as? Bundle)?.toSafeBundle()
+            val name = bundle?.getString(KEY_MENU_ITEM_TITLE)
+            val pendingIntent = bundle?.getParcelable(KEY_PENDING_INTENT) as? PendingIntent
+
+            if (name != null && pendingIntent != null) {
+                CustomTabMenuItem(
+                    name = name,
+                    pendingIntent = pendingIntent
+                )
+            } else {
+                null
+            }
+        }

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
@@ -6,15 +6,15 @@ package mozilla.components.feature.customtabs
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
-import android.util.DisplayMetrics
+import android.content.res.Resources
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.intent.IntentProcessor
 import mozilla.components.browser.session.intent.putSessionId
-import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.utils.toSafeIntent
 
 /**
  * Processor for intents which trigger actions related to custom tabs.
@@ -22,12 +22,12 @@ import mozilla.components.support.utils.SafeIntent
 class CustomTabIntentProcessor(
     private val sessionManager: SessionManager,
     private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase,
-    private val displayMetrics: DisplayMetrics
+    private val resources: Resources
 ) : IntentProcessor {
 
     override fun matches(intent: Intent): Boolean {
-        val safeIntent = SafeIntent(intent)
-        return safeIntent.action == ACTION_VIEW && CustomTabConfig.isCustomTabIntent(safeIntent)
+        val safeIntent = intent.toSafeIntent()
+        return safeIntent.action == ACTION_VIEW && isCustomTabIntent(safeIntent)
     }
 
     override suspend fun process(intent: Intent): Boolean {
@@ -36,7 +36,7 @@ class CustomTabIntentProcessor(
 
         return if (!url.isNullOrEmpty() && matches(intent)) {
             val session = Session(url, private = false, source = Session.Source.CUSTOM_TAB)
-            session.customTabConfig = CustomTabConfig.createFromIntent(safeIntent, displayMetrics)
+            session.customTabConfig = createCustomTabConfigFromIntent(intent, resources)
 
             sessionManager.add(session)
             loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external())

--- a/components/feature/customtabs/src/main/res/values/dimens.xml
+++ b/components/feature/customtabs/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <dimen name="mozac_feature_customtabs_max_close_button_size">24dp</dimen>
+</resources>

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
@@ -52,7 +52,7 @@ class CustomTabIntentProcessorTest {
         val useCases = SessionUseCases(sessionManager)
 
         val handler =
-            CustomTabIntentProcessor(sessionManager, useCases.loadUrl, testContext.resources.displayMetrics)
+            CustomTabIntentProcessor(sessionManager, useCases.loadUrl, testContext.resources)
 
         val intent = mock<Intent>()
         whenever(intent.action).thenReturn(Intent.ACTION_VIEW)

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/IntentProcessor.kt
@@ -29,6 +29,7 @@ typealias IntentHandler = (Intent) -> Boolean
  *
  * @deprecated Use individual intent processors instead.
  */
+@Deprecated("Use individual processors such as TabIntentProcessor instead.")
 class IntentProcessor(
     private val sessionUseCases: SessionUseCases,
     private val sessionManager: SessionManager,
@@ -50,7 +51,7 @@ class IntentProcessor(
         val customTabIntentProcessor = CustomTabIntentProcessor(
             sessionManager,
             sessionUseCases.loadUrl,
-            context.resources.displayMetrics
+            context.resources
         )
         val viewHandlers = listOf(customTabIntentProcessor, tabIntentProcessor)
 

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/IntentProcessorTest.kt
@@ -35,6 +35,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
 
+@Suppress("Deprecation")
 @RunWith(AndroidJUnit4::class)
 class IntentProcessorTest {
 

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
@@ -57,12 +57,7 @@ class SafeIntent(val unsafe: Intent) {
     }
 
     fun getBundleExtra(name: String): SafeBundle? = safeAccess {
-        val bundle = unsafe.getBundleExtra(name)
-        if (bundle != null) {
-            SafeBundle(bundle)
-        } else {
-            null
-        }
+        unsafe.getBundleExtra(name)?.toSafeBundle()
     }
 
     fun getCharSequenceExtra(name: String): CharSequence? = safeAccess {

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/SafeBundleTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/SafeBundleTest.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.doThrow
+
+@RunWith(AndroidJUnit4::class)
+class SafeBundleTest {
+
+    private lateinit var bundle: Bundle
+
+    @Before
+    fun setup() {
+        bundle = mock()
+    }
+
+    @Test
+    fun `getInt returns default value if bundle throws OutOfMemoryError`() {
+
+        doThrow(OutOfMemoryError::class.java).`when`(bundle).getInt(anyString(), anyInt())
+
+        val expected = 1
+        assertEquals(expected, SafeBundle(bundle).getInt("", expected))
+    }
+
+    @Test
+    fun `getString returns null if bundle throws OutOfMemoryError`() {
+
+        doThrow(OutOfMemoryError::class.java).`when`(bundle).getString(anyString())
+
+        assertNull(bundle.toSafeBundle().getString(""))
+    }
+
+    @Test
+    fun `getParcelable returns null if bundle throws OutOfMemoryError`() {
+
+        doThrow(OutOfMemoryError::class.java).`when`(bundle).getParcelable<Parcelable>(anyString())
+
+        assertNull(SafeBundle(bundle).getParcelable(""))
+    }
+
+    @Test
+    fun `getUnsafe returns original bundle`() {
+
+        assertEquals(bundle, SafeBundle(bundle).unsafe)
+    }
+
+    @Test
+    fun `WHEN toSafeBundle wraps an bundle THEN it has the same unsafe bundle as the SafeBundle constructor`() {
+
+        // SafeBundle does not override .equals so we have to do comparison with their underlying unsafe bundles.
+        assertEquals(SafeBundle(bundle).unsafe, bundle.toSafeBundle().unsafe)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,8 +53,20 @@ permalink: /changelog/
 * **browser-icons**
   * Added `BrowserIcons.loadIntoView` to automatically load an icon into an `ImageView`.
 
+* **browser-session**
+  * Added `IntentProcessor` interface to represent a class that processes intents to create sessions.
+  * Deprecated `CustomTabConfig.isCustomTabIntent` and `CustomTabConfig.createFromIntent`. Use `isCustomTabIntent` and `createFromCustomTabIntent` in feature-customtabs instead.
+
+* **feature-customtabs**
+  * Added `CustomTabIntentProcessor` to create custom tab sessions from intents.
+  * Added `isCustomTabIntent` to check if an intent is for creating custom tabs.
+  * Added `createCustomTabConfigFromIntent` to create a `CustomTabConfig` from a custom tab intent.
+
 * **feature-downloads**
   * `FetchDownloadManager` now determines the filename during the download, resulting in more accurate filenames.
+
+* **feature-intent**
+  * Deprecated `IntentProcessor` class and moved some of its code to the new `TabIntentProcessor`.
 
 * **feature-push**
   * Updated the default autopush service endpoint to `updates.push.services.mozilla.com`.

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -117,7 +117,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
     }
     val customTabIntentProcessor by lazy {
-        CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources.displayMetrics)
+        CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources)
     }
 
     // Menu


### PR DESCRIPTION
- Make `CustomTabConfig`'s constructor public.
- Move the `customTabConfigFromIntent` function out of browser-session.

For PWAs, we want to manually build `CustomTabConfig` instances so PWAs can have their own custom tabs. Since the constructor is now public, I'm moving the config-from-intent function into feature-customtabs instead of browser-session. This consolidates the custom tab code into the feature rather than having parts of it across many components. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
