### PR TITLE
Closes #3033: Close toolbar menu on app exit

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -557,6 +557,10 @@ class BrowserToolbar @JvmOverloads constructor(
         return false
     }
 
+    override fun onStop() {
+        displayToolbar.onStop()
+    }
+
     override fun setSearchTerms(searchTerms: String) {
         this.searchTerms = searchTerms
     }

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -573,6 +573,10 @@ internal class DisplayToolbar(
         }
     }
 
+    fun onStop() {
+        menuView.dismissMenu()
+    }
+
     /**
      * Layout the tracking protection views if they are visible and returns where the [siteSecurityIconView]
      * must be layout (left and right) coordinates.

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/MenuButton.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/MenuButton.kt
@@ -10,6 +10,7 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.ColorInt
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import androidx.core.view.setPadding
@@ -25,7 +26,7 @@ internal class MenuButton(
     private val parent: View
 ) : FrameLayout(context) {
 
-    private var menu: BrowserMenu? = null
+    @VisibleForTesting internal var menu: BrowserMenu? = null
 
     private val menuIcon = AppCompatImageView(context).apply {
         setPadding(resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_menu_padding))
@@ -94,6 +95,10 @@ internal class MenuButton(
         } else {
             menuIcon.setBackgroundResource(0)
         }
+    }
+
+    fun dismissMenu() {
+        menu?.dismiss()
     }
 
     fun setColorFilter(@ColorInt color: Int) {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -1092,6 +1092,18 @@ class DisplayToolbarTest {
         assertNull(toolbar.displayToolbar.siteSecurityIconView.background)
     }
 
+    @Test
+    fun `Backgrounding the app dismisses menu if already open`() {
+        val toolbar = mock(BrowserToolbar::class.java)
+        val displayToolbar = DisplayToolbar(testContext, toolbar)
+        val menuView = extractMenuView(displayToolbar)
+
+        menuView.menu = mock()
+        displayToolbar.onStop()
+
+        verify(menuView.menu)?.dismiss()
+    }
+
     companion object {
         private fun extractUrlView(displayToolbar: DisplayToolbar): TextView =
             extractView(displayToolbar) {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/MenuButtonTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/MenuButtonTest.kt
@@ -126,6 +126,15 @@ class MenuButtonTest {
         verify(context).getDrawable(R.drawable.mozac_menu_indicator)
     }
 
+    @Test
+    fun `menu can be dismissed`() {
+        menuButton.menu = menu
+
+        menuButton.dismissMenu()
+
+        verify(menuButton.menu)?.dismiss()
+    }
+
     private fun extractIcon() =
         menuButton.iterator().asSequence().find { it is AppCompatImageView } as AppCompatImageView
 

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -69,6 +69,11 @@ interface Toolbar {
     fun onBackPressed(): Boolean
 
     /**
+     * Should be called by the host activity when it enters the stop state.
+     */
+    fun onStop()
+
+    /**
      * Registers the given function to be invoked when the user selected a new URL i.e. is done
      * editing.
      *

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
@@ -52,6 +52,7 @@ class ToolbarFeature(
      */
     override fun stop() {
         presenter.stop()
+        toolbar.onStop()
     }
 
     /**

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -52,6 +52,10 @@ class ToolbarAutocompleteFeatureTest {
             return false
         }
 
+        override fun onStop() {
+            fail()
+        }
+
         override fun setOnUrlCommitListener(listener: (String) -> Boolean) {
             fail()
         }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarFeatureTest.kt
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.toolbar
+
+import mozilla.components.support.test.mock
+import org.junit.Test
+import org.mockito.Mockito.verify
+
+class ToolbarFeatureTest {
+
+    @Test
+    fun `when app is backgrounded, toolbar onStop method is called`() {
+        val toolbarFeature = ToolbarFeature(
+                toolbar = mock(), sessionManager = mock(), loadUrlUseCase = mock())
+
+        toolbarFeature.stop()
+
+        verify(toolbarFeature.toolbar).onStop()
+    }
+}

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -42,6 +42,10 @@ class ToolbarInteractorTest {
             return false
         }
 
+        override fun onStop() {
+            fail()
+        }
+
         override fun setOnUrlCommitListener(listener: (String) -> Boolean) {
             listener("https://mozilla.org")
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,9 @@ permalink: /changelog/
 * **browser-toolbar**
   * HTTP sites are now marked as insecure with a broken padlock icon, rather than a globe icon. Apps can revert to the globe icon by using a custom `BrowserToolbar.siteSecurityIcon`.
 
+* **feature-toolbar**
+  * Toolbar Menu is now closed on exiting the app.
+
 * **service-firefox-accounts**, `concept-sync`
   * `FxaAccountManager`, if configured with `DeviceCapability.SEND_TAB`, will now automatically refresh device constellation state and poll for device events during initialization and login.
   * `FxaAccountManager.syncNowAsync` can now receive a `debounce` parameter, allowing consumers to specify debounce behaviour of their sync requests.


### PR DESCRIPTION
Currently, on exiting the app, the toolbar menu (if already open), remains open after reopening the app. This fix ensures that the menu gets closed on app exit.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
