### PR TITLE
Add a `GleanTestRule` to the Glean SDK

### DIFF
--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt
@@ -21,10 +21,12 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -34,6 +36,8 @@ import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 class PlacesBookmarksStorageTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(testContext)
 
     private var conn: Connection? = null
     private var reader: PlacesReaderConnection? = null
@@ -279,8 +283,6 @@ class PlacesBookmarksStorageTest {
 
     @Test
     fun `sends bookmarks telemetry pings on success`() = runBlocking {
-        resetGlean()
-
         val now = Date().asSeconds()
         val conn = object : Connection {
             var pingCount = 0
@@ -382,8 +384,6 @@ class PlacesBookmarksStorageTest {
 
     @Test
     fun `sends bookmarks telemetry pings on engine failure`() = runBlocking {
-        resetGlean()
-
         val now = Date().asSeconds()
         val conn = object : Connection {
             var pingCount = 0
@@ -550,8 +550,6 @@ class PlacesBookmarksStorageTest {
 
     @Test
     fun `sends bookmarks telemetry pings on sync failure`() = runBlocking {
-        resetGlean()
-
         val now = Date().asSeconds()
         val conn = object : Connection {
             var pingCount = 0

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -23,6 +23,7 @@ import mozilla.components.concept.storage.PageObservation
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
@@ -32,12 +33,15 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 class PlacesHistoryStorageTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(testContext)
 
     private lateinit var history: PlacesHistoryStorage
 
@@ -593,8 +597,6 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `sends history telemetry pings on success`() = runBlocking {
-        resetGlean()
-
         val now = Date().asSeconds()
         val conn = object : Connection {
             var pingCount = 0
@@ -734,8 +736,6 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `sends history telemetry pings on engine failure`() = runBlocking {
-        resetGlean()
-
         val now = Date().asSeconds()
         val conn = object : Connection {
             var pingCount = 0
@@ -911,8 +911,6 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `sends history telemetry pings on sync failure`() = runBlocking {
-        resetGlean()
-
         val now = Date().asSeconds()
         val conn = object : Connection {
             var pingCount = 0

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/TestUtil.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/TestUtil.kt
@@ -4,28 +4,6 @@
 
 package mozilla.components.browser.storage.sync
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
-import androidx.work.testing.WorkManagerTestInitHelper
-import mozilla.components.service.glean.Glean
 import java.util.Date
-
-/**
- * Enable testing mode, initialize [WorkManagerTestInitHelper] for testing,
- * and initialize Glean. This is used in tests that send Glean pings.
- *
- * @param context the application context to init Glean with
- */
-internal fun resetGlean(
-    context: Context = ApplicationProvider.getApplicationContext()
-) {
-    Glean.enableTestingMode()
-
-    // We're using the WorkManager in a bunch of places, and Glean will crash
-    // in tests without this line. Let's simply put it here.
-    WorkManagerTestInitHelper.initializeTestWorkManager(context)
-
-    Glean.initialize(context)
-}
 
 fun Date.asSeconds() = time / BaseGleanSyncPing.MILLIS_PER_SEC

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/GleanCrashReporterServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/GleanCrashReporterServiceTest.kt
@@ -7,14 +7,14 @@ package mozilla.components.lib.crash.service
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.GleanMetrics.CrashMetrics
-import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
@@ -26,18 +26,11 @@ class GleanCrashReporterServiceTest {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
-    private fun setupGleanCrashReporterServiceTest() {
-        WorkManagerTestInitHelper.initializeTestWorkManager(
-            ApplicationProvider.getApplicationContext())
-
-        Glean.enableTestingMode()
-        Glean.initialize(context)
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(context)
 
     @Test
     fun `GleanCrashReporterService records native code crashes`() {
-        setupGleanCrashReporterServiceTest()
-
         // Because of how Glean is implemented, it can potentially persist information between
         // tests or even between test classes, so we compensate by capturing the initial value
         // to compare to.
@@ -77,8 +70,6 @@ class GleanCrashReporterServiceTest {
 
     @Test
     fun `GleanCrashReporterService records uncaught exceptions`() {
-        setupGleanCrashReporterServiceTest()
-
         // Because of how Glean is implemented, it can potentially persist information between
         // tests or even between test classes, so we compensate by capturing the initial value
         // to compare to.
@@ -117,8 +108,6 @@ class GleanCrashReporterServiceTest {
 
     @Test
     fun `GleanCrashReporterService correctly handles multiple crashes in a single file`() {
-        setupGleanCrashReporterServiceTest()
-
         val initialExceptionValue = try {
             CrashMetrics.crashCount[GleanCrashReporterService.UNCAUGHT_EXCEPTION_KEY].testGetValue()
         } catch (e: NullPointerException) {
@@ -194,8 +183,6 @@ class GleanCrashReporterServiceTest {
 
     @Test
     fun `GleanCrashReporterService does not crash if the persistent file is corrupted`() {
-        setupGleanCrashReporterServiceTest()
-
         // Because of how Glean is implemented, it can potentially persist information between
         // tests or even between test classes, so we compensate by capturing the initial value
         // to compare to.

--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -47,6 +47,15 @@ dependencies {
     implementation project(':concept-fetch')
     implementation project(':lib-fetch-httpurlconnection')
 
+    // We need a compileOnly dependency on the following block of testing
+    // libraries in order to expose the GleanTestRule to applications/libraries
+    // using the Glean SDK.
+    // We can't simply create a separate package otherwise we would need
+    // to provide a public API for the testing package to access the
+    // Glean internals, which is something we would not want to do.
+    compileOnly Dependencies.testing_junit
+    compileOnly Dependencies.androidx_work_testing
+
     testImplementation Dependencies.androidx_test_core
 
     testImplementation Dependencies.testing_junit

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -529,15 +529,45 @@ open class GleanInternalAPI internal constructor () {
     }
 
     /**
-     * Should be called from all users of the Glean testing API.
+     * TEST ONLY FUNCTION.
+     * This is called by the GleanTestRule, to enable test mode.
      *
      * This makes all asynchronous work synchronous so we can test the results of the
      * API synchronously.
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun enableTestingMode() {
+    internal fun enableTestingMode() {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.setTestingMode(enabled = true)
+    }
+
+    /**
+     * TEST ONLY FUNCTION.
+     * Resets the Glean state and trigger init again.
+     *
+     * @param context the application context to init Glean with
+     * @param config the [Configuration] to init Glean with
+     * @param clearStores if true, clear the contents of all stores
+     */
+    internal fun resetGlean(
+        context: Context,
+        config: Configuration,
+        clearStores: Boolean
+    ) {
+        Glean.enableTestingMode()
+
+        if (clearStores) {
+            // Clear all the stored data.
+            val storageManager = StorageEngineManager(applicationContext = context)
+            storageManager.clearAllStores()
+            // The experiments storage engine needs to be cleared manually as it's not listed
+            // in the `StorageEngineManager`.
+            ExperimentsStorageEngine.clearAllStores()
+        }
+
+        // Init Glean.
+        Glean.initialized = false
+        Glean.setUploadEnabled(true)
+        Glean.initialize(context, config)
     }
 }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/testing/GleanTestRule.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/testing/GleanTestRule.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.testing
+
+import android.content.Context
+import androidx.work.testing.WorkManagerTestInitHelper
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.config.Configuration
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * This implements a JUnit rule for writing tests for Glean SDK metrics.
+ *
+ * The rule takes care of resetting the Glean SDK between tests and
+ * initializing all the required dependencies.
+ *
+ * Example usage:
+ *
+ * ```
+ * // Add the following lines to you test class.
+ * @get:Rule
+ * val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+ * ```
+ */
+class GleanTestRule(
+    val context: Context
+) : TestWatcher() {
+    override fun starting(description: Description?) {
+        // We're using the WorkManager in a bunch of places, and Glean will crash
+        // in tests without this line. Let's simply put it here.
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+
+        Glean.resetGlean(
+            context = context,
+            config = Configuration(),
+            clearStores = true
+        )
+    }
+}

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -27,6 +27,7 @@ import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.StorageEngineManager
 import mozilla.components.service.glean.storages.StringsStorageEngine
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.utils.getLanguageFromLocale
 import mozilla.components.service.glean.utils.getLocaleTag
 import org.json.JSONObject
@@ -37,7 +38,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
@@ -60,10 +61,8 @@ import mozilla.components.service.glean.private.TimeUnit as GleanTimeUnit
 @RunWith(RobolectricTestRunner::class)
 class GleanTest {
 
-    @Before
-    fun setup() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `disabling upload should disable metrics recording`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -22,7 +22,6 @@ import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.scheduler.PingUploadWorker
-import mozilla.components.service.glean.storages.ExperimentsStorageEngine
 import mozilla.components.service.glean.storages.StorageEngineManager
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -123,25 +122,10 @@ internal fun resetGlean(
     config: Configuration = Configuration(),
     clearStores: Boolean = true
 ) {
-    Glean.enableTestingMode()
-
     // We're using the WorkManager in a bunch of places, and Glean will crash
     // in tests without this line. Let's simply put it here.
     WorkManagerTestInitHelper.initializeTestWorkManager(context)
-
-    if (clearStores) {
-        // Clear all the stored data.
-        val storageManager = StorageEngineManager(applicationContext = context)
-        storageManager.clearAllStores()
-        // The experiments storage engine needs to be cleared manually as it's not listed
-        // in the `StorageEngineManager`.
-        ExperimentsStorageEngine.clearAllStores()
-    }
-
-    // Init Glean.
-    Glean.initialized = false
-    Glean.setUploadEnabled(true)
-    Glean.initialize(context, config)
+    Glean.resetGlean(context, config, clearStores)
 }
 
 /**

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -22,6 +22,8 @@ import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
 import mozilla.components.service.glean.TestPingTagClient
 import mozilla.components.service.glean.getMockWebServer
+import mozilla.components.service.glean.testing.GleanTestRule
+import org.junit.Rule
 import org.robolectric.Shadows.shadowOf
 import java.util.concurrent.TimeUnit
 
@@ -30,10 +32,11 @@ class GleanDebugActivityTest {
 
     private val testPackageName = "mozilla.components.service.glean"
 
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
     @Before
     fun setup() {
-        resetGlean()
-
         // This makes sure we have a "launch" intent in our package, otherwise
         // it will fail looking for it in `GleanDebugActivityTest`.
         val pm = ApplicationProvider.getApplicationContext<Context>().packageManager

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/error/ErrorRecordingTest.kt
@@ -4,23 +4,23 @@
 
 package mozilla.components.service.glean.error
 
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringMetricType
-import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.storages.CountersStorageEngine
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.base.log.logger.Logger
 import org.junit.Assert.assertEquals
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class ErrorRecordingTest {
-    @Before
-    fun setup() {
-        resetGlean()
-    }
+
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `test recording of all error types`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/BooleanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/BooleanMetricTypeTest.kt
@@ -4,12 +4,13 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,10 +21,8 @@ import java.lang.NullPointerException
 @RunWith(RobolectricTestRunner::class)
 class BooleanMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/CounterMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/CounterMetricTypeTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,10 +22,8 @@ import java.lang.NullPointerException
 @RunWith(RobolectricTestRunner::class)
 class CounterMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/DatetimeMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/DatetimeMetricTypeTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,10 +23,8 @@ import java.util.TimeZone
 @RunWith(RobolectricTestRunner::class)
 class DatetimeMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/EventMetricTypeTest.kt
@@ -5,15 +5,16 @@
 package mozilla.components.service.glean.private
 
 import android.os.SystemClock
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -32,10 +33,8 @@ enum class testNameKeys {
 @RunWith(RobolectricTestRunner::class)
 class EventMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API records to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/LabeledMetricTypeTest.kt
@@ -10,7 +10,6 @@ import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.GleanMetrics.Pings
 import mozilla.components.service.glean.collectAndCheckPingSchema
 import mozilla.components.service.glean.error.ErrorRecording
-import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.storages.BooleansStorageEngine
 import mozilla.components.service.glean.storages.CountersStorageEngine
 import mozilla.components.service.glean.storages.MockGenericStorageEngine
@@ -18,10 +17,11 @@ import mozilla.components.service.glean.storages.StringListsStorageEngine
 import mozilla.components.service.glean.storages.StringsStorageEngine
 import mozilla.components.service.glean.storages.TimespansStorageEngine
 import mozilla.components.service.glean.storages.UuidsStorageEngine
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
@@ -44,10 +44,8 @@ class LabeledMetricTypeTest {
         override val sendInPings: List<String>
     ) : CommonMetricData
 
-    @Before
-    fun setup() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `test labeled counter type`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.checkPingSchema
 import mozilla.components.service.glean.getContextWithMockedInfo
@@ -11,6 +12,7 @@ import mozilla.components.service.glean.getMockWebServer
 import mozilla.components.service.glean.getWorkerStatus
 import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.scheduler.PingUploadWorker
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.triggerWorkManager
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -18,7 +20,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -27,10 +29,8 @@ import java.util.concurrent.TimeUnit
 @RunWith(RobolectricTestRunner::class)
 class PingTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `test sending of custom pings`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringListMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringListMetricTypeTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,10 +22,8 @@ import java.lang.NullPointerException
 @RunWith(RobolectricTestRunner::class)
 class StringListMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API saves to its storage engine by first adding then setting`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/StringMetricTypeTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,10 +22,8 @@ import java.lang.NullPointerException
 @RunWith(RobolectricTestRunner::class)
 class StringMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimespanMetricTypeTest.kt
@@ -1,14 +1,15 @@
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.lang.NullPointerException
@@ -16,10 +17,8 @@ import java.lang.NullPointerException
 @RunWith(RobolectricTestRunner::class)
 class TimespanMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API must record to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/TimingDistributionMetricTypeTest.kt
@@ -4,15 +4,16 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -23,10 +24,8 @@ import java.lang.NullPointerException
 @RunWith(RobolectricTestRunner::class)
 class TimingDistributionMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @After
     fun reset() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/UuidMetricTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/UuidMetricTypeTest.kt
@@ -4,13 +4,14 @@
 
 package mozilla.components.service.glean.private
 
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,10 +23,8 @@ import java.util.UUID
 @RunWith(RobolectricTestRunner::class)
 class UuidMetricTypeTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `The API saves to its storage engine`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/CountersStorageEngineTest.kt
@@ -11,11 +11,11 @@ import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.CounterMetricType
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertFalse
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
@@ -26,10 +26,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CountersStorageEngineTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `counter deserializer should correctly parse integers`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/DatetimesStorageEngineTest.kt
@@ -9,10 +9,10 @@ import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.private.DatetimeMetricType
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
@@ -25,10 +25,8 @@ import java.util.TimeZone
 @RunWith(RobolectricTestRunner::class)
 class DatetimesStorageEngineTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `datetime deserializer should correctly parse datetimes`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -4,6 +4,7 @@
 package mozilla.components.service.glean.storages
 
 import android.os.SystemClock
+import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.checkPingSchema
 import mozilla.components.service.glean.error.ErrorRecording.ErrorType
@@ -14,14 +15,15 @@ import mozilla.components.service.glean.private.EventMetricType
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.triggerWorkManager
 import org.json.JSONObject
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -48,9 +50,11 @@ enum class TruncatedKeys {
 
 @RunWith(RobolectricTestRunner::class)
 class EventsStorageEngineTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
     @Before
     fun setUp() {
-        resetGlean()
         assert(Glean.initialized)
         EventsStorageEngine.clearAllStores()
     }
@@ -276,7 +280,7 @@ class EventsStorageEngineTest {
                 click.record(extra = mapOf(TestEventNumberKeys.TestEventNumber to "$i"))
             }
 
-            Assert.assertTrue(click.testHasValue())
+            assertTrue(click.testHasValue())
 
             // Trigger worker task to upload the pings in the background
             triggerWorkManager()

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringListsStorageEngineTest.kt
@@ -11,13 +11,13 @@ import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringListMetricType
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
@@ -27,10 +27,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class StringListsStorageEngineTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `set() properly sets the value in all stores`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/StringsStorageEngineTest.kt
@@ -10,11 +10,11 @@ import mozilla.components.service.glean.error.ErrorRecording.ErrorType
 import mozilla.components.service.glean.error.ErrorRecording.testGetNumRecordedErrors
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.StringMetricType
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
@@ -25,10 +25,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class StringsStorageEngineTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `string deserializer should correctly parse strings`() {

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimespansStorageEngineTest.kt
@@ -9,7 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.private.Lifetime
 import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimespanMetricType
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.After
 
@@ -17,6 +17,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.Mockito.eq
 import org.mockito.Mockito.mock
@@ -26,9 +27,11 @@ import java.util.concurrent.TimeUnit as AndroidTimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class TimespansStorageEngineTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
     @Before
     fun setUp() {
-        resetGlean()
         TimespansStorageEngine.applicationContext = ApplicationProvider.getApplicationContext()
         TimespansStorageEngine.clearAllStores()
     }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/TimingDistributionsStorageEngineTest.kt
@@ -14,14 +14,14 @@ import mozilla.components.service.glean.private.TimeUnit
 import mozilla.components.service.glean.private.TimingDistributionMetricType
 import mozilla.components.service.glean.error.ErrorRecording
 import mozilla.components.service.glean.private.PingType
-import mozilla.components.service.glean.resetGlean
+import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.service.glean.timing.TimingManager
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
@@ -31,10 +31,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class TimingDistributionsStorageEngineTest {
 
-    @Before
-    fun setUp() {
-        resetGlean()
-    }
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     @After
     fun reset() {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,9 @@ permalink: /changelog/
 
 * **support-ktx**
   * Added `Collection.crossProduct` to retrieve the cartesian product of two `Collections`.
+  
+* **service-glean**
+  * ⚠️ **This is a breaking change**: `Glean.enableTestingMode` is now `internal`. Tests can use the `GleanTestRule` to enable testing mode. [Updated docs available here](https://mozilla.github.io/glean/book/user/testing-metrics.html).
 
 # 5.0.0
 

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -46,6 +46,13 @@ dependencies {
     implementation Dependencies.androidx_browser
 
     implementation project(':samples-glean-library')
+
+    androidTestImplementation Dependencies.androidx_test_core
+    androidTestImplementation Dependencies.androidx_test_runner
+    androidTestImplementation Dependencies.androidx_test_rules
+    androidTestImplementation Dependencies.androidx_test_junit
+    androidTestImplementation Dependencies.androidx_espresso_core
+    androidTestImplementation Dependencies.androidx_work_testing
 }
 
 apply from: '../../components/service/glean/scripts/sdk_generator.gradle'

--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.glean
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import mozilla.components.service.glean.testing.GleanTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.mozilla.samples.glean.GleanMetrics.Test as GleanTestMetrics
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
+
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
+    @Test
+    fun checkGleanClickData() {
+        // Simulate a click on the button.
+        onView(withId(R.id.buttonGenerateData)).perform(click())
+
+        // Use the Glean testing API to check if the expected data was recorded.
+        assertTrue(GleanTestMetrics.testCounter.testHasValue())
+        assertEquals(1, GleanTestMetrics.testCounter.testGetValue())
+    }
+
+    @Test
+    fun checkGleanClickDataAgain() {
+        // Repeat the same test as above: this will fail if the GleanTestRule fails to
+        // clear the Glean SDK state.
+        checkGleanClickData()
+    }
+}


### PR DESCRIPTION
This is broken down in 3 independent commits: each of them consistently builds and runs on its own.

The first commit creates the testing rule, the second updates the Glean SDK tests and the third uses the rule and the glean testing API in the `samples-glean` application.

The documentation will be updated when porting this to glean-core.

**Note**:  this additionally changes lib-crash and browser-sync tests to use the rule.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
