### PR TITLE
For #4009. Added ability to disable `warningsAsError` for local builds.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ plugins {
     id("io.gitlab.arturbosch.detekt").version("1.0.0-RC11")
 }
 
+apply plugin: plugins.LocalPropertiesLoader
+
 allprojects {
     repositories {
         google()
@@ -46,8 +48,15 @@ subprojects {
     apply plugin: 'org.jetbrains.dokka-android'
 
     // Enable Kotlin warnings as errors for all modules
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-        kotlinOptions.allWarningsAsErrors = true
+    def enableWarningsAsErrors = rootProject.ext.getProperties()
+            .get('mozilla.build.kotlin.warnings.as.error', true)
+            .toBoolean()
+    if (enableWarningsAsErrors) {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+            kotlinOptions.allWarningsAsErrors = true
+        }
+    } else {
+        println("Warning: `kotlinOptions.allWarningsAsErrors` is not enabled for module ':${project.name}'.")
     }
 
     // Enforce that all (transitive) dependencies are using the same support library version as we do.

--- a/buildSrc/src/main/java/plugins/LocalPropertiesLoader.kt
+++ b/buildSrc/src/main/java/plugins/LocalPropertiesLoader.kt
@@ -1,0 +1,54 @@
+package plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.kotlin.dsl.extra
+import java.io.File
+import java.util.Properties
+
+/**
+ * Load certain properties from local environment as merge them to projects `extra`s.
+ *
+ * Apply this plugin to root project.
+ */
+class LocalPropertiesLoader : Plugin<Project> {
+
+    private val propertiesToLoad = listOf(
+        "mozilla.build.kotlin.warnings.as.error"
+    )
+
+    override fun apply(project: Project) {
+        val file = project.rootProject.file(PROPERTIES_FILE)
+        if (file.exists()) {
+            file.loadPropertiesIntoExtras(project.extra)
+        } else {
+            notifyAboutFailedLoading(file)
+        }
+    }
+
+    private fun File.loadPropertiesIntoExtras(extras: ExtraPropertiesExtension) {
+        Properties()
+            .apply { load(inputStream()) }
+            .filter { propertiesToLoad.contains(it.key) }
+            .forEach { (key, value) ->
+                extras[key.toString()] = value
+
+                logLoadedProperty(key, value)
+            }
+    }
+
+    private fun notifyAboutFailedLoading(file: File) {
+        println("Warning: Can't load local properties from `${file.absolutePath}`. File not found.")
+    }
+
+    @Suppress("ConstantConditionIf")
+    private fun logLoadedProperty(key: Any, value: Any?) {
+        if (!DEBUG) return
+
+        println("Loaded property '$key' -> $value")
+    }
+}
+
+private const val DEBUG = false
+private const val PROPERTIES_FILE = "local.properties"


### PR DESCRIPTION
To disable `warningsAsError` for local environment add this line into `local.properties`:
```
mozilla.build.kotlin.warnings.as.error=false
```

What do you think?

[ ] Force `warningsAsError` for `detekt` and `ktlint` tasks / in pre-commit hook.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
