### PR TITLE
1574470: Make handleBackgroundEvent internal

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -447,7 +447,7 @@ open class GleanInternalAPI internal constructor () {
     /**
      * Handle the background event and send the appropriate pings.
      */
-    fun handleBackgroundEvent() {
+    internal fun handleBackgroundEvent() {
         // Schedule the baseline and event pings
         sendPings(listOf(Pings.baseline, Pings.events))
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,10 @@ permalink: /changelog/
 * **service-location**
   * Added `RegionSearchLocalizationProvider` - A `SearchLocalizationProvider` implementation that uses a `MozillaLocationService` instance to do a region lookup via GeoIP.
   * ⚠️ **This is a breaking change**: An implementation of `SearchLocalizationProvider` now returns a `SearchLocalization` data class instead of multiple properties.
+  
+* **service-glean**
+  * ⚠️ **This is a breaking change**: `Glean.handleBackgroundEvent` is now an internal API.
+
 
 * **browser-engine-gecko(-beta/nightly)**, **concept-engine**
   * Added simplified `Media.state` derived from `Media.playbackState` events.

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import mozilla.components.service.experiments.Experiments
-import mozilla.components.service.glean.Glean
 import org.mozilla.samples.glean.GleanMetrics.Test
 import org.mozilla.samples.glean.GleanMetrics.BrowserEngagement
 import org.mozilla.samples.glean.library.SamplesGleanLibrary
@@ -44,11 +43,6 @@ open class MainActivity : AppCompatActivity() {
                             BrowserEngagement.clickKeys.key2 to "extra_value_2"
                     )
             )
-        }
-
-        // Generate pings on click by simulating Glean handling a background event.
-        buttonSendPing.setOnClickListener {
-            Glean.handleBackgroundEvent()
         }
 
         Test.testTimespan.stop()

--- a/samples/glean/src/main/res/layout/activity_main.xml
+++ b/samples/glean/src/main/res/layout/activity_main.xml
@@ -51,20 +51,6 @@
         android:text="@string/counter_metric_info" />
 
     <Button
-        android:id="@+id/buttonSendPing"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="@string/send_baseline_ping" />
-
-    <TextView
-        android:id="@+id/textView2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:text="@string/send_ping_info" />
-
-    <Button
         android:id="@+id/buttonCheckExperiments"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/samples/glean/src/main/res/values/strings.xml
+++ b/samples/glean/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <string name="app_name">Glean - Metrics Demo</string>
-    <string name="send_baseline_ping">Send ping(s)</string>
     <string name="generate_data">Record Text</string>
     <string name="string_list_input_hint">Enter some text here</string>
     <string name="counter_metric_info">
@@ -14,9 +13,6 @@
         and should persist from launch to launch of the app.\n\nAn event metric is also being used
         to attach a dictionary of values to the extras of the event ping. See MainActivity for
         where all of this is happening.
-    </string>
-    <string name="send_ping_info">
-        Clicking the SEND PING button simulates an event that causes pings to be sent.
     </string>
     <string name="experiment_not_active">Experiment not active</string>
     <string name="experiment_active_branch">Experiment active, branch: %1$s</string>


### PR DESCRIPTION
This makes `Glean.handleBackgroundEvent` private and removes its use from the sample app.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
