### PR TITLE
Improve parsing for manifest icon sizes & purpose

### DIFF
--- a/components/concept/engine/src/test/resources/manifests/purpose_array.json
+++ b/components/concept/engine/src/test/resources/manifests/purpose_array.json
@@ -11,7 +11,7 @@
     {
       "src": "/images/icon/512-512.png",
       "type": "image/png",
-      "sizes": "512x512",
+      "sizes": ["512x512"],
       "purpose": ["maskable", "foo", "any"]
     }
   ],

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/org/json/JSONObject.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/org/json/JSONObject.kt
@@ -11,6 +11,12 @@ import java.util.TreeMap
  * Returns the value mapped by {@code key} if it exists, and
  * if the value returned is not null. If it's null, it returns null
  */
+fun JSONObject.tryGet(key: String): Any? = if (isNull(key)) null else get(key)
+
+/**
+ * Returns the value mapped by {@code key} if it exists, and
+ * if the value returned is not null. If it's null, it returns null
+ */
 fun JSONObject.tryGetString(key: String): String? = if (isNull(key)) null else getString(key)
 
 /**

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/org/json/JSONObjectTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/org/json/JSONObjectTest.kt
@@ -40,6 +40,19 @@ class JSONObjectTest {
     }
 
     @Test
+    fun tryGetNull() {
+        val jsonObject = JSONObject("""{"key":null}""")
+        assertNull(jsonObject.tryGet("key"))
+        assertNull(jsonObject.tryGet("another-key"))
+    }
+
+    @Test
+    fun tryGetNotNull() {
+        val jsonObject = JSONObject("""{"key":"value"}""")
+        assertEquals("value", jsonObject.tryGet("key"))
+    }
+
+    @Test
     fun tryGetStringNull() {
         val jsonObject = JSONObject("""{"key":null}""")
         assertNull(jsonObject.tryGetString("key"))


### PR DESCRIPTION
Gecko will soon be returning a JSON array for icons sizes as well as icon purpose. 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
