### PR TITLE
No issue: bump a-s to 0.38.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,7 +26,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.37.1"
+    const val mozilla_appservices = "0.38.1"
     const val servo = "0.0.1.20181017.aa95911"
 
     const val material = "1.0.0"


### PR DESCRIPTION
 Changelog here: https://github.com/mozilla/application-services/releases