### PR TITLE
Fix AdaptiveIconProcessor checks

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessor.kt
@@ -33,13 +33,14 @@ class AdaptiveIconProcessor : IconProcessor {
         icon: Icon,
         desiredSize: DesiredSize
     ): Icon {
-        if (!icon.maskable && SDK_INT < Build.VERSION_CODES.O) {
+        val maskable = resource?.maskable == true
+        if (!maskable && SDK_INT < Build.VERSION_CODES.O) {
             return icon
         }
 
         val originalBitmap = icon.bitmap
 
-        val paddingRatio = if (icon.maskable) {
+        val paddingRatio = if (maskable) {
             MASKABLE_ICON_PADDING_RATIO
         } else {
             TRANSPARENT_ICON_PADDING_RATIO

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt
@@ -4,11 +4,9 @@
 
 package mozilla.components.browser.icons
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
@@ -39,13 +37,11 @@ import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
 class BrowserIconsTest {
-    private val context: Context
-        get() = ApplicationProvider.getApplicationContext()
 
     @Before
     @After
     fun cleanUp() {
-        sharedDiskCache.clear(context)
+        sharedDiskCache.clear(testContext)
         sharedMemoryCache.clear()
     }
 
@@ -57,12 +53,12 @@ class BrowserIconsTest {
         `when`(generator.generate(any(), any())).thenReturn(mockedIcon)
 
         val request = IconRequest(url = "https://www.mozilla.org")
-        val icon = BrowserIcons(context, httpClient = mock(), generator = generator)
+        val icon = BrowserIcons(testContext, httpClient = mock(), generator = generator)
             .loadIcon(request)
 
         assertEquals(mockedIcon, runBlocking { icon.await() })
 
-        verify(generator).generate(context, request)
+        verify(generator).generate(testContext, request)
     }
 
     @Test
@@ -102,7 +98,7 @@ class BrowserIconsTest {
             )
 
             val icon = BrowserIcons(
-                context,
+                testContext,
                 httpClient = HttpURLConnectionClient()
             ).loadIcon(request).await()
 
@@ -127,7 +123,7 @@ class BrowserIconsTest {
         server.start()
 
         try {
-            val icons = BrowserIcons(context, httpClient = HttpURLConnectionClient())
+            val icons = BrowserIcons(testContext, httpClient = HttpURLConnectionClient())
 
             val request = IconRequest(
                 url = "https://www.mozilla.org",
@@ -168,7 +164,7 @@ class BrowserIconsTest {
         server.start()
 
         try {
-            val icons = BrowserIcons(context, httpClient = HttpURLConnectionClient())
+            val icons = BrowserIcons(testContext, httpClient = HttpURLConnectionClient())
 
             val request = IconRequest(
                 url = "https://www.mozilla.org",

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/AdaptiveIconProcessorTest.kt
@@ -8,6 +8,8 @@ import android.os.Build
 import androidx.core.graphics.createBitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.icons.IconRequest.Resource.Type.MANIFEST_ICON
 import mozilla.components.support.test.mock
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -33,7 +35,7 @@ class AdaptiveIconProcessorTest {
 
     @Test
     fun `process returns non-maskable icons on legacy devices`() {
-        val icon = Icon(mock(), source = Icon.Source.GENERATOR, maskable = false)
+        val icon = Icon(mock(), source = Icon.Source.GENERATOR)
 
         assertEquals(
             icon,
@@ -49,8 +51,8 @@ class AdaptiveIconProcessorTest {
         val icon = AdaptiveIconProcessor().process(
             mock(),
             mock(),
-            mock(),
-            Icon(bitmap, source = Icon.Source.DISK, maskable = false),
+            IconRequest.Resource("", MANIFEST_ICON, maskable = false),
+            Icon(bitmap, source = Icon.Source.DISK),
             mock()
         )
 
@@ -69,8 +71,8 @@ class AdaptiveIconProcessorTest {
         val icon = AdaptiveIconProcessor().process(
             mock(),
             mock(),
-            mock(),
-            Icon(bitmap, source = Icon.Source.INLINE, maskable = true),
+            IconRequest.Resource("", MANIFEST_ICON, maskable = true),
+            Icon(bitmap, source = Icon.Source.INLINE),
             mock()
         )
 


### PR DESCRIPTION
The `Icon.maskable` field is set by AdaptiveIconProcessor so it needs to check `resource.maskable` instead.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
