### PR TITLE
Issue #3647 - Custom HTTP(S) icons in toolbar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.browser.toolbar.display.DisplayToolbar.Companion.BOTTOM_PROGRESS_BAR
+import mozilla.components.browser.toolbar.display.SiteSecurityIcons
 import mozilla.components.browser.toolbar.display.TrackingProtectionIconView
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.AutocompleteDelegate
@@ -113,12 +114,12 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     /**
-     *  Set/Get the site security icon colours (usually a lock or globe icon). It uses a pair of integers
+     *  Set/Get the site security icons (usually a lock or globe icon). It uses a pair of drawables
      *  which represent the insecure and secure colours respectively.
      */
-    var siteSecurityColor: Pair<Int, Int>
-        get() = displayToolbar.securityIconColor
-        set(value) { displayToolbar.securityIconColor = value }
+    var siteSecurityIcons
+        get() = displayToolbar.securityIcons
+        set(value) { displayToolbar.securityIcons = value }
 
     /**
      * Gets/Sets a custom view that will be drawn as behind the URL and page actions in display mode.
@@ -300,6 +301,11 @@ class BrowserToolbar @JvmOverloads constructor(
             editToolbar.urlView.typeface = value
         }
 
+    fun setSiteSecurityColor(colors: Pair<Int, Int>) {
+        displayToolbar.securityIcons =
+            displayToolbar.securityIcons.withColorFilter(colors.first, colors.second)
+    }
+
     /**
      * Sets a listener to be invoked when focus of the URL input view (in edit mode) changed.
      */
@@ -468,15 +474,20 @@ class BrowserToolbar @JvmOverloads constructor(
                     R.styleable.BrowserToolbar_browserToolbarSuggestionBackgroundColor,
                     suggestionBackgroundColor
                 )
-                val inSecure = getColor(
+                val inSecureIcon = getDrawable(R.styleable.BrowserToolbar_browserToolbarInsecureIcon)
+                    ?: displayToolbar.securityIcons.insecure
+                val secureIcon = getDrawable(R.styleable.BrowserToolbar_browserToolbarSecureIcon)
+                    ?: displayToolbar.securityIcons.secure
+                val inSecureColor = getColor(
                     R.styleable.BrowserToolbar_browserToolbarInsecureColor,
-                    displayToolbar.securityIconColor.first
+                    displayToolbar.defaultColor
                 )
-                val secure = getColor(
+                val secureColor = getColor(
                     R.styleable.BrowserToolbar_browserToolbarSecureColor,
-                    displayToolbar.securityIconColor.second
+                    displayToolbar.defaultColor
                 )
-                siteSecurityColor = Pair(inSecure, secure)
+                siteSecurityIcons = SiteSecurityIcons(inSecureIcon, secureIcon)
+                    .withColorFilter(inSecureColor, secureColor)
                 val fadingEdgeLength = getDimensionPixelSize(
                     R.styleable.BrowserToolbar_browserToolbarFadingEdgeSize,
                     resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_fading_edge_size)

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/SiteSecurityIcons.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/SiteSecurityIcons.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.display
+
+import android.content.Context
+import android.graphics.BlendMode
+import android.graphics.BlendModeColorFilter
+import android.graphics.ColorFilter
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import androidx.annotation.ColorInt
+import mozilla.components.ui.icons.R
+
+/**
+ * Specifies icons to display in the toolbar representing the security of the current website.
+ *
+ * @property insecure Icon to display for HTTP sites.
+ * @property secure Icon to display for HTTPS sites.
+ */
+data class SiteSecurityIcons(
+    val insecure: Drawable?,
+    val secure: Drawable?
+) {
+
+    /**
+     * Returns an instance of [SiteSecurityIcons] with a color filter applied to each icon.
+     */
+    fun withColorFilter(insecureColorFilter: ColorFilter, secureColorFilter: ColorFilter): SiteSecurityIcons {
+        return copy(
+            insecure = insecure?.apply { colorFilter = insecureColorFilter },
+            secure = secure?.apply { colorFilter = secureColorFilter }
+        )
+    }
+
+    /**
+     * Returns an instance of [SiteSecurityIcons] with a color tint applied to each icon.
+     */
+    fun withColorFilter(@ColorInt insecureColor: Int, @ColorInt secureColor: Int): SiteSecurityIcons {
+        val insecureColorFilter: ColorFilter = if (SDK_INT >= Build.VERSION_CODES.Q) {
+            BlendModeColorFilter(insecureColor, BlendMode.SRC_IN)
+        } else {
+            PorterDuffColorFilter(insecureColor, PorterDuff.Mode.SRC_IN)
+        }
+
+        val secureColorFilter: ColorFilter = if (SDK_INT >= Build.VERSION_CODES.Q) {
+            BlendModeColorFilter(secureColor, BlendMode.SRC_IN)
+        } else {
+            PorterDuffColorFilter(secureColor, PorterDuff.Mode.SRC_IN)
+        }
+
+        return withColorFilter(insecureColorFilter, secureColorFilter)
+    }
+
+    companion object {
+        fun getDefaultSecurityIcons(context: Context, @ColorInt color: Int): SiteSecurityIcons {
+            return SiteSecurityIcons(
+                insecure = context.getDrawable(R.drawable.mozac_ic_globe),
+                secure = context.getDrawable(R.drawable.mozac_ic_lock)
+            ).withColorFilter(color, color)
+        }
+    }
+}

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -8,6 +8,8 @@
     <attr name="browserToolbarHintColor" format="color"/>
     <attr name="browserToolbarTextColor" format="color"/>
     <attr name="browserToolbarTextSize" format="dimension"/>
+    <attr name="browserToolbarSecureIcon" format="reference"/>
+    <attr name="browserToolbarInsecureIcon" format="reference"/>
     <attr name="browserToolbarSecureColor" format="color"/>
     <attr name="browserToolbarInsecureColor" format="color"/>
     <attr name="browserToolbarMenuColor" format="color"/>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -6,6 +6,8 @@ package mozilla.components.browser.toolbar
 
 import android.content.Context
 import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
@@ -22,13 +24,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.toolbar.BrowserToolbar.Companion.ACTION_PADDING_DP
 import mozilla.components.browser.toolbar.display.DisplayToolbar
+import mozilla.components.browser.toolbar.display.TrackingProtectionIconView.Companion.DEFAULT_ICON_OFF_FOR_A_SITE
 import mozilla.components.browser.toolbar.display.TrackingProtectionIconView.Companion.DEFAULT_ICON_ON_NO_TRACKERS_BLOCKED
 import mozilla.components.browser.toolbar.display.TrackingProtectionIconView.Companion.DEFAULT_ICON_ON_TRACKERS_BLOCKED
-import mozilla.components.browser.toolbar.display.TrackingProtectionIconView.Companion.DEFAULT_ICON_OFF_FOR_A_SITE
 import mozilla.components.browser.toolbar.edit.EditToolbar
 import mozilla.components.concept.toolbar.Toolbar
-import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection
 import mozilla.components.concept.toolbar.Toolbar.SiteSecurity
+import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -904,6 +906,23 @@ class BrowserToolbarTest {
 
         toolbar.displaySiteSecurityIcon = true
         assertEquals(View.VISIBLE, toolbar.displayToolbar.siteSecurityIconView.visibility)
+    }
+
+    @Test
+    fun `siteSecurityColor setter`() {
+        val toolbar = BrowserToolbar(testContext)
+
+        toolbar.setSiteSecurityColor(Color.RED to Color.BLUE)
+        assertEquals(
+            PorterDuffColorFilter(Color.RED, PorterDuff.Mode.SRC_IN),
+            toolbar.displayToolbar.siteSecurityIconView.drawable.colorFilter
+        )
+
+        toolbar.siteSecure = SiteSecurity.SECURE
+        assertEquals(
+            PorterDuffColorFilter(Color.BLUE, PorterDuff.Mode.SRC_IN),
+            toolbar.displayToolbar.siteSecurityIconView.drawable.colorFilter
+        )
     }
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -48,6 +48,14 @@ import org.robolectric.Shadows.shadowOf
 class DisplayToolbarTest {
 
     @Test
+    fun `initialized with security icon`() {
+        val toolbar = mock(BrowserToolbar::class.java)
+        val displayToolbar = DisplayToolbar(testContext, toolbar)
+
+        assertNotNull(displayToolbar.siteSecurityIconView.drawable)
+    }
+
+    @Test
     fun `clicking on the URL switches the toolbar to editing mode`() {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(testContext, toolbar)
@@ -970,26 +978,27 @@ class DisplayToolbarTest {
     }
 
     @Test
-    fun `securityIconColor is set when securityIconColor changes`() {
+    fun `securityIcons is set when securityIcons changes`() {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(testContext, toolbar)
 
-        displayToolbar.securityIconColor = Pair(R.color.photonBlue40, R.color.photonBlue40)
+        val insecure = testContext.getDrawable(R.drawable.mozac_ic_globe)
+        val secure = testContext.getDrawable(R.drawable.mozac_ic_lock)
+        displayToolbar.securityIcons = SiteSecurityIcons(insecure, secure)
 
-        assertEquals(R.color.photonBlue40, displayToolbar.securityIconColor.first)
-        assertEquals(R.color.photonBlue40, displayToolbar.securityIconColor.second)
+        assertEquals(insecure, displayToolbar.securityIcons.insecure)
+        assertEquals(secure, displayToolbar.securityIcons.secure)
     }
 
     @Test
-    fun `setSiteSecurity is called when securityIconColor changes`() {
+    fun `setSiteSecurity is called when securityIcons changes`() {
         val toolbar = BrowserToolbar(testContext)
-        toolbar.displayToolbar
 
-        assertNull(toolbar.displayToolbar.siteSecurityIconView.colorFilter)
+        val icons = SiteSecurityIcons(mock(), mock())
+        assertNotEquals(icons, toolbar.displayToolbar.securityIcons)
 
-        toolbar.siteSecurityColor = Pair(R.color.photonBlue40, R.color.photonBlue40)
-
-        assertNotNull(toolbar.displayToolbar.siteSecurityIconView.colorFilter)
+        toolbar.siteSecurityIcons = icons
+        assertEquals(icons, toolbar.displayToolbar.securityIcons)
     }
 
     @Test

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/MenuButtonTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/MenuButtonTest.kt
@@ -14,6 +14,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.iterator
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
@@ -29,27 +30,26 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
+import org.mockito.MockitoAnnotations.initMocks
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class MenuButtonTest {
 
-    private lateinit var parent: View
+    @Mock private lateinit var parent: View
+    @Mock private lateinit var menuBuilder: BrowserMenuBuilder
+    @Mock private lateinit var menu: BrowserMenu
     private lateinit var menuButton: MenuButton
-    private lateinit var menuBuilder: BrowserMenuBuilder
-    private lateinit var menu: BrowserMenu
 
     @Before
     fun setup() {
-        parent = mock()
+        initMocks(this)
         menuButton = MenuButton(testContext, parent)
-        menuBuilder = mock()
-        menu = mock()
 
         `when`(parent.layoutParams).thenReturn(mock())
         `when`(menuBuilder.build(testContext)).thenReturn(menu)
@@ -129,7 +129,6 @@ class MenuButtonTest {
     private fun extractIcon() =
         menuButton.iterator().asSequence().find { it is AppCompatImageView } as AppCompatImageView
 
-    @Suppress("DEPRECATION")
     private fun mockContextWithColorResource(@ColorRes resId: Int, @ColorInt color: Int): Context {
         val context: Context = spy(testContext)
 
@@ -141,7 +140,9 @@ class MenuButtonTest {
         doReturn(res).`when`(context).resources
 
         doReturn(color).`when`(context).getColor(resId)
+        @Suppress("Deprecation")
         doReturn(color).`when`(res).getColor(resId)
+
         return context
     }
 }

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/SiteSecurityIconsTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/SiteSecurityIconsTest.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.display
+
+import android.graphics.Color
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.drawable.Drawable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class SiteSecurityIconsTest {
+
+    @Test
+    fun `default returns non-null tinted icons`() {
+        val icons = SiteSecurityIcons.getDefaultSecurityIcons(testContext, Color.RED)
+        assertEquals(PorterDuffColorFilter(Color.RED, PorterDuff.Mode.SRC_IN), icons.insecure?.colorFilter)
+        assertEquals(PorterDuffColorFilter(Color.RED, PorterDuff.Mode.SRC_IN), icons.secure?.colorFilter)
+    }
+
+    @Test
+    fun `withColorFilter tints existing drawables`() {
+        val insecure: Drawable = mock()
+        val secure: Drawable = mock()
+        val icons = SiteSecurityIcons(insecure, secure).withColorFilter(Color.BLUE, Color.RED)
+
+        assertEquals(insecure, icons.insecure)
+        assertEquals(secure, icons.secure)
+        verify(insecure).colorFilter = PorterDuffColorFilter(Color.BLUE, PorterDuff.Mode.SRC_IN)
+        verify(secure).colorFilter = PorterDuffColorFilter(Color.RED, PorterDuff.Mode.SRC_IN)
+    }
+
+    @Test
+    fun `withColorFilter allows custom filters to be used`() {
+        val insecure: Drawable = mock()
+        val secure: Drawable = mock()
+        val filter = ColorMatrixColorFilter(ColorMatrix())
+        val icons = SiteSecurityIcons(insecure, secure).withColorFilter(filter, filter)
+
+        assertEquals(insecure, icons.insecure)
+        assertEquals(secure, icons.secure)
+        verify(insecure).colorFilter = filter
+        verify(secure).colorFilter = filter
+    }
+}

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -101,7 +101,7 @@ class CustomTabsToolbarFeature(
             toolbar.setBackgroundColor(color)
             toolbar.textColor = readableColor
             toolbar.titleColor = readableColor
-            toolbar.siteSecurityColor = Pair(readableColor, readableColor)
+            toolbar.setSiteSecurityColor(readableColor to readableColor)
             toolbar.menuViewColor = readableColor
 
             window?.setStatusBarTheme(color)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,10 @@ permalink: /changelog/
 * **browser-engine-gecko-beta**
   * The component now handles situations where the Android system kills the content process (without killing the main app process) in order to reclaim resources. In those situations the component will automatically recover and restore the last known state of those sessions.
 
+* **browser-toolbar**
+  * ⚠️ **This is a breaking change**: The `BrowserToolbar.siteSecurityColor` property has been replaced with the setter `BrowserToolbar.setSiteSecurityColor`.
+  * Added `BrowserToolbar.siteSecurityIcons` to use custom security icons with multiple colors in the toolbar.
+
 # 7.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.2...v7.0.0)


### PR DESCRIPTION
We want to start displaying a broken padlock icon with a red line through it. To make this easy to configure, I believe we should change `BrowserToolbar` to accept two drawables rather than just two colours. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
