### PR TITLE
Fix changelog entry for AccountObserver [ci skip]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,9 @@ permalink: /changelog/
 * **service-glean**
   * Fixed a bug in`TimeSpanMetricType` that prevented multiple consecutive `start()`/`stop()` calls. This resulted in the `glean.baseline.duration` being missing from most [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings.
 
+* **service-firefox-accounts**
+  * ⚠️ **This is a breaking change**: `AccountObserver.onAuthenticated` now helps observers distinguish when an account is a new authenticated account one with a second `newAccount` boolean parameter.
+
 # 6.0.2
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.1...v6.0.2)
@@ -80,9 +83,6 @@ permalink: /changelog/
 
 * **service-location**
   * 🆕 A new component for accessing Mozilla's and other location services.
-
-* **service-firefox-accounts**
-  * ⚠️ **This is a breaking change**: `AccountObserver.onAuthenticated` now helps observers distinguish when an account is a new authenticated account one with a second `newAccount` boolean parameter.
 
 * **feature-prompts**
   * Improved month picker UI, now we have the same widget as Fennec.


### PR DESCRIPTION
I put the changelog entry in the wrong place. 🤦‍♂ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
