### PR TITLE
Closes #4311: Remove Top and Bottom Padding Causing Issues with Text Alignment and Clipping

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -50,11 +50,14 @@ internal class EditToolbar(
         imeOptions = EditorInfo.IME_ACTION_GO or EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_FULLSCREEN
         gravity = Gravity.CENTER_VERTICAL
         background = null
-        setLines(1)
         textSize = URL_TEXT_SIZE_SP
         inputType = InputType.TYPE_TEXT_VARIATION_URI or InputType.TYPE_CLASS_TEXT
+        setSingleLine()
 
-        setPadding(resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_padding))
+        val horizontalPadding = resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_horizontal_padding)
+        val verticalPadding = resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_vertical_padding)
+
+        setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
 
         setOnCommitListener {
             // We emit the fact before notifying the listener because otherwise the listener may cause a focus

--- a/components/browser/toolbar/src/main/res/values/dimens.xml
+++ b/components/browser/toolbar/src/main/res/values/dimens.xml
@@ -14,6 +14,7 @@
     <dimen name="mozac_browser_toolbar_menu_padding">16dp</dimen>
 
     <!-- EditToolbar -->
-    <dimen name="mozac_browser_toolbar_url_padding">8dp</dimen>
+    <dimen name="mozac_browser_toolbar_url_horizontal_padding">8dp</dimen>
+    <dimen name="mozac_browser_toolbar_url_vertical_padding">0dp</dimen>
     <dimen name="mozac_browser_toolbar_cancel_padding">16dp</dimen>
 </resources>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
@@ -222,26 +222,46 @@ class EditToolbarTest {
 
         assertEquals(1024, editToolbar.measuredWidth)
         assertEquals(56, editToolbar.measuredHeight)
+        assertEquals(0, editToolbar.paddingLeft)
+        assertEquals(0, editToolbar.paddingRight)
+        assertEquals(0, editToolbar.paddingTop)
+        assertEquals(0, editToolbar.paddingBottom)
 
         val clearView = extractClearView(editToolbar)
 
         assertEquals(56, clearView.measuredWidth)
         assertEquals(56, clearView.measuredHeight)
+        assertEquals(16, clearView.paddingLeft)
+        assertEquals(16, clearView.paddingRight)
+        assertEquals(16, clearView.paddingTop)
+        assertEquals(16, clearView.paddingBottom)
 
         val microphoneView = extractActionView(editToolbar, "Microphone")
 
         assertEquals(56, microphoneView.measuredWidth)
         assertEquals(56, microphoneView.measuredHeight)
+        assertEquals(16, microphoneView.paddingLeft)
+        assertEquals(16, microphoneView.paddingRight)
+        assertEquals(16, microphoneView.paddingTop)
+        assertEquals(16, microphoneView.paddingBottom)
 
         val qrView = extractActionView(editToolbar, "QR code scanner")
 
         assertEquals(56, qrView.measuredWidth)
         assertEquals(56, qrView.measuredHeight)
+        assertEquals(16, qrView.paddingLeft)
+        assertEquals(16, qrView.paddingRight)
+        assertEquals(16, qrView.paddingTop)
+        assertEquals(16, qrView.paddingBottom)
 
         val urlView = extractUrlView(editToolbar)
 
         assertEquals(856, urlView.measuredWidth)
         assertEquals(56, urlView.measuredHeight)
+        assertEquals(8, urlView.paddingLeft)
+        assertEquals(8, urlView.paddingRight)
+        assertEquals(0, urlView.paddingTop)
+        assertEquals(0, urlView.paddingBottom)
     }
 
     @Test


### PR DESCRIPTION
…Alignment and Clipping


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
