### PR TITLE
Implement a Gecko runtime telemetry delegate using Glean

### DIFF
--- a/components/browser/engine-gecko-nightly/README.md
+++ b/components/browser/engine-gecko-nightly/README.md
@@ -12,6 +12,25 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:browser-engine-gecko-nightly:{latest-version}"
 ```
 
+### Integration with the Glean SDK
+
+The [Glean SDK](../../../components/service/glean/README.md) can be used to collect [Gecko Telemetry](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html).
+Applications using both this component and the Glean SDK should setup the Gecko Telemetry delegate
+as shown below:
+
+```Kotlin
+    val builder = GeckoRuntimeSettings.Builder()
+    val runtimeSettings = builder
+        .telemetryDelegate(GeckoGleanAdapter()) // Sets up the delegate!
+        .build()
+    // Create the Gecko runtime.
+    GeckoRuntime.create(context, runtimeSettings)
+```
+
+#### Adding new metrics
+
+New Gecko metrics can be added as described [in the Firefox Telemetry docs](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/start/adding-a-new-probe.html).
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/browser/engine-gecko-nightly/metrics.yaml
+++ b/components/browser/engine-gecko-nightly/metrics.yaml
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# IMPORTANT NOTE: this file is here only as a safety measure, to make
+# sure the correct code is generated even though the GeckoView AAR file
+# reports an empty metrics.yaml file. The metric in this file is currently
+# disabled and not supposed to collect any data.
+
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
+test.glean.geckoview:
+  streaming:
+    type: timing_distribution
+    gecko_datapoint: TELEMETRY_TEST_STREAMING
+    disabled: true
+    description: |
+      A test-only, disabled metric. This is required to guarantee
+      that a `GleanGeckoHistogramMapping` is always generated, even
+      though the GeckoView AAR exports no metric. Please note that
+      the data-review field below contains no review, since this
+      metric is disabled and not allowed to collect any data.
+    bugs:
+      - 1566374
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1566374
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/glean/GeckoAdapter.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/glean/GeckoAdapter.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.glean
+
+import mozilla.components.browser.engine.gecko.GleanMetrics.GleanGeckoHistogramMapping
+import org.mozilla.geckoview.RuntimeTelemetry
+
+/**
+ * This implements a [RuntimeTelemetry.Delegate] that dispatches Gecko runtime
+ * telemetry to the Glean SDK.
+ *
+ * Metrics defined in the `metrics.yaml` file in Gecko's mozilla-central repository
+ * will be automatically dispatched to the Glean SDK and sent through the requested
+ * pings.
+ *
+ * This can be used, in products collecting data through the Glean SDK, by
+ * providing an instance to `GeckoRuntimeSettings.Builder().telemetryDelegate`.
+ */
+class GeckoAdapter : RuntimeTelemetry.Delegate {
+    override fun onTelemetryReceived(metric: RuntimeTelemetry.Metric) {
+        // Note that the `GleanGeckoHistogramMapping` is automatically generated at
+        // build time by the Glean SDK parsers.
+        GleanGeckoHistogramMapping[metric.name]?.accumulateSamples(metric.values)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,9 @@ permalink: /changelog/
 * **support-android-test**
   * Added `WebserverRule` - a junit rule that will run a webserver during tests serving content from assets in the test package ([#3893](https://github.com/mozilla-mobile/android-components/issues/3893)).
 
+* **browser-engine-gecko-nightly**
+  * The component now exposes an implementation of the Gecko runtime telemetry delegate, `glean.GeckoAdapter`, which can be used to collect Gecko metrics with the Glean SDK.
+
 * **browser-engine-gecko-beta**
   * The component now handles situations where the Android system kills the content process (without killing the main app process) in order to reclaim resources. In those situations the component will automatically recover and restore the last known state of those sessions.
 


### PR DESCRIPTION
The implemented delegate redirects all streaming telemetry calls to the Glean SDK metrics defined in the `metrics.yaml` file extracted from the GeckoView AAR the engine-gecko-* component depends on.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
