### PR TITLE
For #4083: synchronize all access to engineSessionHolder

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.session
 
 import android.graphics.Bitmap
+import androidx.annotation.GuardedBy
 import mozilla.components.browser.session.engine.EngineSessionHolder
 import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
@@ -50,7 +51,10 @@ class Session(
     /**
      * Holder for keeping a reference to an engine session and its observer to update this session
      * object.
+     *
+     * To ensure atomicity and visibility, make sure to synchronize access to `engineSessionHolder`.
      */
+    @GuardedBy("engineSessionHolder")
     internal val engineSessionHolder = EngineSessionHolder()
 
     // For migration purposes every `Session` has a reference to the `BrowserStore` (if used) in order to dispatch

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineSessionHolder.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineSessionHolder.kt
@@ -11,9 +11,12 @@ import mozilla.components.concept.engine.EngineSessionState
 /**
  * Used for linking a [Session] to an [EngineSession] or the [EngineSessionState] to create an [EngineSession] from it.
  * The attached [EngineObserver] is used to update the [Session] whenever the [EngineSession] emits events.
+ *
+ * To ensure atomicity and sane visibility of enclosed values, make sure to synchronize access to
+ * instances of this class if they are to be used in a multi-threaded context.
  */
 internal class EngineSessionHolder {
-    @Volatile var engineSession: EngineSession? = null
-    @Volatile var engineObserver: EngineObserver? = null
-    @Volatile var engineSessionState: EngineSessionState? = null
+    var engineSession: EngineSession? = null
+    var engineObserver: EngineObserver? = null
+    var engineSessionState: EngineSessionState? = null
 }


### PR DESCRIPTION
Alternatively, we could have made contents of this class immutable,
and swap it entirely on writes. ISTM that while that's arguably a better
solution, it's also more subtle, and this whole codebase is on its way out...



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.