### PR TITLE
`Store` extensions to observe `State` using Kotlin's `Flow` API

### DIFF
--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/Fragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import mozilla.components.lib.state.Action
@@ -26,7 +25,6 @@ import mozilla.components.support.ktx.android.view.toScope
  */
 @MainThread
 @ExperimentalCoroutinesApi // Channel
-@ObsoleteCoroutinesApi // consumeEach
 fun <S : State, A : Action> Fragment.consumeFrom(store: Store<S, A>, block: (S) -> Unit) {
     val fragment = this
     val view = checkNotNull(view) { "Fragment has no view yet. Call from onViewCreated()." }

--- a/components/lib/state/src/main/java/mozilla/components/lib/state/ext/View.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/ext/View.kt
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import mozilla.components.lib.state.Action
@@ -26,7 +25,6 @@ import mozilla.components.support.ktx.android.view.toScope
  * Inside a [Fragment] prefer to use [Fragment.consumeFrom].
  */
 @ExperimentalCoroutinesApi // Channel
-@ObsoleteCoroutinesApi // consumeEach
 fun <S : State, A : Action> View.consumeFrom(
     store: Store<S, A>,
     owner: LifecycleOwner,

--- a/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
+++ b/components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt
@@ -11,30 +11,50 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import mozilla.components.lib.state.Store
 import mozilla.components.lib.state.TestAction
 import mozilla.components.lib.state.TestState
 import mozilla.components.lib.state.reducer
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class StoreExtensionsKtTest {
+    @Before
+    @ExperimentalCoroutinesApi
+    fun setUp() {
+        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    }
+
+    @After
+    @ExperimentalCoroutinesApi
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
     fun `Observer will not get registered if lifecycle is already destroyed`() {
         val owner = MockedLifecycleOwner(Lifecycle.State.DESTROYED)
@@ -126,7 +146,6 @@ class StoreExtensionsKtTest {
     @Test
     @Synchronized
     @ExperimentalCoroutinesApi // Channel
-    @ObsoleteCoroutinesApi // consumeEach
     fun `Reading state updates from channel`() {
         val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
 
@@ -182,7 +201,7 @@ class StoreExtensionsKtTest {
 
     @Test(expected = IllegalArgumentException::class)
     @ExperimentalCoroutinesApi // Channel
-    fun `Creating broadcast channel throws if lifecycle is already DESTROYED`() {
+    fun `Creating channel throws if lifecycle is already DESTROYED`() {
         val owner = MockedLifecycleOwner(Lifecycle.State.DESTROYED)
 
         val store = Store(
@@ -191,6 +210,118 @@ class StoreExtensionsKtTest {
         )
 
         store.channel(owner)
+    }
+
+    @Test
+    @Synchronized
+    @ExperimentalCoroutinesApi
+    fun `Reading state updates from Flow`() {
+        val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
+
+        val store = Store(
+            TestState(counter = 23),
+            ::reducer
+        )
+
+        var receivedValue = 0
+        var latch = CountDownLatch(1)
+
+        val flow = store.flow(owner)
+
+        val job = GlobalScope.launch {
+            flow.collect { state ->
+                receivedValue = state.counter
+                latch.countDown()
+            }
+        }
+
+        // Nothing received yet.
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Updating state: Nothing received yet.
+        latch = CountDownLatch(1)
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Switching to STARTED state: Receiving initial state
+        owner.lifecycleRegistry.markState(Lifecycle.State.STARTED)
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(24, receivedValue)
+        latch = CountDownLatch(1)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(25, receivedValue)
+        latch = CountDownLatch(1)
+
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+        latch = CountDownLatch(1)
+
+        runBlocking { job.cancelAndJoin() }
+
+        // Receiving nothing anymore since coroutine is cancelled
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+    }
+
+    @Test
+    @Synchronized
+    @ExperimentalCoroutinesApi
+    fun `Reading state from scoped flow`() {
+        val owner = MockedLifecycleOwner(Lifecycle.State.INITIALIZED)
+
+        val store = Store(
+            TestState(counter = 23),
+            ::reducer
+        )
+
+        var receivedValue = 0
+        var latch = CountDownLatch(1)
+
+        val scope = store.flowScoped(owner) { flow ->
+            flow.collect { state ->
+                receivedValue = state.counter
+                latch.countDown()
+            }
+        }
+
+        // Nothing received yet.
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Updating state: Nothing received yet.
+        latch = CountDownLatch(1)
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(0, receivedValue)
+
+        // Switching to STARTED state: Receiving initial state
+        latch = CountDownLatch(1)
+        owner.lifecycleRegistry.markState(Lifecycle.State.STARTED)
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(24, receivedValue)
+
+        latch = CountDownLatch(1)
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(25, receivedValue)
+
+        latch = CountDownLatch(1)
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
+
+        scope.cancel()
+
+        latch = CountDownLatch(1)
+        store.dispatch(TestAction.IncrementAction).joinBlocking()
+        assertFalse(latch.await(1, TimeUnit.SECONDS))
+        assertEquals(26, receivedValue)
     }
 
     @Test

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.kotlinx.coroutines.flow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+
+/**
+ * Returns a [Flow] containing only values of the original [Flow] that have changed compared to
+ * the value emitted before them.
+ *
+ * Example:
+ * Original Flow: A, B, B, C, A, A, A, D, A
+ * Returned Flow: A, B, C, A, D, A
+ */
+fun <T> Flow<T>.ifChanged(): Flow<T> {
+    var observedValueOnce = false
+    var lastValue: T? = null
+
+    return filter { value ->
+        if (!observedValueOnce || value !== lastValue) {
+            lastValue = value
+            observedValueOnce = true
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.kotlinx.coroutines.flow
+
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FlowKtTest {
+    @Test
+    fun `ifChanged operator`() {
+        val originalFlow = flowOf("A", "B", "B", "C", "A", "A", "A", "D", "A")
+
+        val items = runBlocking { originalFlow.ifChanged().toList() }
+
+        assertEquals(
+            listOf("A", "B", "C", "A", "D", "A"),
+            items)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,9 +19,12 @@ permalink: /changelog/
   * Added `startImage` to Highlight of HighlightableMenuItem, which allows changing the startImage in addition to the endImage when highlighted
   * Highlight properties of HighlightableMenuItem `startImage` and `endImage` are now both optional
 
+* **lib-state**
+  * Added `Store` extensions to observe `State` using Kotlin's `Flow` API: `Store.flow()`, `Store.flowScoped()`.
+
 * **support-ktx**
   * Added property delegates to work with `SharedPreferences`.
-  * Added `Flow.ifChanged()` operator for filtering a `Flow` based on whether a value has changed from the previous one (e.g. A, A, B, C, A -> A, B, C, A).
+  * Added `Flow.ifChanged()` operator for filtering a `Flow` based on whether a value has changed from the previous one (e.g. `A, A, B, C, A -> A, B, C, A`).
 
 # 10.0.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ permalink: /changelog/
 
 * **support-ktx**
   * Added property delegates to work with `SharedPreferences`.
+  * Added `Flow.ifChanged()` operator for filtering a `Flow` based on whether a value has changed from the previous one (e.g. A, A, B, C, A -> A, B, C, A).
 
 # 10.0.1
 


### PR DESCRIPTION
For #3530. Fixes #3786.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
