### PR TITLE
Fixes #4174 setting setUseCompatPadding to allow for padding on CardView

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
@@ -8,7 +8,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     app:cardCornerRadius="@dimen/mozac_browser_menu_corner_radius"
-    app:cardElevation="@dimen/mozac_browser_menu_elevation">
+    app:cardElevation="@dimen/mozac_browser_menu_elevation"
+    app:cardUseCompatPadding="true">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/mozac_browser_menu_recyclerView"


### PR DESCRIPTION
setUseCompatPadding = true adds same padding values on all platforms>21

Fixes https://github.com/mozilla-mobile/fenix/issues/2105.
Tested on samples-browser. Before and after: 
<img src="https://user-images.githubusercontent.com/48995920/63442624-18859400-c43c-11e9-86ef-ee9b0f5258d9.png" height=500><img src="https://user-images.githubusercontent.com/48995920/63442717-44087e80-c43c-11e9-98cf-a35993a3bec7.png" height=500>


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
