### PR TITLE
Update SafeIntent to match Android SDK 29

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/SafeIntent.kt
@@ -65,7 +65,7 @@ class SafeIntent(val unsafe: Intent) {
     }
 
     fun <T : Parcelable> getParcelableExtra(name: String): T? = safeAccess {
-        unsafe.getParcelableExtra(name) as T
+        unsafe.getParcelableExtra(name) as T?
     }
 
     fun <T : Parcelable> getParcelableArrayListExtra(name: String): ArrayList<T>? {


### PR DESCRIPTION
There was an API change in the (unreleased) SDK 29 that we compile against, so we need to match the new nullable Android API call.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.