### PR TITLE
Closes #3741: Introduce engine startup method

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.annotation.MainThread
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.WebExtension
 import org.json.JSONObject
@@ -50,6 +51,16 @@ interface Engine {
 
         override fun hashCode() = types
     }
+
+    /**
+     * Makes sure all required engine initialization logic is executed. The
+     * details are specific to individual implementations, but the following must be true:
+     *
+     * - The engine must be operational after this method was called successfully
+     * - Calling this method on an engine that is already initialized has no effect
+     */
+    @MainThread
+    fun warmUp() = Unit
 
     /**
      * Creates a new view for rendering web content.

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
@@ -31,8 +31,7 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
     override fun warmup(flags: Long): Boolean {
         // We need to run this on the main thread since that's where GeckoRuntime expects to get initialized (if needed)
         return runBlocking(Dispatchers.Main) {
-            // Just accessing the engine here will make sure that it is created and initialized.
-            logger.debug("Warm up for engine: ${engine.name()}")
+            engine.warmUp()
             true
         }
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -9,6 +9,7 @@ import mozilla.components.support.base.facts.Facts
 import mozilla.components.support.base.facts.processor.LogFactProcessor
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.sink.AndroidLogSink
+import mozilla.components.support.ktx.android.content.isMainProcess
 
 class SampleApplication : Application() {
     val components by lazy { Components(this) }
@@ -18,7 +19,12 @@ class SampleApplication : Application() {
 
         Log.addSink(AndroidLogSink())
 
-        Facts.registerProcessor(
-            LogFactProcessor())
+        if (!isMainProcess()) {
+            return
+        }
+
+        Facts.registerProcessor(LogFactProcessor())
+
+        components.engine.warmUp()
     }
 }


### PR DESCRIPTION
@pocmo putting this up as a draft so we can start pairing/discussing...

There's no code we have to run right now, but we want the lazy engine init blocks to execute in `Application.onCreate` so we can guarantee we're on the main thread. Alternative naming suggestions welcome :) e.g `ensureStarted` or `ensureInitialized`?  

