### PR TITLE
1569765: Indicate that error metrics can be sent on all pings

### DIFF
--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -219,6 +219,8 @@ glean.error:
     notification_emails:
       - telemetry-client-dev@mozilla.com
     expires: never
+    send_in_pings:
+      - all_pings
 
   invalid_label:
     type: labeled_counter
@@ -232,3 +234,5 @@ glean.error:
     notification_emails:
       - telemetry-client-dev@mozilla.com
     expires: never
+    send_in_pings:
+      - all_pings


### PR DESCRIPTION
Error metrics can appear in all pings.  This adds the metadata that will flow down to probe_scraper so it can put these metrics in the table for every ping.

The PR for documentation is here: https://github.com/mozilla/glean/pull/206

This special value has no effect on the client, and the error reporting code already does the right thing with respect to putting the errors in the correct pings.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
