### PR TITLE
 Closes #3758: Add default lifecycle owner for observer registration 

### DIFF
--- a/components/feature/push/build.gradle
+++ b/components/feature/push/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
+    implementation Dependencies.androidx_work_runtime
 
     testImplementation project(':support-test')
 

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -9,6 +9,7 @@ package mozilla.components.feature.push
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -162,21 +163,32 @@ class AutoPushFeature(
 
     /**
      * Register to receive push subscriptions when requested or when they have been re-registered.
+     *
+     * @param observer the observer that will be notified.
+     * @param owner the lifecycle owner for the observer. Defaults to [ProcessLifecycleOwner].
+     * @param autoPause whether to stop notifying the observer during onPause lifecycle events.
+     * Defaults to false so that subscriptions are always delivered to observers.
      */
     fun registerForSubscriptions(
         observer: PushSubscriptionObserver,
-        owner: LifecycleOwner,
-        autoPause: Boolean
+        owner: LifecycleOwner = ProcessLifecycleOwner.get(),
+        autoPause: Boolean = false
     ) = subscriptionObservers.register(observer, owner, autoPause)
 
     /**
      * Register to receive push messages for the associated [PushType].
+     *
+     * @param type the push message type that you want to be registered.
+     * @param observer the observer that will be notified.
+     * @param owner the lifecycle owner for the observer. Defaults to [ProcessLifecycleOwner].
+     * @param autoPause whether to stop notifying the observer during onPause lifecycle events.
+     * Defaults to false so that messages are always delivered to observers.
      */
     fun registerForPushMessages(
         type: PushType,
         observer: Bus.Observer<PushType, String>,
-        owner: LifecycleOwner,
-        autoPause: Boolean
+        owner: LifecycleOwner = ProcessLifecycleOwner.get(),
+        autoPause: Boolean = false
     ) = messageObserverBus.register(type, observer, owner, autoPause)
 
     /**
@@ -319,7 +331,12 @@ enum class Protocol {
 /**
  * The subscription information from Autopush that can be used to send push messages to other devices.
  */
-data class AutoPushSubscription(val type: PushType, val endpoint: String, val publicKey: String, val authKey: String)
+data class AutoPushSubscription(
+    val type: PushType,
+    val endpoint: String,
+    val publicKey: String,
+    val authKey: String
+)
 
 /**
  * Configuration object for initializing the Push Manager.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
-* **browser-engine-gecko-nightly**  
+* **browser-engine-gecko-nightly**
   * Now supports window requests. A new tab will be opened for `target="_blank"` links and `window.open` calls.
 
 * **feature-app-links**
@@ -20,10 +20,10 @@ permalink: /changelog/
 
 * **feature-session**
   * ⚠️ **This is a breaking change**:
-  * The `WindowFeature` no longer needs and engine can now be created using just: 
+  * The `WindowFeature` no longer needs and engine can now be created using just:
   ```kotlin
      val windowFeature = WindowFeature(components.sessionManager)
-  ```  
+  ```
 
 # 6.0.0
 
@@ -91,6 +91,9 @@ permalink: /changelog/
 
 * **support-ktx**
   * Added `Collection.crossProduct` to retrieve the cartesian product of two `Collections`.
+
+* **feature-push**
+  * Added default arguments when registering for subscriptions/messages.
 
 # 5.0.0
 


### PR DESCRIPTION
No tests were added; mocking the `ProcessLifecycleOwner` wasn't straightforward but happy to try suggestions!


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
