### PR TITLE
Issue #2295 - Convert WebNotification to Notification

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -22,7 +22,6 @@ package mozilla.components.concept.engine.webnotifications
  * notification was clicked.
  * @property onClose Callback called when the notification is dismissed.
  */
-@Suppress("Unused")
 data class WebNotification(
     val origin: String,
     val title: String? = null,

--- a/components/feature/webnotifications/build.gradle
+++ b/components/feature/webnotifications/build.gradle
@@ -22,14 +22,20 @@ android {
     }
 }
 
-
 dependencies {
+    implementation project(':browser-icons')
+    implementation project(':concept-engine')
     implementation project(':support-ktx')
+
+    implementation Dependencies.androidx_core_ktx
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_coroutines
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/components/feature/webnotifications/src/main/java/mozilla/components/feature/notifications/Placeholder.kt
+++ b/components/feature/webnotifications/src/main/java/mozilla/components/feature/notifications/Placeholder.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package mozilla.components.feature.webnotifications
-
-class Placeholder

--- a/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
+++ b/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.webnotifications
+
+import android.app.Notification
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import androidx.core.net.toUri
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.Icon.Source
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.icons.IconRequest.Size
+import mozilla.components.concept.engine.webnotifications.WebNotification
+
+internal class NativeNotificationBridge(
+    private val icons: BrowserIcons
+) {
+
+    /**
+     * Create a system [Notification] from this [WebNotification].
+     */
+    suspend fun convertToAndroidNotification(
+        notification: WebNotification,
+        context: Context,
+        channelId: String
+    ): Notification {
+        val builder = if (SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(context, channelId)
+        } else {
+            @Suppress("Deprecation")
+            Notification.Builder(context)
+        }
+
+        with(notification) {
+            loadIcon(iconUrl?.toUri(), origin, Size.DEFAULT)?.let { icon ->
+                builder.setLargeIcon(icon)
+            }
+
+            builder.setContentTitle(title).setContentText(body)
+
+            @Suppress("Deprecation")
+            builder.setVibrate(vibrate)
+
+            timestamp?.let {
+                builder.setShowWhen(true).setWhen(it)
+            }
+
+            if (silent) {
+                @Suppress("Deprecation")
+                builder.setDefaults(0)
+            }
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Load an icon for a notification.
+     */
+    private suspend fun loadIcon(url: Uri?, origin: String, size: Size): Bitmap? {
+        url ?: return null
+        val icon = icons.loadIcon(IconRequest(
+            url = origin,
+            size = size,
+            resources = listOf(IconRequest.Resource(
+                url = url.toString(),
+                type = IconRequest.Resource.Type.MANIFEST_ICON
+            ))
+        )).await()
+
+        return if (icon.source == Source.GENERATOR) null else icon.bitmap
+    }
+}

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/notifications/PlaceholderTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/notifications/PlaceholderTest.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package mozilla.components.feature.webnotifications
-
-class PlaceholderTest

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.webnotifications
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.concept.engine.webnotifications.WebNotification
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class NativeNotificationBridgeTest {
+
+    private val blankNotificaiton = WebNotification(
+        origin = "https://example.com",
+        onClick = {},
+        onClose = {}
+    )
+
+    private lateinit var icons: BrowserIcons
+    private lateinit var bridge: NativeNotificationBridge
+
+    @Before
+    fun setup() {
+        icons = mock()
+        bridge = NativeNotificationBridge(icons)
+
+        val mockIcon = Icon(mock(), source = Icon.Source.GENERATOR)
+        doReturn(CompletableDeferred(mockIcon)).`when`(icons).loadIcon(any())
+    }
+
+    @Test
+    fun `create blank notification`() = runBlockingTest {
+        val notification = bridge.convertToAndroidNotification(
+            blankNotificaiton,
+            testContext,
+            "channel"
+        )
+
+        assertNull(notification.actions)
+        @Suppress("Deprecation")
+        assertArrayEquals(longArrayOf(), notification.vibrate)
+        assertEquals(0, notification.`when`)
+        assertEquals("channel", notification.channelId)
+        assertNull(notification.getLargeIcon())
+        assertNull(notification.smallIcon)
+    }
+
+    @Test
+    fun `set vibration pattern`() = runBlockingTest {
+        val notification = bridge.convertToAndroidNotification(
+            blankNotificaiton.copy(vibrate = longArrayOf(1, 2, 3)),
+            testContext,
+            "channel"
+        )
+
+        @Suppress("Deprecation")
+        assertArrayEquals(longArrayOf(1, 2, 3), notification.vibrate)
+    }
+
+    @Test
+    fun `set when`() = runBlockingTest {
+        val notification = bridge.convertToAndroidNotification(
+            blankNotificaiton.copy(timestamp = 1234567890),
+            testContext,
+            "channel"
+        )
+
+        assertEquals(1234567890, notification.`when`)
+    }
+
+    @Test
+    fun `icon is loaded from BrowserIcons`() = runBlockingTest {
+        bridge.convertToAndroidNotification(
+            blankNotificaiton.copy(iconUrl = "https://example.com/large.png"),
+            testContext,
+            "channel"
+        )
+
+        verify(icons).loadIcon(
+            IconRequest(
+                url = "https://example.com",
+                size = IconRequest.Size.DEFAULT,
+                resources = listOf(IconRequest.Resource(
+                    url = "https://example.com/large.png",
+                    type = IconRequest.Resource.Type.MANIFEST_ICON
+                ))
+            )
+        )
+    }
+}


### PR DESCRIPTION
Adds a new data class for [web notifications](https://developer.mozilla.org/en-US/docs/Web/API/Notification), and a method to convert it to an Android notification (not to actually send the notification, yet).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
