### PR TITLE
Closes #3619 - Absolute max size & scale decoder

### DIFF
--- a/components/browser/icons/src/androidTest/java/mozilla/components/browser/icons/decoder/OnDeviceAndroidIconDecoderTest.kt
+++ b/components/browser/icons/src/androidTest/java/mozilla/components/browser/icons/decoder/OnDeviceAndroidIconDecoderTest.kt
@@ -36,8 +36,8 @@ class OnDeviceAndroidIconDecoderTest {
         ))
 
         assertNotNull(bitmap!!)
-        assertEquals(250, bitmap.width)
-        assertEquals(250, bitmap.height)
+        assertEquals(250 / 3, bitmap.width)
+        assertEquals(250 / 3, bitmap.height)
     }
 
     @Test
@@ -51,8 +51,8 @@ class OnDeviceAndroidIconDecoderTest {
         ))
 
         assertNotNull(bitmap!!)
-        assertEquals(532, bitmap.width)
-        assertEquals(532, bitmap.height)
+        assertEquals(67, bitmap.width)
+        assertEquals(67, bitmap.height)
     }
 
     @Test
@@ -81,8 +81,8 @@ class OnDeviceAndroidIconDecoderTest {
         ))
 
         assertNotNull(bitmap!!)
-        assertEquals(192, bitmap.width)
-        assertEquals(192, bitmap.height)
+        assertEquals(192 / 3, bitmap.width)
+        assertEquals(192 / 3, bitmap.height)
     }
 
     private fun loadImage(fileName: String): ByteArray =

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/DesiredSize.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/DesiredSize.kt
@@ -4,8 +4,19 @@
 
 package mozilla.components.browser.icons
 
+import androidx.annotation.Px
+
+/**
+ * Represents the desired size of an icon loaded by [BrowserIcons].
+ *
+ * @property targetSize The size the image will be displayed at, in pixels.
+ * @property maxSize The maximum size of an image before it will be thrown out, in pixels.
+ * Extremely large images are suspicious and should be ignored.
+ * @property maxScaleFactor The factor that the image can be scaled up before being thrown out.
+ * A lower scale factor results in less pixelation.
+ */
 data class DesiredSize(
-    val targetSize: Int,
-    val maxSize: Int,
+    @Px val targetSize: Int,
+    @Px val maxSize: Int,
     val maxScaleFactor: Float
 )

--- a/components/browser/icons/src/main/res/values/dimens.xml
+++ b/components/browser/icons/src/main/res/values/dimens.xml
@@ -2,11 +2,11 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="mozac_browser_icons_size_default">32dp</dimen>
     <dimen name="mozac_browser_icons_size_launcher">48dp</dimen>
     <dimen name="mozac_browser_icons_size_launcher_adaptive">102dp</dimen>
 
-    <dimen name="mozac_browser_icons_maximum_size">64dp</dimen>
+    <dimen name="mozac_browser_icons_maximum_size" tools:ignore="PxUsage">512px</dimen>
     <dimen name="mozac_browser_icons_generator_default_corner_radius">2dp</dimen>
 </resources>

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/decoder/AndroidIconDecoderTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/decoder/AndroidIconDecoderTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.icons.decoder
 
 import android.graphics.Bitmap
+import android.util.Size
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.DesiredSize
 import mozilla.components.support.test.any
@@ -14,6 +15,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.spy
@@ -37,7 +39,7 @@ class AndroidIconDecoderTest {
     @Test
     fun `WHEN out of memory THEN returns null`() {
         val decoder = spy(AndroidIconDecoder())
-        doThrow(OutOfMemoryError()).`when`(decoder).decodeBitmap(any())
+        doThrow(OutOfMemoryError()).`when`(decoder).decodeBitmap(any(), anyInt())
 
         val bitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 64,
@@ -50,12 +52,8 @@ class AndroidIconDecoderTest {
 
     @Test
     fun `WHEN bitmap width equals zero THEN returns null`() {
-        val bitmap: Bitmap = mock()
-        `when`(bitmap.width).thenReturn(0)
-        `when`(bitmap.height).thenReturn(512)
-
         val decoder = spy(AndroidIconDecoder())
-        doReturn(bitmap).`when`(decoder).decodeBitmap(any())
+        doReturn(Size(0, 512)).`when`(decoder).decodeBitmapBounds(any())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 64,
@@ -68,12 +66,8 @@ class AndroidIconDecoderTest {
 
     @Test
     fun `WHEN bitmap height equals zero THEN returns null`() {
-        val bitmap: Bitmap = mock()
-        `when`(bitmap.width).thenReturn(512)
-        `when`(bitmap.height).thenReturn(0)
-
         val decoder = spy(AndroidIconDecoder())
-        doReturn(bitmap).`when`(decoder).decodeBitmap(any())
+        doReturn(Size(512, 0)).`when`(decoder).decodeBitmapBounds(any())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 64,
@@ -87,7 +81,7 @@ class AndroidIconDecoderTest {
     @Test
     fun `WHEN decoding null bitmap THEN returns null`() {
         val decoder = spy(AndroidIconDecoder())
-        doReturn(null).`when`(decoder).decodeBitmap(any())
+        doReturn(null).`when`(decoder).decodeBitmap(any(), anyInt())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 64,
@@ -105,7 +99,7 @@ class AndroidIconDecoderTest {
         `when`(bitmap.height).thenReturn(250)
 
         val decoder = spy(AndroidIconDecoder())
-        doReturn(bitmap).`when`(decoder).decodeBitmap(any())
+        doReturn(bitmap).`when`(decoder).decodeBitmap(any(), anyInt())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 256,
@@ -123,7 +117,7 @@ class AndroidIconDecoderTest {
         `when`(bitmap.height).thenReturn(50)
 
         val decoder = spy(AndroidIconDecoder())
-        doReturn(bitmap).`when`(decoder).decodeBitmap(any())
+        doReturn(bitmap).`when`(decoder).decodeBitmap(any(), anyInt())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 256,
@@ -141,7 +135,7 @@ class AndroidIconDecoderTest {
         `when`(bitmap.height).thenReturn(250)
 
         val decoder = spy(AndroidIconDecoder())
-        doReturn(bitmap).`when`(decoder).decodeBitmap(any())
+        doReturn(bitmap).`when`(decoder).decodeBitmap(any(), anyInt())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 256,
@@ -159,7 +153,7 @@ class AndroidIconDecoderTest {
         `when`(bitmap.height).thenReturn(2000)
 
         val decoder = spy(AndroidIconDecoder())
-        doReturn(bitmap).`when`(decoder).decodeBitmap(any())
+        doReturn(bitmap).`when`(decoder).decodeBitmap(any(), anyInt())
 
         val decodedBitmap = decoder.decode(ByteArray(0), DesiredSize(
             targetSize = 256,

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -186,7 +186,7 @@ private fun webAppIcons(
         DataUriIconLoader()
     ),
     decoders = listOf(
-        AndroidIconDecoder(ignoreSize = true),
+        AndroidIconDecoder(),
         ICOIconDecoder()
     ),
     processors = listOf(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,13 +16,14 @@ permalink: /changelog/
 
 * **browser-icons**
   * Added `BrowserIcons.loadIntoView` to automatically load an icon into an `ImageView`.
+  * Changed the maximum size for decoded icons. Icons are now scaled to the target size to save memory.
 
 * **service-glean**
   * Hyphens `-` are now allowed in labels for metrics.  See [1566764](https://bugzilla.mozilla.org/show_bug.cgi?id=1566764).
 
 * **support-ktx**
   * ⚠️ **This is a breaking behavior change**: `JSONArray.mapNotNull` is now an inline function, changing the behavior of the `return` keyword within its lambda.
-  
+
 # 4.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v4.0.0...v4.0.1)
@@ -32,7 +33,7 @@ permalink: /changelog/
 
 * **service-glean**
   * Hyphens `-` are now allowed in labels for metrics.  See [1566764](https://bugzilla.mozilla.org/show_bug.cgi?id=1566764).
-  
+
 * Imported latest state of translations.
 
 # 4.0.0


### PR DESCRIPTION
Updates `AndroidIconDecoder` so that larger icons can be loaded. 
- The maximum icon size is now defined in pixels rather than dp. The max size has been increased to 512 * 2 pixels, which covers most icons supplied by websites.
- The icon decoder now scales the image to the target size, resulting in less memory usage.

The Twitter icon now loads properly after this update.
- Also closes mozilla-mobile/fenix#4090

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
