### PR TITLE
Issue #3663 Clear session icon if URL host changes

### DIFF
--- a/components/browser/session/build.gradle
+++ b/components/browser/session/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':support-utils')
     implementation project(':support-ktx')
 
+    implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.session.engine
 
 import android.graphics.Bitmap
 import android.os.Environment
+import androidx.core.net.toUri
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.engine.request.LoadRequestMetadata
@@ -33,6 +34,9 @@ internal class EngineObserver(
     override fun onLocationChange(url: String) {
         if (session.url != url) {
             session.title = ""
+        }
+
+        if (!isHostEquals(session.url, url)) {
             session.icon = null
         }
 
@@ -47,6 +51,13 @@ internal class EngineObserver(
             it.reject()
             true
         }
+    }
+
+    private fun isHostEquals(sessionUrl: String, newUrl: String): Boolean {
+        val sessionUri = sessionUrl.toUri()
+        val newUri = newUrl.toUri()
+
+        return sessionUri.scheme == newUri.scheme && sessionUri.host == newUri.host
     }
 
     override fun onLoadRequest(url: String, triggeredByRedirect: Boolean, triggeredByWebContent: Boolean) {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.session.engine
 
 import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.concept.engine.EngineSession
@@ -26,10 +27,12 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
+@RunWith(AndroidJUnit4::class)
 class EngineObserverTest {
 
     @Test
@@ -447,6 +450,20 @@ class EngineObserverTest {
         observer.onLocationChange("https://www.firefox.com")
 
         assertNull(session.icon)
+    }
+
+    @Test
+    fun `onLocationChange doesn't clear icon when new URL is from the same host as the session URL`() {
+        val session = Session("https://www.mozilla.org/?desktop-redirect=true")
+        session.icon = mock()
+
+        val observer = EngineObserver(session)
+
+        assertNotNull(session.icon)
+
+        observer.onLocationChange("https://www.mozilla.org")
+
+        assertNotNull(session.icon)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-session**
+  * Clear session icon only if URL host changes.
+
 # 10.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v9.0.0...v10.0.0)


### PR DESCRIPTION
Earlier, session icon was cleared whenever URL chagned. But, that resulted in no icon in the scenario of same-host URL redirects. Now, we are clearing session icon only if the scheme and host part of the URL changes.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
