### PR TITLE
Issue #3663 Clear session icon if URL host changes

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.session.engine
 
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Environment
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
@@ -31,7 +32,7 @@ internal class EngineObserver(
 ) : EngineSession.Observer {
 
     override fun onLocationChange(url: String) {
-        if (session.url != url) {
+        if (!isHostEquals(session.url, url)) {
             session.title = ""
             session.icon = null
         }
@@ -47,6 +48,13 @@ internal class EngineObserver(
             it.reject()
             true
         }
+    }
+
+    private fun isHostEquals(sessionUrl: String, newUrl: String): Boolean {
+        val sessionUri = Uri.parse(sessionUrl)
+        val newUri = Uri.parse(newUrl)
+
+        return sessionUri.host.equals(newUri.host)
     }
 
     override fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ permalink: /changelog/
 * **browser-icons**
   * Handles low-memory scenarios by reducing memory footprint.
 
+* **browser-session**
+  * Clear session icon only if URL host changes.
+
 * **feature-app-links**
   * Fixed [#3944](https://github.com/mozilla-mobile/android-components/issues/3944) causing third-party apps being opened when links with a `javascript` scheme are clicked.
 


### PR DESCRIPTION
Earlier, session icon was cleared whenever URL chagned. But, that resulted in no icon in the scenario of same-host URL redirects. Now, we are clearing session icon only if the host part of the URL changes.

Unfortunately, I couldn't test it as Uri class belongs to android library and cannot be mocked. Let me know if you have any suggestions on how to test this.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
