### PR TITLE
Open downloads when download notification tapped

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -4,10 +4,14 @@
 
 package mozilla.components.feature.downloads
 
+import android.app.DownloadManager.ACTION_VIEW_DOWNLOADS
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.app.NotificationCompat
@@ -42,12 +46,16 @@ internal object DownloadNotification {
      */
     fun createDownloadCompletedNotification(context: Context, fileName: String?): Notification {
         val channelId = ensureChannelExists(context)
+        val intent = Intent(ACTION_VIEW_DOWNLOADS).apply {
+            flags = FLAG_ACTIVITY_NEW_TASK
+        }
 
         return NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.mozac_feature_download_ic_download)
             .setContentTitle(fileName)
             .setContentText(context.getString(R.string.mozac_feature_downloads_completed_notification_text))
             .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
+            .setContentIntent(PendingIntent.getActivity(context, 0, intent, 0))
             .build()
     }
 


### PR DESCRIPTION
Opens the downloads page when the successful download notification is clicked on

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x]  **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
