### PR TITLE
Add a way to record metrics to Glean when Glean is not initialized

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Dispatchers.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Dispatchers.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.base.log.logger.Logger
+import java.util.concurrent.ConcurrentLinkedQueue
 
 @ObsoleteCoroutinesApi
 internal object Dispatchers {
@@ -18,24 +20,44 @@ internal object Dispatchers {
         // When true, jobs will be run synchronously
         internal var testingMode = false
 
+        // When true, jobs will be queued and not ran until triggered by calling
+        // flushQueuedInitialTasks()
+        @Volatile
+        private var queueInitialTasks = true
+
+        // Use a [ConcurrentLinkedQueue] to take advantage of it's thread safety and no locking
+        internal val taskQueue: ConcurrentLinkedQueue<() -> Unit> = ConcurrentLinkedQueue()
+
+        private val logger = Logger("glean/Dispatchers")
+
+        companion object {
+            // This value was chosen in order to allow several tasks to be queued for execution but
+            // still be conservative of memory. This queue size is important for cases where
+            // setUploadEnabled(false) is not called so that we don't continue to queue tasks and
+            // waste memory.
+            const val MAX_QUEUE_SIZE = 100
+        }
+
         /**
-         * Launch a block of work asyncronously.
+         * Launch a block of work asynchronously.
          *
-         * If [setTestingMode] has enabled testing mode, the work will run
-         * synchronously.
+         * If [queueInitialTasks] is true, then the work will be queued and executed when
+         * [flushQueuedInitialTasks] is called.
          *
-         * @return [Job], or null if run synchronously.
+         * If [setTestingMode] has enabled testing mode, the work will run synchronously.  This is
+         * true regardless of whether [queueInitialTasks] is true or not.
+         *
+         * @return [Job], or null if queued or run synchronously.
          */
         fun launch(
             block: suspend CoroutineScope.() -> Unit
         ): Job? {
-            return if (testingMode) {
-                runBlocking {
-                    block()
+            return when {
+                queueInitialTasks -> {
+                    addTaskToQueue(block)
+                    null
                 }
-                null
-            } else {
-                coroutineScope.launch(block = block)
+                else -> executeTask(block)
             }
         }
 
@@ -63,6 +85,79 @@ internal object Dispatchers {
         @VisibleForTesting(otherwise = VisibleForTesting.NONE)
         fun setTestingMode(enabled: Boolean) {
             testingMode = enabled
+        }
+
+        /**
+         * Enable queueing mode, which causes tasks to be queued until launched by calling
+         * [flushQueuedInitialTasks].
+         *
+         * @param enabled whether or not to enable the testing mode
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+        fun setTaskQueueing(enabled: Boolean) {
+            queueInitialTasks = enabled
+        }
+
+        /**
+         * Stops queueing tasks and processes any tasks in the queue. Since [queueInitialTasks] is
+         * set to false prior to processing the queue, newly launched tasks should be executed
+         * on the couroutine scope rather than added to the queue.
+         */
+        internal fun flushQueuedInitialTasks() {
+            // Setting this to false first should cause any new tasks to just be executed (see
+            // launch() above) making it safer to process the queue.
+            //
+            // NOTE: This has the potential for causing a task to execute out of order in certain
+            // situations. If a library or thread that runs before init happens to record
+            // between when the queueInitialTasks is set to false and the taskQueue finishing
+            // launching, then that task could be executed out of the queued order. See the bugzilla
+            // bug tracking this for more info: https://bugzilla.mozilla.org/show_bug.cgi?id=1568503
+            queueInitialTasks = false
+            taskQueue.forEach { task ->
+                task.invoke()
+            }
+            taskQueue.clear()
+        }
+
+        /**
+         * Helper function to add task to queue as either a synchronous or asynchronous operation,
+         * depending on whether [testingMode] is true.
+         */
+        private fun addTaskToQueue(block: suspend CoroutineScope.() -> Unit) {
+            if (taskQueue.size >= MAX_QUEUE_SIZE) {
+                logger.error("Exceeded maximum queue size, discarding task")
+                return
+            }
+
+            if (testingMode) {
+                logger.info("Task queued for execution in test mode")
+                taskQueue.add {
+                    runBlocking {
+                        block()
+                    }
+                }
+            } else {
+                logger.info("Task queued for execution and delayed until flushed")
+                taskQueue.add {
+                    coroutineScope.launch(block = block)
+                }
+            }
+        }
+
+        /**
+         * Helper function to execute the task as either an synchronous or asynchronous operation,
+         * depending on whether [testingMode] is true.
+         */
+        private fun executeTask(block: suspend CoroutineScope.() -> Unit): Job? {
+            return when {
+                testingMode -> {
+                    runBlocking {
+                        block()
+                    }
+                    null
+                }
+                else -> coroutineScope.launch(block = block)
+            }
         }
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -85,6 +85,7 @@ open class GleanInternalAPI internal constructor () {
      * as shared preferences
      * @param configuration A Glean [Configuration] object with global settings.
      */
+    @Suppress("LongMethod")
     fun initialize(
         applicationContext: Context,
         configuration: Configuration = Configuration()
@@ -133,6 +134,10 @@ open class GleanInternalAPI internal constructor () {
         if (!Dispatchers.API.testingMode) {
             metricsPingScheduler.startupCheck()
         }
+
+        // Signal Dispatcher that init is complete
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.flushQueuedInitialTasks()
 
         // At this point, all metrics and events can be recorded.
         ProcessLifecycleOwner.get().lifecycle.addObserver(gleanLifecycleObserver)

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/CommonMetricData.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/CommonMetricData.kt
@@ -39,12 +39,6 @@ interface CommonMetricData {
     val identifier: String get() = if (category.isEmpty()) { name } else { "$category.$name" }
 
     fun shouldRecord(logger: Logger): Boolean {
-        // Don't record metrics if we aren't initialized
-        if (!Glean.isInitialized()) {
-            logger.error("Glean must be initialized before metrics are recorded")
-            return false
-        }
-
         // Silently drop if metrics are turned off globally or locally
         if (!Glean.getUploadEnabled() || disabled) {
             return false

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/DispatchersTest.kt
@@ -11,17 +11,17 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 
+@Suppress("EXPERIMENTAL_API_USAGE")
 class DispatchersTest {
 
     @Test
     fun `API scope runs off the main thread`() {
         val mainThread = Thread.currentThread()
         var threadCanary = false
-        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.setTestingMode(false)
+        Dispatchers.API.setTaskQueueing(false)
 
         runBlocking {
-            @Suppress("EXPERIMENTAL_API_USAGE")
             Dispatchers.API.launch {
                 assertNotSame(mainThread, Thread.currentThread())
                 // Use the canary bool to make sure this is getting called before
@@ -31,9 +31,33 @@ class DispatchersTest {
             }!!.join()
         }
 
-        @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.setTestingMode(true)
         assertEquals(true, threadCanary)
         assertSame(mainThread, Thread.currentThread())
+    }
+
+    @Test
+    fun `launch() correctly adds tests to queue if queueTasks is true`() {
+        var threadCanary = 0
+
+        Dispatchers.API.setTestingMode(true)
+        Dispatchers.API.setTaskQueueing(true)
+
+        // Add 3 tasks to queue each one setting threadCanary to true to indicate if any task has ran
+        repeat(3) {
+            Dispatchers.API.launch {
+                threadCanary += 1
+            }
+        }
+
+        assertEquals("Task queue contains the correct number of tasks",
+            3, Dispatchers.API.taskQueue.size)
+        assertEquals("Tasks have not run while in queue", 0, threadCanary)
+
+        // Now trigger execution to ensure the tasks fired
+        Dispatchers.API.flushQueuedInitialTasks()
+
+        assertEquals("Tasks have executed", 3, threadCanary)
+        assertEquals("Task queue is cleared", 0, Dispatchers.API.taskQueue.size)
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.service.glean.GleanMetrics.GleanInternalMetrics
 import mozilla.components.service.glean.GleanMetrics.Pings
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.private.CounterMetricType
 import mozilla.components.service.glean.private.DatetimeMetricType
 import mozilla.components.service.glean.private.EventMetricType
 import mozilla.components.service.glean.private.Lifetime
@@ -206,6 +207,7 @@ class GleanTest {
             sendInPings = listOf("store1")
         )
         Glean.initialized = false
+        Dispatchers.API.testingMode = false
         stringMetric.set("foo")
         assertNull(
             "Metrics should not be recorded if Glean is not initialized",
@@ -213,6 +215,38 @@ class GleanTest {
         )
 
         Glean.initialized = true
+    }
+
+    @Test
+    fun `queued recorded metrics correctly record during init`() {
+        val counterMetric = CounterMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Application,
+            name = "counter_metric",
+            sendInPings = listOf("store1")
+        )
+
+        // First set to a pre-init state
+        Glean.initialized = false
+        Dispatchers.API.setTaskQueueing(true)
+
+        // This will queue 3 tasks that will add to the metric value once Glean is initialized
+        for (i in 0..2) {
+            counterMetric.add()
+        }
+
+        // Ensure that no value has been stored yet since the tasks have only been queued and not
+        // executed yet
+        assertFalse("No value must be stored", counterMetric.testHasValue())
+
+        // Calling resetGlean here will cause Glean to be initialized and should cause the queued
+        // tasks recording metrics to execute
+        resetGlean(clearStores = false)
+
+        // Verify that the callback was executed by testing for the correct value
+        assertTrue("Value must exist", counterMetric.testHasValue())
+        assertEquals("Value must match", 3, counterMetric.testGetValue())
     }
 
     @Test


### PR DESCRIPTION
This is what I was thinking as a possible solution to this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566917)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
