### PR TITLE
Closes #3487 - Display PWA site controls notification

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeature.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeature.kt
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.feature
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.BADGE_ICON_NONE
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.getSystemService
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.feature.pwa.R
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.base.ids.cancel
+import mozilla.components.support.base.ids.notify
+
+/**
+ * Displays site controls notification for fullscreen web apps.
+ */
+class WebAppSiteControlsFeature(
+    private val applicationContext: Context,
+    private val sessionManager: SessionManager,
+    private val reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase,
+    private val sessionId: String,
+    private val manifest: WebAppManifest?
+) : BroadcastReceiver(), LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    fun onResume() {
+        val filter = IntentFilter().apply {
+            addAction(ACTION_COPY)
+            addAction(ACTION_REFRESH)
+        }
+        applicationContext.registerReceiver(this, filter)
+
+        NotificationManagerCompat.from(applicationContext)
+            .notify(applicationContext, NOTIFICATION_TAG, buildNotification())
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    fun onPause() {
+        applicationContext.unregisterReceiver(this)
+
+        NotificationManagerCompat.from(applicationContext)
+            .cancel(applicationContext, NOTIFICATION_TAG)
+    }
+
+    /**
+     * Responds to [PendingIntent]s fired by the site controls notification.
+     */
+    override fun onReceive(context: Context, intent: Intent) {
+        sessionManager.findSessionById(sessionId)?.also { session ->
+            when (intent.action) {
+                ACTION_COPY -> {
+                    applicationContext.getSystemService<ClipboardManager>()?.let { clipboardManager ->
+                        clipboardManager.setPrimaryClip(ClipData.newPlainText(session.url, session.url))
+                        Toast.makeText(
+                            applicationContext,
+                            applicationContext.getString(R.string.mozac_feature_pwa_copy_success),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+                ACTION_REFRESH -> reloadUrlUseCase(session)
+            }
+        }
+    }
+
+    /**
+     * Build the notification with site controls to be displayed while the web app is active.
+     */
+    @Suppress("LongMethod")
+    private fun buildNotification(): Notification {
+        val channelId = ensureChannelExists()
+
+        with(applicationContext) {
+            val copyIntent = createPendingIntent(ACTION_COPY, 1)
+            val refreshAction = NotificationCompat.Action(
+                R.drawable.ic_refresh,
+                getString(R.string.mozac_feature_pwa_site_controls_refresh),
+                createPendingIntent(ACTION_REFRESH, 2)
+            )
+
+            return NotificationCompat.Builder(this, channelId)
+                .setSmallIcon(R.drawable.ic_pwa)
+                .setContentTitle(manifest?.name)
+                .setContentText(getString(R.string.mozac_feature_pwa_site_controls_notification_text))
+                .setBadgeIconType(BADGE_ICON_NONE)
+                .setColor(manifest?.themeColor ?: NotificationCompat.COLOR_DEFAULT)
+                .setPriority(NotificationCompat.PRIORITY_MIN)
+                .setShowWhen(false)
+                .setContentIntent(copyIntent)
+                .addAction(refreshAction)
+                .setOngoing(true)
+                .build()
+        }
+    }
+
+    /**
+     * Make sure a notification channel for site controls notifications exists.
+     *
+     * Returns the channel id to be used for notifications.
+     */
+    private fun ensureChannelExists(): String {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager: NotificationManager = applicationContext.getSystemService()!!
+
+            val channel = NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                applicationContext.getString(R.string.mozac_feature_pwa_site_controls_notification_channel),
+                NotificationManager.IMPORTANCE_MIN
+            )
+
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        return NOTIFICATION_CHANNEL_ID
+    }
+
+    private fun createPendingIntent(action: String, requestCode: Int): PendingIntent {
+        val intent = Intent(action)
+        intent.setPackage(applicationContext.packageName)
+        return PendingIntent.getBroadcast(applicationContext, requestCode, intent, 0)
+    }
+
+    companion object {
+        private const val NOTIFICATION_CHANNEL_ID = "Site Controls"
+        private const val NOTIFICATION_TAG = "SiteControls"
+        private const val ACTION_COPY = "mozilla.components.feature.pwa.COPY"
+        private const val ACTION_REFRESH = "mozilla.components.feature.pwa.REFRESH"
+    }
+}

--- a/components/feature/pwa/src/main/res/drawable/ic_pwa.xml
+++ b/components/feature/pwa/src/main/res/drawable/ic_pwa.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16.72 14.42l0.58-1.46h1.67l-0.8-2.22 1-2.5L22 15.76h-2.1l-0.48-1.35h-2.7zM14.94 15.77l3.03-7.54h-2.01l-2.08 4.87-1.48-4.86h-1.54L9.27 13.1l-1.12-2.22-1 3.12 1.02 1.77h1.98l1.43-4.37 1.37 4.37h1.99zM3.91 13.18h1.24c0.38 0 0.71-0.04 1-0.13l0.32-0.98 0.9-2.76A2.2 2.2 0 0 0 7.14 9c-0.46-0.51-1.14-0.77-2.02-0.77H2v7.54h1.91v-2.59zm1.64-3.21c0.18 0.18 0.27 0.42 0.27 0.72s-0.08 0.55-0.24 0.73c-0.17 0.2-0.49 0.3-0.95 0.3H3.9V9.7h0.72c0.44 0 0.74 0.09 0.92 0.27z"/>
+</vector>

--- a/components/feature/pwa/src/main/res/drawable/ic_refresh.xml
+++ b/components/feature/pwa/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,4.04a0.96,0.96 0,0 0,-0.96 0.96V8a8.981,8.981 0,1 0,-1.676 10.361A1,1 0,0 0,16.95 16.95a7.031,7.031 0,1 1,1.72 -6.91H15a0.96,0.96 0,0 0,0 1.92h6a0.96,0.96 0,0 0,0.96 -0.96V5A0.96,0.96 0,0 0,21 4.04Z"/>
+</vector>

--- a/components/feature/pwa/src/main/res/values/strings.xml
+++ b/components/feature/pwa/src/main/res/values/strings.xml
@@ -5,4 +5,13 @@
 <resources>
     <!-- Default shortcut label used if website has no title -->
     <string name="mozac_feature_pwa_default_shortcut_label">Website</string>
+
+    <!-- Name of the "notification channel" used for displaying site controls notification. See https://developer.android.com/training/notify-user/channels -->
+    <string name="mozac_feature_pwa_site_controls_notification_channel">Full screen site controls</string>
+    <!-- Text shown on the second row of the site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_notification_text">Tap to copy the URL for this app</string>
+    <!-- Refresh button in site controls notification. -->
+    <string name="mozac_feature_pwa_site_controls_refresh">Refresh</string>
+    <!-- Toast displayed when the website URL is copied. -->
+    <string name="mozac_feature_pwa_copy_success">URL copied.</string>
 </resources>

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeatureTest.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.feature
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class WebAppSiteControlsFeatureTest {
+
+    @Test
+    fun `register receiver on resume`() {
+        val context = spy(testContext)
+
+        val feature = WebAppSiteControlsFeature(context, mock(), mock(), "session-id", mock())
+        feature.onResume()
+
+        verify(context).registerReceiver(eq(feature), any())
+    }
+
+    @Test
+    fun `unregister receiver on pause`() {
+        val context = spy(testContext)
+
+        doNothing().`when`(context).unregisterReceiver(any())
+
+        val feature = WebAppSiteControlsFeature(context, mock(), mock(), "session-id", mock())
+        feature.onPause()
+
+        verify(context).unregisterReceiver(feature)
+    }
+
+    @Test
+    fun `reload page when reload action is activated`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        val reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase = mock()
+
+        doReturn(session).`when`(sessionManager).findSessionById("session-id")
+
+        val feature = WebAppSiteControlsFeature(testContext, sessionManager, reloadUrlUseCase, "session-id", mock())
+        feature.onReceive(testContext, Intent("mozilla.components.feature.pwa.REFRESH"))
+
+        verify(reloadUrlUseCase).invoke(session)
+    }
+}

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Window.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Window.kt
@@ -7,6 +7,7 @@
 package mozilla.components.support.ktx.android.view
 
 import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 import android.view.View
 import android.view.Window
 import androidx.annotation.ColorInt
@@ -17,7 +18,7 @@ import mozilla.components.support.utils.ColorUtils.isDark
  * If the color is light enough, a light status bar with dark icons will be used.
  */
 fun Window.setStatusBarTheme(@ColorInt color: Int) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (SDK_INT >= Build.VERSION_CODES.M) {
         val flags = decorView.systemUiVisibility
         decorView.systemUiVisibility =
             flags.useLightFlag(color, View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR)
@@ -30,10 +31,13 @@ fun Window.setStatusBarTheme(@ColorInt color: Int) {
  * If the color is light enough, a light navigation bar with dark icons will be used.
  */
 fun Window.setNavigationBarTheme(@ColorInt color: Int) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    if (SDK_INT >= Build.VERSION_CODES.O) {
         val flags = decorView.systemUiVisibility
         decorView.systemUiVisibility =
             flags.useLightFlag(color, View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR)
+    }
+    if (SDK_INT >= Build.VERSION_CODES.P) {
+        navigationBarDividerColor = 0
     }
     navigationBarColor = color
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/WindowTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/WindowTest.kt
@@ -64,6 +64,19 @@ class WindowTest {
     }
 
     @Test
+    fun `setNavigationBarTheme changes navigation bar color`() {
+        window.setNavigationBarTheme(Color.RED)
+        verify(window, never()).navigationBarDividerColor
+        verify(window).navigationBarColor = Color.RED
+        verify(decorView, never()).systemUiVisibility
+
+        setStaticField(Build.VERSION::SDK_INT.javaField, Build.VERSION_CODES.P)
+        window.setNavigationBarTheme(Color.BLUE)
+        verify(window).navigationBarDividerColor = 0
+        verify(window).navigationBarColor = Color.BLUE
+    }
+
+    @Test
     fun `check setNavigationBarTheme sets the correct flags`() {
         setStaticField(Build.VERSION::SDK_INT.javaField, Build.VERSION_CODES.O)
         val expectedFlags = View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,11 @@ permalink: /changelog/
   ```kotlin
      val windowFeature = WindowFeature(components.sessionManager)
   ```
-  
+
+* **feature-pwa**
+  * Added full support for pinning websites to the home screen.
+  * Added full support for Progressive Web Apps, which can be pinned and open in their own window.
+
 * **service-glean**
   * Fixed a bug in`TimeSpanMetricType` that prevented multiple consecutive `start()`/`stop()` calls. This resulted in the `glean.baseline.duration` being missing from most [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings.
 
@@ -106,7 +110,7 @@ permalink: /changelog/
 
 * **support-ktx**
   * Added `Collection.crossProduct` to retrieve the cartesian product of two `Collections`.
-  
+
 * **service-glean**
   * ⚠️ **This is a breaking change**: `Glean.enableTestingMode` is now `internal`. Tests can use the `GleanTestRule` to enable testing mode. [Updated docs available here](https://mozilla.github.io/glean/book/user/testing-metrics.html).
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -16,6 +16,7 @@ import mozilla.components.feature.pwa.ext.getWebAppManifest
 import mozilla.components.feature.pwa.ext.putWebAppManifest
 import mozilla.components.feature.pwa.feature.WebAppActivityFeature
 import mozilla.components.feature.pwa.feature.WebAppHideToolbarFeature
+import mozilla.components.feature.pwa.feature.WebAppSiteControlsFeature
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.samples.browser.ext.components
@@ -64,6 +65,15 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
                 WebAppActivityFeature(
                     activity!!,
                     components.icons,
+                    manifest
+                )
+            )
+            activity?.lifecycle?.addObserver(
+                WebAppSiteControlsFeature(
+                    context?.applicationContext!!,
+                    components.sessionManager,
+                    components.sessionUseCases.reload,
+                    sessionId!!,
                     manifest
                 )
             )


### PR DESCRIPTION
Builds on top of #3816, merge that first.

Adds a new silent site controls notification when a PWA is open. These controls show an action for copying the URL of the web app and an action for refreshing the page.

Collapsed:
![Screenshot_20190722-151726](https://user-images.githubusercontent.com/1782266/61659943-c3b4f900-ac96-11e9-866d-aa5c4d30a3a0.png)

Expanded:
![Screenshot_20190722-151731](https://user-images.githubusercontent.com/1782266/61659946-c6175300-ac96-11e9-8de4-1edb98a23ab2.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
