### PR TITLE
fixes #3962 Suppress or fix tab-collections' Room feature

### DIFF
--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
@@ -29,7 +29,7 @@ internal interface TabCollectionDao {
 
     @Transaction
     @Query("""
-        SELECT tab_collections.id, tab_collections.title, tab_collections.created_at,tab_collections.updated_at
+        SELECT tab_collections.id, tab_collections.title, tab_collections.created_at, tab_collections.updated_at
         FROM tab_collections LEFT JOIN tabs ON tab_collections.id = tab_collection_id
         GROUP BY tab_collections.id
         ORDER BY tab_collections.updated_at DESC

--- a/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
+++ b/components/feature/tab-collections/src/main/java/mozilla/components/feature/tab/collections/db/TabCollectionDao.kt
@@ -10,6 +10,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 
 /**
@@ -26,14 +27,16 @@ internal interface TabCollectionDao {
     @Update
     fun updateTabCollection(collection: TabCollectionEntity)
 
+    @Transaction
     @Query("""
-        SELECT *
+        SELECT tab_collections.id, tab_collections.title, tab_collections.created_at,tab_collections.updated_at
         FROM tab_collections LEFT JOIN tabs ON tab_collections.id = tab_collection_id
         GROUP BY tab_collections.id
-        ORDER BY updated_at DESC
+        ORDER BY tab_collections.updated_at DESC
     """)
     fun getTabCollectionsPaged(): DataSource.Factory<Int, TabCollectionWithTabs>
 
+    @Transaction
     @Query("""
         SELECT *
         FROM tab_collections


### PR DESCRIPTION
added explicit select instead of * select. A * join select returns columns from both tables when column_names are the same. the alternative would be using the "USING" keyword in JOIN, but the name of the column with id is not the same in TabEntity and TabCollectionEntity.

added @Transaction annotation to make query run in a single transaction. TabCollectionWithTabs defines a @Relation  that makes any query that returns one of the POJO's also fetch all it's relations. That makes all fields in the JOIN clause a separate query that could return inconsistent results if the dataset is modified in the meantime.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
