### PR TITLE
Closes #3861: Add a component for synchronizing Application Services' unit testing dependencies used in Android Components.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -256,6 +256,10 @@ projects:
     path: components/support/android-test
     description: 'A collection of helpers for testing components from instrumented (on device) tests.'
     publish: true
+  support-test-appservices:
+    path: components/support/test-appservices
+    description: 'A component for synchronizing Application Services'' unit testing dependencies used in Android Components.'
+    publish: true
   support-utils:
     path: components/support/utils
     description: 'A collection of generic helper classes.'

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ _Supporting components with generic helper code._
 
 * 🔵 [**Test**](components/support/test/README.md) - A collection of helpers for testing components in local unit tests (`src/test`).
 
+* 🔵 [**Test Appservices**](components/support/test-appservices/README.md) - A component for synchronizing Application Services' unit testing dependencies used in Android Components.
+
 * 🔵 [**Utils**](components/support/utils/README.md) - Generic utility classes to be shared between projects.
 
 ## Standalone libraries

--- a/components/support/test-appservices/README.md
+++ b/components/support/test-appservices/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Support > Test Appservices
+
+A component for synchronizing Application Services' unit testing dependencies used in Android Components.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:support-test-appservices:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/support/test-appservices/build.gradle
+++ b/components/support/test-appservices/build.gradle
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt')
+        }
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
+}
+
+dependencies {
+    api Dependencies.mozilla_full_megazord_forUnitTests
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
+

--- a/components/support/test-appservices/src/main/AndroidManifest.xml
+++ b/components/support/test-appservices/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.support.test.appservices" />

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-test-appservices**
+  * 🆕 New component for synchronizing Application Services' unit testing dependencies used in Android Components.
+
 # 9.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v8.0.0...v9.0.0)


### PR DESCRIPTION
…forUnitTests dependencies as transitive dependencies.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
