### PR TITLE
Issue #4033: Abandon audio focus when media service is shutting down.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocusController.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocusController.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.focus
+
+/**
+ * A controller that knows how to request and abandon audio focus.
+ */
+internal interface AudioFocusController {
+    fun request(): Int
+    fun abandon()
+}

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocusControllerV21.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocusControllerV21.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.focus
+
+import android.media.AudioManager
+
+/**
+ * [AudioFocusController] implementation for Android API 21+.
+ */
+@Suppress("DEPRECATION")
+internal class AudioFocusControllerV21(
+    private val audioManager: AudioManager,
+    private val listener: AudioManager.OnAudioFocusChangeListener
+) : AudioFocusController {
+    override fun request(): Int {
+        return audioManager.requestAudioFocus(
+            listener,
+            AudioManager.STREAM_MUSIC,
+            AudioManager.AUDIOFOCUS_GAIN
+        )
+    }
+
+    override fun abandon() {
+        audioManager.abandonAudioFocus(listener)
+    }
+}

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocusControllerV26.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocusControllerV26.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.focus
+
+import android.annotation.TargetApi
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+
+import android.os.Build
+
+/**
+ * [AudioFocusController] implementation for Android API 26+.
+ */
+@TargetApi(Build.VERSION_CODES.O)
+internal class AudioFocusControllerV26(
+    private val audioManager: AudioManager,
+    listener: AudioManager.OnAudioFocusChangeListener
+) : AudioFocusController {
+    private val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build()
+        )
+        .setWillPauseWhenDucked(false)
+        .setOnAudioFocusChangeListener(listener)
+        .build()
+
+    override fun request(): Int {
+        return audioManager.requestAudioFocus(request)
+    }
+
+    override fun abandon() {
+        audioManager.abandonAudioFocusRequest(request)
+    }
+}

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaService.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaService.kt
@@ -8,6 +8,7 @@ import android.app.Service
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.media.AudioManager
 import android.os.IBinder
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
@@ -36,7 +37,7 @@ internal class MediaService : Service() {
     private val logger = Logger("MediaService")
     private val notification = MediaNotification(this)
     private val mediaSession by lazy { MediaSessionCompat(this, "MozacMedia") }
-    private val audioFocus = AudioFocus(this)
+    private val audioFocus by lazy { AudioFocus(getSystemService(Context.AUDIO_SERVICE) as AudioManager) }
 
     override fun onCreate() {
         super.onCreate()
@@ -102,6 +103,7 @@ internal class MediaService : Service() {
     }
 
     private fun shutdown() {
+        audioFocus.abandon()
         mediaSession.release()
         stopSelf()
     }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/focus/AudioFocusTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/focus/AudioFocusTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.media.focus
 
-import android.content.Context
 import android.media.AudioManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
@@ -14,7 +13,6 @@ import mozilla.components.feature.media.state.MediaState
 import mozilla.components.feature.media.state.MediaStateMachine
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,18 +20,14 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
-import java.lang.IllegalStateException
 
 @RunWith(AndroidJUnit4::class)
 class AudioFocusTest {
-    private lateinit var context: Context
     private lateinit var audioManager: AudioManager
 
     @Before
     fun setUp() {
-        context = spy(testContext)
         audioManager = mock()
-        doReturn(audioManager).`when`(context).getSystemService(Context.AUDIO_SERVICE)
     }
 
     @Test
@@ -45,7 +39,7 @@ class AudioFocusTest {
             Session("https://www.mozilla.org"),
             listOf(MockMedia(Media.PlaybackState.PLAYING))))
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
         audioFocus.request(state)
 
         verify(audioManager).requestAudioFocus(any())
@@ -63,7 +57,7 @@ class AudioFocusTest {
             Session("https://www.mozilla.org"),
             listOf(media)))
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
         audioFocus.request(state)
 
         verify(audioManager).requestAudioFocus(any())
@@ -81,7 +75,7 @@ class AudioFocusTest {
             Session("https://www.mozilla.org"),
             listOf(media)))
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
         audioFocus.request(state)
 
         verify(audioManager).requestAudioFocus(any())
@@ -95,7 +89,7 @@ class AudioFocusTest {
         doReturn(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
             .`when`(audioManager).requestAudioFocus(any())
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
 
         verifyNoMoreInteractions(media.controller)
 
@@ -125,7 +119,7 @@ class AudioFocusTest {
 
         val media = MockMedia(Media.PlaybackState.PLAYING)
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
         audioFocus.request(MediaState.Playing(
             Session("https://www.mozilla.org"),
             listOf(media)))
@@ -150,7 +144,7 @@ class AudioFocusTest {
             Session("https://www.mozilla.org"),
             listOf(MockMedia(Media.PlaybackState.PLAYING))))
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
         audioFocus.request(state)
     }
 
@@ -161,7 +155,7 @@ class AudioFocusTest {
         doReturn(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
             .`when`(audioManager).requestAudioFocus(any())
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
 
         verifyNoMoreInteractions(media.controller)
 
@@ -179,7 +173,7 @@ class AudioFocusTest {
 
         val media = MockMedia(Media.PlaybackState.PLAYING)
 
-        val audioFocus = AudioFocus(context)
+        val audioFocus = AudioFocus(audioManager)
         audioFocus.request(MediaState.Playing(
             Session("https://www.mozilla.org"),
             listOf(media)))


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
