### PR TITLE
Closes #3797: Do not display site title/url/icon in media notification in private mode.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
@@ -60,10 +60,10 @@ internal class MediaNotification(
 private fun MediaState.toNotificationData(context: Context): NotificationData {
     return when (this) {
         is MediaState.Playing -> NotificationData(
-            title = session.titleOrUrl,
-            description = session.url,
+            title = session.getTitleOrUrl(context),
+            description = session.nonPrivateUrl,
             icon = R.drawable.mozac_feature_media_playing,
-            largeIcon = session.icon,
+            largeIcon = session.nonPrivateIcon,
             action = NotificationCompat.Action.Builder(
                 R.drawable.mozac_feature_media_action_pause,
                 context.getString(R.string.mozac_feature_media_notification_action_pause),
@@ -75,10 +75,10 @@ private fun MediaState.toNotificationData(context: Context): NotificationData {
             ).build()
         )
         is MediaState.Paused -> NotificationData(
-            title = session.titleOrUrl,
-            description = session.url,
+            title = session.getTitleOrUrl(context),
+            description = session.nonPrivateUrl,
             icon = R.drawable.mozac_feature_media_paused,
-            largeIcon = session.icon,
+            largeIcon = session.nonPrivateIcon,
             action = NotificationCompat.Action.Builder(
                 R.drawable.mozac_feature_media_action_play,
                 context.getString(R.string.mozac_feature_media_notification_action_play),
@@ -93,8 +93,17 @@ private fun MediaState.toNotificationData(context: Context): NotificationData {
     }
 }
 
-private val Session.titleOrUrl
-    get() = if (title.isNotEmpty()) title else url
+private fun Session.getTitleOrUrl(context: Context): String = when {
+    private -> context.getString(R.string.mozac_feature_media_notification_private_mode)
+    title.isNotEmpty() -> title
+    else -> url
+}
+
+private val Session.nonPrivateUrl
+    get() = if (private) "" else url
+
+private val Session.nonPrivateIcon: Bitmap?
+    get() = if (private) null else icon
 
 private data class NotificationData(
     val title: String,

--- a/components/feature/media/src/main/res/values/strings.xml
+++ b/components/feature/media/src/main/res/values/strings.xml
@@ -18,4 +18,7 @@
 
     <!--This is the title of the "pause" action shown in the media notification while web content is playing media. Clicking it will pause currently playing media. On most modern Android system only an icon is visible. But screen readers may read this title. -->
     <string name="mozac_feature_media_notification_action_pause">Pause</string>
+
+    <!-- Neutral title of the media notification for when a website that is open in private mode. -->
+    <string name="mozac_feature_media_notification_private_mode">A site is playing media</string>
 </resources>

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
@@ -85,6 +85,44 @@ class MediaNotificationTest {
 
         assertEquals(R.drawable.mozac_feature_media_playing, notification.iconResource)
     }
+
+    @Test
+    fun `media notification for playing state in private mode`() {
+        val state = MediaState.Playing(
+                Session("https://www.mozilla.org", private = true).apply {
+                    title = "Mozilla"
+                },
+                listOf(
+                    MockMedia(Media.PlaybackState.PLAYING)
+                ))
+
+        val notification = MediaNotification(testContext)
+            .create(state, mock())
+
+        assertEquals("", notification.text)
+        assertEquals("A site is playing media", notification.title)
+
+        assertEquals(R.drawable.mozac_feature_media_playing, notification.iconResource)
+    }
+
+    @Test
+    fun `media notification for paused state in private mode`() {
+        val state = MediaState.Paused(
+                Session("https://www.mozilla.org", private = true).apply {
+                    title = "Mozilla"
+                },
+                listOf(
+                        MockMedia(Media.PlaybackState.PAUSE)
+                ))
+
+        val notification = MediaNotification(testContext)
+                .create(state, mock())
+
+        assertEquals("", notification.text)
+        assertEquals("A site is playing media", notification.title)
+
+        assertEquals(R.drawable.mozac_feature_media_paused, notification.iconResource)
+    }
 }
 
 private val Notification.text: String?

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-menu**
   * Updated the styling of the menu to not have padding on top or bottom. Also modified size of `BrowserMenuItemToolbar` to match `BrowserToolbar`'s height
 
+* **feature-media**
+  * Do not display title/url/icon of website in media notification if website is opened in private mode.
+
 # 8.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v7.0.0...v8.0.0)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
