### PR TITLE
Closes #3544: Add custom tab config to browser-state

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -10,7 +10,6 @@ import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.session.ext.toSecurityInfoState
-import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.browser.state.action.ContentAction.RemoveIconAction
 import mozilla.components.browser.state.action.ContentAction.RemoveThumbnailAction
 import mozilla.components.browser.state.action.ContentAction.UpdateIconAction
@@ -22,6 +21,7 @@ import mozilla.components.browser.state.action.ContentAction.UpdateThumbnailActi
 import mozilla.components.browser.state.action.ContentAction.UpdateTitleAction
 import mozilla.components.browser.state.action.ContentAction.UpdateUrlAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
+import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt
@@ -19,10 +19,11 @@ fun Session.toTabSessionState(): TabSessionState {
 }
 
 /**
- * Creates a matching [CustomTabSessionState] from a [Session]
+ * Creates a matching [CustomTabSessionState] from a custom tab [Session].
  */
 fun Session.toCustomTabSessionState(): CustomTabSessionState {
-    return CustomTabSessionState(id, toContentState())
+    val config = customTabConfig ?: throw IllegalStateException("Session is not a custom tab session")
+    return CustomTabSessionState(id, toContentState(), toTrackingProtectionState(), config)
 }
 
 private fun Session.toContentState(): ContentState {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -41,6 +41,28 @@ class SessionManagerMigrationTest {
     }
 
     @Test
+    fun `Add custom tab session`() {
+        val store = BrowserStore()
+
+        val sessionManager = SessionManager(engine = mock(), store = store)
+
+        assertTrue(sessionManager.sessions.isEmpty())
+        assertTrue(store.state.tabs.isEmpty())
+
+        val customTabSession = Session("https://www.mozilla.org")
+        customTabSession.customTabConfig = mock()
+        sessionManager.add(customTabSession)
+
+        assertEquals(0, sessionManager.sessions.size)
+        assertEquals(1, sessionManager.all.size)
+        assertEquals(0, store.state.tabs.size)
+        assertEquals(1, store.state.customTabs.size)
+
+        val tab = store.state.customTabs[0]
+        assertEquals("https://www.mozilla.org", tab.content.url)
+    }
+
+    @Test
     fun `Remove session`() {
         val store = BrowserStore()
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.browser.session
 
 import android.graphics.Bitmap
-import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -13,8 +13,8 @@ import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.browser.session.ext.toSecurityInfoState
-import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/ext/SessionExtensionsTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/ext/SessionExtensionsTest.kt
@@ -1,0 +1,32 @@
+package mozilla.components.browser.session.ext
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.IllegalStateException
+
+@RunWith(AndroidJUnit4::class)
+class SessionExtensionsTest {
+
+    @Test
+    fun `toCustomTabSessionState - Can convert custom tab session`() {
+        val session = Session("https://mozilla.org")
+        session.customTabConfig = CustomTabConfig()
+
+        val customTabState = session.toCustomTabSessionState()
+        assertEquals(customTabState.id, session.id)
+        assertEquals(customTabState.content.url, session.url)
+        assertSame(customTabState.config, session.customTabConfig)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `toCustomTabSessionState - Throws exception when converting a non-custom tab session`() {
+        val session: Session = mock()
+        session.toCustomTabSessionState()
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.session.tab
+package mozilla.components.browser.state.state
 
 import android.app.PendingIntent
 import android.graphics.Bitmap
@@ -10,10 +10,12 @@ import android.os.Bundle
 import androidx.annotation.ColorInt
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsSessionToken
+import java.util.UUID
 
 /**
  * Holds configuration data for a Custom Tab.
  *
+ * @property id a unique ID of this custom tab.
  * @property toolbarColor Background color for the toolbar.
  * @property closeButtonIcon Custom icon of the back button on the toolbar.
  * @property enableUrlbarHiding Enables the toolbar to hide as the user scrolls down on the page.
@@ -26,8 +28,8 @@ import androidx.browser.customtabs.CustomTabsSessionToken
  * @property sessionToken The token associated with the custom tab.
  */
 data class CustomTabConfig(
-    val id: String,
-    @ColorInt val toolbarColor: Int?,
+    val id: String = UUID.randomUUID().toString(),
+    @ColorInt val toolbarColor: Int? = null,
     val closeButtonIcon: Bitmap? = null,
     val enableUrlbarHiding: Boolean = false,
     val actionButtonConfig: CustomTabActionButtonConfig? = null,

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -12,16 +12,23 @@ import java.util.UUID
  * @property id the ID of this custom tab and session.
  * @property content the [ContentState] of this custom tab.
  * @property trackingProtection the [TrackingProtectionState] of this custom tab.
+ * @property config the [CustomTabConfig] used to create this custom tab.
  */
 data class CustomTabSessionState(
     override val id: String = UUID.randomUUID().toString(),
     override val content: ContentState,
-    override val trackingProtection: TrackingProtectionState = TrackingProtectionState()
+    override val trackingProtection: TrackingProtectionState = TrackingProtectionState(),
+    val config: CustomTabConfig
 ) : SessionState
 
-internal fun createCustomTab(url: String, id: String = UUID.randomUUID().toString()): CustomTabSessionState {
+internal fun createCustomTab(
+    url: String,
+    id: String = UUID.randomUUID().toString(),
+    config: CustomTabConfig = CustomTabConfig()
+): CustomTabSessionState {
     return CustomTabSessionState(
         id = id,
-        content = ContentState(url)
+        content = ContentState(url),
+        config = config
     )
 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/CustomTabListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/CustomTabListActionTest.kt
@@ -5,14 +5,17 @@
 package mozilla.components.browser.state.action
 
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 class CustomTabListActionTest {
+
     @Test
     fun `AddCustomTabAction - Adds provided tab`() {
         val store = BrowserStore()
@@ -20,13 +23,15 @@ class CustomTabListActionTest {
         assertEquals(0, store.state.tabs.size)
         assertEquals(0, store.state.customTabs.size)
 
-        val customTab = createCustomTab("https://www.mozilla.org")
+        val config = CustomTabConfig("test")
+        val customTab = createCustomTab("https://www.mozilla.org", config = config)
 
         store.dispatch(CustomTabListAction.AddCustomTabAction(customTab)).joinBlocking()
 
         assertEquals(0, store.state.tabs.size)
         assertEquals(1, store.state.customTabs.size)
         assertEquals(customTab, store.state.customTabs[0])
+        assertSame(config, store.state.customTabs[0].config)
     }
 
     @Test

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
@@ -31,10 +31,10 @@ import androidx.browser.customtabs.CustomTabsIntent.SHOW_PAGE_TITLE
 import androidx.browser.customtabs.CustomTabsIntent.TOOLBAR_ACTION_BUTTON_ID
 import androidx.browser.customtabs.CustomTabsSessionToken
 import androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY
-import mozilla.components.browser.session.tab.CustomTabActionButtonConfig
-import mozilla.components.browser.session.tab.CustomTabConfig
-import mozilla.components.browser.session.tab.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
-import mozilla.components.browser.session.tab.CustomTabMenuItem
+import mozilla.components.browser.state.state.CustomTabActionButtonConfig
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
+import mozilla.components.browser.state.state.CustomTabMenuItem
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.toSafeBundle
 import mozilla.components.support.utils.toSafeIntent

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -19,8 +19,8 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.runWithSession
-import mozilla.components.browser.session.tab.CustomTabActionButtonConfig
-import mozilla.components.browser.session.tab.CustomTabMenuItem
+import mozilla.components.browser.state.state.CustomTabActionButtonConfig
+import mozilla.components.browser.state.state.CustomTabMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.feature.BackHandler

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt
@@ -14,7 +14,7 @@ import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.TrustedWebUtils
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.tab.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
+import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -19,9 +19,9 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.tab.CustomTabActionButtonConfig
-import mozilla.components.browser.session.tab.CustomTabConfig
-import mozilla.components.browser.session.tab.CustomTabMenuItem
+import mozilla.components.browser.state.state.CustomTabActionButtonConfig
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.CustomTabMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.test.any

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -9,7 +9,7 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
 import androidx.core.net.toUri
-import mozilla.components.browser.session.tab.CustomTabConfig
+import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.support.utils.ColorUtils.isDark
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -19,7 +19,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.intent.IntentProcessor
 import mozilla.components.browser.session.intent.putSessionId
-import mozilla.components.browser.session.tab.CustomTabConfig.Companion.EXTRA_ADDITIONAL_TRUSTED_ORIGINS
+import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_ADDITIONAL_TRUSTED_ORIGINS
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent


### PR DESCRIPTION
Instead of copying/duplicating `CustomTabConfig`, I decided to move the existing one to browser-state. This works as browser-session already depends on browser-state. `CustomTabConfig` is not used by applications directly, so this doesn't break API either.

We shouldn't need a separate action to update this config, as the config is provided when the custom tab is created and then doesn't change.

I've also added some missing tests.