### PR TITLE
Closes #4172: MediaService: Always, always, ALWAYS call startForeground()

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/media/Media.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/media/Media.kt
@@ -190,7 +190,7 @@ abstract class Media(
         }
     }
 
-    override fun toString(): String = "Media($playbackState)"
+    override fun toString(): String = "Media(state=$state,playbackState=$playbackState)"
 }
 
 /**

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/notification/MediaNotification.kt
@@ -39,12 +39,19 @@ internal class MediaNotification(
             .setContentTitle(data.title)
             .setContentText(data.description)
             .setLargeIcon(data.largeIcon)
-            .addAction(data.action)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setStyle(androidx.media.app.NotificationCompat.MediaStyle()
-                .setMediaSession(mediaSession.sessionToken)
-                .setShowActionsInCompactView(0))
+
+        val style = androidx.media.app.NotificationCompat.MediaStyle()
+            .setMediaSession(mediaSession.sessionToken)
+
+        if (data.action != null) {
+            builder.addAction(data.action)
+
+            style.setShowActionsInCompactView(0)
+        }
+
+        builder.setStyle(style)
 
         if (!state.isForExternalApp()) {
             // We only set a content intent if this media notification is not for an "external app"
@@ -89,7 +96,9 @@ private fun MediaState.toNotificationData(context: Context): NotificationData {
                     0)
             ).build()
         )
-        else -> throw IllegalArgumentException("Cannot create notification for state: $this")
+        // Dummy notification that is only used to satisfy the requirement to ALWAYS call
+        // startForeground with a notification.
+        else -> NotificationData()
     }
 }
 
@@ -106,11 +115,11 @@ private val Session.nonPrivateIcon: Bitmap?
     get() = if (private) null else icon
 
 private data class NotificationData(
-    val title: String,
-    val description: String,
-    @DrawableRes val icon: Int,
+    val title: String = "",
+    val description: String = "",
+    @DrawableRes val icon: Int = R.drawable.mozac_feature_media_playing,
     val largeIcon: Bitmap? = null,
-    val action: NotificationCompat.Action
+    val action: NotificationCompat.Action? = null
 )
 
 private fun MediaState.isForExternalApp(): Boolean {

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt
@@ -17,7 +17,6 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.IllegalArgumentException
 
 @RunWith(AndroidJUnit4::class)
 class MediaNotificationTest {
@@ -59,14 +58,20 @@ class MediaNotificationTest {
         assertEquals(R.drawable.mozac_feature_media_paused, notification.iconResource)
     }
 
-    @Test(expected = IllegalArgumentException::class)
     fun `media notification for none state`() {
-        // This notification will actually never get displayed
+        // This notification is only used to call into startForeground() to fulfil the API contract.
+        // It gets immediately replaced or removed.
 
         val state = MediaState.None
 
         MediaNotification(testContext)
             .create(state, mock())
+
+        val notification = MediaNotification(testContext)
+            .create(state, mock())
+
+        assertEquals("", notification.text)
+        assertEquals("", notification.title)
     }
 
     @Test


### PR DESCRIPTION
---

On top of #4169 (ignore first commit).

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
