### PR TITLE
Closes #3877: Beta Uplift: Recover when content process gets killed

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -44,6 +44,11 @@ class GeckoEngineView @JvmOverloads constructor(
         override fun onCrash() {
             rebind()
         }
+
+        override fun onProcessKilled() {
+            rebind()
+        }
+
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
         override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
     }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -15,8 +15,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.never
+import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
@@ -107,6 +107,26 @@ class GeckoEngineViewTest {
     }
 
     @Test
+    fun `View will rebind session if process gets killed`() {
+        val engineView = GeckoEngineView(context)
+        val engineSession = mock<GeckoEngineSession>()
+        val geckoSession = mock<GeckoSession>()
+        val geckoView = mock<NestedGeckoView>()
+
+        whenever(engineSession.geckoSession).thenReturn(geckoSession)
+        engineView.currentGeckoView = geckoView
+
+        engineView.render(engineSession)
+
+        reset(geckoView)
+        verify(geckoView, never()).setSession(geckoSession)
+
+        engineView.observer.onProcessKilled()
+
+        verify(geckoView).setSession(geckoSession)
+    }
+
+    @Test
     fun `View will rebind session if session crashed`() {
         val engineView = GeckoEngineView(context)
         val engineSession = mock<GeckoEngineSession>()
@@ -118,7 +138,7 @@ class GeckoEngineViewTest {
 
         engineView.render(engineSession)
 
-        Mockito.reset(geckoView)
+        reset(geckoView)
         verify(geckoView, never()).setSession(geckoSession)
 
         engineView.observer.onCrash()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **support-test**
   * Fixed [#3893](https://github.com/mozilla-mobile/android-components/issues/3893) Moving WebserverRule to support-test.
 
+* **browser-engine-gecko-beta**
+  * The component now handles situations where the Android system kills the content process (without killing the main app process) in order to reclaim resources. In those situations the component will automatically recover and restore the last known state of those sessions.
+
 # 7.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.2...v7.0.0)


### PR DESCRIPTION
Original implementation for nightly can be found here: https://github.com/mozilla-mobile/android-components/commit/cf82f8e2b7f542fa235000a80667eaf9203dfedf