### PR TITLE
Closes #4121: Use startForegroundService() to start media service.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaService.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/service/MediaService.kt
@@ -13,6 +13,7 @@ import android.os.IBinder
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import mozilla.components.feature.media.ext.pauseIfPlaying
 import mozilla.components.feature.media.ext.playIfPaused
 import mozilla.components.feature.media.ext.toPlaybackState
@@ -25,7 +26,7 @@ import mozilla.components.support.base.ids.NotificationIds
 import mozilla.components.support.base.log.logger.Logger
 
 private const val NOTIFICATION_TAG = "mozac.feature.media.foreground-service"
-private const val ACTION_UODATE_STATE = "mozac.feature.media.service.UPDATE_STATE"
+private const val ACTION_UPDATE_STATE = "mozac.feature.media.service.UPDATE_STATE"
 private const val ACTION_PLAY = "mozac.feature.media.service.PLAY"
 private const val ACTION_PAUSE = "mozac.feature.media.service.PAUSE"
 
@@ -55,7 +56,7 @@ internal class MediaService : Service() {
         logger.debug("Command received")
 
         when (intent?.action) {
-            ACTION_UODATE_STATE -> processCurrentState()
+            ACTION_UPDATE_STATE -> processCurrentState()
             ACTION_PLAY -> MediaStateMachine.state.playIfPaused()
             ACTION_PAUSE -> MediaStateMachine.state.pauseIfPlaying()
             else -> logger.debug("Can't process action: ${intent?.action}")
@@ -112,10 +113,10 @@ internal class MediaService : Service() {
 
     companion object {
         fun updateState(context: Context) {
-            context.startService(updateStateIntent(context))
+            ContextCompat.startForegroundService(context, updateStateIntent(context))
         }
 
-        fun updateStateIntent(context: Context) = Intent(ACTION_UODATE_STATE).apply {
+        fun updateStateIntent(context: Context) = Intent(ACTION_UPDATE_STATE).apply {
             component = ComponentName(context, MediaService::class.java)
         }
 

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/MediaFeatureTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/MediaFeatureTest.kt
@@ -51,12 +51,12 @@ class MediaFeatureTest {
         media.playbackState = Media.PlaybackState.WAITING
 
         // So far nothing has happened yet
-        verify(context, never()).startService(any())
+        verify(context, never()).startForegroundService(any())
 
         // Media starts playing!
         media.playbackState = Media.PlaybackState.PLAYING
 
-        verify(context).startService(any())
+        verify(context).startForegroundService(any())
     }
 
     @Test
@@ -81,13 +81,13 @@ class MediaFeatureTest {
         media.playbackState = Media.PlaybackState.WAITING
 
         // So far nothing has happened yet
-        verify(context, never()).startService(any())
+        verify(context, never()).startForegroundService(any())
 
         // Media starts playing!
         media.playbackState = Media.PlaybackState.PLAYING
 
         // Service still not started since duration is too short
-        verify(context, never()).startService(any())
+        verify(context, never()).startForegroundService(any())
     }
 
     @Test
@@ -106,11 +106,11 @@ class MediaFeatureTest {
         feature.enable()
 
         reset(context)
-        verify(context, never()).startService(any())
+        verify(context, never()).startForegroundService(any())
 
         media.playbackState = Media.PlaybackState.PAUSE
 
-        verify(context).startService(any())
+        verify(context).startForegroundService(any())
     }
 
     @Test
@@ -130,13 +130,13 @@ class MediaFeatureTest {
 
         media.playbackState = Media.PlaybackState.PLAYING
 
-        verify(context).startService(any())
+        verify(context).startForegroundService(any())
 
         reset(context)
-        verify(context, never()).startService(any())
+        verify(context, never()).startForegroundService(any())
 
         media.playbackState = Media.PlaybackState.ENDED
 
-        verify(context).startService(any())
+        verify(context).startForegroundService(any())
     }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
