### PR TITLE
Allow `start` again after `stop` in the TimespanMetricType

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
@@ -60,7 +60,7 @@ data class TimespanMetricType(
 
     /**
      * Stop tracking time for the provided metric.
-     * Add the elapsed time to the time currently stored in the metric. This will record
+     * Sets the metric to the elapsed time.This will record
      * an error if no [start] was called.
      */
     fun stop() {
@@ -82,7 +82,10 @@ data class TimespanMetricType(
             TimingManager.stop(this, id)?.let { elapsedNanos ->
                 @Suppress("EXPERIMENTAL_API_USAGE")
                 Dispatchers.API.launch {
-                    TimespansStorageEngine.sum(this@TimespanMetricType, timeUnit, elapsedNanos)
+                    TimespansStorageEngine.set(this@TimespanMetricType, timeUnit, elapsedNanos)
+
+                    // Reset the timerId.
+                    timerId = null
                 }
             }
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,9 @@ permalink: /changelog/
      val windowFeature = WindowFeature(components.sessionManager)
   ```
   
+* **service-glean**
+  * Fixed a bug in`TimeSpanMetricType` that prevented multiple consecutive `start()`/`stop()` calls. This resulted in the `glean.baseline.duration` being missing from most [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings.
+
 # 6.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.0...v6.0.1)


### PR DESCRIPTION
This also changes the testing function testGetNumberOfErrors
to not crash, but rather report 0, if no error was reported.
This whole PR addresses the problem of 'glean.baseline.duration'
not being reported after the first baseline ping.

**Note**: the tests changes are due to backporting the tests from glean-core, which are a bit more comprehensive

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
