### PR TITLE
No issue: bump a-s to 0.37.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,7 +26,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.36.0"
+    const val mozilla_appservices = "0.37.1"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Devices.kt
@@ -127,6 +127,9 @@ interface DeviceConstellationObserver {
 enum class DeviceType {
     DESKTOP,
     MOBILE,
+    TABLET,
+    TV,
+    VR,
     UNKNOWN
 }
 

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -25,7 +25,7 @@ class AuthException(type: AuthExceptionType, cause: Exception? = null) : Throwab
  */
 @SuppressWarnings("TooManyFunctions")
 interface OAuthAccount : AutoCloseable {
-    fun beginOAuthFlowAsync(scopes: Set<String>, wantsKeys: Boolean): Deferred<String?>
+    fun beginOAuthFlowAsync(scopes: Set<String>): Deferred<String?>
     fun beginPairingFlowAsync(pairingUrl: String, scopes: Set<String>): Deferred<String?>
     fun getProfileAsync(ignoreCache: Boolean): Deferred<Profile?>
     fun getProfileAsync(): Deferred<Profile?>

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
@@ -129,7 +129,7 @@ class FirefoxAccountsAuthFeatureTest {
         val profile = Profile(uid = "testUID", avatar = null, email = "test@example.com", displayName = "test profile")
 
         `when`(mockAccount.getProfileAsync(anyBoolean())).thenReturn(CompletableDeferred(profile))
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
 
@@ -154,7 +154,7 @@ class FirefoxAccountsAuthFeatureTest {
 
         `when`(mockAccount.getProfileAsync(anyBoolean())).thenReturn(CompletableDeferred(profile))
 
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred(value = null))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred(value = null))
         `when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred(value = null))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -103,13 +103,12 @@ class FirefoxAccount internal constructor(
      * Constructs a URL used to begin the OAuth flow for the requested scopes and keys.
      *
      * @param scopes List of OAuth scopes for which the client wants access
-     * @param wantsKeys Fetch keys for end-to-end encryption of data from Mozilla-hosted services
      * @return Deferred<String> that resolves to the flow URL when complete
      */
-    override fun beginOAuthFlowAsync(scopes: Set<String>, wantsKeys: Boolean): Deferred<String?> {
+    override fun beginOAuthFlowAsync(scopes: Set<String>): Deferred<String?> {
         return scope.async {
             handleFxaExceptions(logger, "begin oauth flow", { null }) {
-                inner.beginOAuthFlow(scopes.toTypedArray(), wantsKeys)
+                inner.beginOAuthFlow(scopes.toTypedArray())
             }
         }
     }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Types.kt
@@ -73,6 +73,9 @@ fun Device.Type.into(): mozilla.components.concept.sync.DeviceType {
     return when (this) {
         Device.Type.DESKTOP -> DeviceType.DESKTOP
         Device.Type.MOBILE -> DeviceType.MOBILE
+        Device.Type.TABLET -> DeviceType.TABLET
+        Device.Type.TV -> DeviceType.TV
+        Device.Type.VR -> DeviceType.VR
         Device.Type.UNKNOWN -> DeviceType.UNKNOWN
     }
 }
@@ -81,6 +84,9 @@ fun mozilla.components.concept.sync.DeviceType.into(): Device.Type {
     return when (this) {
         DeviceType.DESKTOP -> Device.Type.DESKTOP
         DeviceType.MOBILE -> Device.Type.MOBILE
+        DeviceType.TABLET -> Device.Type.TABLET
+        DeviceType.TV -> Device.Type.TV
+        DeviceType.VR -> Device.Type.VR
         DeviceType.UNKNOWN -> Device.Type.UNKNOWN
     }
 }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -744,7 +744,7 @@ open class FxaAccountManager(
     }
 
     private suspend fun doAuthenticate(): Event? {
-        val url = account.beginOAuthFlowAsync(scopes, true).await()
+        val url = account.beginOAuthFlowAsync(scopes).await()
         if (url == null) {
             oauthObservers.notifyObservers { onError() }
             return Event.FailedToAuthenticate

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -721,7 +721,7 @@ class FxaAccountManagerTest {
         var accessTokenErrorCalled = false
         var latestMigrateAuthInfo: ShareableAuthInfo? = null
 
-        override fun beginOAuthFlowAsync(scopes: Set<String>, wantsKeys: Boolean): Deferred<String?> {
+        override fun beginOAuthFlowAsync(scopes: Set<String>): Deferred<String?> {
             return CompletableDeferred("auth://url")
         }
 
@@ -1059,7 +1059,7 @@ class FxaAccountManagerTest {
         assertNull(manager.accountProfile())
 
         // Try again, without any network problems this time.
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(constellation.initDeviceAsync(any(), any(), any())).thenReturn(CompletableDeferred(true))
 
         assertEquals("auth://url", manager.beginAuthenticationAsync().await())
@@ -1230,7 +1230,7 @@ class FxaAccountManagerTest {
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
         `when`(constellation.initDeviceAsync(any(), any(), any())).thenReturn(CompletableDeferred(true))
         `when`(mockAccount.getProfileAsync(anyBoolean())).thenReturn(CompletableDeferred(value = null))
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.
         `when`(accountStorage.read()).thenReturn(null)
@@ -1302,7 +1302,7 @@ class FxaAccountManagerTest {
         // Our recovery flow should attempt to hit this API. Model the "can't recover" condition by returning false.
         `when`(mockAccount.checkAuthorizationStatusAsync(eq("profile"))).thenReturn(CompletableDeferred(false))
 
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.
         `when`(accountStorage.read()).thenReturn(null)
@@ -1358,7 +1358,7 @@ class FxaAccountManagerTest {
         // Our recovery flow should attempt to hit this API. Model the "don't know what's up" condition by returning null.
         `when`(mockAccount.checkAuthorizationStatusAsync(eq("profile"))).thenReturn(CompletableDeferred(value = null))
 
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.
         `when`(accountStorage.read()).thenReturn(null)
@@ -1424,7 +1424,7 @@ class FxaAccountManagerTest {
         // Recovery flow will hit this API, return a success.
         `when`(mockAccount.checkAuthorizationStatusAsync(eq("profile"))).thenReturn(CompletableDeferred(true))
 
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.
         `when`(accountStorage.read()).thenReturn(null)
@@ -1482,7 +1482,7 @@ class FxaAccountManagerTest {
         `when`(mockAccount.deviceConstellation()).thenReturn(constellation)
         `when`(constellation.initDeviceAsync(any(), any(), any())).thenReturn(CompletableDeferred(true))
         `when`(mockAccount.getProfileAsync(anyBoolean())).thenReturn(exceptionalProfile)
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.
         `when`(accountStorage.read()).thenReturn(null)
@@ -1523,7 +1523,7 @@ class FxaAccountManagerTest {
     ): FxaAccountManager {
 
         `when`(mockAccount.getProfileAsync(anyBoolean())).thenReturn(CompletableDeferred(profile))
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred("auth://url"))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred("auth://url"))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.
@@ -1555,7 +1555,7 @@ class FxaAccountManagerTest {
     ): FxaAccountManager {
         `when`(mockAccount.getProfileAsync(anyBoolean())).thenReturn(CompletableDeferred(profile))
 
-        `when`(mockAccount.beginOAuthFlowAsync(any(), anyBoolean())).thenReturn(CompletableDeferred(value = null))
+        `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred(value = null))
         `when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred(value = null))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))
         // There's no account at the start.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,11 @@ permalink: /changelog/
   * `MediaFeature` is no longer showing a notification for playing media with a very short duration.
   * Lowererd priority of media notification channel to avoid the media notification makign any sounds itself.
 
+* **concept-sync**, **service-firefox-account**
+  * ⚠️ **This is a breaking change**
+  * In `OAuthAccount` (and by extension, `FirefoxAccount`) `beginOAuthFlowAsync` no longer need to specify `wantsKeys` parameter; it's automatically inferred from the requested `scopes`.
+  * Three new device types now available: `tablet`, `tv`, `vr`.
+
 # 7.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.2...v7.0.0)

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -36,7 +36,6 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
     private var scopesWithoutKeys: Set<String> = setOf("profile")
     private var scopesWithKeys: Set<String> = setOf("profile", "https://identity.mozilla.com/apps/oldsync")
     private var scopes: Set<String> = scopesWithoutKeys
-    private var wantsKeys: Boolean = false
 
     private lateinit var qrFeature: QrFeature
 
@@ -90,7 +89,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
 
         findViewById<View>(R.id.buttonCustomTabs).setOnClickListener {
             launch {
-                account.beginOAuthFlowAsync(scopes, wantsKeys).await()?.let {
+                account.beginOAuthFlowAsync(scopes).await()?.let {
                     openTab(it)
                 }
             }
@@ -98,7 +97,7 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
 
         findViewById<View>(R.id.buttonWebView).setOnClickListener {
             launch {
-                account.beginOAuthFlowAsync(scopes, wantsKeys).await()?.let {
+                account.beginOAuthFlowAsync(scopes).await()?.let {
                     openWebView(it)
                 }
             }
@@ -115,7 +114,6 @@ open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteList
         }
 
         findViewById<CheckBox>(R.id.checkboxKeys).setOnCheckedChangeListener { _, isChecked ->
-            wantsKeys = isChecked
             scopes = if (isChecked) scopesWithKeys else scopesWithoutKeys
         }
     }

--- a/samples/firefox-accounts/src/main/res/values/strings.xml
+++ b/samples/firefox-accounts/src/main/res/values/strings.xml
@@ -10,5 +10,5 @@
     <string name="signed_in">Signed in: %1$s</string>
     <string name="log_out">FxA Log Out</string>
     <string name="logged_out">Logged out!</string>
-    <string name="wants_keys">Get keys?</string>
+    <string name="wants_keys">Request sync scope?</string>
 </resources>

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceRecyclerViewAdapter.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/DeviceRecyclerViewAdapter.kt
@@ -43,6 +43,9 @@ class DeviceRecyclerViewAdapter(
         holder.typeView.text = when (item.deviceType) {
             DeviceType.DESKTOP -> "Desktop"
             DeviceType.MOBILE -> "Mobile"
+            DeviceType.TABLET -> "Tablet"
+            DeviceType.TV -> "TV"
+            DeviceType.VR -> "VR"
             DeviceType.UNKNOWN -> "Unknown"
         }
 


### PR DESCRIPTION
Let's try this again - update a-s to 0.37.1, follow-up to https://github.com/mozilla-mobile/android-components/pull/4070 which got backed out (0.37's megazord publication was busted).
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
