### PR TITLE
Initial draft SyncEngineStore

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/SyncEngineState.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/SyncEngineState.kt
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.browser.storage.sync.engine
+
+import mozilla.components.concept.sync.engines.SyncAbleEngine
+import mozilla.components.lib.state.State
+
+data class SyncEngineState(
+    val enabledEngines: List<SyncAbleEngine> = emptyList()
+) : State

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/SyncEngineStore.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/SyncEngineStore.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync.engine
+
+import mozilla.components.browser.storage.sync.engine.action.SyncEngineAction
+import mozilla.components.concept.sync.engines.reducer.SyncEngineReduce
+import mozilla.components.lib.state.Store
+
+class SyncEngineStore(
+    initialState: SyncEngineState = SyncEngineState()
+) : Store<SyncEngineState, SyncEngineAction>(
+    initialState,
+    SyncEngineReduce::reduce
+)

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/action/SyncEngineAction.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/action/SyncEngineAction.kt
@@ -1,0 +1,10 @@
+package mozilla.components.browser.storage.sync.engine.action
+
+import mozilla.components.concept.sync.engines.SyncAbleEngine
+import mozilla.components.lib.state.Action
+
+sealed class SyncEngineAction : Action
+
+data class EnableSyncEngineAction(val engine: SyncAbleEngine) : SyncEngineAction()
+data class DisableSyncEngineAction(val engine: SyncAbleEngine) : SyncEngineAction()
+object  DisableAllSyncEnginesAction : SyncEngineAction()

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/reducer/SyncEngineReduce.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/engine/reducer/SyncEngineReduce.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.sync.engines.reducer
+
+import mozilla.components.concept.sync.engines.SyncEngineState
+import mozilla.components.browser.storage.sync.engine.action.EnableSyncEngineAction
+import mozilla.components.browser.storage.sync.engine.action.DisableAllSyncEnginesAction
+import mozilla.components.browser.storage.sync.engine.action.DisableSyncEngineAction
+import mozilla.components.browser.storage.sync.engine.action.SyncEngineAction
+
+internal object SyncEngineReduce {
+
+    fun reduce(state: SyncEngineState, action: SyncEngineAction): SyncEngineState {
+        return when (action) {
+            //TODO: validate for duplicate enabledEngines.
+            is EnableSyncEngineAction -> state.copy(enabledEngines = state.enabledEngines + action.engine)
+            is DisableSyncEngineAction -> state.copy(enabledEngines = state.enabledEngines - action.engine)
+            is DisableAllSyncEnginesAction -> state.copy(enabledEngines = emptyList())
+        }
+    }
+}

--- a/components/concept/sync/build.gradle
+++ b/components/concept/sync/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     // Observables are part of the public API of this module.
     api project(':support-base')
+    api project(':lib-state')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/engines/SyncAbleEngine.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/engines/SyncAbleEngine.kt
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.sync.engines
+
+enum class SyncAbleEngine {
+    Bookmarks, History, Passwords
+}


### PR DESCRIPTION
@grigoryk  I would like to know what do you think about  using a `SyncEngineStore` for keeping the
state of which engines the users want to be able to sync from. In the future, I will also like to have a component that will  persist/ restore the state for the `SyncEngineStore` (ideally using shared pref).

```kotlin
    val engineStore = SyncEngineStore()

    // Activating Bookmarks
    engineStore.dispatch(EnableSyncEngineAction(SyncAbleEngine.Bookmarks))

    // Activating History
    engineStore.dispatch(EnableSyncEngineAction(SyncAbleEngine.History))

    // Disabling History
    engineStore.dispatch(DisableSyncEngineAction(SyncAbleEngine.Bookmarks))

    // Disabling all engines
    engineStore.dispatch(DisableAllSyncEnginesAction)

    // Apps and other components can react to changes on the enabledEngines
    engineStore.observe(view){ newState ->
        newState.enabledEngines
    }
```
