### PR TITLE
Issue #2295 - Add WebNotification class

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.webnotifications
+
+/**
+ * A notification sent by the Web Notifications API.
+ *
+ * @property origin The website that fired this notification.
+ * @property title Title of the notification to be displayed in the first row.
+ * @property body Body of the notification to be displayed in the second row.
+ * @property tag Tag used to identify the notification.
+ * @property iconUrl Medium image to display in the notification.
+ * Corresponds to [android.app.Notification.Builder.setLargeIcon].
+ * @property vibrate Vibration pattern felt when the notification is displayed.
+ * @property timestamp Time when the notification was created.
+ * @property requireInteraction Preference flag that indicates the notification should remain
+ * active until the user clicks or dismisses it.
+ * @property silent Preference flag that indicates no sounds or vibrations should be made.
+ * @property onClick Callback called with the selected action, or null if the main body of the
+ * notification was clicked.
+ * @property onClose Callback called when the notification is dismissed.
+ */
+@Suppress("Unused")
+data class WebNotification(
+    val origin: String,
+    val title: String? = null,
+    val body: String? = null,
+    val tag: String? = null,
+    val iconUrl: String? = null,
+    val vibrate: LongArray = longArrayOf(),
+    val timestamp: Long? = null,
+    val requireInteraction: Boolean = false,
+    val silent: Boolean = false,
+    val onClick: () -> Unit,
+    val onClose: () -> Unit
+)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,9 @@ permalink: /changelog/
 * **lib-push-adm**, **lib-push-firebase**, **concept-push**
   * Added `isServiceAvailable` to signify if the push service is supported on the device.
 
+* **concept-engine**
+  * Added `WebNotification` data class for the web notifications API.
+
 # 9.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v8.0.0...v9.0.0)


### PR DESCRIPTION
Added a new class for the [web notifications](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API) API.

Web notifications can be closed by the website, so a separate close request is also present. 

GV patch: https://phabricator.services.mozilla.com/D36342

---

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
