### PR TITLE
Deprecate `service-telemetry`

### DIFF
--- a/components/service/telemetry/README.md
+++ b/components/service/telemetry/README.md
@@ -2,6 +2,12 @@
 
 A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 
+## Deprecated
+This component is now deprecated: only maintenance fixes will be provided and no new feature development will happen.
+Use [the Glean SDK](../glean) instead.
+This library will not be removed until all projects using it start using the Glean SDK.
+Please do reach out to the Glean team (Mozilla Slack in *#glean* or *glean-team@mozilla.com*) for support transitioning to the new SDK.
+
 ## Motivation
 
 The goal of this library is to provide a generic set of components to support a variety of telemetry use cases. It tries to not be opinionated about dependency injection frameworks or http clients. The only dependency is ``support-annotations`` to ensure code quality.

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
@@ -35,6 +35,11 @@ import java.util.concurrent.Executors;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function0;
 
+/**
+ * @deprecated The whole service-telemetry library is deprecated. Please use the
+ *              <a href="https://mozilla.github.io/glean/book/index.html">Glean SDK</a> instead.
+ */
+@Deprecated
 public class Telemetry {
     private final TelemetryConfiguration configuration;
     private final TelemetryStorage storage;

--- a/components/service/telemetry/src/main/java/org/mozilla/telemetry/TelemetryHolder.java
+++ b/components/service/telemetry/src/main/java/org/mozilla/telemetry/TelemetryHolder.java
@@ -8,7 +8,11 @@ package org.mozilla.telemetry;
  * Holder of a static reference to the Telemetry instance. This is required for background services
  * that somehow need to get access to the configuration and storage. This is not particular nice.
  * Hopefully we can replace this with something better.
+ *
+ * @deprecated The whole service-telemetry library is deprecated. Please use the
+ *              <a href="https://mozilla.github.io/glean/book/index.html">Glean SDK</a> instead.
  */
+@Deprecated
 public class TelemetryHolder {
     private static Telemetry telemetry;
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,9 @@ permalink: /changelog/
   * Added `CustomTabState.trustedOrigins` extension method to turn the verification state of a custom tab into a list of origins.
   * Added `WebAppHideToolbarFeature.onTrustedScopesChange` to change the trusted scopes after the feature is created.
 
+* **service-telemetry**
+  * This component is now deprecated. Please use the [Glean SDK](https://mozilla.github.io/glean/book/index.html) instead. This library will not be removed until all projects using it start using the Glean SDK.
+
 # 10.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v10.0.0...v10.0.1)


### PR DESCRIPTION
This adds a deprecation annotation to `Telemetry` and `TelemetryHolder` in addition to the README and changelog entries.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
