### PR TITLE
1569683- Record active experiment in Glean when loaded from cache

### DIFF
--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/Experiments.kt
@@ -192,10 +192,11 @@ open class ExperimentsInternalAPI internal constructor() {
         assert(activeExperiment == null) { "Should not have an active experiment" }
 
         val activeExperiment = ActiveExperiment.load(context, experiments)
-        logger.info(activeExperiment?.let
-        { """Loaded active experiment from cache - id="${it.experiment.id}", branch="${it.branch}"""" }
-            ?: "No active experiment in cache"
-        )
+
+        activeExperiment?.let {
+            Glean.setExperimentActive(it.experiment.id, it.branch)
+            logger.info("""Loaded active experiment from cache - id="${it.experiment.id}", branch="${it.branch}"""")
+        } ?: logger.info("No active experiment in cache")
 
         return activeExperiment
     }


### PR DESCRIPTION
When loading from cached experiments, the service-experiments library was not reporting the active experiment to Glean.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
