### PR TITLE
Closes #4058: TrackingProtectionIconView#onCreateDrawableState getting called before class properties get initialized.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
@@ -58,7 +58,13 @@ internal class TrackingProtectionIconView @JvmOverloads constructor(
         updateIcon()
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     override fun onCreateDrawableState(extraSpace: Int): IntArray {
+        // We need this here because in some situations, this function is getting called from
+        // the super() constructor on the View class, way before this class properties get
+        // initialized causing a null pointer exception.
+        // See for more details: https://github.com/mozilla-mobile/android-components/issues/4058
+        if (siteTrackingProtection == null) return super.onCreateDrawableState(extraSpace)
 
         val drawableState = when (siteTrackingProtection) {
             ON_NO_TRACKERS_BLOCKED -> R.attr.stateOnNoTrackersBlocked


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.