### PR TITLE
Fixes #3900 - Catch download IOExceptions

### DIFF
--- a/components/feature/downloads/src/main/AndroidManifest.xml
+++ b/components/feature/downloads/src/main/AndroidManifest.xml
@@ -8,4 +8,5 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 </manifest>

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.NotificationManagerCompat.IMPORTANCE_NONE
+import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
+
+internal object DownloadNotification {
+
+    private const val NOTIFICATION_CHANNEL_ID = "Downloads"
+
+    /**
+     * Build the notification to be displayed while the download service is active.
+     */
+    fun createOngoingDownloadNotification(context: Context): Notification {
+        val channelId = ensureChannelExists(context)
+
+        return NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.mozac_feature_download_ic_ongoing_download)
+            .setContentTitle(context.getString(R.string.mozac_feature_downloads_ongoing_notification_title))
+            .setContentText(context.getString(R.string.mozac_feature_downloads_ongoing_notification_text))
+            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setProgress(1, 0, true)
+            .setOngoing(true)
+            .build()
+    }
+
+    /**
+     * Build the notification to be displayed when a download finishes.
+     */
+    fun createDownloadCompletedNotification(context: Context, fileName: String?): Notification {
+        val channelId = ensureChannelExists(context)
+
+        return NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.mozac_feature_download_ic_download)
+            .setContentTitle(fileName)
+            .setContentText(context.getString(R.string.mozac_feature_downloads_completed_notification_text))
+            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .build()
+    }
+
+    /**
+     * Build the notification to be displayed when a download fails to finish.
+     */
+    fun createDownloadFailedNotification(context: Context, fileName: String?): Notification {
+        val channelId = ensureChannelExists(context)
+
+        return NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.mozac_feature_download_ic_download)
+            .setContentTitle(fileName)
+            .setContentText(context.getString(R.string.mozac_feature_downloads_failed_notification_text))
+            .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .build()
+    }
+
+    /**
+     * Check if notifications from the download channel are enabled.
+     * Verifies that app notifications, channel notifications, and group notifications are enabled.
+     */
+    fun isChannelEnabled(context: Context): Boolean {
+        return if (SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager: NotificationManager = context.getSystemService()!!
+            if (!notificationManager.areNotificationsEnabled()) return false
+
+            val channelId = ensureChannelExists(context)
+            val channel = notificationManager.getNotificationChannel(channelId)
+            if (channel.importance == IMPORTANCE_NONE) return false
+
+            if (SDK_INT >= Build.VERSION_CODES.P) {
+                val group = notificationManager.getNotificationChannelGroup(channel.group)
+                group?.isBlocked != true
+            } else {
+                true
+            }
+        } else {
+            NotificationManagerCompat.from(context).areNotificationsEnabled()
+        }
+    }
+
+    /**
+     * Make sure a notification channel for download notification exists.
+     *
+     * Returns the channel id to be used for download notifications.
+     */
+    private fun ensureChannelExists(context: Context): String {
+        if (SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager: NotificationManager = context.getSystemService()!!
+
+            val channel = NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                context.getString(R.string.mozac_feature_downloads_notification_channel),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        return NOTIFICATION_CHANNEL_ID
+    }
+}

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_download.xml
@@ -2,11 +2,14 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<animation-list xmlns:android="http://schemas.android.com/apk/res/android" android:oneshot="false">
-    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim0" android:duration="200" />
-    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim1" android:duration="200" />
-    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim2" android:duration="200" />
-    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim3" android:duration="200" />
-    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim4" android:duration="200" />
-    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim5" android:duration="200" />
-</animation-list>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <clip-path android:pathData="M13,3a1,1 0,1 0,-2 0v11.6l-4.3,-4.3a1,1 0,0 0,-1.4 1.4l6,6a1,1 0,0 0,1.4 0l6,-6a1,1 0,0 0,-1.4 -1.4L13,14.6V3zM5,21a1,1 0,0 1,1 -1h12a1,1 0,1 1,0 2H6a1,1 0,0 1,-1 -1z"/>
+    <path
+        android:pathData="M 0 0 L 24 0 L 24 24 L 0 24 Z"
+        android:fillColor="#FFF"/>
+</vector>

--- a/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_ongoing_download.xml
+++ b/components/feature/downloads/src/main/res/drawable/mozac_feature_download_ic_ongoing_download.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<animation-list xmlns:android="http://schemas.android.com/apk/res/android" android:oneshot="false">
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim0" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim1" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim2" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim3" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim4" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download_anim5" android:duration="200" />
+    <item android:drawable="@drawable/mozac_feature_download_ic_download" android:duration="200" />
+</animation-list>

--- a/components/feature/downloads/src/main/res/values/colors.xml
+++ b/components/feature/downloads/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <color name="mozac_feature_downloads_notification">#607D8B</color>
+</resources>

--- a/components/feature/downloads/src/main/res/values/strings.xml
+++ b/components/feature/downloads/src/main/res/values/strings.xml
@@ -10,6 +10,11 @@
     <!-- Text shown on the second row of an ongoing download notification. -->
     <string name="mozac_feature_downloads_ongoing_notification_text">Download in progress</string>
 
+    <!-- Text shown on the second row of an completed download notification. The filename is shown on the first row. -->
+    <string name="mozac_feature_downloads_completed_notification_text">Download completed.</string>
+    <!-- Text shown on the second row of an failed download notification. The filename is shown on the first row. -->
+    <string name="mozac_feature_downloads_failed_notification_text">Failed to download.</string>
+
     <!-- Alert dialog confirmation before download a file, this is the title. -->
     <string name="mozac_feature_downloads_dialog_title">Download file</string>
     <!-- Alert dialog confirmation before download a file, this is the positive action. -->

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.downloads.ext.putDownloadExtra
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,9 +39,11 @@ class AbstractFetchDownloadServiceTest {
     @Before
     fun setup() {
         initMocks(this)
-        service = spy(object : AbstractFetchDownloadService(broadcastManager) {
+        service = spy(object : AbstractFetchDownloadService() {
             override val httpClient = client
         })
+        doReturn(broadcastManager).`when`(service).broadcastManager
+        doReturn(testContext).`when`(service).context
     }
 
     @Test


### PR DESCRIPTION
Adds notifications for completed and failed downloads. `IOException` is now caught and displays the failed download notification.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
