### PR TITLE
Closes #4158: Expose ADM SDK version we compile against

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,6 +31,8 @@ object Versions {
 
     const val material = "1.0.0"
 
+    const val amazon_device_messaging = "1.0.1"
+
     object AndroidX {
         const val annotation = "1.0.2"
         const val appcompat = "1.0.0"

--- a/components/lib/push-amazon/build.gradle
+++ b/components/lib/push-amazon/build.gradle
@@ -13,6 +13,8 @@ android {
     defaultConfig {
         minSdkVersion config.minSdkVersion
         targetSdkVersion config.targetSdkVersion
+
+        buildConfigField("String", "AMAZON_DEVICE_MESSAGING_VERSION", "\"" + Versions.amazon_device_messaging + "\"")
     }
 
     buildTypes {
@@ -24,8 +26,8 @@ android {
 }
 
 dependencies {
-    compileOnly files('libs/amazon-device-messaging-1.0.1.jar')
-    testImplementation files('libs/amazon-device-messaging-1.0.1.jar')
+    compileOnly files('libs/amazon-device-messaging-' + Versions.amazon_device_messaging + '.jar')
+    testImplementation files('libs/amazon-device-messaging-' + Versions.amazon_device_messaging + '.jar')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.androidx_annotation


### PR DESCRIPTION
We need to expose the SDK version that we compile against for apps to synchronize their dependencies as well.

I'm not sure if we need to do something similar to our `Config.kt` class as well or is the `BuildConfig.AMAZON_DEVICE_MESSAGING_VERSION` good enough.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
