### PR TITLE
Closes #3871: Autocomplete incorrectly fills urls that contains a port number.

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/DomainMatcher.kt
@@ -69,7 +69,7 @@ private fun matchSegment(query: String, rawUrl: String): String? {
     val url = Uri.parse(rawUrl)
     return url.host?.let { host ->
         if (host.startsWith(query)) {
-            host + url.path + url.port.orEmpty()
+            host + url.port.orEmpty() + url.path
         } else {
             val strippedHost = host.noCommonSubdomains()
             if (strippedHost != url.host) {

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DomainMatcherTest.kt
@@ -23,7 +23,7 @@ class DomainMatcherTest {
                 "https://en.Wikipedia.org/Wiki/Mozilla",
                 "http://192.168.254.254:8000", "http://192.168.254.254:8000/admin",
                 "http://иННая.локаль", // TODO add more test data for non-english locales
-                "about:config", "about:crashes"
+                "about:config", "about:crashes", "http://localhost:8080/index.html"
         )
         // Full url matching.
         assertEquals(
@@ -69,6 +69,11 @@ class DomainMatcherTest {
         assertEquals(
                 DomainMatch("http://192.168.254.254:8000/admin", "192.168.254.254:8000/admin"),
                 segmentAwareDomainMatch("192.168.254.254:8000/a", urls)
+        )
+
+        assertEquals(
+                DomainMatch("http://localhost:8080/index.html", "localhost:8080/index.html"),
+                segmentAwareDomainMatch("localhost", urls)
         )
 
         // About urls.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-utils**
+  * Fixed [#3871](https://github.com/mozilla-mobile/android-components/issues/3871) autocomplete incorrectly fills urls that contains a port number.
+
 * **feature-readerview**
   * Fixed [#3864](https://github.com/mozilla-mobile/android-components/issues/3864) now minus and plus buttons have the same size on reader view.
 


### PR DESCRIPTION
changed '/' position , after port number, in order to correctly show suggestions for addresses containing port numbers

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ]x **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
