### PR TITLE
Closes #1503: Add support for window requests to engine-gecko.

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -8,10 +8,13 @@ import android.annotation.SuppressLint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
+import mozilla.components.browser.engine.gecko.window.GeckoWindowRequest
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
@@ -58,7 +61,8 @@ class GeckoEngineSession(
             .build()
         GeckoSession(settings)
     },
-    private val context: CoroutineContext = Dispatchers.IO
+    private val context: CoroutineContext = Dispatchers.IO,
+    openGeckoSession: Boolean = true
 ) : CoroutineScope, EngineSession() {
 
     internal lateinit var geckoSession: GeckoSession
@@ -90,7 +94,7 @@ class GeckoEngineSession(
         get() = context + job
 
     init {
-        createGeckoSession()
+        createGeckoSession(shouldOpen = openGeckoSession)
     }
 
     /**
@@ -307,11 +311,8 @@ class GeckoEngineSession(
             session: GeckoSession,
             request: NavigationDelegate.LoadRequest
         ): GeckoResult<AllowOrDeny> {
-            // TODO use onNewSession and create window request:
-            // https://github.com/mozilla-mobile/android-components/issues/1503
             if (request.target == GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW) {
-                geckoSession.loadUri(request.uri)
-                return GeckoResult.fromValue(AllowOrDeny.DENY)
+                return GeckoResult.fromValue(AllowOrDeny.ALLOW)
             }
 
             val response = settings.requestInterceptor?.onLoadRequest(
@@ -353,7 +354,15 @@ class GeckoEngineSession(
         override fun onNewSession(
             session: GeckoSession,
             uri: String
-        ): GeckoResult<GeckoSession> = GeckoResult.fromValue(null)
+        ): GeckoResult<GeckoSession> {
+            val newEngineSession = GeckoEngineSession(runtime, privateMode, defaultSettings, openGeckoSession = false)
+            notifyObservers {
+                MainScope().launch {
+                    onOpenWindowRequest(GeckoWindowRequest(uri, newEngineSession))
+                }
+            }
+            return GeckoResult.fromValue(newEngineSession.geckoSession)
+        }
 
         override fun onLoadError(
             session: GeckoSession,
@@ -689,7 +698,8 @@ class GeckoEngineSession(
         }
     }
 
-    private fun createGeckoSession() {
+    @Suppress("LongMethod")
+    private fun createGeckoSession(shouldOpen: Boolean = true) {
         this.geckoSession = geckoSessionProvider()
 
         defaultSettings?.trackingProtectionPolicy?.let { enableTrackingProtection(it) }
@@ -699,7 +709,9 @@ class GeckoEngineSession(
         defaultSettings?.userAgentString?.let { geckoSession.settings.userAgentOverride = it }
         defaultSettings?.suspendMediaWhenInactive?.let { geckoSession.settings.suspendMediaWhenInactive = it }
 
-        geckoSession.open(runtime)
+        if (shouldOpen) {
+            geckoSession.open(runtime)
+        }
 
         geckoSession.navigationDelegate = createNavigationDelegate()
         geckoSession.progressDelegate = createProgressDelegate()

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/window/GeckoWindowRequest.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/window/GeckoWindowRequest.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.window
+
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.window.WindowRequest
+
+/**
+ * Gecko-based implementation of [WindowRequest].
+ */
+class GeckoWindowRequest(
+    override val url: String,
+    private val engineSession: GeckoEngineSession
+) : WindowRequest {
+
+    override fun prepare(): EngineSession {
+        return this.engineSession
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/window/GeckoWindowRequestTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/window/GeckoWindowRequestTest.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.window
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeckoWindowRequestTest {
+
+    @Test
+    fun testPrepare() {
+        val engineSession: GeckoEngineSession = mock()
+        val windowRequest = GeckoWindowRequest("mozilla.org", engineSession)
+        assertEquals(engineSession, windowRequest.prepare())
+    }
+}

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -567,8 +567,9 @@ class SystemEngineView @JvmOverloads constructor(
             resultMsg: Message?
         ): Boolean {
             session?.internalNotifyObservers {
+                val newEngineSession = SystemEngineSession(context, session?.settings)
                 onOpenWindowRequest(SystemWindowRequest(
-                    view, NestedWebView(context), isDialog, isUserGesture, resultMsg
+                    view, newEngineSession, NestedWebView(context), isDialog, isUserGesture, resultMsg
                 ))
             }
             return true

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/window/SystemWindowRequest.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/window/SystemWindowRequest.kt
@@ -15,12 +15,14 @@ import mozilla.components.concept.engine.window.WindowRequest
  *
  * @property webView the WebView from which the request originated.
  * @property newWebView the WebView to use for opening a new window, may be null for close requests.
+ * @property newEngineSession the new [EngineSession] to handle this request.
  * @property openAsDialog whether or not the window should be opened as a dialog, defaults to false.
  * @property triggeredByUser whether or not the request was triggered by the user, defaults to false.
  * @property resultMsg the message to send to the new WebView, may be null.
  */
 class SystemWindowRequest(
     private val webView: WebView,
+    private val newEngineSession: EngineSession? = null,
     private val newWebView: WebView? = null,
     val openAsDialog: Boolean = false,
     val triggeredByUser: Boolean = false,
@@ -29,10 +31,13 @@ class SystemWindowRequest(
 
     override val url: String = ""
 
-    override fun prepare(engineSession: EngineSession) {
+    override fun prepare(): EngineSession {
+        requireNotNull(newEngineSession)
+
         newWebView?.let {
-            (engineSession as SystemEngineSession).webView = it
+            (newEngineSession as SystemEngineSession).webView = it
         }
+        return newEngineSession
     }
 
     override fun start() {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/window/SystemWindowRequestTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/window/SystemWindowRequestTest.kt
@@ -26,7 +26,8 @@ class SystemWindowRequestTest {
     fun `init request`() {
         val curWebView = mock<WebView>()
         val newWebView = mock<WebView>()
-        val request = SystemWindowRequest(curWebView, newWebView, true, true)
+        val newEngineSession = mock<SystemEngineSession>()
+        val request = SystemWindowRequest(curWebView, newEngineSession, newWebView, true, true)
 
         assertTrue(request.openAsDialog)
         assertTrue(request.triggeredByUser)
@@ -37,10 +38,10 @@ class SystemWindowRequestTest {
     fun `prepare sets webview on engine session`() {
         val curWebView = mock<WebView>()
         val newWebView = mock<WebView>()
-        val request = SystemWindowRequest(curWebView, newWebView)
+        val newEngineSession = SystemEngineSession(testContext)
+        val request = SystemWindowRequest(curWebView, newEngineSession, newWebView)
 
-        val engineSession = SystemEngineSession(testContext)
-        request.prepare(engineSession)
+        val engineSession = request.prepare() as SystemEngineSession
         assertSame(newWebView, engineSession.webView)
     }
 
@@ -49,19 +50,20 @@ class SystemWindowRequestTest {
         val curWebView = mock<WebView>()
         val newWebView = mock<WebView>()
         val resultMsg = mock<Message>()
+        val newEngineSession = mock<SystemEngineSession>()
 
-        SystemWindowRequest(curWebView, newWebView, false, false).start()
+        SystemWindowRequest(curWebView, newEngineSession, newWebView, false, false).start()
         verify(resultMsg, never()).sendToTarget()
 
-        SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
+        SystemWindowRequest(curWebView, newEngineSession, newWebView, false, false, resultMsg).start()
         verify(resultMsg, never()).sendToTarget()
 
         resultMsg.obj = ""
-        SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
+        SystemWindowRequest(curWebView, newEngineSession, newWebView, false, false, resultMsg).start()
         verify(resultMsg, never()).sendToTarget()
 
         resultMsg.obj = mock<WebView.WebViewTransport>()
-        SystemWindowRequest(curWebView, newWebView, false, false, resultMsg).start()
+        SystemWindowRequest(curWebView, newEngineSession, newWebView, false, false, resultMsg).start()
         verify(resultMsg, times(1)).sendToTarget()
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/window/WindowRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/window/WindowRequest.kt
@@ -19,15 +19,15 @@ interface WindowRequest {
     val url: String
 
     /**
-     * Prepares the provided [EngineSession] for the window request. This
-     * is used to attach state (e.g. a native session) to the engine session.
+     * Prepares an [EngineSession] for the window request. This is used to
+     * attach state (e.g. a native session or view) to the engine session.
      *
-     * @param engineSession the engine session to prepare.
+     * @return the prepared and ready-to-use [EngineSession].
      */
-    fun prepare(engineSession: EngineSession)
+    fun prepare(): EngineSession
 
     /**
      * Starts the window request.
      */
-    fun start()
+    fun start() = Unit
 }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/WindowFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/WindowFeature.kt
@@ -7,20 +7,18 @@ package mozilla.components.feature.session
 import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 /**
  * Feature implementation for handling window requests.
  */
-class WindowFeature(private val engine: Engine, private val sessionManager: SessionManager) : LifecycleAwareFeature {
+class WindowFeature(private val sessionManager: SessionManager) : LifecycleAwareFeature {
 
     internal val windowObserver = object : SelectionAwareSessionObserver(sessionManager) {
         override fun onOpenWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
             val newSession = Session(windowRequest.url, session.private)
-            val newEngineSession = engine.createSession(session.private)
-            windowRequest.prepare(newEngineSession)
+            val newEngineSession = windowRequest.prepare()
 
             sessionManager.add(newSession, true, newEngineSession, parent = session)
             windowRequest.start()

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/WindowFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/WindowFeatureTest.kt
@@ -29,7 +29,7 @@ class WindowFeatureTest {
 
     @Test
     fun `start registers window observer`() {
-        val feature = WindowFeature(engine, sessionManager)
+        val feature = WindowFeature(sessionManager)
         feature.start()
         verify(sessionManager).register(feature.windowObserver)
     }
@@ -40,10 +40,10 @@ class WindowFeatureTest {
         val request = mock<WindowRequest>()
         whenever(request.url).thenReturn("about:blank")
 
-        val feature = WindowFeature(engine, sessionManager)
+        val feature = WindowFeature(sessionManager)
         feature.windowObserver.onOpenWindowRequested(session, request)
 
-        verify(request).prepare(any())
+        verify(request).prepare()
         verify(sessionManager).add(any(), eq(true), any(), eq(session))
         verify(request).start()
     }
@@ -52,14 +52,14 @@ class WindowFeatureTest {
     fun `session is removed when window should be closed`() {
         val session = Session("https://www.mozilla.org")
 
-        val feature = WindowFeature(engine, sessionManager)
+        val feature = WindowFeature(sessionManager)
         feature.windowObserver.onCloseWindowRequested(session, mock())
         verify(sessionManager).remove(session)
     }
 
     @Test
     fun `stop unregisters window observer`() {
-        val feature = WindowFeature(engine, sessionManager)
+        val feature = WindowFeature(sessionManager)
         feature.stop()
         verify(sessionManager).unregister(feature.windowObserver)
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,8 +12,18 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-engine-gecko-nightly**  
+  * Now supports window requests. A new tab will be opened for `target="_blank"` links and `window.open` calls.
+
 * **feature-app-links**
   * Fixed [#3944](https://github.com/mozilla-mobile/android-components/issues/3944) causing third-party apps being opened when links with a `javascript` scheme are clicked.
+
+* **feature-session**
+  * ⚠️ **This is a breaking change**:
+  * The `WindowFeature` no longer needs and engine can now be created using just: 
+  ```kotlin
+     val windowFeature = WindowFeature(components.sessionManager)
+  ```  
 
 # 6.0.0
 
@@ -31,6 +41,7 @@ permalink: /changelog/
 
 * **browser-engine-gecko-nightly**
   * The component now handles situations where the Android system kills the content process (without killing the main app process) in order to reclaim resources. In those situations the component will automatically recover and restore the last known state of those sessions.
+  * Now supports window requests. A new tab will be opened for `target="_blank"` links and `window.open` calls.
 
 * **service-location**
   * 🆕 A new component for accessing Mozilla's and other location services.

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -139,7 +139,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler {
             owner = this,
             view = layout)
 
-        val windowFeature = WindowFeature(components.engine, components.sessionManager)
+        val windowFeature = WindowFeature(components.sessionManager)
 
         sitePermissionsFeature.set(
             feature = SitePermissionsFeature(


### PR DESCRIPTION
This brings in window request support for `engine-gecko-nightly`. We can now open new tabs for `target="_blank"` links and `window.open` calls.  🎉 

The trick here was to have an API that works with both `engine-system` and `engine-gecko`, but luckily I only needed a small API change and neither R-B nor Fenix use the feature yet.

@pocmo there's one interesting problem here that we could solve with lib-state. I had to use `MainScope.launch()` when notifying observers of the window request. This is because (for engine-gecko) processing the window request will itself have a side-effect and change the observers list. The side-effect is that a new session is selected causing an observer (the crash observer) to get unregistered (in `GeckoEngineView.render`). This affects the observers we're currently iterating over causing a `ConcurrentModificationException`. By "launching", we can complete the current iteration over existing observers and avoid the problem. 