### PR TITLE
Closes #3864: Make text size of minus and plus buttons have the same size on reader view

### DIFF
--- a/components/feature/readerview/src/main/res/layout/mozac_feature_readerview_view.xml
+++ b/components/feature/readerview/src/main/res/layout/mozac_feature_readerview_view.xml
@@ -32,7 +32,7 @@
             android:fontFamily="sans-serif"
             android:gravity="center"
             android:contentDescription="@string/mozac_feature_readerview_sans_serif_font_desc"
-            android:textSize="21sp"
+            android:textSize="24sp"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="1" />

--- a/components/feature/readerview/src/main/res/values/mozac_feature_readerview_strings.xml
+++ b/components/feature/readerview/src/main/res/values/mozac_feature_readerview_strings.xml
@@ -6,6 +6,6 @@
   -->
 
 <resources>
-    <string name="mozac_feature_readerview_negative_sign" translatable="false">-</string>
+    <string name="mozac_feature_readerview_negative_sign" translatable="false">−</string>
     <string name="mozac_feature_readerview_positive_sign" translatable="false">+</string>
 </resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-readerview**
+  * Fixed [#3864](https://github.com/mozilla-mobile/android-components/issues/3864) now minus and plus buttons have the same size on reader view.
+
 # 5.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v4.0.0...v5.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/64?closed=1)


### PR DESCRIPTION
changed "sans-serif" textsize to match "serif"
changed sign used from h'yphen-minus' to true 'minus'

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
