### PR TITLE
Add parameter to pass in TWA API key

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
@@ -38,12 +38,13 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
     abstract val engine: Engine
     open val customTabsServiceStore: CustomTabsServiceStore? = null
     open val httpClient: Client? = null
+    open val apiKey: String? = null
 
     private val verifier by lazy {
         val client = httpClient
         val store = customTabsServiceStore
         if (client != null && store != null) {
-            OriginVerifierFeature(client, packageManager) { store.dispatch(it) }
+            OriginVerifierFeature(client, packageManager, apiKey) { store.dispatch(it) }
         } else {
             null
         }

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeature.kt
@@ -22,6 +22,7 @@ import mozilla.components.feature.customtabs.verify.OriginVerifier
 class OriginVerifierFeature(
     private val httpClient: Client,
     private val packageManager: PackageManager,
+    private val apiKey: String?,
     private val dispatch: (CustomTabsAction) -> Unit
 ) {
 
@@ -51,5 +52,5 @@ class OriginVerifierFeature(
 
     @VisibleForTesting
     internal fun getVerifier(packageName: String, @Relation relation: Int) =
-        OriginVerifier(packageName, relation, packageManager, httpClient)
+        OriginVerifier(packageName, relation, packageManager, httpClient, apiKey)
 }

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/verify/OriginVerifier.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/verify/OriginVerifier.kt
@@ -35,11 +35,12 @@ class OriginVerifier(
     private val packageName: String,
     @Relation private val relation: Int,
     packageManager: PackageManager,
-    httpClient: Client
+    httpClient: Client,
+    apiKey: String?
 ) {
 
     @VisibleForTesting
-    internal val handler = DigitalAssetLinksHandler(httpClient)
+    internal val handler = DigitalAssetLinksHandler(httpClient, apiKey)
     @VisibleForTesting
     internal val signatureFingerprint by lazy {
         getCertificateSHA256FingerprintForPackage(packageManager)

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
@@ -36,16 +36,18 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 class OriginVerifierFeatureTest {
 
+    private val apiKey = "XXXXXXXXX"
+
     @Test
     fun `verify fails if no creatorPackageName is saved`() = runBlockingTest {
-        val feature = OriginVerifierFeature(mock(), mock(), mock())
+        val feature = OriginVerifierFeature(mock(), mock(), apiKey, mock())
 
         assertFalse(feature.verify(CustomTabState(), mock(), RELATION_HANDLE_ALL_URLS, mock()))
     }
 
     @Test
     fun `verify returns existing relationship`() = runBlockingTest {
-        val feature = OriginVerifierFeature(mock(), mock(), mock())
+        val feature = OriginVerifierFeature(mock(), mock(), apiKey, mock())
         val origin = "https://example.com".toUri()
         val state = CustomTabState(
             creatorPackageName = "com.example.twa",
@@ -64,7 +66,7 @@ class OriginVerifierFeatureTest {
     fun `verify checks new relationships`() = runBlockingTest {
         val store: CustomTabsServiceStore = mock()
         val verifier: OriginVerifier = mock()
-        val feature = spy(OriginVerifierFeature(mock(), mock()) { store.dispatch(it) })
+        val feature = spy(OriginVerifierFeature(mock(), mock(), apiKey) { store.dispatch(it) })
         doReturn(verifier).`when`(feature).getVerifier(anyString(), anyInt())
         doReturn(true).`when`(verifier).verifyOrigin(any())
 

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/DigitalAssetLinksHandlerTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/DigitalAssetLinksHandlerTest.kt
@@ -21,13 +21,14 @@ import org.mockito.Mockito.doReturn
 @ExperimentalCoroutinesApi
 class DigitalAssetLinksHandlerTest {
 
+    private val apiKey = "XXXXXXXXXXX"
     private lateinit var client: Client
-    private lateinit var handler: mozilla.components.feature.customtabs.verify.DigitalAssetLinksHandler
+    private lateinit var handler: DigitalAssetLinksHandler
 
     @Before
     fun setup() {
         client = mock()
-        handler = mozilla.components.feature.customtabs.verify.DigitalAssetLinksHandler(client)
+        handler = DigitalAssetLinksHandler(client, apiKey)
     }
 
     @Test

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/OriginVerifierTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/OriginVerifierTest.kt
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit
 @ExperimentalCoroutinesApi
 class OriginVerifierTest {
 
+    private val apiKey = "XXXXXXXXX"
     @Mock private lateinit var client: Client
     @Mock private lateinit var packageManager: PackageManager
     @Mock private lateinit var response: Response
@@ -45,9 +46,9 @@ class OriginVerifierTest {
     fun setup() {
         initMocks(this)
         handleAllUrlsVerifier =
-            spy(OriginVerifier(testContext.packageName, RELATION_HANDLE_ALL_URLS, packageManager, client))
+            spy(OriginVerifier(testContext.packageName, RELATION_HANDLE_ALL_URLS, packageManager, client, apiKey))
         useAsOriginVerifier =
-            spy(OriginVerifier(testContext.packageName, RELATION_USE_AS_ORIGIN, packageManager, client))
+            spy(OriginVerifier(testContext.packageName, RELATION_USE_AS_ORIGIN, packageManager, client, apiKey))
 
         doReturn(response).`when`(client).fetch(any())
         doReturn(body).`when`(response).body
@@ -81,7 +82,8 @@ class OriginVerifierTest {
                     "https://www.example.com",
                     testContext.packageName,
                     "AA:BB:CC:10:20:30:01:02",
-                    "delegate_permission/common.use_as_origin"
+                    "delegate_permission/common.use_as_origin",
+                    apiKey
                 ),
                 connectTimeout = 3L to TimeUnit.SECONDS,
                 readTimeout = 3L to TimeUnit.SECONDS

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -39,10 +39,11 @@ class TrustedWebActivityIntentProcessor(
     private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase,
     httpClient: Client,
     packageManager: PackageManager,
+    apiKey: String?,
     private val store: CustomTabsServiceStore
 ) : IntentProcessor {
 
-    private val verifier = OriginVerifierFeature(httpClient, packageManager) { store.dispatch(it) }
+    private val verifier = OriginVerifierFeature(httpClient, packageManager, apiKey) { store.dispatch(it) }
     private val scope = MainScope()
 
     override fun matches(intent: Intent): Boolean {

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
@@ -32,9 +32,11 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 class TrustedWebActivityIntentProcessorTest {
 
+    private val apiKey = "XXXXXXXXX"
+
     @Test
     fun `matches checks if intent is a trusted web activity intent`() {
-        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), mock())
+        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), apiKey, mock())
 
         assertFalse(processor.matches(Intent(ACTION_VIEW_PWA)))
         assertFalse(processor.matches(Intent(ACTION_VIEW)))
@@ -57,7 +59,7 @@ class TrustedWebActivityIntentProcessorTest {
 
     @Test
     fun `process checks if intent action is not valid`() = runBlockingTest {
-        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), mock())
+        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), apiKey, mock())
 
         assertFalse(processor.process(Intent(ACTION_VIEW_PWA)))
         assertFalse(processor.process(Intent(ACTION_VIEW)))
@@ -94,7 +96,7 @@ class TrustedWebActivityIntentProcessorTest {
         val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase = mock()
         val store: CustomTabsServiceStore = mock()
 
-        val processor = spy(TrustedWebActivityIntentProcessor(mock(), loadUrlUseCase, mock(), mock(), store))
+        val processor = spy(TrustedWebActivityIntentProcessor(mock(), loadUrlUseCase, mock(), mock(), apiKey, store))
 
         assertTrue(processor.process(intent))
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -130,6 +130,7 @@ open class DefaultComponents(private val applicationContext: Context) {
                 sessionUseCases.loadUrl,
                 client,
                 applicationContext.packageManager,
+                null,
                 customTabsStore
             ),
             CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources)


### PR DESCRIPTION
Adds methods to pass in an API key for Digital Asset Links. If no API key is passed, the API still works so the parameter is nullable.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
