### PR TITLE
fixes #4118 added String function for conversion to date for minDateString and maxDateString of unknown date formats

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -380,8 +380,8 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         geckoCallback: TextCallback
     ) {
         val initialDate = initialDateString.toDate(format)
-        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate(format)
-        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate(format)
+        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate()
+        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate()
         val onSelect: (Date) -> Unit = {
             val stringDate = it.toString(format)
             geckoCallback.confirm(stringDate)
@@ -389,6 +389,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
 
         val selectionType = when (format) {
             "HH:mm" -> TimeSelection.Type.TIME
+            "yyyy-MM" -> TimeSelection.Type.MONTH
             "yyyy-MM-dd'T'HH:mm" -> TimeSelection.Type.DATE_AND_TIME
             else -> TimeSelection.Type.DATE
         }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -370,8 +370,8 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         onConfirm: (String) -> Unit
     ) {
         val initialDate = initialDateString.toDate(format)
-        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate(format)
-        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate(format)
+        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate()
+        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate()
         val onSelect: (Date) -> Unit = {
             val stringDate = it.toString(format)
             onConfirm(stringDate)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -377,8 +377,8 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
         geckoCallback: TextCallback
     ) {
         val initialDate = initialDateString.toDate(format)
-        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate(format)
-        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate(format)
+        val minDate = if (minDateString.isNullOrEmpty()) null else minDateString.toDate()
+        val maxDate = if (maxDateString.isNullOrEmpty()) null else maxDateString.toDate()
         val onSelect: (Date) -> Unit = {
             val stringDate = it.toString(format)
             geckoCallback.confirm(stringDate)
@@ -386,6 +386,7 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
 
         val selectionType = when (format) {
             "HH:mm" -> TimeSelection.Type.TIME
+            "yyyy-MM" -> TimeSelection.Type.MONTH
             "yyyy-MM-dd'T'HH:mm" -> TimeSelection.Type.DATE_AND_TIME
             else -> TimeSelection.Type.DATE
         }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -6,6 +6,7 @@ package mozilla.components.support.ktx.kotlin
 
 import mozilla.components.support.utils.URLStringUtils
 import java.security.MessageDigest
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -59,4 +60,29 @@ fun String.sha1(): String {
     return digest.joinToString(separator = "", transform = { byte ->
         String(charArrayOf(characters[byte.toInt() shr 4 and 0x0f], characters[byte.toInt() and 0x0f]))
     })
+}
+
+/**
+ * Tries to convert a [String] to a [Date] using a list of [possibleFormats].
+ * @param possibleFormats one ore more possible format.
+ * @return a [Date] object with the values in the provided in this string,
+ * if the conversion is not possible null will be returned.
+ */
+fun String.toDate(
+    vararg possibleFormats: String = arrayOf(
+            "yyyy-MM-dd'T'HH:mm",
+            "yyyy-MM-dd",
+            "yyyy-'W'ww",
+            "yyyy-MM",
+            "HH:mm"
+    )
+): Date? {
+    possibleFormats.forEach {
+        try {
+            return this.toDate(it)
+        } catch (pe: ParseException) {
+            // move to next possible format
+        }
+    }
+    return null
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -95,6 +95,16 @@ class StringTest {
     }
 
     @Test
+    fun `string to date conversion using multiple formats`() {
+
+        assertEquals("2019-08-16T01:02".toDate("yyyy-MM-dd'T'HH:mm"), "2019-08-16T01:02".toDate())
+
+        assertEquals("2019-08-16T01:02:03".toDate("yyyy-MM-dd'T'HH:mm"), "2019-08-16T01:02:03".toDate())
+
+        assertEquals("2019-08-16".toDate("yyyy-MM-dd"), "2019-08-16".toDate())
+    }
+
+    @Test
     fun sha1() {
         assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", "".sha1())
 


### PR DESCRIPTION
minDateString and maxDateString are not always in same format as initialDate, so we need to convert them to date trying multiple formats, catching parseException and having a null value ass fallback. Other date formats can be supported by adding them to the array in the future.
Function is using original toDate() function so it keeps returning null for empty or null strings and also considers Locale.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
