### PR TITLE
1570647 - Do not send 'metrics' ping if the app was not used

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -131,7 +131,7 @@ open class GleanInternalAPI internal constructor () {
         // threaded race conditions.
         @Suppress("EXPERIMENTAL_API_USAGE")
         if (!Dispatchers.API.testingMode) {
-            metricsPingScheduler.startupCheck()
+            metricsPingScheduler.schedule()
         }
 
         // Signal Dispatcher that init is complete


### PR DESCRIPTION
This attempts to address the issue around sending of metrics pings when the app hasn't been used for that day.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
