### PR TITLE
Issue #3738: update_geckoview.sh: Update command to build sample browser with GeckoView beta. [ci skip]

### DIFF
--- a/automation/taskcluster/action/update_geckoview.sh
+++ b/automation/taskcluster/action/update_geckoview.sh
@@ -50,7 +50,7 @@ elif [ "$CHANNEL" = "beta" ]
 then
     ./gradlew browser-engine-gecko-beta:assemble \
           browser-engine-gecko-beta:test \
-          sample-browser:assembleGeckoBetaArm
+          sample-browser:assembleGeckoBetaUniversal
 elif [ "$CHANNEL" = "release" ]
 then
     ./gradlew browser-engine-gecko:assemble \


### PR DESCRIPTION
That's something I forgot in #3738 and without that GV Beta is not updated automatically anymore.