### PR TITLE
Closes #3952 - Add Digital Asset Link processing

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/tab/CustomTabConfig.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import androidx.annotation.ColorInt
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsSessionToken
 
 /**
  * Holds configuration data for a Custom Tab.
@@ -22,22 +23,25 @@ import androidx.browser.customtabs.CustomTabsIntent
  * @property exitAnimations Bundle containing custom exit animations for the tab.
  * @property navigationBarColor Background color for the navigation bar.
  * @property titleVisible Whether the title should be shown in the custom tab.
+ * @property sessionToken The token associated with the custom tab.
  */
 data class CustomTabConfig(
     val id: String,
     @ColorInt val toolbarColor: Int?,
-    val closeButtonIcon: Bitmap?,
-    val enableUrlbarHiding: Boolean,
-    val actionButtonConfig: CustomTabActionButtonConfig?,
-    val showShareMenuItem: Boolean,
+    val closeButtonIcon: Bitmap? = null,
+    val enableUrlbarHiding: Boolean = false,
+    val actionButtonConfig: CustomTabActionButtonConfig? = null,
+    val showShareMenuItem: Boolean = false,
     val menuItems: List<CustomTabMenuItem> = emptyList(),
     val exitAnimations: Bundle? = null,
     @ColorInt val navigationBarColor: Int? = null,
-    val titleVisible: Boolean = false
+    val titleVisible: Boolean = false,
+    val sessionToken: CustomTabsSessionToken? = null
 ) {
 
     companion object {
         const val EXTRA_NAVIGATION_BAR_COLOR = "androidx.browser.customtabs.extra.NAVIGATION_BAR_COLOR"
+        const val EXTRA_ADDITIONAL_TRUSTED_ORIGINS = "android.support.customtabs.extra.ADDITIONAL_TRUSTED_ORIGINS"
     }
 }
 

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
@@ -29,6 +29,7 @@ import androidx.browser.customtabs.CustomTabsIntent.KEY_PENDING_INTENT
 import androidx.browser.customtabs.CustomTabsIntent.NO_TITLE
 import androidx.browser.customtabs.CustomTabsIntent.SHOW_PAGE_TITLE
 import androidx.browser.customtabs.CustomTabsIntent.TOOLBAR_ACTION_BUTTON_ID
+import androidx.browser.customtabs.CustomTabsSessionToken
 import androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY
 import mozilla.components.browser.session.tab.CustomTabActionButtonConfig
 import mozilla.components.browser.session.tab.CustomTabConfig
@@ -82,7 +83,7 @@ fun isTrustedWebActivityIntent(safeIntent: SafeIntent) = isCustomTabIntent(safeI
  */
 fun createCustomTabConfigFromIntent(
     intent: Intent,
-    resources: Resources
+    resources: Resources?
 ): CustomTabConfig {
     val safeIntent = intent.toSafeIntent()
 
@@ -96,7 +97,13 @@ fun createCustomTabConfigFromIntent(
         showShareMenuItem = safeIntent.getBooleanExtra(EXTRA_DEFAULT_SHARE_MENU_ITEM, false),
         menuItems = getMenuItems(safeIntent),
         exitAnimations = safeIntent.getBundleExtra(EXTRA_EXIT_ANIMATION_BUNDLE)?.unsafe,
-        titleVisible = safeIntent.getIntExtra(EXTRA_TITLE_VISIBILITY_STATE, NO_TITLE) == SHOW_PAGE_TITLE
+        titleVisible = safeIntent.getIntExtra(EXTRA_TITLE_VISIBILITY_STATE, NO_TITLE) == SHOW_PAGE_TITLE,
+        sessionToken = if (intent.extras != null) {
+            // getSessionTokenFromIntent throws if extras is null
+            CustomTabsSessionToken.getSessionTokenFromIntent(intent)
+        } else {
+            null
+        }
     )
 }
 
@@ -104,9 +111,9 @@ fun createCustomTabConfigFromIntent(
 private fun SafeIntent.getColorExtra(name: String): Int? =
     if (hasExtra(name)) getIntExtra(name, 0) else null
 
-private fun getCloseButtonIcon(intent: SafeIntent, resources: Resources): Bitmap? {
+private fun getCloseButtonIcon(intent: SafeIntent, resources: Resources?): Bitmap? {
     val icon = intent.getParcelableExtra(EXTRA_CLOSE_BUTTON_ICON) as? Bitmap
-    val maxSize = resources.getDimension(R.dimen.mozac_feature_customtabs_max_close_button_size)
+    val maxSize = resources?.getDimension(R.dimen.mozac_feature_customtabs_max_close_button_size) ?: Float.MAX_VALUE
 
     return if (icon != null && max(icon.width, icon.height) <= maxSize) {
         icon

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.customtabs
 

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeature.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.feature
+
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import androidx.browser.customtabs.CustomTabsService.Relation
+import androidx.browser.customtabs.CustomTabsSessionToken
+import mozilla.components.concept.fetch.Client
+import mozilla.components.feature.customtabs.store.CustomTabState
+import mozilla.components.feature.customtabs.store.CustomTabsAction
+import mozilla.components.feature.customtabs.store.OriginRelationPair
+import mozilla.components.feature.customtabs.store.ValidateRelationshipAction
+import mozilla.components.feature.customtabs.store.VerificationStatus.FAILURE
+import mozilla.components.feature.customtabs.store.VerificationStatus.PENDING
+import mozilla.components.feature.customtabs.store.VerificationStatus.SUCCESS
+import mozilla.components.feature.customtabs.verify.OriginVerifier
+
+class OriginVerifierFeature(
+    private val httpClient: Client,
+    private val packageManager: PackageManager,
+    private val dispatch: (CustomTabsAction) -> Unit
+) {
+
+    suspend fun verify(
+        state: CustomTabState,
+        token: CustomTabsSessionToken,
+        @Relation relation: Int,
+        origin: Uri
+    ): Boolean {
+        val packageName = state.creatorPackageName ?: return false
+
+        val existingRelation = state.relationships[OriginRelationPair(origin, relation)]
+        return if (existingRelation == SUCCESS || existingRelation == FAILURE) {
+            // Return if relation is already success or failure
+            existingRelation == SUCCESS
+        } else {
+            val verifier = getVerifier(packageName, relation)
+            dispatch(ValidateRelationshipAction(token, relation, origin, PENDING))
+
+            val result = verifier.verifyOrigin(origin)
+            val status = if (result) SUCCESS else FAILURE
+
+            dispatch(ValidateRelationshipAction(token, relation, origin, status))
+            result
+        }
+    }
+
+    @VisibleForTesting
+    internal fun getVerifier(packageName: String, @Relation relation: Int) =
+        OriginVerifier(packageName, relation, packageManager, httpClient)
+}

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsAction.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsAction.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.store
+
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsService.Relation
+import androidx.browser.customtabs.CustomTabsSessionToken
+import mozilla.components.lib.state.Action
+
+sealed class CustomTabsAction : Action {
+    abstract val token: CustomTabsSessionToken
+}
+
+/**
+ * Saves the package name corresponding to a custom tab token.
+ *
+ * @property token Token of the custom tab.
+ * @property packageName Package name of the app that created the custom tab.
+ */
+data class SaveCreatorPackageNameAction(
+    override val token: CustomTabsSessionToken,
+    val packageName: String
+) : CustomTabsAction()
+
+/**
+ * Marks the state of a custom tabs [Relation] verification.
+ *
+ * @property token Token of the custom tab to verify.
+ * @property relation Relationship type to verify.
+ * @property origin Origin to verify.
+ * @property status State of the verification process.
+ */
+data class ValidateRelationshipAction(
+    override val token: CustomTabsSessionToken,
+    @Relation val relation: Int,
+    val origin: Uri,
+    val status: VerificationStatus
+) : CustomTabsAction()

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsServiceState.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsServiceState.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.store
+
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsService
+import androidx.browser.customtabs.CustomTabsSessionToken
+import mozilla.components.lib.state.State
+
+/**
+ * Value type that represents the custom tabs state
+ * accessible from both the service and activity.
+ */
+data class CustomTabsServiceState(
+    val tabs: Map<CustomTabsSessionToken, CustomTabState> = emptyMap()
+) : State
+
+/**
+ * Value type that represents the state of a single custom tab
+ * accessible from both the service and activity.
+ *
+ * This data is meant to supplement [mozilla.components.browser.session.tab.CustomTabConfig],
+ * not replace it. It only contains data that the service also needs to work with.
+ *
+ * @property creatorPackageName Package name of the app that created the custom tab.
+ * @property relationships Map of origin and relationship type to current verification state.
+ */
+data class CustomTabState(
+    val creatorPackageName: String? = null,
+    val relationships: Map<OriginRelationPair, VerificationStatus> = emptyMap()
+)
+
+/**
+ * Pair of origin and relation type used as key in [CustomTabState.relationships].
+ *
+ * @property origin URL that contains only the scheme, host, and port.
+ * https://html.spec.whatwg.org/multipage/origin.html#concept-origin
+ * @property relation Enum that indicates the relation type.
+ */
+data class OriginRelationPair(
+    val origin: Uri,
+    @CustomTabsService.Relation val relation: Int
+)
+
+/**
+ * Different states of Digital Asset Link verification.
+ */
+enum class VerificationStatus {
+    /**
+     * Indicates verification has started and hasn't returned yet.
+     *
+     * To avoid flashing the toolbar, we choose to hide it when a Digital Asset Link is being verified.
+     * We only show the toolbar when the verification fails, or an origin never requested to be verified.
+     */
+    PENDING,
+
+    /**
+     * Indicates that verification has completed and the link was verified.
+     */
+    SUCCESS,
+
+    /**
+     * Indicates that verification has completed and the link was invalid.
+     */
+    FAILURE
+}

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsServiceStateReducer.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsServiceStateReducer.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.store
+
+internal object CustomTabsServiceStateReducer {
+
+    fun reduce(state: CustomTabsServiceState, action: CustomTabsAction): CustomTabsServiceState {
+        val tabState = state.tabs.getOrElse(action.token) { CustomTabState() }
+        val newTabState = reduceTab(tabState, action)
+        return state.copy(tabs = state.tabs + Pair(action.token, newTabState))
+    }
+
+    private fun reduceTab(state: CustomTabState, action: CustomTabsAction): CustomTabState {
+        return when (action) {
+            is SaveCreatorPackageNameAction ->
+                state.copy(creatorPackageName = action.packageName)
+            is ValidateRelationshipAction ->
+                state.copy(
+                    relationships = state.relationships + Pair(
+                        OriginRelationPair(action.origin, action.relation),
+                        action.status
+                    )
+                )
+        }
+    }
+}

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsServiceStore.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/store/CustomTabsServiceStore.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.store
+
+import mozilla.components.lib.state.Store
+
+class CustomTabsServiceStore(
+    initialState: CustomTabsServiceState = CustomTabsServiceState()
+) : Store<CustomTabsServiceState, CustomTabsAction>(
+    initialState,
+    CustomTabsServiceStateReducer::reduce
+)

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/AbstractCustomTabsServiceTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/AbstractCustomTabsServiceTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.customtabs
 
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.os.IBinder
@@ -31,6 +32,8 @@ class AbstractCustomTabsServiceTest {
         val customTabsService = object : AbstractCustomTabsService() {
             override val engine: Engine
                 get() = mock()
+
+            override fun getPackageManager(): PackageManager = mock()
         }
 
         val customTabsServiceStub = customTabsService.onBind(mock())

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.os.Binder
 import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.TrustedWebUtils
@@ -86,6 +87,11 @@ class CustomTabConfigHelperTest {
         assertEquals(closeButtonIcon, customTabConfig.closeButtonIcon)
         assertEquals(size, customTabConfig.closeButtonIcon?.width)
         assertEquals(size, customTabConfig.closeButtonIcon?.height)
+
+        val customTabConfigNoResources = createCustomTabConfigFromIntent(builder.build().intent, null)
+        assertEquals(closeButtonIcon, customTabConfigNoResources.closeButtonIcon)
+        assertEquals(size, customTabConfigNoResources.closeButtonIcon?.width)
+        assertEquals(size, customTabConfigNoResources.closeButtonIcon?.height)
     }
 
     @Test
@@ -97,6 +103,9 @@ class CustomTabConfigHelperTest {
 
         val customTabConfig = createCustomTabConfigFromIntent(builder.build().intent, testContext.resources)
         assertNull(customTabConfig.closeButtonIcon)
+
+        val customTabConfigNoResources = createCustomTabConfigFromIntent(builder.build().intent, null)
+        assertEquals(closeButtonIcon, customTabConfigNoResources.closeButtonIcon)
     }
 
     @Test
@@ -219,5 +228,17 @@ class CustomTabConfigHelperTest {
 
         val customTabConfig = createCustomTabConfigFromIntent(customTabsIntent.intent, testContext.resources)
         assertTrue(customTabConfig.titleVisible)
+    }
+
+    @Test
+    fun createFromIntentWithSessionToken() {
+        val customTabsIntent: Intent = mock()
+        val bundle: Bundle = mock()
+        val binder: Binder = mock()
+        `when`(customTabsIntent.extras).thenReturn(bundle)
+        `when`(bundle.getBinder(CustomTabsIntent.EXTRA_SESSION)).thenReturn(binder)
+
+        val customTabConfig = createCustomTabConfigFromIntent(customTabsIntent, testContext.resources)
+        assertNotNull(customTabConfig.sessionToken)
     }
 }

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -81,6 +81,19 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
+    fun `stop calls unregister`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        val feature = CustomTabsToolbarFeature(sessionManager, mock(), "") {}
+
+        `when`(sessionManager.findSessionById(anyString())).thenReturn(session)
+
+        feature.stop()
+
+        verify(session).unregister(any())
+    }
+
+    @Test
     fun `initialize returns true if session is a customtab`() {
         val session: Session = mock()
         val toolbar = spy(BrowserToolbar(testContext))

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.feature
+
+import androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_URLS
+import androidx.browser.customtabs.CustomTabsService.RELATION_USE_AS_ORIGIN
+import androidx.browser.customtabs.CustomTabsSessionToken
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.feature.customtabs.store.CustomTabState
+import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
+import mozilla.components.feature.customtabs.store.OriginRelationPair
+import mozilla.components.feature.customtabs.store.ValidateRelationshipAction
+import mozilla.components.feature.customtabs.store.VerificationStatus.FAILURE
+import mozilla.components.feature.customtabs.store.VerificationStatus.PENDING
+import mozilla.components.feature.customtabs.store.VerificationStatus.SUCCESS
+import mozilla.components.feature.customtabs.verify.OriginVerifier
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class OriginVerifierFeatureTest {
+
+    @Test
+    fun `verify fails if no creatorPackageName is saved`() = runBlockingTest {
+        val feature = OriginVerifierFeature(mock(), mock(), mock())
+
+        assertFalse(feature.verify(CustomTabState(), mock(), RELATION_HANDLE_ALL_URLS, mock()))
+    }
+
+    @Test
+    fun `verify returns existing relationship`() = runBlockingTest {
+        val feature = OriginVerifierFeature(mock(), mock(), mock())
+        val origin = "https://example.com".toUri()
+        val state = CustomTabState(
+            creatorPackageName = "com.example.twa",
+            relationships = mapOf(
+                OriginRelationPair(origin, RELATION_HANDLE_ALL_URLS) to SUCCESS,
+                OriginRelationPair(origin, RELATION_USE_AS_ORIGIN) to FAILURE,
+                OriginRelationPair("https://sample.com".toUri(), RELATION_HANDLE_ALL_URLS) to PENDING
+            )
+        )
+
+        assertTrue(feature.verify(state, mock(), RELATION_HANDLE_ALL_URLS, origin))
+        assertFalse(feature.verify(state, mock(), RELATION_USE_AS_ORIGIN, origin))
+    }
+
+    @Test
+    fun `verify checks new relationships`() = runBlockingTest {
+        val store: CustomTabsServiceStore = mock()
+        val verifier: OriginVerifier = mock()
+        val feature = spy(OriginVerifierFeature(mock(), mock()) { store.dispatch(it) })
+        doReturn(verifier).`when`(feature).getVerifier(anyString(), anyInt())
+        doReturn(true).`when`(verifier).verifyOrigin(any())
+
+        val token: CustomTabsSessionToken = mock()
+        val origin = "https://sample.com".toUri()
+        val state = CustomTabState(creatorPackageName = "com.example.twa")
+        assertNotNull(state)
+
+        assertTrue(feature.verify(state, token, RELATION_HANDLE_ALL_URLS, origin))
+
+        verify(verifier).verifyOrigin(origin)
+        verify(store).dispatch(ValidateRelationshipAction(token, RELATION_HANDLE_ALL_URLS, origin, PENDING))
+        verify(store).dispatch(ValidateRelationshipAction(token, RELATION_HANDLE_ALL_URLS, origin, SUCCESS))
+    }
+}

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/store/CustomTabsServiceStateReducerTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/store/CustomTabsServiceStateReducerTest.kt
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.store
+
+import androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_URLS
+import androidx.browser.customtabs.CustomTabsService.RELATION_USE_AS_ORIGIN
+import androidx.browser.customtabs.CustomTabsSessionToken
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CustomTabsServiceStateReducerTest {
+
+    @Test
+    fun `reduce adds new tab to map`() {
+        val token: CustomTabsSessionToken = mock()
+        val initialState = CustomTabsServiceState()
+        val action = SaveCreatorPackageNameAction(token, "com.example.twa")
+
+        assertEquals(
+            CustomTabsServiceState(tabs = mapOf(
+                token to CustomTabState(creatorPackageName = "com.example.twa")
+            )),
+            CustomTabsServiceStateReducer.reduce(initialState, action)
+        )
+    }
+
+    @Test
+    fun `reduce replaces existing tab in map`() {
+        val token: CustomTabsSessionToken = mock()
+        val initialState = CustomTabsServiceState(tabs = mapOf(
+            token to CustomTabState(creatorPackageName = "com.example.twa")
+        ))
+        val action = SaveCreatorPackageNameAction(token, "com.example.trusted.web.app")
+
+        assertEquals(
+            CustomTabsServiceState(tabs = mapOf(
+                token to CustomTabState(creatorPackageName = "com.example.trusted.web.app")
+            )),
+            CustomTabsServiceStateReducer.reduce(initialState, action)
+        )
+    }
+
+    @Test
+    fun `reduce adds new relationship`() {
+        val token: CustomTabsSessionToken = mock()
+        val initialState = CustomTabsServiceState(tabs = mapOf(
+            token to CustomTabState(creatorPackageName = "com.example.twa")
+        ))
+        val action = ValidateRelationshipAction(
+            token,
+            RELATION_HANDLE_ALL_URLS,
+            "https://example.com".toUri(),
+            VerificationStatus.PENDING
+        )
+
+        assertEquals(
+            CustomTabsServiceState(tabs = mapOf(
+                token to CustomTabState(
+                    creatorPackageName = "com.example.twa",
+                    relationships = mapOf(
+                        Pair(
+                            OriginRelationPair("https://example.com".toUri(), RELATION_HANDLE_ALL_URLS),
+                            VerificationStatus.PENDING
+                        )
+                    )
+                )
+            )),
+            CustomTabsServiceStateReducer.reduce(initialState, action)
+        )
+    }
+
+    @Test
+    fun `reduce adds new relationship of different type`() {
+        val token: CustomTabsSessionToken = mock()
+        val initialState = CustomTabsServiceState(tabs = mapOf(
+            token to CustomTabState(
+                creatorPackageName = "com.example.twa",
+                relationships = mapOf(
+                    Pair(
+                        OriginRelationPair("https://example.com".toUri(), RELATION_HANDLE_ALL_URLS),
+                        VerificationStatus.FAILURE
+                    )
+                )
+            )
+        ))
+        val action = ValidateRelationshipAction(
+            token,
+            RELATION_USE_AS_ORIGIN,
+            "https://example.com".toUri(),
+            VerificationStatus.PENDING
+        )
+
+        assertEquals(
+            CustomTabsServiceState(tabs = mapOf(
+                token to CustomTabState(
+                    creatorPackageName = "com.example.twa",
+                    relationships = mapOf(
+                        Pair(
+                            OriginRelationPair("https://example.com".toUri(), RELATION_HANDLE_ALL_URLS),
+                            VerificationStatus.FAILURE
+                        ),
+                        Pair(
+                            OriginRelationPair("https://example.com".toUri(), RELATION_USE_AS_ORIGIN),
+                            VerificationStatus.PENDING
+                        )
+                    )
+                )
+            )),
+            CustomTabsServiceStateReducer.reduce(initialState, action)
+        )
+    }
+
+    @Test
+    fun `reduce replaces existing relationship`() {
+        val token: CustomTabsSessionToken = mock()
+        val initialState = CustomTabsServiceState(tabs = mapOf(
+            token to CustomTabState(
+                creatorPackageName = "com.example.twa",
+                relationships = mapOf(
+                    Pair(
+                        OriginRelationPair("https://example.com".toUri(), RELATION_HANDLE_ALL_URLS),
+                        VerificationStatus.PENDING
+                    )
+                )
+            )
+        ))
+        val action = ValidateRelationshipAction(
+            token,
+            RELATION_HANDLE_ALL_URLS,
+            "https://example.com".toUri(),
+            VerificationStatus.SUCCESS
+        )
+
+        assertEquals(
+            CustomTabsServiceState(tabs = mapOf(
+                token to CustomTabState(
+                    creatorPackageName = "com.example.twa",
+                    relationships = mapOf(
+                        Pair(
+                            OriginRelationPair("https://example.com".toUri(), RELATION_HANDLE_ALL_URLS),
+                            VerificationStatus.SUCCESS
+                        )
+                    )
+                )
+            )),
+            CustomTabsServiceStateReducer.reduce(initialState, action)
+        )
+    }
+}

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/CustomTabState.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/CustomTabState.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.ext
+
+import androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_URLS
+import mozilla.components.feature.customtabs.store.CustomTabState
+import mozilla.components.feature.customtabs.store.VerificationStatus.PENDING
+import mozilla.components.feature.customtabs.store.VerificationStatus.SUCCESS
+
+/**
+ * Returns a list of trusted (or pending) origins.
+ */
+val CustomTabState.trustedOrigins
+    get() = relationships.mapNotNull { (pair, status) ->
+        if (pair.relation == RELATION_HANDLE_ALL_URLS && (status == PENDING || status == SUCCESS)) {
+            pair.origin
+        } else {
+            null
+        }
+    }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Uri.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Uri.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.ext
+
+import android.net.Uri
+
+/**
+ * Returns just the origin of the [Uri].
+ *
+ * The origin is a URL that contains only the scheme, host, and port.
+ * https://html.spec.whatwg.org/multipage/origin.html#concept-origin
+ *
+ * Null is returned if the URI was invalid (i.e.: `"/foo/bar".toUri()`)
+ */
+fun Uri.toOrigin(): Uri? {
+    var authority = host
+    if (port != -1) {
+        authority += ":$port"
+    }
+
+    val result = Uri.Builder().scheme(scheme).encodedAuthority(authority).build().normalizeScheme()
+    return if (result.toString().isNotEmpty()) result else null
+}

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.intent
+
+import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_URLS
+import androidx.browser.customtabs.CustomTabsSessionToken
+import androidx.core.net.toUri
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.intent.IntentProcessor
+import mozilla.components.browser.session.intent.putSessionId
+import mozilla.components.browser.session.tab.CustomTabConfig.Companion.EXTRA_ADDITIONAL_TRUSTED_ORIGINS
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.fetch.Client
+import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent
+import mozilla.components.feature.customtabs.feature.OriginVerifierFeature
+import mozilla.components.feature.customtabs.isTrustedWebActivityIntent
+import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
+import mozilla.components.feature.pwa.ext.toOrigin
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.utils.toSafeIntent
+
+/**
+ * Processor for intents which open Trusted Web Activities.
+ */
+class TrustedWebActivityIntentProcessor(
+    private val sessionManager: SessionManager,
+    private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase,
+    httpClient: Client,
+    packageManager: PackageManager,
+    private val store: CustomTabsServiceStore
+) : IntentProcessor {
+
+    private val verifier = OriginVerifierFeature(httpClient, packageManager) { store.dispatch(it) }
+    private val scope = MainScope()
+
+    override fun matches(intent: Intent): Boolean {
+        val safeIntent = intent.toSafeIntent()
+        return safeIntent.action == ACTION_VIEW && isTrustedWebActivityIntent(safeIntent)
+    }
+
+    override suspend fun process(intent: Intent): Boolean {
+        val safeIntent = SafeIntent(intent)
+        val url = safeIntent.dataString
+
+        return if (!url.isNullOrEmpty() && matches(intent)) {
+            val session = Session(url, private = false, source = Session.Source.HOME_SCREEN)
+            val customTabConfig = createCustomTabConfigFromIntent(intent, null)
+            session.customTabConfig = customTabConfig
+
+            sessionManager.add(session)
+            loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external())
+            intent.putSessionId(session.id)
+
+            customTabConfig.sessionToken?.let { token ->
+                val origin = listOfNotNull(safeIntent.data?.toOrigin())
+                val additionalOrigins = safeIntent
+                    .getStringArrayListExtra(EXTRA_ADDITIONAL_TRUSTED_ORIGINS)
+                    .orEmpty()
+                    .mapNotNull { it.toUri().toOrigin() }
+
+                // Launch verification separately so the intent processing isn't held up
+                scope.launch {
+                    verify(token, origin + additionalOrigins)
+                }
+            }
+
+            true
+        } else {
+            false
+        }
+    }
+
+    private suspend fun verify(token: CustomTabsSessionToken, origins: List<Uri>) {
+        val tabState = store.state.tabs[token] ?: return
+        origins.map { origin ->
+            scope.async {
+                verifier.verify(tabState, token, RELATION_HANDLE_ALL_URLS, origin)
+            }
+        }.awaitAll()
+    }
+}

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/CustomTabStateKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/CustomTabStateKtTest.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.ext
+
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_URLS
+import androidx.browser.customtabs.CustomTabsService.RELATION_USE_AS_ORIGIN
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.feature.customtabs.store.CustomTabState
+import mozilla.components.feature.customtabs.store.OriginRelationPair
+import mozilla.components.feature.customtabs.store.VerificationStatus.FAILURE
+import mozilla.components.feature.customtabs.store.VerificationStatus.PENDING
+import mozilla.components.feature.customtabs.store.VerificationStatus.SUCCESS
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CustomTabStateKtTest {
+
+    @Test
+    fun `trustedOrigins is empty when there are no relationships`() {
+        val state = CustomTabState(relationships = emptyMap())
+        assertEquals(emptyList<Uri>(), state.trustedOrigins)
+    }
+
+    @Test
+    fun `trustedOrigins only includes the HANDLE_ALL_URLS relationship`() {
+        val state = CustomTabState(relationships = mapOf(
+            OriginRelationPair("https://firefox.com".toUri(), RELATION_HANDLE_ALL_URLS) to SUCCESS,
+            OriginRelationPair("https://example.com".toUri(), RELATION_USE_AS_ORIGIN) to SUCCESS,
+            OriginRelationPair("https://mozilla.org".toUri(), RELATION_HANDLE_ALL_URLS) to PENDING
+        ))
+        assertEquals(
+            listOf("https://firefox.com".toUri(), "https://mozilla.org".toUri()),
+            state.trustedOrigins
+        )
+    }
+
+    @Test
+    fun `trustedOrigins only includes pending or success statuses`() {
+        val state = CustomTabState(relationships = mapOf(
+            OriginRelationPair("https://firefox.com".toUri(), RELATION_HANDLE_ALL_URLS) to SUCCESS,
+            OriginRelationPair("https://example.com".toUri(), RELATION_USE_AS_ORIGIN) to FAILURE,
+            OriginRelationPair("https://mozilla.org".toUri(), RELATION_HANDLE_ALL_URLS) to PENDING
+        ))
+        assertEquals(
+            listOf("https://firefox.com".toUri(), "https://mozilla.org".toUri()),
+            state.trustedOrigins
+        )
+    }
+}

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/UriKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/UriKtTest.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.ext
+
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UriKtTest {
+
+    @Test
+    fun `extracts scheme, host and port`() {
+        assertEquals("https://example.com", "https://example.com".toUri().toOrigin())
+        assertEquals("http://mozilla.org:80", "http://mozilla.org:80".toUri().toOrigin())
+        assertEquals("http://localhost:8080", "http://localhost:8080".toUri().toOrigin())
+    }
+
+    @Test
+    fun `removes user info`() {
+        assertEquals("https://example.com", "https://bob@example.com".toUri().toOrigin())
+        assertEquals("http://google.com", "HTTP://bob:pass@google.com".toUri().toOrigin())
+    }
+
+    @Test
+    fun `removes path`() {
+        assertEquals("https://example.com", "https://example.com/".toUri().toOrigin())
+        assertEquals("http://google.com", "http://google.com/search".toUri().toOrigin())
+        assertEquals("http://firefox.com", "http://firefox.com/en-US/foo".toUri().toOrigin())
+    }
+
+    @Test
+    fun `preserves missing scheme`() {
+        assertNull("example.com".toUri().toOrigin())
+        assertNull("/foo/bar".toUri().toOrigin())
+    }
+
+    private fun assertEquals(expected: String, actual: Uri?) = assertEquals(expected.toUri(), actual)
+}

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppHideToolbarFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppHideToolbarFeatureTest.kt
@@ -9,14 +9,13 @@ import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.never
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -39,9 +38,6 @@ class WebAppHideToolbarFeatureTest {
         val session: Session = mock()
         `when`(sessionManager.findSessionById("id")).thenReturn(session)
 
-        WebAppHideToolbarFeature(sessionManager, mock(), "id", emptyList()).start()
-        verify(session, never()).register(any())
-
         val feature = WebAppHideToolbarFeature(sessionManager, mock(), "id", listOf(mock()))
 
         feature.start()
@@ -52,7 +48,7 @@ class WebAppHideToolbarFeatureTest {
     }
 
     @Test
-    fun `hides toolbar if URL is in origin`() {
+    fun `onUrlChanged hides toolbar if URL is in origin`() {
         val trusted = listOf("https://mozilla.com".toUri(), "https://m.mozilla.com".toUri())
         val toolbar = View(testContext)
         val feature = WebAppHideToolbarFeature(mock(), toolbar, "id", trusted)
@@ -71,7 +67,7 @@ class WebAppHideToolbarFeatureTest {
     }
 
     @Test
-    fun `hides toolbar if URL is in scope`() {
+    fun `onUrlChanged hides toolbar if URL is in scope`() {
         val trusted = listOf("https://mozilla.github.io/my-app/".toUri())
         val toolbar = View(testContext)
         val feature = WebAppHideToolbarFeature(mock(), toolbar, "id", trusted)
@@ -90,7 +86,7 @@ class WebAppHideToolbarFeatureTest {
     }
 
     @Test
-    fun `hides toolbar if URL is in ambiguous scope`() {
+    fun `onUrlChanged hides toolbar if URL is in ambiguous scope`() {
         val trusted = listOf("https://mozilla.github.io/prefix".toUri())
         val toolbar = View(testContext)
         val feature = WebAppHideToolbarFeature(mock(), toolbar, "id", trusted)
@@ -99,6 +95,63 @@ class WebAppHideToolbarFeatureTest {
         assertEquals(View.GONE, toolbar.visibility)
 
         feature.onUrlChanged(mock(), "https://mozilla.github.io/prefix-of/resource.html")
+        assertEquals(View.GONE, toolbar.visibility)
+    }
+
+    @Test
+    fun `onTrustedScopesChange hides toolbar if URL is in origin`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        val trusted = listOf("https://mozilla.com".toUri(), "https://m.mozilla.com".toUri())
+        val toolbar = View(testContext)
+        val feature = WebAppHideToolbarFeature(sessionManager, toolbar, "id", trusted)
+
+        doReturn(session).`when`(sessionManager).findSessionById("id")
+        doReturn("https://mozilla.com/example-page").`when`(session).url
+
+        feature.onTrustedScopesChange(listOf("https://m.mozilla.com".toUri()))
+        assertEquals(View.VISIBLE, toolbar.visibility)
+
+        feature.onTrustedScopesChange(listOf("https://mozilla.com".toUri()))
+        assertEquals(View.GONE, toolbar.visibility)
+    }
+
+    @Test
+    fun `onTrustedScopesChange hides toolbar if URL is in scope`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        val trusted = listOf("https://mozilla.github.io/my-app/".toUri())
+        val toolbar = View(testContext)
+        val feature = WebAppHideToolbarFeature(sessionManager, toolbar, "id", trusted)
+
+        doReturn(session).`when`(sessionManager).findSessionById("id")
+        doReturn("https://mozilla.github.io/my-app/").`when`(session).url
+
+        feature.onTrustedScopesChange(listOf("https://mozilla.github.io/my-app/".toUri()))
+        assertEquals(View.GONE, toolbar.visibility)
+
+        feature.onTrustedScopesChange(listOf("https://firefox.com/out-of-scope/".toUri()))
+        assertEquals(View.VISIBLE, toolbar.visibility)
+
+        feature.onTrustedScopesChange(listOf("https://mozilla.github.io/my-app-almost-in-scope".toUri()))
+        assertEquals(View.VISIBLE, toolbar.visibility)
+    }
+
+    @Test
+    fun `onTrustedScopesChange hides toolbar if URL is in ambiguous scope`() {
+        val sessionManager: SessionManager = mock()
+        val session: Session = mock()
+        val trusted = listOf("https://mozilla.github.io/prefix".toUri())
+        val toolbar = View(testContext)
+        val feature = WebAppHideToolbarFeature(sessionManager, toolbar, "id", trusted)
+
+        doReturn(session).`when`(sessionManager).findSessionById("id")
+        doReturn("https://mozilla.github.io/prefix-of/resource.html").`when`(session).url
+
+        feature.onTrustedScopesChange(listOf("https://mozilla.github.io/prefix".toUri()))
+        assertEquals(View.GONE, toolbar.visibility)
+
+        feature.onTrustedScopesChange(listOf("https://mozilla.github.io/prefix-of/".toUri()))
         assertEquals(View.GONE, toolbar.visibility)
     }
 }

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.intent
+
+import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.os.Bundle
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_SESSION
+import androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
+import mozilla.components.feature.pwa.intent.WebAppIntentProcessor.Companion.ACTION_VIEW_PWA
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class TrustedWebActivityIntentProcessorTest {
+
+    @Test
+    fun `matches checks if intent is a trusted web activity intent`() {
+        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), mock())
+
+        assertFalse(processor.matches(Intent(ACTION_VIEW_PWA)))
+        assertFalse(processor.matches(Intent(ACTION_VIEW)))
+        assertFalse(processor.matches(
+            Intent(ACTION_VIEW).apply { putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true) }
+        ))
+        assertFalse(processor.matches(
+            Intent(ACTION_VIEW).apply {
+                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, false)
+                putExtra(EXTRA_SESSION, null as Bundle?)
+            }
+        ))
+        assertTrue(processor.matches(
+            Intent(ACTION_VIEW).apply {
+                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true)
+                putExtra(EXTRA_SESSION, null as Bundle?)
+            }
+        ))
+    }
+
+    @Test
+    fun `process checks if intent action is not valid`() = runBlockingTest {
+        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), mock())
+
+        assertFalse(processor.process(Intent(ACTION_VIEW_PWA)))
+        assertFalse(processor.process(Intent(ACTION_VIEW)))
+        assertFalse(processor.process(
+            Intent(ACTION_VIEW).apply { putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true) }
+        ))
+        assertFalse(processor.process(
+            Intent(ACTION_VIEW).apply {
+                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, false)
+                putExtra(EXTRA_SESSION, null as Bundle?)
+            }
+        ))
+        assertFalse(processor.process(
+            Intent(ACTION_VIEW).apply {
+                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true)
+                putExtra(EXTRA_SESSION, null as Bundle?)
+            }
+        ))
+        assertFalse(processor.process(
+            Intent(ACTION_VIEW, null).apply {
+                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true)
+                putExtra(EXTRA_SESSION, null as Bundle?)
+            }
+        ))
+    }
+
+    @Test
+    fun `process adds custom tab config`() = runBlockingTest {
+        val intent = Intent(ACTION_VIEW, "https://example.com".toUri()).apply {
+            putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true)
+            putExtra(EXTRA_SESSION, null as Bundle?)
+        }
+
+        val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase = mock()
+        val store: CustomTabsServiceStore = mock()
+
+        val processor = spy(TrustedWebActivityIntentProcessor(mock(), loadUrlUseCase, mock(), mock(), store))
+
+        assertTrue(processor.process(intent))
+
+        verify(loadUrlUseCase).invoke(eq("https://example.com"), any(), eq(EngineSession.LoadUrlFlags.external()))
+        verify(store, never()).state
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,15 @@ permalink: /changelog/
 * **support-ktx**
   * Added property delegates to work with `SharedPreferences`.
 
+* **feature-customtabs**
+  * Added `CustomTabsServiceStore` to track custom tab data in `AbstractCustomTabsService`.
+
+* **feature-pwa**
+  * Added support for hiding the toolbar in a Trusted Web Activity.
+  * Added `TrustedWebActivityIntentProcessor` to process TWA intents.
+  * Added `CustomTabState.trustedOrigins` extension method to turn the verification state of a custom tab into a list of origins.
+  * Added `WebAppHideToolbarFeature.onTrustedScopesChange` to change the trusted scopes after the feature is created.
+
 # 10.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v10.0.0...v10.0.1)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -29,13 +29,15 @@ import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
+import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.intent.TabIntentProcessor
 import mozilla.components.feature.media.MediaFeature
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.state.MediaStateMachine
 import mozilla.components.feature.pwa.ManifestStorage
-import mozilla.components.feature.pwa.intent.WebAppIntentProcessor
 import mozilla.components.feature.pwa.WebAppUseCases
+import mozilla.components.feature.pwa.intent.TrustedWebActivityIntentProcessor
+import mozilla.components.feature.pwa.intent.WebAppIntentProcessor
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.feature.session.SessionUseCases
@@ -72,6 +74,8 @@ open class DefaultComponents(private val applicationContext: Context) {
     private val sessionStorage by lazy { SessionStorage(applicationContext, engine) }
 
     val store by lazy { BrowserStore() }
+
+    val customTabsStore by lazy { CustomTabsServiceStore() }
 
     val sessionManager by lazy {
         SessionManager(engine, store).apply {
@@ -118,11 +122,18 @@ open class DefaultComponents(private val applicationContext: Context) {
     val tabIntentProcessor by lazy {
         TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
     }
-    val customTabIntentProcessor by lazy {
-        CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources)
-    }
-    val webAppIntentProcessor by lazy {
-        WebAppIntentProcessor(sessionManager, sessionUseCases.loadUrl, ManifestStorage(applicationContext))
+    val externalAppIntentProcessors by lazy {
+        listOf(
+            WebAppIntentProcessor(sessionManager, sessionUseCases.loadUrl, ManifestStorage(applicationContext)),
+            TrustedWebActivityIntentProcessor(
+                sessionManager,
+                sessionUseCases.loadUrl,
+                client,
+                applicationContext.packageManager,
+                customTabsStore
+            ),
+            CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources)
+        )
     }
 
     // Menu

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserActivity.kt
@@ -5,7 +5,6 @@
 package org.mozilla.samples.browser
 
 import androidx.fragment.app.Fragment
-import mozilla.components.feature.pwa.ext.getTrustedScope
 import mozilla.components.feature.pwa.ext.getWebAppManifest
 
 /**
@@ -20,8 +19,7 @@ class ExternalAppBrowserActivity : BrowserActivity() {
 
             ExternalAppBrowserFragment.create(
                 sessionId,
-                manifest = manifest,
-                trustedScopes = listOfNotNull(manifest?.getTrustedScope())
+                manifest = manifest
             )
         } else {
             // Fall back to browser fragment

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
@@ -17,11 +17,7 @@ class IntentReceiverActivity : Activity() {
         super.onCreate(savedInstanceState)
         MainScope().launch {
             val intent = intent?.let { Intent(it) } ?: Intent()
-            val intentProcessors = listOf(
-                components.webAppIntentProcessor,
-                components.customTabIntentProcessor,
-                components.tabIntentProcessor
-            )
+            val intentProcessors = components.externalAppIntentProcessors + components.tabIntentProcessor
 
             intentProcessors.any { it.process(intent) }
 
@@ -36,12 +32,7 @@ class IntentReceiverActivity : Activity() {
      * Sets the activity that this [intent] will launch.
      */
     private fun setBrowserActivity(intent: Intent) {
-        val externalAppIntentProcessors = listOf(
-            components.webAppIntentProcessor,
-            components.customTabIntentProcessor
-        )
-
-        val className = if (externalAppIntentProcessors.any { it.matches(intent) }) {
+        val className = if (components.externalAppIntentProcessors.any { it.matches(intent) }) {
             ExternalAppBrowserActivity::class
         } else {
             BrowserActivity::class

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/customtabs/CustomTabsService.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/customtabs/CustomTabsService.kt
@@ -5,9 +5,13 @@
 package org.mozilla.samples.browser.customtabs
 
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.AbstractCustomTabsService
+import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import org.mozilla.samples.browser.ext.components
 
 class CustomTabsService : AbstractCustomTabsService() {
     override val engine: Engine by lazy { components.engine }
+    override val httpClient: Client by lazy { components.client }
+    override val customTabsServiceStore: CustomTabsServiceStore by lazy { components.customTabsStore }
 }


### PR DESCRIPTION
Uses `AbstractCustomTabsService` to record the package name of the custom tab launching app, 
then use it to later verify Digital Asset Links.

A store is used to track the validation state of the Digital Asset Links. (Naming TBD.)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

To test:
- Change the AndroidX Browser dependency to `1.2.0-alpha07`
- Add the `androidx.browser.trusted.category.TrustedWebActivities` category to `CustomTabsService`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
