### PR TITLE
Consume new `substitute-local-geckoview.gradle` script from Bug 1533465.  Fixes #4068.

### DIFF
--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -182,3 +182,11 @@ dependencies {
     androidTestImplementation Dependencies.androidx_espresso_core
     androidTestImplementation Dependencies.testing_mockwebserver
 }
+
+if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcdir')) {
+    if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdir')) {
+        ext.topobjdir = gradle."localProperties.dependencySubstitutions.geckoviewTopobjdir"
+    }
+    ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
+    apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,10 @@ if (file('local.properties').canRead()) {
 }
 
 if (localProperties != null) {
+    localProperties.each { prop ->
+        gradle.ext.set("localProperties.${prop.key}", prop.value)
+    }
+
     String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath);
 
     if (appServicesLocalPath != null) {


### PR DESCRIPTION
@pocmo this works for me locally.  The upstream script doesn't use `allprojects` (figured consumers can do that), but I'm not sure you really want to do this for all projects when it will impact ~50 projects.  Consider doing that or, or else plumb the single line into the relevant projecst (~7, it looked like to me).