### PR TITLE
Fix CrashReporter crash on using new API

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,7 +39,7 @@ permalink: /changelog/
         // passed-in context allows easily opening new activities for handling urls.
         tabsUseCases.addTab(authUrl)
      }
-     
+
      // ... elsewhere, in the UI code, handling click on button "Sign In":
      components.feature.beginAuthentication(activityContext)
     ```
@@ -72,6 +72,9 @@ permalink: /changelog/
 
 * **concept-sync**, **service-firefox-accounts**:
   * ⚠️ **This is a breaking change**: Added `OAuthAccount@disconnectAsync`, which replaced `DeviceConstellation@destroyCurrentDeviceAsync`.
+
+* **lib-crash**
+  * ⚠️ **Known issue**: Sending a crash using the `MozillaSocorroService` with GeckoView 69.0 or 68.0, will lead to a `NoSuchMethodError` when using this particular version of android components. See [#4052](https://github.com/mozilla-mobile/android-components/issues/4052).
 
 # 6.0.2
 


### PR DESCRIPTION
GeckoView Nightly introduced a breaking API change to the crash reporter that has not been uplifted to beta. Since our CrashReporter does not follow the same abstractions as the engine, this results in a `NoSuchMethodError` being thrown.
We should fix this in the future to make the crash reporter be part of the same engine extraction.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.