### PR TITLE
fixes #2760  - Custom Tabs: Title doesn't fade to the end like the title 

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -388,6 +388,8 @@ class BrowserToolbar @JvmOverloads constructor(
                 )
                 displayToolbar.urlView.setFadingEdgeLength(fadingEdgeLength)
                 displayToolbar.urlView.isHorizontalFadingEdgeEnabled = fadingEdgeLength > 0
+                displayToolbar.titleView.setFadingEdgeLength(fadingEdgeLength)
+                displayToolbar.titleView.isHorizontalFadingEdgeEnabled = fadingEdgeLength > 0
             }
             recycle()
         }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.toolbar.display
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.text.TextUtils
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -90,7 +89,6 @@ internal class DisplayToolbar(
         gravity = Gravity.CENTER_VERTICAL
         textSize = URL_TEXT_SIZE_SP
         visibility = View.GONE
-        ellipsize = TextUtils.TruncateAt.END
 
         setSingleLine(true)
     }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -49,7 +49,6 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.Robolectric
 import org.robolectric.Robolectric.buildAttributeSet
 import org.robolectric.Shadows
-import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
 class BrowserToolbarTest {
@@ -807,16 +806,18 @@ class BrowserToolbarTest {
     fun `titleView fading is set properly with null attrs`() {
         val toolbar = BrowserToolbar(testContext)
         val titleView = toolbar.displayToolbar.titleView
-        val edgeLength = Random.nextInt(1, 24)
+        val edgeLengthArray = arrayOf(1, 12, 24)
 
         assertFalse(titleView.isHorizontalFadingEdgeEnabled)
         assertEquals(0, titleView.horizontalFadingEdgeLength)
 
-        titleView.setFadingEdgeLength(edgeLength)
-        titleView.isHorizontalFadingEdgeEnabled = edgeLength > 0
+        for (edgeLength in edgeLengthArray) {
+            titleView.setFadingEdgeLength(edgeLength)
+            titleView.isHorizontalFadingEdgeEnabled = edgeLength > 0
 
-        assertTrue(titleView.isHorizontalFadingEdgeEnabled)
-        assertEquals(edgeLength, titleView.horizontalFadingEdgeLength)
+            assertTrue(titleView.isHorizontalFadingEdgeEnabled)
+            assertEquals(edgeLength, titleView.horizontalFadingEdgeLength)
+        }
     }
 
     @Test
@@ -835,16 +836,18 @@ class BrowserToolbarTest {
     fun `urlView fading is set properly with null attrs`() {
         val toolbar = BrowserToolbar(testContext)
         val urlView = toolbar.displayToolbar.urlView
-        val edgeLength = Random.nextInt(1, 24)
+        val edgeLengthArray = arrayOf(1, 12, 24)
 
         assertFalse(urlView.isHorizontalFadingEdgeEnabled)
         assertEquals(0, urlView.horizontalFadingEdgeLength)
 
-        urlView.setFadingEdgeLength(edgeLength)
-        urlView.isHorizontalFadingEdgeEnabled = edgeLength > 0
+        for (edgeLength in edgeLengthArray) {
+            urlView.setFadingEdgeLength(edgeLength)
+            urlView.isHorizontalFadingEdgeEnabled = edgeLength > 0
 
-        assertTrue(urlView.isHorizontalFadingEdgeEnabled)
-        assertEquals(edgeLength, urlView.horizontalFadingEdgeLength)
+            assertTrue(urlView.isHorizontalFadingEdgeEnabled)
+            assertEquals(edgeLength, urlView.horizontalFadingEdgeLength)
+        }
     }
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.util.AttributeSet
 import android.view.View
 import android.view.ViewParent
 import android.view.accessibility.AccessibilityEvent
@@ -45,8 +46,10 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
+import org.robolectric.Robolectric
 import org.robolectric.Robolectric.buildAttributeSet
 import org.robolectric.Shadows
+import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
 class BrowserToolbarTest {
@@ -798,6 +801,62 @@ class BrowserToolbarTest {
 
         toolbar.title = "Mozilla"
         assertEquals(toolbar.displayToolbar.titleView.text, "Mozilla")
+    }
+
+    @Test
+    fun `titleView fading is set properly with null attrs`() {
+        val toolbar = BrowserToolbar(testContext)
+        val titleView = toolbar.displayToolbar.titleView
+        val edgeLength = Random.nextInt(1, 24)
+
+        assertFalse(titleView.isHorizontalFadingEdgeEnabled)
+        assertEquals(0, titleView.horizontalFadingEdgeLength)
+
+        titleView.setFadingEdgeLength(edgeLength)
+        titleView.isHorizontalFadingEdgeEnabled = edgeLength > 0
+
+        assertTrue(titleView.isHorizontalFadingEdgeEnabled)
+        assertEquals(edgeLength, titleView.horizontalFadingEdgeLength)
+    }
+
+    @Test
+    fun `titleView fading is set properly with non-null attrs`() {
+        val attributeSet: AttributeSet = Robolectric.buildAttributeSet().build()
+
+        val toolbar = BrowserToolbar(testContext, attributeSet)
+        val titleView = toolbar.displayToolbar.titleView
+        val edgeLength = testContext.resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_fading_edge_size)
+
+        assertTrue(titleView.isHorizontalFadingEdgeEnabled)
+        assertEquals(edgeLength, titleView.horizontalFadingEdgeLength)
+    }
+
+    @Test
+    fun `urlView fading is set properly with null attrs`() {
+        val toolbar = BrowserToolbar(testContext)
+        val urlView = toolbar.displayToolbar.urlView
+        val edgeLength = Random.nextInt(1, 24)
+
+        assertFalse(urlView.isHorizontalFadingEdgeEnabled)
+        assertEquals(0, urlView.horizontalFadingEdgeLength)
+
+        urlView.setFadingEdgeLength(edgeLength)
+        urlView.isHorizontalFadingEdgeEnabled = edgeLength > 0
+
+        assertTrue(urlView.isHorizontalFadingEdgeEnabled)
+        assertEquals(edgeLength, urlView.horizontalFadingEdgeLength)
+    }
+
+    @Test
+    fun `urlView fading is set properly with non-null attrs`() {
+        val attributeSet: AttributeSet = Robolectric.buildAttributeSet().build()
+
+        val toolbar = BrowserToolbar(testContext, attributeSet)
+        val urlView = toolbar.displayToolbar.urlView
+        val edgeLength = testContext.resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_fading_edge_size)
+
+        assertTrue(urlView.isHorizontalFadingEdgeEnabled)
+        assertEquals(edgeLength, urlView.horizontalFadingEdgeLength)
     }
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -674,6 +674,15 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `titleView in displayToolbar is not ellipsized`() {
+        val toolbar = mock(BrowserToolbar::class.java)
+        val displayToolbar = DisplayToolbar(testContext, toolbar)
+        val titleView = displayToolbar.titleView
+
+        assertNull(titleView.ellipsize)
+    }
+
+    @Test
     fun `urlView is properly laid out when a title is shown`() {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(testContext, toolbar)


### PR DESCRIPTION
removed ellipsize from titleView.
added fading for titleView (same as urlView)
also added test for DisplayToolBar and BrowserToolbar

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
