### PR TITLE
Closes #3647 - Change HTTP icon to broken lock

### DIFF
--- a/components/browser/toolbar/src/main/res/drawable/mozac_ic_site_security.xml
+++ b/components/browser/toolbar/src/main/res/drawable/mozac_ic_site_security.xml
@@ -4,5 +4,5 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:ac="http://schemas.android.com/apk/res-auto">
     <item android:drawable="@drawable/mozac_ic_lock" ac:state_site_secure="true" />
-    <item android:drawable="@drawable/mozac_ic_globe" />
+    <item android:drawable="@drawable/mozac_ic_broken_lock" />
 </selector>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
 * **feature-media**
   * Do not display title/url/icon of website in media notification if website is opened in private mode.
 
+* **browser-toolbar**
+  * HTTP sites are now marked as insecure with a broken padlock icon, rather than a globe icon. Apps can revert to the globe icon by using a custom `BrowserToolbar.siteSecurityIcon`.
+
 # 8.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v7.0.0...v8.0.0)
@@ -54,7 +57,7 @@ permalink: /changelog/
     onTabsReceiver = { from, tabs -> /* Do cool things here! */ }
   )
   ```
-  
+
 * **feature-media**
   * `MediaFeature` is no longer showing a notification for playing media with a very short duration.
   * Lowererd priority of media notification channel to avoid the media notification makign any sounds itself.


### PR DESCRIPTION
All HTTP sites are now marked insecure by default.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

![](https://user-images.githubusercontent.com/1782266/63032272-7dad1880-be83-11e9-8dce-1751e3973b81.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
