### PR TITLE
Pass redirect source and target flags to history tracking delegates

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -25,6 +25,8 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -660,7 +662,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -677,7 +679,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -697,7 +699,7 @@ class GeckoEngineSessionTest {
 
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
 
@@ -728,7 +730,7 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.TEMPORARY)))
 
         historyDelegate.value.onVisited(
                 geckoSession,
@@ -739,7 +741,7 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.PERMANENT)))
 
         // Visits below are targets of redirects, not redirects themselves.
         // Check that they're mapped to "link".
@@ -752,18 +754,18 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE)))
 
         historyDelegate.value.onVisited(
                 geckoSession,
                 "https://www.mozilla.com/targetperm",
                 null,
                 GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
-                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_PERMANENT
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -25,6 +25,8 @@ import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.manifest.WebAppManifestParser
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
@@ -487,13 +489,30 @@ class GeckoEngineSession(
             val visitType = if (isReload) {
                 VisitType.RELOAD
             } else {
-                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0) {
+                // Note the difference between `VISIT_REDIRECT_PERMANENT`,
+                // `VISIT_REDIRECT_TEMPORARY`, `VISIT_REDIRECT_SOURCE`, and
+                // `VISIT_REDIRECT_SOURCE_PERMANENT`.
+                //
+                // The former two indicate if the visited page is the *target*
+                // of a redirect; that is, another page redirected to it.
+                //
+                // The latter two indicate if the visited page is the *source*
+                // of a redirect: it's redirecting to another page, because the
+                // server returned an HTTP 3xy status code.
+                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_PERMANENT != 0) {
                     VisitType.REDIRECT_PERMANENT
-                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0) {
+                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY != 0) {
                     VisitType.REDIRECT_TEMPORARY
                 } else {
                     VisitType.LINK
                 }
+            }
+            val redirectSource = when {
+                flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0 ->
+                    RedirectSource.PERMANENT
+                flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0 ->
+                    RedirectSource.TEMPORARY
+                else -> RedirectSource.NOT_A_SOURCE
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
@@ -504,7 +523,7 @@ class GeckoEngineSession(
             }
 
             return launchGeckoResult {
-                delegate.onVisited(url, visitType)
+                delegate.onVisited(url, PageVisit(visitType, redirectSource))
                 true
             }
         }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -25,6 +25,8 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -660,7 +662,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -677,7 +679,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -697,7 +699,7 @@ class GeckoEngineSessionTest {
 
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
 
@@ -728,7 +730,7 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.TEMPORARY)))
 
         historyDelegate.value.onVisited(
                 geckoSession,
@@ -739,7 +741,7 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.PERMANENT)))
 
         // Visits below are targets of redirects, not redirects themselves.
         // Check that they're mapped to "link".
@@ -752,18 +754,18 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE)))
 
         historyDelegate.value.onVisited(
                 geckoSession,
                 "https://www.mozilla.com/targetperm",
                 null,
                 GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
-                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_PERMANENT
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -22,6 +22,8 @@ import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.manifest.WebAppManifestParser
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.ktx.android.util.Base64
 import mozilla.components.support.ktx.kotlin.isEmail
@@ -437,13 +439,30 @@ class GeckoEngineSession(
             val visitType = if (isReload) {
                 VisitType.RELOAD
             } else {
-                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0) {
+                // Note the difference between `VISIT_REDIRECT_PERMANENT`,
+                // `VISIT_REDIRECT_TEMPORARY`, `VISIT_REDIRECT_SOURCE`, and
+                // `VISIT_REDIRECT_SOURCE_PERMANENT`.
+                //
+                // The former two indicate if the visited page is the *target*
+                // of a redirect; that is, another page redirected to it.
+                //
+                // The latter two indicate if the visited page is the *source*
+                // of a redirect: it's redirecting to another page, because the
+                // server returned an HTTP 3xy status code.
+                if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_PERMANENT != 0) {
                     VisitType.REDIRECT_PERMANENT
-                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0) {
+                } else if (flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY != 0) {
                     VisitType.REDIRECT_TEMPORARY
                 } else {
                     VisitType.LINK
                 }
+            }
+            val redirectSource = when {
+                flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE_PERMANENT != 0 ->
+                    RedirectSource.PERMANENT
+                flags and GeckoSession.HistoryDelegate.VISIT_REDIRECT_SOURCE != 0 ->
+                    RedirectSource.TEMPORARY
+                else -> RedirectSource.NOT_A_SOURCE
             }
 
             val delegate = settings.historyTrackingDelegate ?: return GeckoResult.fromValue(false)
@@ -454,7 +473,7 @@ class GeckoEngineSession(
             }
 
             return launchGeckoResult {
-                delegate.onVisited(url, visitType)
+                delegate.onVisited(url, PageVisit(visitType, redirectSource))
                 true
             }
         }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -23,6 +23,8 @@ import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -607,7 +609,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -624,7 +626,7 @@ class GeckoEngineSessionTest {
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -644,7 +646,7 @@ class GeckoEngineSessionTest {
 
             engineSession.job.children.forEach { it.join() }
             verify(historyTrackingDelegate).shouldStoreUri("https://www.mozilla.com/allowed")
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/allowed"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
 
         historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)
 
@@ -675,7 +677,7 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.TEMPORARY)))
 
         historyDelegate.value.onVisited(
                 geckoSession,
@@ -686,7 +688,7 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(PageVisit(VisitType.LINK, RedirectSource.PERMANENT)))
 
         // Visits below are targets of redirects, not redirects themselves.
         // Check that they're mapped to "link".
@@ -699,18 +701,18 @@ class GeckoEngineSessionTest {
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targettemp"), eq(PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE)))
 
         historyDelegate.value.onVisited(
                 geckoSession,
                 "https://www.mozilla.com/targetperm",
                 null,
                 GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL
-                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY
+                        or GeckoSession.HistoryDelegate.VISIT_REDIRECT_PERMANENT
         )
 
             engineSession.job.children.forEach { it.join() }
-            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(VisitType.LINK))
+            verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/targetperm"), eq(PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -55,6 +55,8 @@ import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.ktx.android.view.getRectWithViewLocation
 import mozilla.components.support.utils.DownloadUtils
@@ -152,7 +154,8 @@ class SystemEngineView @JvmOverloads constructor(
             }
 
             runBlocking {
-                session?.settings?.historyTrackingDelegate?.onVisited(url, visitType)
+                session?.settings?.historyTrackingDelegate?.onVisited(url,
+                    PageVisit(visitType, RedirectSource.NOT_A_SOURCE))
             }
         }
 

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -39,6 +39,8 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.request.RequestInterceptor
 import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -296,10 +298,10 @@ class SystemEngineViewTest {
         whenever(historyDelegate.shouldStoreUri(any())).thenReturn(true)
 
         engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com", false)
-        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
+        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
 
         engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com", true)
-        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.RELOAD))
+        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE)))
     }
 
     @Test
@@ -316,7 +318,7 @@ class SystemEngineViewTest {
 
         // Verify that engine session asked delegate if uri should be stored.
         engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com", false)
-        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(VisitType.LINK))
+        verify(historyDelegate).onVisited(eq("https://www.mozilla.com"), eq(PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE)))
         verify(historyDelegate).shouldStoreUri("https://www.mozilla.com")
 
         // Verify that engine won't try to store a uri that delegate doesn't want.
@@ -332,7 +334,7 @@ class SystemEngineViewTest {
 
         val engineView = SystemEngineView(testContext)
         val historyDelegate = object : HistoryTrackingDelegate {
-            override suspend fun onVisited(uri: String, type: VisitType) {
+            override suspend fun onVisited(uri: String, visit: PageVisit) {
                 fail()
             }
 

--- a/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
+++ b/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
@@ -9,6 +9,8 @@ import mozilla.components.concept.storage.HistoryAutocompleteResult
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.PageObservation
 import mozilla.components.concept.storage.SearchResult
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitInfo
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.utils.StorageUtils.levenshteinDistance
@@ -28,14 +30,17 @@ class InMemoryHistoryStorage : HistoryStorage {
     @VisibleForTesting
     internal val pageMeta: HashMap<String, PageObservation> = hashMapOf()
 
-    override suspend fun recordVisit(uri: String, visitType: VisitType) {
+    override suspend fun recordVisit(uri: String, visit: PageVisit) {
         val now = System.currentTimeMillis()
+        if (visit.redirectSource != RedirectSource.NOT_A_SOURCE) {
+            return
+        }
 
         synchronized(pages) {
             if (!pages.containsKey(uri)) {
-                pages[uri] = mutableListOf(Visit(now, visitType))
+                pages[uri] = mutableListOf(Visit(now, visit.visitType))
             } else {
-                pages[uri]!!.add(Visit(now, visitType))
+                pages[uri]!!.add(Visit(now, visit.visitType))
             }
         }
     }

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -11,6 +11,8 @@ import mozilla.appservices.places.PlacesException
 import mozilla.appservices.places.PlacesReaderConnection
 import mozilla.appservices.places.PlacesWriterConnection
 import mozilla.components.concept.storage.PageObservation
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
@@ -43,15 +45,15 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `storage allows recording and querying visits of different types`() = runBlocking {
-        history.recordVisit("http://www.firefox.com/1", VisitType.LINK)
-        history.recordVisit("http://www.firefox.com/2", VisitType.RELOAD)
-        history.recordVisit("http://www.firefox.com/3", VisitType.TYPED)
-        history.recordVisit("http://www.firefox.com/4", VisitType.REDIRECT_TEMPORARY)
-        history.recordVisit("http://www.firefox.com/5", VisitType.REDIRECT_PERMANENT)
-        history.recordVisit("http://www.firefox.com/6", VisitType.FRAMED_LINK)
-        history.recordVisit("http://www.firefox.com/7", VisitType.EMBED)
-        history.recordVisit("http://www.firefox.com/8", VisitType.BOOKMARK)
-        history.recordVisit("http://www.firefox.com/9", VisitType.DOWNLOAD)
+        history.recordVisit("http://www.firefox.com/1", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/2", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/3", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/4", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/5", PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/6", PageVisit(VisitType.FRAMED_LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/7", PageVisit(VisitType.EMBED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/8", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com/9", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
 
         val recordedVisits = history.getDetailedVisits(0)
         assertEquals(9, recordedVisits.size)
@@ -126,7 +128,7 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `storage passes through recordObservation calls`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", VisitType.LINK)
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("http://www.mozilla.org", PageObservation(title = "Mozilla"))
 
         val recordedVisits = history.getDetailedVisits(0)
@@ -136,12 +138,12 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `store can be used to query detailed visit information`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", VisitType.LINK)
-        history.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("http://www.mozilla.org", PageObservation("Mozilla"))
-        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
 
-        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_TEMPORARY)
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
 
         val visits = history.getDetailedVisits(0, excludeTypes = listOf(VisitType.REDIRECT_TEMPORARY))
         assertEquals(3, visits.size)
@@ -167,21 +169,21 @@ class PlacesHistoryStorageTest {
         assertEquals(0, history.getVisited().size)
 
         // Regular visits are tracked.
-        history.recordVisit("https://www.mozilla.org", VisitType.LINK)
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         assertEquals(listOf("https://www.mozilla.org/"), history.getVisited())
 
         // Multiple visits can be tracked, results ordered by "URL's first seen first".
-        history.recordVisit("https://www.firefox.com", VisitType.LINK)
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         assertEquals(listOf("https://www.mozilla.org/", "https://www.firefox.com/"), history.getVisited())
 
         // Visits marked as reloads can be tracked.
-        history.recordVisit("https://www.firefox.com", VisitType.RELOAD)
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
         assertEquals(listOf("https://www.mozilla.org/", "https://www.firefox.com/"), history.getVisited())
 
         // Visited urls are certainly a set.
-        history.recordVisit("https://www.firefox.com", VisitType.LINK)
-        history.recordVisit("https://www.mozilla.org", VisitType.LINK)
-        history.recordVisit("https://www.wikipedia.org", VisitType.LINK)
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         assertEquals(
                 listOf("https://www.mozilla.org/", "https://www.firefox.com/", "https://www.wikipedia.org/"),
                 history.getVisited()
@@ -193,7 +195,7 @@ class PlacesHistoryStorageTest {
         assertEquals(0, history.getVisited(listOf()).size)
 
         // Regular visits are tracked
-        history.recordVisit("https://www.mozilla.org", VisitType.LINK)
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         assertEquals(listOf(true), history.getVisited(listOf("https://www.mozilla.org")))
 
         // Duplicate requests are handled.
@@ -205,16 +207,16 @@ class PlacesHistoryStorageTest {
         assertEquals(listOf(false, true), history.getVisited(listOf("https://www.unknown.com", "https://www.mozilla.org")))
 
         // Multiple visits can be tracked. Reloads can be tracked.
-        history.recordVisit("https://www.firefox.com", VisitType.LINK)
-        history.recordVisit("https://www.mozilla.org", VisitType.RELOAD)
-        history.recordVisit("https://www.wikipedia.org", VisitType.LINK)
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         assertEquals(listOf(true, true, false, true), history.getVisited(listOf("https://www.firefox.com", "https://www.wikipedia.org", "https://www.unknown.com", "https://www.mozilla.org")))
     }
 
     @Test
     fun `store can be used to track page meta information - title changes`() = runBlocking {
         // Title changes are recorded.
-        history.recordVisit("https://www.wikipedia.org", VisitType.TYPED)
+        history.recordVisit("https://www.wikipedia.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("https://www.wikipedia.org", PageObservation("Wikipedia"))
         var recorded = history.getDetailedVisits(0)
         assertEquals(1, recorded.size)
@@ -226,9 +228,9 @@ class PlacesHistoryStorageTest {
         assertEquals("Википедия", recorded[0].title)
 
         // Titles for different pages are recorded.
-        history.recordVisit("https://www.firefox.com", VisitType.TYPED)
+        history.recordVisit("https://www.firefox.com", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("https://www.firefox.com", PageObservation("Firefox"))
-        history.recordVisit("https://www.mozilla.org", VisitType.TYPED)
+        history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("https://www.mozilla.org", PageObservation("Мозилла"))
         recorded = history.getDetailedVisits(0)
         assertEquals(3, recorded.size)
@@ -241,13 +243,13 @@ class PlacesHistoryStorageTest {
     fun `store can provide suggestions`() = runBlocking {
         assertEquals(0, history.getSuggestions("Mozilla", 100).size)
 
-        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         val search = history.getSuggestions("Mozilla", 100)
         assertEquals(0, search.size)
 
-        history.recordVisit("http://www.wikipedia.org", VisitType.LINK)
-        history.recordVisit("http://www.mozilla.org", VisitType.LINK)
-        history.recordVisit("http://www.moscow.ru", VisitType.LINK)
+        history.recordVisit("http://www.wikipedia.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.moscow.ru", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("http://www.mozilla.org", PageObservation("Mozilla"))
         history.recordObservation("http://www.firefox.com", PageObservation("Mozilla Firefox"))
         history.recordObservation("http://www.moscow.ru", PageObservation("Moscow City"))
@@ -291,21 +293,21 @@ class PlacesHistoryStorageTest {
     fun `store can provide autocomplete suggestions`() = runBlocking {
         assertNull(history.getAutocompleteSuggestion("moz"))
 
-        history.recordVisit("http://www.mozilla.org", VisitType.LINK)
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         var res = history.getAutocompleteSuggestion("moz")!!
         assertEquals("mozilla.org/", res.text)
         assertEquals("http://www.mozilla.org/", res.url)
         assertEquals("placesHistory", res.source)
         assertEquals(1, res.totalItems)
 
-        history.recordVisit("http://firefox.com", VisitType.LINK)
+        history.recordVisit("http://firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         res = history.getAutocompleteSuggestion("firefox")!!
         assertEquals("firefox.com/", res.text)
         assertEquals("http://firefox.com/", res.url)
         assertEquals("placesHistory", res.source)
         assertEquals(1, res.totalItems)
 
-        history.recordVisit("https://en.wikipedia.org/wiki/Mozilla", VisitType.LINK)
+        history.recordVisit("https://en.wikipedia.org/wiki/Mozilla", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         res = history.getAutocompleteSuggestion("en")!!
         assertEquals("en.wikipedia.org/", res.text)
         assertEquals("https://en.wikipedia.org/", res.url)
@@ -325,20 +327,20 @@ class PlacesHistoryStorageTest {
     fun `store ignores url parse exceptions during record operations`() = runBlocking {
         // These aren't valid URIs, and if we're not explicitly ignoring exceptions from the underlying
         // storage layer, these calls will throw.
-        history.recordVisit("mozilla.org", VisitType.LINK)
+        history.recordVisit("mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
         history.recordObservation("mozilla.org", PageObservation("mozilla"))
     }
 
     @Test
     fun `store can delete everything`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", VisitType.TYPED)
-        history.recordVisit("http://www.mozilla.org", VisitType.DOWNLOAD)
-        history.recordVisit("http://www.mozilla.org", VisitType.BOOKMARK)
-        history.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
-        history.recordVisit("http://www.firefox.com", VisitType.EMBED)
-        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_PERMANENT)
-        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_TEMPORARY)
-        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.EMBED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
 
         history.recordObservation("http://www.firefox.com", PageObservation("Firefox"))
 
@@ -351,14 +353,14 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `store can delete by url`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", VisitType.TYPED)
-        history.recordVisit("http://www.mozilla.org", VisitType.DOWNLOAD)
-        history.recordVisit("http://www.mozilla.org", VisitType.BOOKMARK)
-        history.recordVisit("http://www.mozilla.org", VisitType.RELOAD)
-        history.recordVisit("http://www.firefox.com", VisitType.EMBED)
-        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_PERMANENT)
-        history.recordVisit("http://www.firefox.com", VisitType.REDIRECT_TEMPORARY)
-        history.recordVisit("http://www.firefox.com", VisitType.LINK)
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.EMBED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_PERMANENT, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.REDIRECT_TEMPORARY, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.firefox.com", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
 
         history.recordObservation("http://www.firefox.com", PageObservation("Firefox"))
 
@@ -375,9 +377,9 @@ class PlacesHistoryStorageTest {
 
     @Test
     fun `store can delete by 'since'`() = runBlocking {
-        history.recordVisit("http://www.mozilla.org", VisitType.TYPED)
-        history.recordVisit("http://www.mozilla.org", VisitType.DOWNLOAD)
-        history.recordVisit("http://www.mozilla.org", VisitType.BOOKMARK)
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
+        history.recordVisit("http://www.mozilla.org", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
 
         history.deleteVisitsSince(0)
         val visits = history.getVisited()
@@ -387,11 +389,11 @@ class PlacesHistoryStorageTest {
     @Test
     fun `store can delete by 'range'`() {
         runBlocking {
-            history.recordVisit("http://www.mozilla.org/1", VisitType.TYPED)
+            history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/2", VisitType.DOWNLOAD)
+            history.recordVisit("http://www.mozilla.org/2", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/3", VisitType.BOOKMARK)
+            history.recordVisit("http://www.mozilla.org/3", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
         }
 
         val ts = runBlocking {
@@ -416,11 +418,11 @@ class PlacesHistoryStorageTest {
     @Test
     fun `store can delete visit by 'url' and 'timestamp'`() {
         runBlocking {
-            history.recordVisit("http://www.mozilla.org/1", VisitType.TYPED)
+            history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/2", VisitType.DOWNLOAD)
+            history.recordVisit("http://www.mozilla.org/2", PageVisit(VisitType.DOWNLOAD, RedirectSource.NOT_A_SOURCE))
             Thread.sleep(10)
-            history.recordVisit("http://www.mozilla.org/3", VisitType.BOOKMARK)
+            history.recordVisit("http://www.mozilla.org/3", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
         }
 
         val ts = runBlocking {
@@ -464,7 +466,7 @@ class PlacesHistoryStorageTest {
     fun `can run prune on the store`() = runBlocking {
         // Empty.
         history.prune()
-        history.recordVisit("http://www.mozilla.org/1", VisitType.TYPED)
+        history.recordVisit("http://www.mozilla.org/1", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         // Non-empty.
         history.prune()
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/history/HistoryTrackingDelegate.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.concept.engine.history
 
-import mozilla.components.concept.storage.VisitType
+import mozilla.components.concept.storage.PageVisit
 
 /**
  * An interface used for providing history information to an engine (e.g. for link highlighting),
@@ -17,7 +17,7 @@ interface HistoryTrackingDelegate {
     /**
      * A URI visit happened that an engine considers worthy of being recorded in browser's history.
      */
-    suspend fun onVisited(uri: String, type: VisitType)
+    suspend fun onVisited(uri: String, visit: PageVisit)
 
     /**
      * Title changed for a given URI.

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/HistoryStorage.kt
@@ -12,9 +12,9 @@ interface HistoryStorage : Storage {
     /**
      * Records a visit to a page.
      * @param uri of the page which was visited.
-     * @param visitType type of the visit, see [VisitType].
+     * @param visit Information about the visit; see [PageVisit].
      */
-    suspend fun recordVisit(uri: String, visitType: VisitType)
+    suspend fun recordVisit(uri: String, visit: PageVisit)
 
     /**
      * Records an observation about a page.
@@ -117,6 +117,30 @@ interface HistoryStorage : Storage {
      * Prune history storage, removing stale history.
      */
     suspend fun prune()
+}
+
+/**
+ * Information to record about a visit.
+ *
+ * @property visitType The transition type for this visit. See [VisitType].
+ * @property redirectSource If this visit is redirecting to another page,
+ *  what kind of redirect is it? See [RedirectSource] for the options.
+ */
+data class PageVisit(
+    val visitType: VisitType,
+    val redirectSource: RedirectSource
+)
+
+/**
+ * A redirect source describes how a page redirected to another page.
+ */
+enum class RedirectSource {
+    // The page didn't redirect to another page.
+    NOT_A_SOURCE,
+    // The page temporarily redirected to another page.
+    TEMPORARY,
+    // The page permanently redirected to another page.
+    PERMANENT,
 }
 
 data class PageObservation(val title: String?)

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
@@ -7,6 +7,8 @@ package mozilla.components.feature.awesomebar.provider
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.SearchResult
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.support.test.eq
@@ -32,7 +34,7 @@ class HistoryStorageSuggestionProviderTest {
         val history = InMemoryHistoryStorage()
         val provider = HistoryStorageSuggestionProvider(history, mock())
 
-        history.recordVisit("http://www.mozilla.com", VisitType.TYPED)
+        history.recordVisit("http://www.mozilla.com", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
 
         val suggestions = provider.onInputChanged("moz")
         assertEquals(1, suggestions.size)
@@ -45,7 +47,7 @@ class HistoryStorageSuggestionProviderTest {
         val provider = HistoryStorageSuggestionProvider(history, mock())
 
         for (i in 1..100) {
-            history.recordVisit("http://www.mozilla.com/$i", VisitType.TYPED)
+            history.recordVisit("http://www.mozilla.com/$i", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         }
 
         val suggestions = provider.onInputChanged("moz")

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
@@ -8,17 +8,17 @@ import android.net.Uri
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.PageObservation
-import mozilla.components.concept.storage.VisitType
+import mozilla.components.concept.storage.PageVisit
 
 /**
  * Implementation of the [HistoryTrackingDelegate] which delegates work to an instance of [HistoryStorage].
  */
 class HistoryDelegate(private val historyStorage: HistoryStorage) : HistoryTrackingDelegate {
-    override suspend fun onVisited(uri: String, type: VisitType) {
+    override suspend fun onVisited(uri: String, visit: PageVisit) {
         // While we expect engine implementations to check URIs against `shouldStoreUri`, we don't
         // depend on them to actually do this check.
         if (shouldStoreUri(uri)) {
-            historyStorage.recordVisit(uri, type)
+            historyStorage.recordVisit(uri, visit)
         }
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.HistoryAutocompleteResult
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.PageObservation
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.SearchResult
 import mozilla.components.concept.storage.VisitInfo
 import mozilla.components.concept.storage.VisitType
@@ -30,17 +32,17 @@ class HistoryDelegateTest {
         val storage: HistoryStorage = mock()
         val delegate = HistoryDelegate(storage)
 
-        delegate.onVisited("about:blank", VisitType.TYPED)
-        verify(storage, never()).recordVisit("about:blank", VisitType.TYPED)
+        delegate.onVisited("about:blank", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
+        verify(storage, never()).recordVisit("about:blank", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
 
-        delegate.onVisited("http://www.mozilla.org", VisitType.LINK)
-        verify(storage).recordVisit("http://www.mozilla.org", VisitType.LINK)
+        delegate.onVisited("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
+        verify(storage).recordVisit("http://www.mozilla.org", PageVisit(VisitType.LINK, RedirectSource.NOT_A_SOURCE))
 
-        delegate.onVisited("http://www.firefox.com", VisitType.RELOAD)
-        verify(storage).recordVisit("http://www.firefox.com", VisitType.RELOAD)
+        delegate.onVisited("http://www.firefox.com", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
+        verify(storage).recordVisit("http://www.firefox.com", PageVisit(VisitType.RELOAD, RedirectSource.NOT_A_SOURCE))
 
-        delegate.onVisited("http://www.firefox.com", VisitType.BOOKMARK)
-        verify(storage).recordVisit("http://www.firefox.com", VisitType.BOOKMARK)
+        delegate.onVisited("http://www.firefox.com", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
+        verify(storage).recordVisit("http://www.firefox.com", PageVisit(VisitType.BOOKMARK, RedirectSource.NOT_A_SOURCE))
     }
 
     @Test
@@ -61,7 +63,7 @@ class HistoryDelegateTest {
             var getVisitedListCalled = false
             var getVisitedPlainCalled = false
 
-            override suspend fun recordVisit(uri: String, visitType: VisitType) {
+            override suspend fun recordVisit(uri: String, visit: PageVisit) {
                 fail()
             }
 

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -11,6 +11,8 @@ import mozilla.components.browser.domains.autocomplete.BaseDomainAutocompletePro
 import mozilla.components.browser.domains.autocomplete.DomainList
 import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.storage.HistoryStorage
+import mozilla.components.concept.storage.PageVisit
+import mozilla.components.concept.storage.RedirectSource
 import mozilla.components.concept.storage.VisitType
 import mozilla.components.concept.toolbar.AutocompleteDelegate
 import mozilla.components.concept.toolbar.AutocompleteResult
@@ -132,7 +134,7 @@ class ToolbarAutocompleteFeatureTest {
 
         // Can autocomplete with a non-empty history provider.
         runBlocking {
-            history.recordVisit("https://www.mozilla.org", VisitType.TYPED)
+            history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         }
 
         verifyNoAutocompleteResult(toolbar, autocompleteDelegate, "hi")
@@ -192,7 +194,7 @@ class ToolbarAutocompleteFeatureTest {
         )
 
         runBlocking {
-            history.recordVisit("https://www.mozilla.org", VisitType.TYPED)
+            history.recordVisit("https://www.mozilla.org", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         }
 
         verifyAutocompleteResult(toolbar, autocompleteDelegate, "mo",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@ permalink: /changelog/
     })
   }
   ```
+  * ⚠️ **This is a breaking change**: Redirect source and target flags are now passed to history tracking delegates. As part of this change, `HistoryTrackingDelegate.onVisited()` receives a new `PageVisit` data class as its second argument, specifying the `visitType` and `redirectSource`. For more details, please see [PR #4268](https://github.com/mozilla-mobile/android-components/pull/4268).
 
 * **support-webextensions**
   * Added functionality to make sure web extension related events in the engine are reflected in the browser state / store. Instead of attaching a `WebExtensionDelegate` to the engine, and manually reacting to all events, it's now possible to initialize `WebExtensionSupport`, which provides overridable default behaviour for all web extension related engine events:


### PR DESCRIPTION
There's some confusion in `GeckoEngineSession` about redirect flags.
The `VISIT_REDIRECT_SOURCE` and `VISIT_REDIRECT_SOURCE_PERMANENT` flags
that we get from GeckoView's history delegate are for the redirect
_source_, not the visit type. They indicate if the URL passed to
`onVisited` is redirecting _to_ another URL, most likely because the
server returned an HTTP 3xy status code with a `Location` header.
Rust Places decides whether to mark the URL as hidden based on
these flags.

`VISIT_REDIRECT_{PERMANENT, TEMPORARY}`, however, indicate if the
URL passed to `onVisited` is the _target_ of a redirect (in other
words, the page that's _in_ the `Location` header). These get
translated into `VisitType` flags, which Rust Places stores as the
visit transition type. These two flags don't affect whether a URL
is hidden.

Note that, in a redirect chain, the middle links are both sources and
targets. For example, in "mozilla.org" -> "www.mozilla.org" ->
"www.mozilla.org/en-US", "www.mozilla.org" is both a redirect target
(since "mozilla.org" redirected to it), and a source (it redirected
to "www.mozilla.org/en-US").

See mozilla-mobile/fenix#3526.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
