### PR TITLE
For mozilla-mobile#4336: Fix download names

### DIFF
--- a/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -11,8 +11,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
 
-private val CONTENT_DISPOSITION_TYPES = listOf("attachment", "inline")
-
 @RunWith(AndroidJUnit4::class)
 class DownloadUtilsTest {
 
@@ -57,10 +55,6 @@ class DownloadUtilsTest {
         }
     }
 
-    private fun assertUrl(expected: String, url: String) {
-        assertEquals(expected, DownloadUtils.guessFileName(null, url, null))
-    }
-
     @Test
     fun guessFileName_url() {
         assertUrl("downloadfile.bin", "http://example.com/")
@@ -72,8 +66,26 @@ class DownloadUtilsTest {
     @Test
     fun guessFileName_mimeType() {
         Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("jpg", "image/jpeg")
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("zip", "application/zip")
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("tar.gz", "application/gzip")
 
         assertEquals("file.jpg", DownloadUtils.guessFileName(null, "http://example.com/file.jpg", "image/jpeg"))
         assertEquals("file.jpg", DownloadUtils.guessFileName(null, "http://example.com/file.bin", "image/jpeg"))
+        assertEquals(
+            "Caesium-wahoo-v3.6-b792615ced1b.zip",
+            DownloadUtils.guessFileName(null, "https://download.msfjarvis.website/caesium/wahoo/beta/Caesium-wahoo-v3.6-b792615ced1b.zip", "application/zip")
+        )
+        assertEquals(
+            "compressed.TAR.GZ",
+            DownloadUtils.guessFileName(null, "http://example.com/compressed.TAR.GZ", "application/gzip")
+        )
+    }
+
+    companion object {
+        private val CONTENT_DISPOSITION_TYPES = listOf("attachment", "inline")
+
+        private fun assertUrl(expected: String, url: String) {
+            assertEquals(expected, DownloadUtils.guessFileName(null, url, null))
+        }
     }
 }


### PR DESCRIPTION
When a mimetype is specified with a null content disposition, the filename was truncated based on the first `.` character rather than the last.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
