### PR TITLE
Closes #3280: Add isServiceAvailable to PushService 

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -68,6 +68,7 @@ object Dependencies {
 
     const val testing_junit = "junit:junit:${Versions.junit}"
     const val testing_robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
+    const val testing_robolectric_playservices = "org.robolectric:shadows-playservices:${Versions.robolectric}"
     const val testing_mockito = "org.mockito:mockito-core:${Versions.mockito}"
     const val testing_mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.mockwebserver}"
     const val testing_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"

--- a/components/concept/push/src/main/java/mozilla/components/concept/push/PushService.kt
+++ b/components/concept/push/src/main/java/mozilla/components/concept/push/PushService.kt
@@ -28,4 +28,9 @@ interface PushService {
      * Tells the push service to delete the registration token.
      */
     fun deleteToken()
+
+    /**
+     * If the push service is support on the device.
+     */
+    fun isServiceAvailable(context: Context): Boolean
 }

--- a/components/lib/push-amazon/src/test/java/mozilla/components/lib/push/amazon/AbstractAmazonPushServiceTest.kt
+++ b/components/lib/push-amazon/src/test/java/mozilla/components/lib/push/amazon/AbstractAmazonPushServiceTest.kt
@@ -72,7 +72,7 @@ class AbstractAmazonPushServiceTest {
 
     @Test
     fun `registration errors are forwarded to the processor`() {
-        val service = object: AbstractAmazonPushService() {
+        val service = object : AbstractAmazonPushService() {
             public override fun onRegistrationError(errorId: String) {
                 super.onRegistrationError(errorId)
             }
@@ -143,8 +143,7 @@ class ShadowADM {
 
     @Implementation
     @Suppress("UNUSED_PARAMETER")
-    fun __constructor__(context: Context) {
-    }
+    fun __constructor__(context: Context) {}
 
     fun isSupported() = true
 }

--- a/components/lib/push-firebase/build.gradle
+++ b/components/lib/push-firebase/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_robolectric_playservices
     testImplementation Dependencies.testing_mockito
 }
 

--- a/components/lib/push-firebase/src/main/java/mozilla/components/lib/push/firebase/AbstractFirebasePushService.kt
+++ b/components/lib/push-firebase/src/main/java/mozilla/components/lib/push/firebase/AbstractFirebasePushService.kt
@@ -7,6 +7,8 @@
 package mozilla.components.lib.push.firebase
 
 import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.FirebaseApp
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.messaging.FirebaseMessaging
@@ -83,5 +85,9 @@ abstract class AbstractFirebasePushService(
                 logger.error("Force registration renewable failed.", e)
             }
         }
+    }
+
+    override fun isServiceAvailable(context: Context): Boolean {
+        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,13 +21,15 @@ permalink: /changelog/
 * **service-location**
   * Added `RegionSearchLocalizationProvider` - A `SearchLocalizationProvider` implementation that uses a `MozillaLocationService` instance to do a region lookup via GeoIP.
   * ⚠️ **This is a breaking change**: An implementation of `SearchLocalizationProvider` now returns a `SearchLocalization` data class instead of multiple properties.
-  
+
 * **service-glean**
   * ⚠️ **This is a breaking change**: `Glean.handleBackgroundEvent` is now an internal API.
 
-
 * **browser-engine-gecko(-beta/nightly)**, **concept-engine**
   * Added simplified `Media.state` derived from `Media.playbackState` events.
+
+* **lib-push-adm**, **lib-push-firebase**, **concept-push**
+  * Added `isServiceAvailable` to signify if the push service is supported on the device.
 
 # 9.0.0
 


### PR DESCRIPTION
Added the implementations of `isServiceAvailable` for Firebase and Amazon. I spent a bit trying to better test the exception part for ADM without making the implementation more complicated to no avail.

Also fixed a bug where registration errors were not being forwarded to the processor.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
