### PR TITLE
Use color from Palette API if PWA bkg is white

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/ColorProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/ColorProcessor.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.icons.processor
 
 import android.content.Context
+import android.graphics.Color
 import androidx.palette.graphics.Palette
 import mozilla.components.browser.icons.DesiredSize
 import mozilla.components.browser.icons.Icon
@@ -22,8 +23,13 @@ class ColorProcessor : IconProcessor {
         icon: Icon,
         desiredSize: DesiredSize
     ): Icon {
+        // If the icon already has a color set, just return
         if (icon.color != null) return icon
-        if (request.color != null) return icon.copy(color = request.color)
+        // If the request already has a color set, then return.
+        // Some PWAs just set the background color to white (such as Twitter, Starbucks)
+        // but the icons would work better if we fill the background using the Palette API.
+        // If a PWA really want a white background a maskable icon can be used.
+        if (request.color != null && request.color != Color.WHITE) return icon.copy(color = request.color)
 
         val swatch = Palette.from(icon.bitmap).generate().dominantSwatch
         return swatch?.run { icon.copy(color = rgb) } ?: icon


### PR DESCRIPTION
Some PWAs just set the background color to white (such as Twitter, Starbucks) but the icons would work better if we fill the background using the Palette API. If a PWA really want a white background a maskable icon can be used.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
