### PR TITLE
Make MenuButton class public

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/MenuButton.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/MenuButton.kt
@@ -21,7 +21,7 @@ import mozilla.components.browser.toolbar.R
 import mozilla.components.browser.toolbar.facts.emitOpenMenuFact
 
 @Suppress("ViewConstructor") // This view is only instantiated in code
-internal class MenuButton(
+class MenuButton(
     context: Context,
     private val parent: View
 ) : FrameLayout(context) {


### PR DESCRIPTION
Making MenuButton public so it can be used in Fenix's buttons :)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
