### PR TITLE
Issue #3656: Reduce browser icons memory footprint

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -199,6 +199,10 @@ class BrowserIcons(
             view.get()?.setTag(R.id.mozac_browser_icons_tag_job, null)
         }
     }
+
+    fun onLowMemory() {
+        sharedMemoryCache.clear()
+    }
 }
 
 private fun prepare(context: Context, preparers: List<IconPreprarer>, request: IconRequest): IconRequest =

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconMemoryCache.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconMemoryCache.kt
@@ -6,7 +6,6 @@ package mozilla.components.browser.icons.utils
 
 import android.graphics.Bitmap
 import android.util.LruCache
-import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.icons.Icon
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.icons.loader.MemoryIconLoader.LoaderMemoryCache
@@ -45,7 +44,6 @@ class IconMemoryCache : ProcessorMemoryCache, LoaderMemoryCache, MemoryIconPrepa
         }
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     internal fun clear() {
         iconResourcesCache.evictAll()
         iconBitmapCache.evictAll()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-engine-gecko-nightly**
   * Now supports window requests. A new tab will be opened for `target="_blank"` links and `window.open` calls.
 
+* **browser-icons**
+  * Handles low-memory scenarios by reducing memory footprint.
+
 * **feature-app-links**
   * Fixed [#3944](https://github.com/mozilla-mobile/android-components/issues/3944) causing third-party apps being opened when links with a `javascript` scheme are clicked.
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -68,5 +68,6 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
 
     override fun onTrimMemory(level: Int) {
         components.sessionManager.onLowMemory()
+        components.icons.onLowMemory()
     }
 }


### PR DESCRIPTION
When the system triggers a low memory event, handle it by clearing the memory cache of browser icons.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
