### PR TITLE
Introduce an `HistogramBase` interface in the GleanSDK

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/error/ErrorRecording.kt
@@ -41,12 +41,15 @@ object ErrorRecording {
      *     ping.  It does not need to include the metric name, as that is automatically
      *     prepended to the message.
      * @param logger The [Logger] instance to display the warning.
+     * @param numErrors The optional number of errors to report for this [ErrorType].
      */
+    @Suppress("LongMethod")
     internal fun recordError(
         metricData: CommonMetricData,
         errorType: ErrorType,
         message: String,
-        logger: Logger
+        logger: Logger,
+        numErrors: Int? = null
     ) {
         val errorName = GLEAN_ERROR_NAMES[errorType]!!
 
@@ -82,7 +85,7 @@ object ErrorRecording {
         // in the __other__ category.
         CountersStorageEngine.record(
             errorMetric,
-            amount = 1
+            amount = numErrors ?: 1
         )
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/HistogramBase.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/HistogramBase.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.private
+
+/**
+ * A common interface to be implemented by all the histogram-like metric types
+ * supported by the Glean SDK.
+ */
+interface HistogramBase {
+    /**
+     * Accumulates the provided samples in the metric.
+     *
+     * Please note that this assumes that the provided samples are already in the
+     * "unit" declared by the instance of the implementing metric type (e.g. if the
+     * implementing class is a [TimingDistributionMetricType] and the instance this
+     * method was called on is using [TimeUnit.Second], then `samples` are assumed
+     * to be in that unit).
+     *
+     * @param samples the [LongArray] holding the samples to be recorded by the metric.
+     */
+    fun accumulateSamples(samples: LongArray)
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
@@ -25,7 +25,7 @@ data class TimingDistributionMetricType(
     override val name: String,
     override val sendInPings: List<String>,
     val timeUnit: TimeUnit
-) : CommonMetricData {
+) : CommonMetricData, HistogramBase {
 
     private val logger = Logger("glean/TimingDistributionMetricType")
 
@@ -83,6 +83,21 @@ data class TimingDistributionMetricType(
         }
 
         TimingManager.cancel(this, timerId)
+    }
+
+    override fun accumulateSamples(samples: LongArray) {
+        if (!shouldRecord(logger)) {
+            return
+        }
+
+        @Suppress("EXPERIMENTAL_API_USAGE")
+        Dispatchers.API.launch {
+            TimingDistributionsStorageEngine.accumulateSamples(
+                metricData = this@TimingDistributionMetricType,
+                samples = samples,
+                timeUnit = timeUnit
+            )
+        }
     }
 
     /**

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
@@ -35,6 +35,11 @@ class ErrorRecordingTest {
             sendInPings = listOf("store1", "store2")
         )
 
+        val expectedErrors = mapOf(
+            ErrorRecording.ErrorType.InvalidValue to 1,
+            ErrorRecording.ErrorType.InvalidLabel to 2
+        )
+
         ErrorRecording.recordError(
             stringMetric,
             ErrorRecording.ErrorType.InvalidValue,
@@ -46,16 +51,14 @@ class ErrorRecordingTest {
             stringMetric,
             ErrorRecording.ErrorType.InvalidLabel,
             "Invalid label",
-            logger
+            logger,
+            numErrors = expectedErrors[ErrorRecording.ErrorType.InvalidLabel]
         )
 
         for (storeName in listOf("store1", "store2", "metrics")) {
-            for (errorType in listOf(
-                ErrorRecording.ErrorType.InvalidValue,
-                ErrorRecording.ErrorType.InvalidLabel
-            )) {
+            for (errorType in expectedErrors.keys) {
                 assertEquals(
-                    1,
+                    expectedErrors[errorType],
                     ErrorRecording.testGetNumRecordedErrors(stringMetric, errorType, storeName)
                 )
             }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -148,4 +148,33 @@ class TimingDistributionMetricTypeTest {
         // Check that the 3L fell into the third bucket
         assertEquals(1L, snapshot2.values[3])
     }
+
+    @Test
+    fun `The accumulateSamples API correctly stores timing values`() {
+        // Define a timing distribution metric which will be stored in multiple stores
+        val metric = TimingDistributionMetricType(
+            disabled = false,
+            category = "telemetry",
+            lifetime = Lifetime.Ping,
+            name = "timing_distribution_samples",
+            sendInPings = listOf("store1"),
+            timeUnit = TimeUnit.Second
+        )
+
+        // Accumulate a few values
+        val testSamples = (1L..3L).toList().toLongArray()
+        metric.accumulateSamples(testSamples)
+
+        // Check that data was properly recorded in the second ping.
+        assertTrue(metric.testHasValue("store1"))
+        val snapshot = metric.testGetValue("store1")
+        // Check the sum
+        assertEquals(6L, snapshot.sum)
+        // Check that the 1L fell into the first bucket
+        assertEquals(1L, snapshot.values[1])
+        // Check that the 2L fell into the second bucket
+        assertEquals(1L, snapshot.values[2])
+        // Check that the 3L fell into the third bucket
+        assertEquals(1L, snapshot.values[3])
+    }
 }


### PR DESCRIPTION
The context for this is bug 1566368: this is needed in order for the glean parsers to generate an API to route batched streaming telemetry calls to the Glean SDK. It additionally:

* Changes the error reporting mechanism to allow for reporting more than 1 error of the same type.
* Adds support for accumulating multiple samples in `TimingDistributionStorageEngine`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
