### PR TITLE
Add property delegates for shared preferences

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/SharedPreferences.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/SharedPreferences.kt
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("MatchingDeclarationName")
+
+package mozilla.components.support.ktx.android.content
+
+import android.content.SharedPreferences
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Represents a class that holds a reference to [SharedPreferences].
+ */
+interface PreferencesHolder {
+    val preferences: SharedPreferences
+}
+
+private class BooleanPreference(
+    private val key: String,
+    private val default: Boolean
+) : ReadWriteProperty<PreferencesHolder, Boolean> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Boolean =
+        thisRef.preferences.getBoolean(key, default)
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Boolean) =
+        thisRef.preferences.edit().putBoolean(key, value).apply()
+}
+
+private class FloatPreference(
+    private val key: String,
+    private val default: Float
+) : ReadWriteProperty<PreferencesHolder, Float> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Float =
+        thisRef.preferences.getFloat(key, default)
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Float) =
+        thisRef.preferences.edit().putFloat(key, value).apply()
+}
+
+private class IntPreference(
+    private val key: String,
+    private val default: Int
+) : ReadWriteProperty<PreferencesHolder, Int> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Int =
+        thisRef.preferences.getInt(key, default)
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Int) =
+        thisRef.preferences.edit().putInt(key, value).apply()
+}
+
+private class LongPreference(
+    private val key: String,
+    private val default: Long
+) : ReadWriteProperty<PreferencesHolder, Long> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Long =
+        thisRef.preferences.getLong(key, default)
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Long) =
+        thisRef.preferences.edit().putLong(key, value).apply()
+}
+
+private class StringPreference(
+    private val key: String,
+    private val default: String
+) : ReadWriteProperty<PreferencesHolder, String> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): String =
+        thisRef.preferences.getString(key, default) ?: default
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: String) =
+        thisRef.preferences.edit().putString(key, value).apply()
+}
+
+private class StringSetPreference(
+    private val key: String,
+    private val default: Set<String>
+) : ReadWriteProperty<PreferencesHolder, Set<String>> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Set<String> =
+        thisRef.preferences.getStringSet(key, default) ?: default
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Set<String>) =
+        thisRef.preferences.edit().putStringSet(key, value).apply()
+}
+
+/**
+ * Property delegate for getting and setting a boolean shared preference.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     val isTelemetryOn by booleanPreference("telemetry", default = false)
+ * }
+ * ```
+ */
+fun booleanPreference(key: String, default: Boolean): ReadWriteProperty<PreferencesHolder, Boolean> =
+    BooleanPreference(key, default)
+
+/**
+ * Property delegate for getting and setting a float number shared preference.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     var percentage by floatPreference("percentage", default = 0f)
+ * }
+ * ```
+ */
+fun floatPreference(key: String, default: Float): ReadWriteProperty<PreferencesHolder, Float> =
+    FloatPreference(key, default)
+
+/**
+ * Property delegate for getting and setting an int number shared preference.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     var widgetNumInvocations by intPreference("widget_number_of_invocations", default = 0)
+ * }
+ * ```
+ */
+fun intPreference(key: String, default: Int): ReadWriteProperty<PreferencesHolder, Int> =
+    IntPreference(key, default)
+
+/**
+ * Property delegate for getting and setting a long number shared preference.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     val appInstanceId by longPreference("app_instance_id", default = 123456789L)
+ * }
+ * ```
+ */
+fun longPreference(key: String, default: Long): ReadWriteProperty<PreferencesHolder, Long> =
+    LongPreference(key, default)
+
+/**
+ * Property delegate for getting and setting a string shared preference.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     var permissionsEnabledEnum by stringPreference("permissions_enabled", default = "blocked")
+ * }
+ * ```
+ */
+fun stringPreference(key: String, default: String): ReadWriteProperty<PreferencesHolder, String> =
+    StringPreference(key, default)
+
+/**
+ * Property delegate for getting and setting a string set shared preference.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     var connectedDevices by stringSetPreference("connected_devices", default = emptySet())
+ * }
+ * ```
+ */
+fun stringSetPreference(key: String, default: Set<String>): ReadWriteProperty<PreferencesHolder, Set<String>> =
+    StringSetPreference(key, default)

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/SharedPreferencesTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/SharedPreferencesTest.kt
@@ -1,0 +1,261 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.content
+
+import android.content.SharedPreferences
+import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyFloat
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations.initMocks
+
+class SharedPreferencesTest {
+    @Mock private lateinit var sharedPrefs: SharedPreferences
+    @Mock private lateinit var editor: SharedPreferences.Editor
+
+    @Before
+    fun setup() {
+        initMocks(this)
+
+        `when`(sharedPrefs.edit()).thenReturn(editor)
+        `when`(editor.putBoolean(anyString(), anyBoolean())).thenReturn(editor)
+        `when`(editor.putFloat(anyString(), anyFloat())).thenReturn(editor)
+        `when`(editor.putInt(anyString(), anyInt())).thenReturn(editor)
+        `when`(editor.putLong(anyString(), anyLong())).thenReturn(editor)
+        `when`(editor.putString(anyString(), anyString())).thenReturn(editor)
+        `when`(editor.putStringSet(anyString(), any())).thenReturn(editor)
+    }
+
+    @Test
+    fun `getter returns boolean from shared preferences`() {
+        val holder = MockPreferencesHolder()
+        `when`(sharedPrefs.getBoolean(eq("boolean"), anyBoolean())).thenReturn(true)
+
+        assertTrue(holder.boolean)
+        verify(sharedPrefs).getBoolean("boolean", false)
+    }
+
+    @Test
+    fun `setter applies boolean to shared preferences`() {
+        val holder = MockPreferencesHolder(defaultBoolean = true)
+        holder.boolean = false
+
+        verify(editor).putBoolean("boolean", false)
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `getter uses default boolean value`() {
+        val holderFalse = MockPreferencesHolder(defaultBoolean = false)
+        // Call the getter for the test
+        holderFalse.boolean
+
+        verify(sharedPrefs).getBoolean("boolean", false)
+
+        val holderTrue = MockPreferencesHolder(defaultBoolean = true)
+        // Call the getter for the test
+        holderTrue.boolean
+
+        verify(sharedPrefs).getBoolean("boolean", true)
+    }
+
+    @Test
+    fun `getter returns float from shared preferences`() {
+        val holder = MockPreferencesHolder()
+        `when`(sharedPrefs.getFloat(eq("float"), anyFloat())).thenReturn(2.4f)
+
+        assertEquals(2.4f, holder.float)
+        verify(sharedPrefs).getFloat("float", 0f)
+    }
+
+    @Test
+    fun `setter applies float to shared preferences`() {
+        val holder = MockPreferencesHolder(defaultFloat = 1f)
+        holder.float = 0f
+
+        verify(editor).putFloat("float", 0f)
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `getter uses default float value`() {
+        val holderDefault = MockPreferencesHolder(defaultFloat = 0f)
+        // Call the getter for the test
+        holderDefault.float
+
+        verify(sharedPrefs).getFloat("float", 0f)
+
+        val holderOther = MockPreferencesHolder(defaultFloat = 12f)
+        // Call the getter for the test
+        holderOther.float
+
+        verify(sharedPrefs).getFloat("float", 12f)
+    }
+
+    @Test
+    fun `getter returns int from shared preferences`() {
+        val holder = MockPreferencesHolder()
+        `when`(sharedPrefs.getInt(eq("int"), anyInt())).thenReturn(5)
+
+        assertEquals(5, holder.int)
+        verify(sharedPrefs).getInt("int", 0)
+    }
+
+    @Test
+    fun `setter applies int to shared preferences`() {
+        val holder = MockPreferencesHolder(defaultInt = 1)
+        holder.int = 0
+
+        verify(editor).putInt("int", 0)
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `getter uses default int value`() {
+        val holderDefault = MockPreferencesHolder(defaultInt = 0)
+        // Call the getter for the test
+        holderDefault.int
+
+        verify(sharedPrefs).getInt("int", 0)
+
+        val holderOther = MockPreferencesHolder(defaultInt = 23)
+        // Call the getter for the test
+        holderOther.int
+
+        verify(sharedPrefs).getInt("int", 23)
+    }
+
+    @Test
+    fun `getter returns long from shared preferences`() {
+        val holder = MockPreferencesHolder()
+        `when`(sharedPrefs.getLong(eq("long"), anyLong())).thenReturn(200L)
+
+        assertEquals(200L, holder.long)
+        verify(sharedPrefs).getLong("long", 0)
+    }
+
+    @Test
+    fun `setter applies long to shared preferences`() {
+        val holder = MockPreferencesHolder(defaultLong = 1)
+        holder.long = 0
+
+        verify(editor).putLong("long", 0)
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `getter uses default long value`() {
+        val holderDefault = MockPreferencesHolder(defaultLong = 0)
+        // Call the getter for the test
+        holderDefault.long
+
+        verify(sharedPrefs).getLong("long", 0)
+
+        val holderOther = MockPreferencesHolder(defaultLong = 23)
+        // Call the getter for the test
+        holderOther.long
+
+        verify(sharedPrefs).getLong("long", 23)
+    }
+
+    @Test
+    fun `getter returns string from shared preferences`() {
+        val holder = MockPreferencesHolder()
+        `when`(sharedPrefs.getString(eq("string"), anyString())).thenReturn("foo")
+
+        assertEquals("foo", holder.string)
+        verify(sharedPrefs).getString("string", "")
+    }
+
+    @Test
+    fun `setter applies string to shared preferences`() {
+        val holder = MockPreferencesHolder(defaultString = "foo")
+        holder.string = "bar"
+
+        verify(editor).putString("string", "bar")
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `getter uses default string value`() {
+        val holderDefault = MockPreferencesHolder()
+        // Call the getter for the test
+        holderDefault.string
+
+        verify(sharedPrefs).getString("string", "")
+
+        val holderOther = MockPreferencesHolder(defaultString = "hello")
+        // Call the getter for the test
+        holderOther.string
+
+        verify(sharedPrefs).getString("string", "hello")
+    }
+
+    @Test
+    fun `getter returns string set from shared preferences`() {
+        val holder = MockPreferencesHolder()
+        `when`(sharedPrefs.getStringSet(eq("string_set"), any())).thenReturn(setOf("foo"))
+
+        assertEquals(setOf("foo"), holder.stringSet)
+        verify(sharedPrefs).getStringSet("string_set", emptySet())
+    }
+
+    @Test
+    fun `setter applies string set to shared preferences`() {
+        val holder = MockPreferencesHolder(defaultString = "foo")
+        holder.stringSet = setOf("bar")
+
+        verify(editor).putStringSet("string_set", setOf("bar"))
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `getter uses default string set value`() {
+        val holderDefault = MockPreferencesHolder()
+        // Call the getter for the test
+        holderDefault.stringSet
+
+        verify(sharedPrefs).getStringSet("string_set", emptySet())
+
+        val holderOther = MockPreferencesHolder(defaultSet = setOf("hello", "world"))
+        // Call the getter for the test
+        holderOther.stringSet
+
+        verify(sharedPrefs).getStringSet("string_set", setOf("hello", "world"))
+    }
+
+    private inner class MockPreferencesHolder(
+        defaultBoolean: Boolean = false,
+        defaultFloat: Float = 0f,
+        defaultInt: Int = 0,
+        defaultLong: Long = 0L,
+        defaultString: String = "",
+        defaultSet: Set<String> = emptySet()
+    ) : PreferencesHolder {
+        override val preferences = sharedPrefs
+
+        var boolean by booleanPreference("boolean", default = defaultBoolean)
+
+        var float by floatPreference("float", default = defaultFloat)
+
+        var int by intPreference("int", default = defaultInt)
+
+        var long by longPreference("long", default = defaultLong)
+
+        var string by stringPreference("string", default = defaultString)
+
+        var stringSet by stringSetPreference("string_set", default = defaultSet)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-ktx**
+  * Added property delegates to work with `SharedPreferences`.
+
 # 10.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v9.0.0...v10.0.0)
@@ -50,7 +53,7 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: `TrackingProtectionPolicy` does not have a `safeBrowsingCategories` anymore, Safe Browsing is now a separate setting on the Engine level. To change the default value of `SafeBrowsingPolicy.RECOMMENDED` you have set it through `engine.settings.safeBrowsingPolicy`.
   * This decouples the tracking protection API and safe browsing from each other so you can change the tracking protection policy without affecting your safe browsing policy as described in this issue [#4190](https://github.com/mozilla-mobile/android-components/issues/4190).
   * ⚠️ **Alert for SystemEngine consumers**: The Safe Browsing API is not yet supported on this engine, this will be covered on [#4206](https://github.com/mozilla-mobile/android-components/issues/4206). If you use this API you will get a `UnsupportedSettingException`, however you can use a manifest tag to activate it.
-  
+
   ```xml
     <manifest>
     <application>


### PR DESCRIPTION
Its a common pattern to have some `Settings` singleton holding a reference to `SharedPreferences` with getters/setters for various preferences.

The delegates in Fenix seem pretty useful and other apps could benefit from having them as well. 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
