### PR TITLE
Fix parsing of "purpose" field from Gecko

### DIFF
--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
@@ -370,6 +370,52 @@ class WebAppManifestParserTest {
     }
 
     @Test
+    fun `Parsing manifest where purpose field is array instead of string`() {
+        val json = loadManifest("purpose_array.json")
+        val result = WebAppManifestParser().parse(json)
+        assertTrue(result is WebAppManifestParser.Result.Success)
+        val manifest = (result as WebAppManifestParser.Result.Success).manifest
+
+        assertNotNull(manifest)
+        assertEquals("The Sample Manifest", manifest.name)
+        assertEquals("Sample", manifest.shortName)
+        assertEquals("/start", manifest.startUrl)
+        assertEquals(WebAppManifest.DisplayMode.MINIMAL_UI, manifest.display)
+        assertNull(manifest.backgroundColor)
+        assertNull(manifest.description)
+        assertEquals(WebAppManifest.TextDirection.RTL, manifest.dir)
+        assertNull(manifest.lang)
+        assertEquals(WebAppManifest.Orientation.PORTRAIT, manifest.orientation)
+        assertEquals("/", manifest.scope)
+        assertNull(manifest.themeColor)
+
+        assertEquals(2, manifest.icons.size)
+
+        manifest.icons[0].apply {
+            assertEquals("/images/icon/favicon.ico", src)
+            assertEquals("image/png", type)
+            assertEquals(3, sizes.size)
+            assertEquals(48, sizes[0].width)
+            assertEquals(48, sizes[0].height)
+            assertEquals(96, sizes[1].width)
+            assertEquals(96, sizes[1].height)
+            assertEquals(128, sizes[2].width)
+            assertEquals(128, sizes[2].height)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.BADGE), purpose)
+        }
+
+        manifest.icons[1].apply {
+            assertEquals("/images/icon/512-512.png", src)
+            assertEquals("image/png", type)
+            assertEquals(1, sizes.size)
+            assertEquals("image/png", type)
+            assertEquals(512, sizes[0].width)
+            assertEquals(512, sizes[0].height)
+            assertEquals(setOf(WebAppManifest.Icon.Purpose.MASKABLE, WebAppManifest.Icon.Purpose.ANY), purpose)
+        }
+    }
+
+    @Test
     fun `Serializing minimal manifest`() {
         val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
         val json = WebAppManifestParser().serialize(manifest)

--- a/components/concept/engine/src/test/resources/manifests/purpose_array.json
+++ b/components/concept/engine/src/test/resources/manifests/purpose_array.json
@@ -1,0 +1,23 @@
+{
+  "name": "The Sample Manifest",
+  "short_name": "Sample",
+  "icons": [
+    {
+      "src": "/images/icon/favicon.ico",
+      "type": "image/png",
+      "sizes": "48x48 96x96 128x128",
+      "purpose": ["badge"]
+    },
+    {
+      "src": "/images/icon/512-512.png",
+      "type": "image/png",
+      "sizes": "512x512",
+      "purpose": ["maskable", "foo", "any"]
+    }
+  ],
+  "start_url": "/start",
+  "scope": "/",
+  "display": "minimal-ui",
+  "dir": "rtl",
+  "orientation": "portrait"
+}


### PR DESCRIPTION
In Web App Manifests, the [purpose](https://www.w3.org/TR/appmanifest/#purpose-member) property is normally a string. Right now Gecko is returning an array of strings, so this patches in support for either style until Gecko is fixed.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
