### PR TITLE
Closes #3272, #2438: Improve FirefoxAccountsAuthFeature to allow apps to decide how to open the FxA login.

### DIFF
--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
-import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.service.fxa.ServerConfig
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.any
@@ -21,10 +20,10 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.service.fxa.DeviceConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 
 // Same as the actual account manager, except we get to control how FirefoxAccountShaped instances
 // are created. This is necessary because due to some build issues (native dependencies not available
@@ -48,63 +47,99 @@ class FirefoxAccountsAuthFeatureTest {
     @Test
     fun `begin authentication`() {
         val manager = prepareAccountManagerForSuccessfulAuthentication()
-        val mockAddTab: TabsUseCases.AddNewTabUseCase = mock()
-        val mockTabs: TabsUseCases = mock()
-        `when`(mockTabs.addTab).thenReturn(mockAddTab)
+        var path = ""
+        var wasCalled = false
+        val onBeginAuthentication: (String) -> Unit = {
+            path = it
+            wasCalled = true
+        }
 
         runBlocking {
-            val feature = FirefoxAccountsAuthFeature(manager, mockTabs, "somePath", this.coroutineContext)
+            val feature = FirefoxAccountsAuthFeature(
+                manager,
+                "somePath",
+                this.coroutineContext,
+                onBeginAuthentication
+            )
             feature.beginAuthentication()
         }
 
-        verify(mockAddTab, times(1)).invoke("auth://url")
+        assertTrue(wasCalled)
+        assertEquals("auth://url", path)
     }
 
     @Test
     fun `begin pairing authentication`() {
         val manager = prepareAccountManagerForSuccessfulAuthentication()
-        val mockAddTab: TabsUseCases.AddNewTabUseCase = mock()
-        val mockTabs: TabsUseCases = mock()
-        `when`(mockTabs.addTab).thenReturn(mockAddTab)
+        var path = ""
+        var wasCalled = false
+        val onBeginAuthentication: (String) -> Unit = {
+            path = it
+            wasCalled = true
+        }
 
         runBlocking {
-            val feature = FirefoxAccountsAuthFeature(manager, mockTabs, "somePath", this.coroutineContext)
+            val feature = FirefoxAccountsAuthFeature(
+                manager,
+                "somePath",
+                this.coroutineContext,
+                onBeginAuthentication
+            )
             feature.beginPairingAuthentication("auth://pair")
         }
 
-        verify(mockAddTab, times(1)).invoke("auth://url")
+        assertTrue(wasCalled)
+        assertEquals("auth://url", path)
     }
 
     @Test
     fun `begin authentication with errors`() {
         val manager = prepareAccountManagerForFailedAuthentication()
-        val mockAddTab: TabsUseCases.AddNewTabUseCase = mock()
-        val mockTabs: TabsUseCases = mock()
-        `when`(mockTabs.addTab).thenReturn(mockAddTab)
+        var path = ""
+        var wasCalled = false
+        val onBeginAuthentication: (String) -> Unit = {
+            path = it
+            wasCalled = true
+        }
 
         runBlocking {
-            val feature = FirefoxAccountsAuthFeature(manager, mockTabs, "somePath", this.coroutineContext)
+            val feature = FirefoxAccountsAuthFeature(
+                manager,
+                "somePath",
+                this.coroutineContext,
+                onBeginAuthentication
+            )
             feature.beginAuthentication()
         }
 
         // Fallback url is invoked.
-        verify(mockAddTab, times(1)).invoke("https://accounts.firefox.com/signin")
+        assertTrue(wasCalled)
+        assertEquals("https://accounts.firefox.com/signin", path)
     }
 
     @Test
     fun `begin pairing authentication with errors`() {
         val manager = prepareAccountManagerForFailedAuthentication()
-        val mockAddTab: TabsUseCases.AddNewTabUseCase = mock()
-        val mockTabs: TabsUseCases = mock()
-        `when`(mockTabs.addTab).thenReturn(mockAddTab)
+        var path = ""
+        var wasCalled = false
+        val onBeginAuthentication: (String) -> Unit = {
+            path = it
+            wasCalled = true
+        }
 
         runBlocking {
-            val feature = FirefoxAccountsAuthFeature(manager, mockTabs, "somePath", this.coroutineContext)
+            val feature = FirefoxAccountsAuthFeature(
+                manager,
+                "somePath",
+                this.coroutineContext,
+                onBeginAuthentication
+            )
             feature.beginPairingAuthentication("auth://pair")
         }
 
         // Fallback url is invoked.
-        verify(mockAddTab, times(1)).invoke("https://accounts.firefox.com/signin")
+        assertTrue(wasCalled)
+        assertEquals("https://accounts.firefox.com/signin", path)
     }
 
     private fun prepareAccountManagerForSuccessfulAuthentication(): TestableFxaAccountManager {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,20 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-accounts**
+    * ⚠️ **This is a breaking change**:
+    * The `FirefoxAccountsAuthFeature` no longer needs an `TabsUseCases` instead it takes a lambda to
+      allow apps to decide which action should be taken fixing [#2438](https://github.com/mozilla-mobile/android-components/issues/2438) and [#3272](https://github.com/mozilla-mobile/android-components/issues/3272).
+
+    ```kotlin
+     val feature = FirefoxAccountsAuthFeature(
+         accountManager,
+         redirectUrl
+     ){
+        tabsUseCases.addTab(authUrl)
+     }
+    ```
+
 * **browser-engine-gecko-nightly**
   * Now supports window requests. A new tab will be opened for `target="_blank"` links and `window.open` calls.
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
