### PR TITLE
Closes #3791 - Derive app icon for likely app-link app

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinkRedirect.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinkRedirect.kt
@@ -5,6 +5,8 @@
 package mozilla.components.feature.app.links
 
 import android.content.Intent
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 
 /**
  * Data class for the external Intent or fallback URL a given URL encodes for.
@@ -12,11 +14,17 @@ import android.content.Intent
 data class AppLinkRedirect(
     val appIntent: Intent?,
     val webUrl: String?,
-    val isFallback: Boolean
+    val isFallback: Boolean,
+    @StringRes
+    val appName: Int? = null,
+    @DrawableRes
+    val appIconResource: Int? = null
 ) {
     fun hasExternalApp() = appIntent != null
 
     fun hasFallback() = webUrl != null && isFallback
 
     fun isRedirect() = hasExternalApp() || hasFallback()
+
+    fun isInstall() = appIntent?.data?.scheme == "market"
 }

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinkRedirect.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinkRedirect.kt
@@ -5,8 +5,7 @@
 package mozilla.components.feature.app.links
 
 import android.content.Intent
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
+import android.content.pm.ResolveInfo
 
 /**
  * Data class for the external Intent or fallback URL a given URL encodes for.
@@ -15,16 +14,25 @@ data class AppLinkRedirect(
     val appIntent: Intent?,
     val webUrl: String?,
     val isFallback: Boolean,
-    @StringRes
-    val appName: Int? = null,
-    @DrawableRes
-    val appIconResource: Int? = null
+    val info: ResolveInfo? = null
 ) {
+    /**
+     * If there is a third-party app intent.
+     */
     fun hasExternalApp() = appIntent != null
 
+    /**
+     * If there is a fallback URL (should the intent fails).
+     */
     fun hasFallback() = webUrl != null && isFallback
 
+    /**
+     * If the app link is a redirect (to an app or URL).
+     */
     fun isRedirect() = hasExternalApp() || hasFallback()
 
-    fun isInstall() = appIntent?.data?.scheme == "market"
+    /**
+     * Is the app link one that can be installed from a store.
+     */
+    fun isInstallable() = appIntent?.data?.scheme == "market"
 }

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -51,7 +51,7 @@ class AppLinksFeature(
     private val alwaysDeniedSchemes: Set<String> = setOf("javascript"),
     private val fragmentManager: FragmentManager? = null,
     private var dialog: RedirectDialogFragment = SimpleRedirectDialogFragment.newInstance(),
-    val useCases: AppLinksUseCases = AppLinksUseCases(context)
+    private val useCases: AppLinksUseCases = AppLinksUseCases(context)
 ) : LifecycleAwareFeature {
 
     @VisibleForTesting

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -51,7 +51,7 @@ class AppLinksFeature(
     private val alwaysDeniedSchemes: Set<String> = setOf("javascript"),
     private val fragmentManager: FragmentManager? = null,
     private var dialog: RedirectDialogFragment = SimpleRedirectDialogFragment.newInstance(),
-    private val useCases: AppLinksUseCases = AppLinksUseCases(context)
+    val useCases: AppLinksUseCases = AppLinksUseCases(context)
 ) : LifecycleAwareFeature {
 
     @VisibleForTesting

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -104,9 +104,9 @@ class AppLinksUseCases(
 
             val webUrl = webUrls.firstOrNull { it != url } ?: webUrls.firstOrNull()
 
-            val appInfo = resolveInfos?.firstOrNull()?.let { it.labelRes to it.iconResource }
+            val appInfo = resolveInfos?.firstOrNull()
 
-            return AppLinkRedirect(appIntent, webUrl, webUrl != url, appInfo?.first, appInfo?.second)
+            return AppLinkRedirect(appIntent, webUrl, webUrl != url, appInfo)
         }
 
         private fun getNonBrowserActivities(intent: Intent): List<ResolveInfo> {

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinkRedirectTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinkRedirectTest.kt
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.app.links
+
+import android.content.Intent
+import android.net.Uri
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.`when`
+
+class AppLinkRedirectTest {
+
+    @Test
+    fun hasExternalApp() {
+        var appLink = AppLinkRedirect(appIntent = mock(), webUrl = null, isFallback = true)
+        assertTrue(appLink.hasExternalApp())
+
+        appLink = AppLinkRedirect(appIntent = null, webUrl = null, isFallback = true)
+        assertFalse(appLink.hasExternalApp())
+    }
+
+    @Test
+    fun hasFallback() {
+        var appLink = AppLinkRedirect(appIntent = mock(), webUrl = null, isFallback = true)
+        assertFalse(appLink.hasFallback())
+
+        appLink = AppLinkRedirect(appIntent = mock(), webUrl = "https://example.com", isFallback = false)
+        assertFalse(appLink.hasFallback())
+
+        appLink = AppLinkRedirect(appIntent = mock(), webUrl = "https://example.com", isFallback = true)
+        assertTrue(appLink.hasFallback())
+    }
+
+    @Test
+    fun isRedirect() {
+        var appLink = AppLinkRedirect(appIntent = null, webUrl = null, isFallback = true)
+        assertFalse(appLink.isRedirect())
+
+        appLink = AppLinkRedirect(appIntent = mock(), webUrl = null, isFallback = true)
+        assertTrue(appLink.isRedirect())
+
+        appLink = AppLinkRedirect(appIntent = null, webUrl = "https://example.com", isFallback = true)
+        assertTrue(appLink.isRedirect())
+
+        appLink = AppLinkRedirect(appIntent = mock(), webUrl = "https://example.com", isFallback = true)
+        assertTrue(appLink.isRedirect())
+    }
+
+    @Test
+    fun isInstallable() {
+        val intent: Intent = mock()
+        val uri: Uri = mock()
+        `when`(intent.data).thenReturn(uri)
+        `when`(uri.scheme).thenReturn("market")
+
+        var appLink = AppLinkRedirect(appIntent = null, webUrl = "https://example.com", isFallback = true)
+        assertFalse(appLink.isInstallable())
+
+        appLink = AppLinkRedirect(appIntent = intent, webUrl = "https://example.com", isFallback = true)
+        assertTrue(appLink.isInstallable())
+    }
+}


### PR DESCRIPTION
This PR exposes the icon and name of the app used to open a given link. 

This is to allow Fenix to display the app icon in the Quick Action Bar `Open in App` action.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
