### PR TITLE
lib-state: Pause/Resume, Channel, consume helpers

### DIFF
--- a/components/lib/state/build.gradle
+++ b/components/lib/state/build.gradle
@@ -27,10 +27,12 @@ android {
 dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
-
     implementation Dependencies.androidx_lifecycle_extensions
 
+    implementation project(':support-ktx')
+
     testImplementation project(':support-test')
+
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric

--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
@@ -34,10 +34,6 @@ fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) 
     val channel = store.broadcastChannel(owner = this)
 
     scope.launch {
-        try {
-            channel.consumeEach { state -> block(state) }
-        } finally {
-            channel.close()
-        }
+        channel.consumeEach { state -> block(state) }
     }
 }

--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.state.ext
+
+import android.view.View
+import androidx.annotation.MainThread
+import androidx.fragment.app.Fragment
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
+import mozilla.components.lib.state.Action
+import mozilla.components.lib.state.State
+import mozilla.components.lib.state.Store
+import mozilla.components.support.ktx.android.view.toScope
+
+/**
+ * Helper extension method for consuming [State] from a [Store] sequentially in order inside a
+ * [Fragment]. The [block] function will get invoked for every [State] update.
+ *
+ * This helper will automatically stop observing the [Store] once the [View] of the [Fragment] gets
+ * detached. The fragment's lifecycle will be used to determine when to resume/pause observing the
+ * [Store].
+ */
+@MainThread
+@ExperimentalCoroutinesApi // Channel
+@ObsoleteCoroutinesApi // consumeEach
+fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) -> Unit) {
+    val view = checkNotNull(view) { "Fragment has no view yet. Call from onViewCreated()." }
+
+    val scope = view.toScope()
+    val channel = store.broadcastChannel(owner = this)
+
+    scope.launch {
+        try {
+            channel.consumeEach { state -> block(state) }
+        } finally {
+            channel.close()
+        }
+    }
+}

--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/View.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/View.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.state.ext
+
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
+import mozilla.components.lib.state.Action
+import mozilla.components.lib.state.State
+import mozilla.components.lib.state.Store
+import mozilla.components.support.ktx.android.view.toScope
+
+/**
+ * Helper extension method for consuming [State] from a [Store] sequentially in order scoped to the
+ * lifetime of the [View]. The [block] function will get invoked for every [State] update.
+ *
+ * This helper will automatically stop observing the [Store] once the [View] gets detached. The
+ * provided [LifecycleOwner] is used to determine when observing should be stopped or resumed.
+ *
+ * Inside a [Fragment] prefer to use [Fragment.consumeFrom].
+ */
+@ExperimentalCoroutinesApi // Channel
+@ObsoleteCoroutinesApi // consumeEach
+fun <S : State, A : Action> View.consumeFrom(
+    store: Store<S, A>,
+    owner: LifecycleOwner,
+    block: (S) -> Unit
+) {
+    val scope = toScope()
+    val channel = store.broadcastChannel(owner)
+
+    scope.launch {
+        try {
+            channel.consumeEach { state -> block(state) }
+        } finally {
+            channel.close()
+        }
+    }
+}

--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/View.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/View.kt
@@ -36,10 +36,6 @@ fun <S : State, A : Action> View.consumeFrom(
     val channel = store.broadcastChannel(owner)
 
     scope.launch {
-        try {
-            channel.consumeEach { state -> block(state) }
-        } finally {
-            channel.close()
-        }
+        channel.consumeEach { state -> block(state) }
     }
 }

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/StoreTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/StoreTest.kt
@@ -37,7 +37,9 @@ class StoreTest {
 
         var observedValue = 0
 
-        store.observeManually { state -> observedValue = state.counter }
+        store.observeManually { state -> observedValue = state.counter }.also {
+            it.resume()
+        }
 
         store.dispatch(TestAction.IncrementAction).joinBlocking()
 
@@ -53,7 +55,9 @@ class StoreTest {
 
         var observedValue = 0
 
-        store.observeManually { state -> observedValue = state.counter }
+        store.observeManually { state -> observedValue = state.counter }.also {
+            it.resume()
+        }
 
         assertEquals(23, observedValue)
     }
@@ -67,7 +71,9 @@ class StoreTest {
 
         var stateChangeObserved = false
 
-        store.observeManually { stateChangeObserved = true }
+        store.observeManually { stateChangeObserved = true }.also {
+            it.resume()
+        }
 
         // Initial state observed
         assertTrue(stateChangeObserved)
@@ -89,6 +95,8 @@ class StoreTest {
 
         val subscription = store.observeManually { state ->
             observedValue = state.counter
+        }.also {
+            it.resume()
         }
 
         store.dispatch(TestAction.IncrementAction).joinBlocking()

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/FragmentKtTest.kt
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.state.ext
+
+import android.app.Activity
+import android.view.View
+import android.view.WindowManager
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import mozilla.components.lib.state.Store
+import mozilla.components.lib.state.TestAction
+import mozilla.components.lib.state.TestState
+import mozilla.components.lib.state.reducer
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.robolectric.Robolectric
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class FragmentKtTest {
+    @Before
+    @ExperimentalCoroutinesApi
+    fun setUp() {
+        // We create a separate thread for the main dispatcher so that we do not deadlock our test
+        // thread.
+        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    }
+
+    @After
+    @ExperimentalCoroutinesApi
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    @Synchronized
+    @ExperimentalCoroutinesApi // consumeFrom
+    @ObsoleteCoroutinesApi // consumeFrom
+    fun `consumeFrom reads states from store`() {
+        val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
+
+        val store = Store(
+            TestState(counter = 23),
+            ::reducer
+        )
+
+        val fragment: Fragment = mock()
+
+        val view = View(testContext)
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        activity.windowManager.addView(view, WindowManager.LayoutParams(100, 100))
+        assertTrue(view.isAttachedToWindow)
+        doReturn(view).`when`(fragment).view
+        doReturn(owner.lifecycle).`when`(fragment).lifecycle
+
+        var receivedValue = 0
+        var latch = CountDownLatch(1)
+
+        fragment.consumeFrom(store) { state ->
+            receivedValue = state.counter
+            latch.countDown()
+        }
+
+        // Nothing received yet.
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Updating state: Nothing received yet.
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Switching to STARTED state: Receiving initial state
+        owner.lifecycleRegistry.markState(Lifecycle.State.STARTED)
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(24, receivedValue)
+        latch = CountDownLatch(1)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(25, receivedValue)
+        latch = CountDownLatch(1)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+        latch = CountDownLatch(1)
+
+        // View gets detached
+        activity.windowManager.removeView(view)
+        assertFalse(view.isAttachedToWindow)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+    }
+}

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
@@ -280,7 +280,7 @@ class StoreExtensionsKtTest {
     }
 }
 
-private class MockedLifecycleOwner(initialState: Lifecycle.State) : LifecycleOwner {
+internal class MockedLifecycleOwner(initialState: Lifecycle.State) : LifecycleOwner {
     val lifecycleRegistry = LifecycleRegistry(this).apply {
         markState(initialState)
     }

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/ViewKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/ViewKtTest.kt
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.state.ext
+
+import android.app.Activity
+import android.view.View
+import android.view.WindowManager
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import mozilla.components.lib.state.Store
+import mozilla.components.lib.state.TestAction
+import mozilla.components.lib.state.TestState
+import mozilla.components.lib.state.reducer
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class ViewKtTest {
+    @Before
+    @ExperimentalCoroutinesApi
+    fun setUp() {
+        // We create a separate thread for the main dispatcher so that we do not deadlock our test
+        // thread.
+        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    }
+
+    @After
+    @ExperimentalCoroutinesApi
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    @Synchronized
+    @ExperimentalCoroutinesApi // consumeFrom
+    @ObsoleteCoroutinesApi // consumeFrom
+    fun `consumeFrom reads states from store`() {
+        val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
+
+        val store = Store(
+            TestState(counter = 23),
+            ::reducer
+        )
+
+        val view = View(testContext)
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        activity.windowManager.addView(view, WindowManager.LayoutParams(100, 100))
+        assertTrue(view.isAttachedToWindow)
+
+        var receivedValue = 0
+        var latch = CountDownLatch(1)
+
+        view.consumeFrom(store, owner) { state ->
+            receivedValue = state.counter
+            latch.countDown()
+        }
+
+        // Nothing received yet.
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Updating state: Nothing received yet.
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Switching to STARTED state: Receiving initial state
+        owner.lifecycleRegistry.markState(Lifecycle.State.STARTED)
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(24, receivedValue)
+        latch = CountDownLatch(1)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(25, receivedValue)
+        latch = CountDownLatch(1)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+        latch = CountDownLatch(1)
+
+        // View gets detached
+        activity.windowManager.removeView(view)
+        assertFalse(view.isAttachedToWindow)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+    }
+}

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/helpers/HelpersKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/helpers/HelpersKtTest.kt
@@ -24,13 +24,15 @@ class HelpersKtTest {
         var callbackExecuted = false
         var callbackValue = false
 
-        store.observeManually(onlyIfChanged<TestState, Boolean>(
+        store.observeManually(observer = onlyIfChanged<TestState, Boolean>(
             map = { state -> state.counter % 2 == 0 },
             then = { _, _isEven ->
                 callbackExecuted = true
                 callbackValue = _isEven
             }
-        ))
+        )).also {
+            it.resume()
+        }
 
         // Initial notify
         assertTrue(callbackExecuted)
@@ -63,12 +65,14 @@ class HelpersKtTest {
 
         var callbackExecuted = false
 
-        store.observeManually(onlyIfChanged<TestState, TestState>(
+        store.observeManually(observer = onlyIfChanged<TestState, TestState>(
             map = { state -> if (state.counter % 2 == 0) null else state },
             then = { _, _ ->
                 callbackExecuted = true
             }
-        ))
+        )).also {
+            it.resume()
+        }
 
         assertTrue(callbackExecuted)
 

--- a/components/support/ktx/build.gradle
+++ b/components/support/ktx/build.gradle
@@ -25,6 +25,7 @@ android {
 
 dependencies {
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
     implementation Dependencies.androidx_core
     implementation Dependencies.androidx_core_ktx
 
@@ -32,6 +33,8 @@ dependencies {
     implementation project(':support-utils')
 
     testImplementation project(':support-test')
+
+    testImplementation Dependencies.kotlin_coroutines_test
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -11,10 +11,16 @@ import android.os.Looper
 import android.view.View
 import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
+import androidx.annotation.MainThread
 import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
+import androidx.fragment.app.Fragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.ktx.android.util.dpToPx
+import java.lang.IllegalStateException
 import java.lang.ref.WeakReference
 
 /**
@@ -98,6 +104,39 @@ fun View.setPadding(padding: Padding) {
             padding.bottom.dpToPx(displayMetrics)
         )
     }
+}
+
+/**
+ * Creates a [CoroutineScope] that is active as long as this [View] is attached. Once this [View]
+ * gets detached this [CoroutineScope] gets cancelled automatically.
+ *
+ * By default coroutines dispatched on the created [CoroutineScope] run on the main dispatcher.
+ *
+ * @throws IllegalArgumentException if this [View] is not attached yet. It is the responsibility of
+ * the caller to make sure the [View] is attached before turning it into a [CoroutineScope], e.g.
+ * inside a [Fragment] call this from [Fragment.onViewCreated].
+ */
+@MainThread
+fun View.toScope(): CoroutineScope {
+    if (!isAttachedToWindow) {
+        // We can't pause a CoroutineScope until the View is attached; So we just throw in this
+        // situation. The calling code needs to make sure the View is attached first (e.g. call
+        // this from onViewCreated in a Fragment).
+        throw IllegalStateException("View is not attached")
+    }
+
+    val scope = CoroutineScope(Dispatchers.Main)
+
+    addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(view: View) = Unit
+
+        override fun onViewDetachedFromWindow(view: View) {
+            scope.cancel()
+            view.removeOnAttachStateChangeListener(this)
+        }
+    })
+
+    return scope
 }
 
 /**

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/View.kt
@@ -14,13 +14,11 @@ import android.view.inputmethod.InputMethodManager
 import androidx.annotation.MainThread
 import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
-import androidx.fragment.app.Fragment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.ktx.android.util.dpToPx
-import java.lang.IllegalStateException
 import java.lang.ref.WeakReference
 
 /**
@@ -112,19 +110,11 @@ fun View.setPadding(padding: Padding) {
  *
  * By default coroutines dispatched on the created [CoroutineScope] run on the main dispatcher.
  *
- * @throws IllegalArgumentException if this [View] is not attached yet. It is the responsibility of
- * the caller to make sure the [View] is attached before turning it into a [CoroutineScope], e.g.
- * inside a [Fragment] call this from [Fragment.onViewCreated].
+ * Note: This scope gets only cancelled if the [View] gets detached. In cases where the [View] never
+ * gets attached this may create a scope that never gets cancelled!
  */
 @MainThread
 fun View.toScope(): CoroutineScope {
-    if (!isAttachedToWindow) {
-        // We can't pause a CoroutineScope until the View is attached; So we just throw in this
-        // situation. The calling code needs to make sure the View is attached first (e.g. call
-        // this from onViewCreated in a Fragment).
-        throw IllegalStateException("View is not attached")
-    }
-
     val scope = CoroutineScope(Dispatchers.Main)
 
     addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
@@ -159,12 +159,6 @@ class ViewTest {
         verify(viewTreeObserver).removeOnGlobalLayoutListener(any())
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `toScope throws if view is not attached`() {
-        val view = View(testContext)
-        view.toScope()
-    }
-
     @Test
     fun `can dispatch coroutines to view scope`() {
         val activity = Robolectric.buildActivity(Activity::class.java).create().get()

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ViewTest.kt
@@ -4,16 +4,27 @@
 
 package mozilla.components.support.ktx.android.view
 
+import android.app.Activity
 import android.view.View
+import android.view.WindowManager
 import android.widget.EditText
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.any
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -22,10 +33,27 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
 import org.robolectric.shadows.ShadowLooper
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class ViewTest {
+    @Before
+    @ExperimentalCoroutinesApi
+    fun setUp() {
+        // We create a separate thread for the main dispatcher so that we do not deadlock our test
+        // thread.
+        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    }
+
+    @After
+    @ExperimentalCoroutinesApi
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `showKeyboard should request focus`() {
@@ -129,5 +157,60 @@ class ViewTest {
         viewTreeObserver.dispatchOnGlobalLayout()
 
         verify(viewTreeObserver).removeOnGlobalLayoutListener(any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `toScope throws if view is not attached`() {
+        val view = View(testContext)
+        view.toScope()
+    }
+
+    @Test
+    fun `can dispatch coroutines to view scope`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val view = View(testContext)
+        activity.windowManager.addView(view, WindowManager.LayoutParams(100, 100))
+
+        assertTrue(view.isAttachedToWindow)
+
+        val latch = CountDownLatch(1)
+        var coroutineExecuted = false
+
+        view.toScope().launch {
+            coroutineExecuted = true
+            latch.countDown()
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+
+        assertTrue(coroutineExecuted)
+    }
+
+    @Test
+    fun `scope is cancelled when view is detached`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val view = View(testContext)
+        activity.windowManager.addView(view, WindowManager.LayoutParams(100, 100))
+
+        val scope = view.toScope()
+
+        assertTrue(view.isAttachedToWindow)
+        assertTrue(scope.isActive)
+
+        activity.windowManager.removeView(view)
+
+        assertFalse(view.isAttachedToWindow)
+        assertFalse(scope.isActive)
+
+        val latch = CountDownLatch(1)
+        var coroutineExecuted = false
+
+        scope.launch {
+            coroutineExecuted = true
+            latch.countDown()
+        }
+
+        assertFalse(latch.await(5, TimeUnit.SECONDS))
+        assertFalse(coroutineExecuted)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,12 @@ permalink: /changelog/
   * Hyphens `-` are now allowed in labels for metrics.  See [1566764](https://bugzilla.mozilla.org/show_bug.cgi?id=1566764).
   * ⚠️ **This is a breaking change**: Timespan values are returned in their configured time unit in the testing API.
 
+* **lib-state**
+  * Added ability to pause/resume observing a `Store` via `pause()` and `resume()` methods on the subscription
+  * When using `observeManually` the returned `Subscription` is in paused state by default.
+  * When binding a subscription to a `LifecycleOwner` then this subscription will automatically paused and resumed based on whether the lifecycle is in STARTED state.
+  * When binding a subscription to a `View` then this subscription will be paused until the `View` gets attached.
+
 * **support-ktx**
   * ⚠️ **This is a breaking behavior change**: `JSONArray.mapNotNull` is now an inline function, changing the behavior of the `return` keyword within its lambda.
   * Added `View.toScope()` to create a `CoroutineScope` that is active as long as the `View` is attached. Once the `View` gets detached the `CoroutineScope` gets cancelled automatically.  By default coroutines dispatched on the created [CoroutineScope] run on the main dispatcher

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,7 @@ permalink: /changelog/
   * When using `observeManually` the returned `Subscription` is in paused state by default.
   * When binding a subscription to a `LifecycleOwner` then this subscription will automatically paused and resumed based on whether the lifecycle is in STARTED state.
   * When binding a subscription to a `View` then this subscription will be paused until the `View` gets attached.
+  * Added `Store.broadcastChannel()` to observe state from a coroutine sequentially ordered.
 
 * **support-ktx**
   * ⚠️ **This is a breaking behavior change**: `JSONArray.mapNotNull` is now an inline function, changing the behavior of the `return` keyword within its lambda.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -80,6 +80,7 @@ permalink: /changelog/
 
 * **support-ktx**
   * ⚠️ **This is a breaking behavior change**: `JSONArray.mapNotNull` is now an inline function, changing the behavior of the `return` keyword within its lambda.
+  * Added `View.toScope()` to create a `CoroutineScope` that is active as long as the `View` is attached. Once the `View` gets detached the `CoroutineScope` gets cancelled automatically.  By default coroutines dispatched on the created [CoroutineScope] run on the main dispatcher
 
 * **concept-push**, **lib-push-firebase**, **feature-push**
   * Added `deleteToken` to the PushService interface.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,6 +84,7 @@ permalink: /changelog/
   * When binding a subscription to a `LifecycleOwner` then this subscription will automatically paused and resumed based on whether the lifecycle is in STARTED state.
   * When binding a subscription to a `View` then this subscription will be paused until the `View` gets attached.
   * Added `Store.broadcastChannel()` to observe state from a coroutine sequentially ordered.
+  * Added helpers to process states coming from a `Store` sequentially via `Fragment.consumeFrom(Store)` and `View.consumeFrom(Store)`.
 
 * **support-ktx**
   * ⚠️ **This is a breaking behavior change**: `JSONArray.mapNotNull` is now an inline function, changing the behavior of the `return` keyword within its lambda.


### PR DESCRIPTION
@csadilek Okay, this is my proposal after I came out of the rabbit hole.

For working on UI pieces based on state I think our requirements are:
- **view scope** - We only want to observe as long as the `View` is around. Once the view is gone everything should be cancelled.
* **lifecycle pause/resume** - We only want to update UI while the app is visible. Once it becomes visible we want to render the latest state.
* **main thread**: We want to always do that on the main thread - the only place where we can update UI.
- **order** - We want to always process state in order. The wrong order will lead to UI being in an inconsistent state.

So here's my proposal:
* **Scope**: I introduced `View.toScope()` which creates a `CoroutineScope` that is active as long as the `View` is attached. Once the `View` gets detached the scope gets cancelled. In theory in a fragment that would be the same as `viewLifecycleOwner.lifecycleScope`. But we see in Fenix that it has a bug if an `Activity.recreate()` happens and the Fragment gets recreated. In that situation we see the scope of the first Fragment not getting cancelled. I want to file this as a bug against AndroidX once I have the time to isolate this issue in a minimal reproducible sample. `View.toScope()` does not have this issue and it works outside of `Fragment` or deep in components where we do not know about the `Fragment` too.
* **Lifecycle**: We added the pause/resume behavior and this is still the same as before.
* **Order** / **MainThread**: I added an extension method on `Store` that creates a [BroadcastChannel](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/). This has two major advantages:
  * States will always be received in order. Other than multiple `launch` calls.
  * The state can be observed from a single coroutine (per higher-level observer) using the main dispatcher.
* And then I added some helper methods to make it nicer to use. See below.

So in Fenix, in the `SearchFragment` the very verbose way would be to observe the channel from a Coroutine:

```Kotlin
        val channel = searchStore.broadcastChannel(owner = this)

        view.toScope().launch {
            try {
                channel.openSubscription().consumeEach { state ->
                    awesomeBarView.update(state)
                    toolbarView.update(state)
                    updateSearchEngineIcon(state)
                    updateSearchShortuctsIcon(state)
                    updateSearchWithLabel(state)
                }
            } finally {
                channel.close()
            }
        }
```

The syntactic sugar version of that is just:

```Kotlin
        consumeFrom(searchStore) { state ->
            // Always on main thread. Always in order.
            awesomeBarView.update(state)
            toolbarView.update(state)
            updateSearchEngineIcon(state)
            updateSearchShortuctsIcon(state)
            updateSearchWithLabel(state)
        }
```