### PR TITLE
Fixes #3516 - Use response to determine file name

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -508,7 +508,7 @@ class GeckoEngineSession(
         override fun onExternalResponse(session: GeckoSession, response: GeckoSession.WebResponseInfo) {
             notifyObservers {
                 val fileName = response.filename
-                    ?: DownloadUtils.guessFileName("", response.uri, response.contentType)
+                    ?: DownloadUtils.guessFileName(null, response.uri, response.contentType)
                 onExternalResource(
                         url = response.uri,
                         contentLength = response.contentLength,

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1546,37 +1546,6 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun whenOnExternalResponseDoNotProvideAFileNameMustProvideMeaningFulFileNameToTheSessionObserver() {
-        val engineSession = GeckoEngineSession(mock())
-        var meaningFulFileName = ""
-
-        val observer = object : EngineSession.Observer {
-            override fun onExternalResource(
-                url: String,
-                fileName: String,
-                contentLength: Long?,
-                contentType: String?,
-                cookie: String?,
-                userAgent: String?
-            ) {
-                meaningFulFileName = fileName
-            }
-        }
-        engineSession.register(observer)
-
-        val info: GeckoSession.WebResponseInfo = MockWebResponseInfo(
-            uri = "http://ipv4.download.thinkbroadband.com/1MB.zip",
-            contentLength = 0,
-            contentType = "",
-            filename = null
-        )
-
-        engineSession.geckoSession.contentDelegate!!.onExternalResponse(mock(), info)
-
-        assertEquals("1MB.zip", meaningFulFileName)
-    }
-
-    @Test
     fun `Closing engine session should close underlying gecko session`() {
         val geckoSession = mockGeckoSession()
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -27,7 +27,6 @@ import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
-import mozilla.components.support.utils.DownloadUtils
 import org.json.JSONObject
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
@@ -513,13 +512,11 @@ class GeckoEngineSession(
 
         override fun onExternalResponse(session: GeckoSession, response: GeckoSession.WebResponseInfo) {
             notifyObservers {
-                val fileName = response.filename
-                    ?: DownloadUtils.guessFileName("", response.uri, response.contentType)
                 onExternalResource(
                         url = response.uri,
                         contentLength = response.contentLength,
                         contentType = response.contentType,
-                        fileName = fileName)
+                        fileName = response.filename)
             }
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1543,37 +1543,6 @@ class GeckoEngineSessionTest {
     }
 
     @Test
-    fun whenOnExternalResponseDoNotProvideAFileNameMustProvideMeaningFulFileNameToTheSessionObserver() {
-        val engineSession = GeckoEngineSession(mock())
-        var meaningFulFileName = ""
-
-        val observer = object : EngineSession.Observer {
-            override fun onExternalResource(
-                url: String,
-                fileName: String,
-                contentLength: Long?,
-                contentType: String?,
-                cookie: String?,
-                userAgent: String?
-            ) {
-                meaningFulFileName = fileName
-            }
-        }
-        engineSession.register(observer)
-
-        val info: GeckoSession.WebResponseInfo = MockWebResponseInfo(
-            uri = "http://ipv4.download.thinkbroadband.com/1MB.zip",
-            contentLength = 0,
-            contentType = "",
-            filename = null
-        )
-
-        engineSession.geckoSession.contentDelegate!!.onExternalResponse(mock(), info)
-
-        assertEquals("1MB.zip", meaningFulFileName)
-    }
-
-    @Test
     fun `Closing engine session should close underlying gecko session`() {
         val geckoSession = mockGeckoSession()
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -27,7 +27,6 @@ import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
 import mozilla.components.support.ktx.kotlin.isGeoLocation
 import mozilla.components.support.ktx.kotlin.isPhone
-import mozilla.components.support.utils.DownloadUtils
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoResult
@@ -509,13 +508,11 @@ class GeckoEngineSession(
 
         override fun onExternalResponse(session: GeckoSession, response: GeckoSession.WebResponseInfo) {
             notifyObservers {
-                val fileName = response.filename
-                    ?: DownloadUtils.guessFileName("", response.uri, response.contentType)
                 onExternalResource(
                         url = response.uri,
                         contentLength = response.contentLength,
                         contentType = response.contentType,
-                        fileName = fileName)
+                        fileName = response.filename)
             }
         }
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -234,8 +234,8 @@ class GeckoEngineSessionTest {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
 
-        var observedContentPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
-        var observedAppPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
+        val observedContentPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
+        val observedAppPermissionRequests: MutableList<PermissionRequest> = mutableListOf()
         engineSession.register(object : EngineSession.Observer {
             override fun onContentPermissionRequest(permissionRequest: PermissionRequest) {
                 observedContentPermissionRequests.add(permissionRequest)
@@ -1516,37 +1516,6 @@ class GeckoEngineSessionTest {
 
         assertFalse(oldGeckoSession.isOpen)
         assertTrue(engineSession.geckoSession != oldGeckoSession)
-    }
-
-    @Test
-    fun whenOnExternalResponseDoNotProvideAFileNameMustProvideMeaningFulFileNameToTheSessionObserver() {
-        val engineSession = GeckoEngineSession(mock())
-        var meaningFulFileName = ""
-
-        val observer = object : EngineSession.Observer {
-            override fun onExternalResource(
-                url: String,
-                fileName: String,
-                contentLength: Long?,
-                contentType: String?,
-                cookie: String?,
-                userAgent: String?
-            ) {
-                meaningFulFileName = fileName
-            }
-        }
-        engineSession.register(observer)
-
-        val info: GeckoSession.WebResponseInfo = MockWebResponseInfo(
-            uri = "http://ipv4.download.thinkbroadband.com/1MB.zip",
-            contentLength = 0,
-            contentType = "",
-            filename = null
-        )
-
-        engineSession.geckoSession.contentDelegate!!.onExternalResponse(mock(), info)
-
-        assertEquals("1MB.zip", meaningFulFileName)
     }
 
     @Test

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -438,7 +438,7 @@ class SystemEngineViewTest {
         engineSession.register(object : EngineSession.Observer {
             override fun onExternalResource(
                 url: String,
-                fileName: String,
+                fileName: String?,
                 contentLength: Long?,
                 contentType: String?,
                 cookie: String?,

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Download.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Download.kt
@@ -19,7 +19,7 @@ import android.os.Environment
  */
 data class Download(
     val url: String,
-    val fileName: String,
+    val fileName: String? = null,
     val contentType: String? = null,
     val contentLength: Long? = null,
     val userAgent: String? = null,

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -111,7 +111,7 @@ internal class EngineObserver(
 
     override fun onExternalResource(
         url: String,
-        fileName: String,
+        fileName: String?,
         contentLength: Long?,
         contentType: String?,
         cookie: String?,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -17,7 +17,6 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
-import java.lang.UnsupportedOperationException
 
 /**
  * Class representing a single engine session.
@@ -71,7 +70,7 @@ abstract class EngineSession(
         @Suppress("LongParameterList")
         fun onExternalResource(
             url: String,
-            fileName: String,
+            fileName: String? = null,
             contentLength: Long? = null,
             contentType: String? = null,
             cookie: String? = null,

--- a/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
+++ b/components/concept/fetch/src/main/java/mozilla/components/concept/fetch/Headers.kt
@@ -159,3 +159,5 @@ class MutableHeaders(headers: List<Header>) : Headers, MutableIterable<Header> {
 
     override fun hashCode() = headers.hashCode()
 }
+
+fun List<Header>.toMutableHeaders() = MutableHeaders(this)

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -15,7 +15,6 @@ import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.base.observer.Consumable
-import mozilla.components.support.utils.DownloadUtils
 
 /**
  * A candidate for an item to be displayed in the context menu.
@@ -149,9 +148,7 @@ data class ContextMenuCandidate(
             label = context.getString(R.string.mozac_feature_contextmenu_save_image),
             showFor = { _, hitResult -> hitResult.isImage() },
             action = { session, hitResult ->
-                session.download = Consumable.from(Download(
-                    hitResult.src,
-                    DownloadUtils.guessFileName(null, hitResult.src, null)))
+                session.download = Consumable.from(Download(hitResult.src))
             }
         )
 

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadDialogFragment.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadDialogFragment.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.downloads
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import mozilla.components.browser.session.Download
+import mozilla.components.support.utils.DownloadUtils
 
 /**
  * This is a general representation of a dialog meant to be used in collaboration with [DownloadsFeature]
@@ -28,7 +29,8 @@ abstract class DownloadDialogFragment : DialogFragment() {
      */
     fun setDownload(download: Download) {
         val args = arguments ?: Bundle()
-        args.putString(KEY_FILE_NAME, download.fileName)
+        args.putString(KEY_FILE_NAME, download.fileName
+            ?: DownloadUtils.guessFileName(null, download.url, download.contentType))
         args.putString(KEY_URL, download.url)
         args.putLong(KEY_CONTENT_LENGTH, download.contentLength ?: 0)
         arguments = args

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/Download.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/Download.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads.ext
+
+import androidx.core.net.toUri
+import mozilla.components.browser.session.Download
+import mozilla.components.concept.fetch.Headers
+import mozilla.components.concept.fetch.Headers.Names.CONTENT_DISPOSITION
+import mozilla.components.concept.fetch.Headers.Names.CONTENT_LENGTH
+import mozilla.components.concept.fetch.Headers.Names.CONTENT_TYPE
+import mozilla.components.support.utils.DownloadUtils
+import java.io.InputStream
+import java.net.URLConnection
+
+fun Download.isScheme(protocols: Iterable<String>): Boolean {
+    val scheme = url.trim().toUri().scheme ?: return false
+    return protocols.contains(scheme)
+}
+
+/**
+ * Returns a copy of the download with some fields filled in based on values from a response.
+ *
+ * @param headers Headers from the response.
+ * @param stream Stream of the response body.
+ */
+fun Download.withResponse(headers: Headers, stream: InputStream?): Download {
+    val contentDisposition = headers[CONTENT_DISPOSITION]
+    var contentType = this.contentType
+    if (contentType == null && stream != null) {
+        contentType = URLConnection.guessContentTypeFromStream(stream)
+    }
+    if (contentType == null) {
+        contentType = headers[CONTENT_TYPE]
+    }
+
+    return copy(
+        fileName = if (fileName.isNullOrBlank()) {
+            DownloadUtils.guessFileName(contentDisposition, url, contentType)
+        } else {
+            fileName
+        },
+        contentType = contentType,
+        contentLength = contentLength ?: headers[CONTENT_LENGTH]?.toLongOrNull()
+    )
+}

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/Intent.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/Intent.kt
@@ -36,7 +36,7 @@ fun Intent.getDownloadExtra(): Download? =
         val url = getString(INTENT_URL)
         val fileName = getString(INTENT_FILE_NAME)
         val destination = getString(INTENT_DESTINATION)
-        if (url == null || fileName == null || destination == null) return null
+        if (url == null || destination == null) return null
 
         Download(
             url = url,

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/AndroidDownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/AndroidDownloadManager.kt
@@ -23,6 +23,8 @@ import mozilla.components.browser.session.Download
 import mozilla.components.concept.fetch.Headers.Names.COOKIE
 import mozilla.components.concept.fetch.Headers.Names.REFERRER
 import mozilla.components.concept.fetch.Headers.Names.USER_AGENT
+import mozilla.components.feature.downloads.ext.isScheme
+import mozilla.components.support.utils.DownloadUtils
 
 typealias SystemDownloadManager = android.app.DownloadManager
 typealias SystemRequest = android.app.DownloadManager.Request
@@ -124,7 +126,12 @@ private fun Download.toAndroidRequest(cookie: String): SystemRequest {
         addRequestHeaderSafely(REFERRER, referrerUrl)
     }
 
-    request.setDestinationInExternalPublicDir(destinationDirectory, getFileName())
+    val fileName = if (fileName.isNullOrBlank()) {
+        DownloadUtils.guessFileName(null, url, contentType)
+    } else {
+        fileName
+    }
+    request.setDestinationInExternalPublicDir(destinationDirectory, fileName)
 
     return request
 }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/DownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/DownloadManager.kt
@@ -5,10 +5,8 @@
 package mozilla.components.feature.downloads.manager
 
 import android.content.Context
-import androidx.core.net.toUri
 import mozilla.components.browser.session.Download
 import mozilla.components.support.ktx.android.content.isPermissionGranted
-import mozilla.components.support.utils.DownloadUtils
 
 typealias OnDownloadCompleted = (Download, Long) -> Unit
 
@@ -37,17 +35,5 @@ fun DownloadManager.validatePermissionGranted(context: Context) {
         throw SecurityException("You must be granted ${permissions.joinToString()}")
     }
 }
-
-fun Download.isScheme(protocols: Iterable<String>): Boolean {
-    val scheme = url.trim().toUri().scheme ?: return false
-    return protocols.contains(scheme)
-}
-
-fun Download.getFileName(contentDisposition: String? = null) =
-    if (fileName.isNotBlank()) {
-        fileName
-    } else {
-        DownloadUtils.guessFileName(contentDisposition, url, contentType)
-    }
 
 internal val noop: OnDownloadCompleted = { _, _ -> }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
@@ -21,6 +21,7 @@ import androidx.core.util.set
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import mozilla.components.browser.session.Download
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
+import mozilla.components.feature.downloads.ext.isScheme
 import mozilla.components.feature.downloads.ext.putDownloadExtra
 import kotlin.random.Random
 import kotlin.reflect.KClass

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -53,7 +53,7 @@ class AbstractFetchDownloadServiceTest {
             Response.Body(mock())
         )
         doReturn(response).`when`(client).fetch(Request("https://example.com/file.txt"))
-        doNothing().`when`(service).useFileStream(eq(download), eq(response), eq("file.txt"), any())
+        doNothing().`when`(service).useFileStream(eq(download), any())
 
         val downloadIntent = Intent("ACTION_DOWNLOAD").apply {
             putExtra(EXTRA_DOWNLOAD_ID, 1L)
@@ -62,7 +62,7 @@ class AbstractFetchDownloadServiceTest {
 
         service.onStartCommand(downloadIntent, 0)
 
-        verify(service).useFileStream(eq(download), eq(response), eq("file.txt"), any())
+        verify(service).useFileStream(eq(download), any())
         verify(broadcastManager).sendBroadcast(any())
         Unit
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@ permalink: /changelog/
 * **browser-icons**
   * Added `BrowserIcons.loadIntoView` to automatically load an icon into an `ImageView`.
 
+* **feature-downloads**
+  * `FetchDownloadManager` now determines the filename during the download, resulting in more accurate filenames.
+
 * **feature-push**
   * Updated the default autopush service endpoint to `updates.push.services.mozilla.com`.
 


### PR DESCRIPTION
Changes `Download` so that the filename is determined when the download begins rather than when the request is made. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
