### PR TITLE
 Bug 1548535 - Cancel any pending workers when ping upload disabled

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.work.WorkManager
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
 import mozilla.components.service.glean.GleanMetrics.GleanBaseline
@@ -23,6 +24,7 @@ import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
 import mozilla.components.service.glean.scheduler.MetricsPingScheduler
+import mozilla.components.service.glean.scheduler.MetricsPingWorker
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.StorageEngineManager
 import mozilla.components.service.glean.storages.PingStorageEngine
@@ -205,8 +207,18 @@ open class GleanInternalAPI internal constructor () {
         if (enabled) {
             initializeCoreMetrics(applicationContext!!)
         } else {
+            cancelPingWorkers()
             clearMetrics()
         }
+    }
+
+    /**
+     * Cancel any pending [PingUploadWorker] objects that have been enqueued.
+     */
+    private fun cancelPingWorkers() {
+        val workManager = WorkManager.getInstance()
+        workManager.cancelUniqueWork(PingUploadWorker.PING_WORKER_TAG)
+        workManager.cancelUniqueWork(MetricsPingWorker.TAG)
     }
 
     /**


### PR DESCRIPTION
This ensures that any `PingUploadWorkers` and `MetricsPingWorkers` are cancelled if upload is disabled.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.