### PR TITLE
Closes #3921: Adapt tracking protection icons in Custom tab toolbar.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -104,6 +104,16 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     /**
+     * Set/Get whether a separator view should be visible between the tracking protection icon and
+     * the security indicator icon.
+     */
+    var displaySeparatorView: Boolean
+        get() = displayToolbar.displaySeparatorView
+        set(value) {
+            displayToolbar.displaySeparatorView = value
+        }
+
+    /**
      * Set/Get whether a site security icon (usually a lock or globe icon) should be visible next to the URL.
      */
     var displaySiteSecurityIcon: Boolean

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -87,7 +87,7 @@ internal class DisplayToolbar(
             field = value
             setTrackingProtectionState(siteTrackingProtection)
         }
-
+    internal var displaySeparatorView = false
     private val browserActions: MutableList<ActionWrapper> = mutableListOf()
     private val pageActions: MutableList<ActionWrapper> = mutableListOf()
     private val navigationActions: MutableList<ActionWrapper> = mutableListOf()
@@ -156,8 +156,7 @@ internal class DisplayToolbar(
         setOnClickListener(null)
     }
 
-    internal val trackingProtectionAndSecurityIndicatorSeparatorView =
-        AppCompatImageView(context).apply {
+    internal val separatorView = AppCompatImageView(context).apply {
             importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
             isVisible = false
 
@@ -223,7 +222,7 @@ internal class DisplayToolbar(
 
     init {
         addView(trackingProtectionIconView)
-        addView(trackingProtectionAndSecurityIndicatorSeparatorView)
+        addView(separatorView)
         addView(siteSecurityIconView)
         addView(titleView)
         addView(urlView)
@@ -343,8 +342,8 @@ internal class DisplayToolbar(
             OFF_GLOBALLY -> false
         }
 
-        trackingProtectionAndSecurityIndicatorSeparatorView.apply {
-            isVisible = isSeparatorVisible
+        separatorView.apply {
+            isVisible = if (displaySeparatorView) isSeparatorVisible else false
             setColorFilter(separatorColor)
         }
 
@@ -581,7 +580,7 @@ internal class DisplayToolbar(
     @VisibleForTesting
     internal fun layoutTrackingProtectionViewIfNeeded(navigationActionsWidth: Int): Pair<Int, Int> {
         val trackingProtectionWidth = trackingProtectionIconView.measuredWidth
-        val separatorWidth = trackingProtectionAndSecurityIndicatorSeparatorView.measuredWidth
+        val separatorWidth = getSeparatorMeasuredWidth()
         val securityWidth = siteSecurityIconView.measuredWidth
 
         return if (shouldTrackingProtectionViewBeVisible()) {
@@ -592,14 +591,16 @@ internal class DisplayToolbar(
                 measuredHeight
             )
 
-            trackingProtectionAndSecurityIndicatorSeparatorView.layout(
-                trackingProtectionWidth,
-                0,
-                separatorWidth + trackingProtectionWidth,
-                measuredHeight
-            )
+            if (displaySeparatorView) {
+                separatorView.layout(
+                    navigationActionsWidth + trackingProtectionWidth,
+                    0,
+                    separatorWidth + navigationActionsWidth + trackingProtectionWidth,
+                    measuredHeight
+                )
+            }
 
-            separatorWidth + trackingProtectionWidth to
+            navigationActionsWidth + separatorWidth + trackingProtectionWidth to
                 navigationActionsWidth + separatorWidth + securityWidth + trackingProtectionWidth
         } else {
             navigationActionsWidth to navigationActionsWidth + securityWidth
@@ -608,19 +609,25 @@ internal class DisplayToolbar(
 
     private fun getTrackingProtectionMeasuredWidth(): Int {
         return if (trackingProtectionIconView.isVisible) {
-            trackingProtectionIconView.measuredWidth + trackingProtectionAndSecurityIndicatorSeparatorView.measuredWidth
+            trackingProtectionIconView.measuredWidth + getSeparatorMeasuredWidth()
         } else 0
+    }
+
+    private fun getSeparatorMeasuredWidth(): Int {
+        return if (displaySeparatorView) separatorView.measuredWidth else 0
     }
 
     private fun measureTrackingProtectionViewsIfNeeded(squareSpec: Int) {
         if (shouldTrackingProtectionViewBeVisible()) {
             trackingProtectionIconView.measure(squareSpec, squareSpec)
-            val height =
-                resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_icons_separator_height)
-            val width =
-                resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_icons_separator_width)
 
-            trackingProtectionAndSecurityIndicatorSeparatorView.measure(width, height)
+            if (displaySeparatorView) {
+                val height =
+                    resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_icons_separator_height)
+                val width =
+                    resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_icons_separator_width)
+                separatorView.measure(width, height)
+            }
         }
     }
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -1056,6 +1056,17 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `displaySeparatorView will forward to display displaySeparatorView`() {
+        val toolbar = BrowserToolbar(testContext)
+        toolbar.displayToolbar = spy(toolbar.displayToolbar)
+
+        toolbar.displaySeparatorView = false
+
+        verify(toolbar.displayToolbar).displaySeparatorView = false
+        assertFalse(toolbar.displaySeparatorView)
+    }
+
+    @Test
     fun `private flag sets IME_FLAG_NO_PERSONALIZED_LEARNING on url edit view`() {
         val toolbar = BrowserToolbar(testContext)
         val editToolbar = toolbar.editToolbar

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -106,11 +106,12 @@ class DisplayToolbarTest {
         val heightSpec = View.MeasureSpec.makeMeasureSpec(56, View.MeasureSpec.EXACTLY)
 
         displayToolbar.displayTrackingProtectionIcon = true
+        displayToolbar.displaySeparatorView = true
         displayToolbar.setTrackingProtectionState(SiteTrackingProtection.ON_NO_TRACKERS_BLOCKED)
 
         displayToolbar.measure(widthSpec, heightSpec)
 
-        val iconView = displayToolbar.trackingProtectionAndSecurityIndicatorSeparatorView
+        val iconView = displayToolbar.separatorView
 
         assertEquals(1, iconView.measuredWidth)
         assertEquals(24, iconView.measuredHeight)
@@ -121,12 +122,13 @@ class DisplayToolbarTest {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(testContext, toolbar)
         val trackingView = displayToolbar.trackingProtectionIconView
-        val separatorView = displayToolbar.trackingProtectionAndSecurityIndicatorSeparatorView
+        val separatorView = displayToolbar.separatorView
 
         assertTrue(trackingView.visibility == View.GONE)
         assertTrue(separatorView.visibility == View.GONE)
 
         displayToolbar.displayTrackingProtectionIcon = true
+        displayToolbar.displaySeparatorView = true
         displayToolbar.setTrackingProtectionState(SiteTrackingProtection.ON_NO_TRACKERS_BLOCKED)
 
         assertTrue(trackingView.isVisible)
@@ -168,8 +170,7 @@ class DisplayToolbarTest {
 
         totalViewsWidth = urlView.measuredWidth + securityIcon.measuredWidth
         val trackingProtectionWidth = displayToolbar.trackingProtectionIconView.measuredWidth
-        val separatorWidth =
-            displayToolbar.trackingProtectionAndSecurityIndicatorSeparatorView.measuredWidth
+        val separatorWidth = displayToolbar.separatorView.measuredWidth
 
         // Tracking protection views MUST be measured
         assertEquals(totalViewsWidth + trackingProtectionWidth + separatorWidth, view.measuredWidth)
@@ -207,11 +208,11 @@ class DisplayToolbarTest {
         val heightSpec = View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.AT_MOST)
 
         displayToolbar.displayTrackingProtectionIcon = true
+        displayToolbar.displaySeparatorView = true
         displayToolbar.setTrackingProtectionState(SiteTrackingProtection.ON_NO_TRACKERS_BLOCKED)
         displayToolbar.measure(widthSpec, heightSpec)
 
-        val separatorWidth =
-            displayToolbar.trackingProtectionAndSecurityIndicatorSeparatorView.measuredWidth
+        val separatorWidth = displayToolbar.separatorView.measuredWidth
 
         val trackingProtectionWidth = displayToolbar.trackingProtectionIconView.measuredWidth
         val securityIconWidth = displayToolbar.siteSecurityIconView.measuredWidth
@@ -219,7 +220,7 @@ class DisplayToolbarTest {
         val LEFT_WITHOUT_TP_VIEWS = navigationActionsWidth
         val RIGHT_WITHOUT_TP_VIEWS = navigationActionsWidth + securityIconWidth
 
-        val LEFT_WITH_TP_VIEWS = separatorWidth + trackingProtectionWidth
+        val LEFT_WITH_TP_VIEWS = navigationActionsWidth + separatorWidth + trackingProtectionWidth
 
         val RIGHT_WITH_TP_VIEWS =
             navigationActionsWidth + separatorWidth + securityIconWidth + trackingProtectionWidth


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

![image](https://user-images.githubusercontent.com/773158/63024642-a0383500-be75-11e9-8093-76fddafb0a36.png)

![image](https://user-images.githubusercontent.com/773158/63024688-b47c3200-be75-11e9-9a09-a9072a5ec501.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
