### PR TITLE
Issue #1200: Disable taskcluster checks for bors tmp branches.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -157,7 +157,7 @@ tasks:
                       metadata:
                         name: 'Android Components - Decision task (Pull Request #${pull_request_number})'
                         description: 'Building and testing Android components - triggered by [#${pull_request_number}](${pull_request_url})'
-            - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/"'
+            - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/" && head_branch != "staging.tmp" && head_branch != "trying.tmp"'
               then:
                 $mergeDeep:
                   - {$eval: 'default_task_definition'}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Task Status](https://github.taskcluster.net/v1/repository/mozilla-mobile/android-components/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla-mobile/android-components/master/latest)
 [![codecov](https://codecov.io/gh/mozilla-mobile/android-components/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla-mobile/android-components)
+[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/19637)
 
 _A collection of Android libraries to build browsers or browser-like applications._
 


### PR DESCRIPTION
Those branches are created temporarily and then deleted by bors. Running taskcluster tasks for them is a waste of energy and also slows down other tasks that are waiting for the resources.