### PR TITLE
Update worker cancel functions to be more like glean-core

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -10,7 +10,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.WorkManager
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
 import mozilla.components.service.glean.GleanMetrics.GleanBaseline
@@ -24,7 +23,6 @@ import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
 import mozilla.components.service.glean.scheduler.MetricsPingScheduler
-import mozilla.components.service.glean.scheduler.MetricsPingWorker
 import mozilla.components.service.glean.scheduler.PingUploadWorker
 import mozilla.components.service.glean.storages.StorageEngineManager
 import mozilla.components.service.glean.storages.PingStorageEngine
@@ -213,12 +211,12 @@ open class GleanInternalAPI internal constructor () {
     }
 
     /**
-     * Cancel any pending [PingUploadWorker] objects that have been enqueued.
+     * Cancel any pending [PingUploadWorker] objects that have been enqueued so that we don't
+     * accidentally upload or collect data after the upload has been disabled.
      */
     private fun cancelPingWorkers() {
-        val workManager = WorkManager.getInstance()
-        workManager.cancelUniqueWork(PingUploadWorker.PING_WORKER_TAG)
-        workManager.cancelUniqueWork(MetricsPingWorker.TAG)
+        MetricsPingScheduler.cancel()
+        PingUploadWorker.cancel()
     }
 
     /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
@@ -51,6 +51,13 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
         const val DUE_HOUR_OF_THE_DAY = 4
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal var isInForeground = false
+
+        /**
+         * Function to cancel any pending metrics ping workers
+         */
+        internal fun cancel() {
+            WorkManager.getInstance().cancelUniqueWork(MetricsPingWorker.TAG)
+        }
     }
 
     init {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/PingUploadWorker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/PingUploadWorker.kt
@@ -67,6 +67,13 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
             val httpPingUploader = HttpPingUploader()
             return Glean.pingStorageEngine.process(httpPingUploader::upload)
         }
+
+        /**
+         * Function to cancel any pending ping upload workers
+         */
+        internal fun cancel() {
+            WorkManager.getInstance().cancelUniqueWork(PING_WORKER_TAG)
+        }
     }
 
     /**

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/MetricsPingSchedulerTest.kt
@@ -459,6 +459,24 @@ class MetricsPingSchedulerTest {
         assertTrue(getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
     }
 
+    @Test
+    fun `cancel() correctly cancels worker`() {
+        val mps = MetricsPingScheduler(ApplicationProvider.getApplicationContext())
+
+        mps.schedulePingCollection(Calendar.getInstance(), true)
+
+        // Verify that the worker is enqueued
+        assertTrue("MetricsPingWorker is enqueued",
+            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+
+        // Cancel the worker
+        MetricsPingScheduler.cancel()
+
+        // Verify worker has been cancelled
+        assertFalse("MetricsPingWorker is not enqueued",
+            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+    }
+
     // @Test
     // fun `Glean should close the measurement window for overdue pings before recording new data`() {
     //     // This test is a bit tricky: we want to make sure that, when our metrics ping is overdue

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
@@ -6,6 +6,7 @@ import androidx.work.BackoffPolicy
 import androidx.work.NetworkType
 import androidx.work.WorkerParameters
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.getWorkerStatus
 import mozilla.components.service.glean.resetGlean
 import org.junit.Assert
 import org.junit.Before
@@ -49,5 +50,21 @@ class PingUploadWorkerTest {
     fun testDoWorkSuccess() {
         val result = pingUploadWorker!!.doWork()
         Assert.assertTrue(result.toString().contains("Success"))
+    }
+
+    @Test
+    fun `cancel() correctly cancels worker`() {
+        PingUploadWorker.enqueueWorker()
+
+        // Verify that the worker is enqueued
+        Assert.assertTrue("PingUploadWorker is enqueued",
+            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+
+        // Cancel the worker
+        PingUploadWorker.cancel()
+
+        // Verify worker has been cancelled
+        Assert.assertFalse("PingUploadWorker is not enqueued",
+            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 }


### PR DESCRIPTION
This updates the cancel functions that were recently added to cancel WorkManager workers when the metrics were disabled.  This keeps glean-ac in line with the change requests for [this PR](https://github.com/mozilla/glean/pull/235) in Glean-Core.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.