### PR TITLE
Issue #4284: Add DownloadState to browser-state.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.lib.state.Action
 
@@ -166,6 +167,16 @@ sealed class ContentAction : BrowserAction() {
      * Updates the thumbnail of the [ContentState] with the given [sessionId].
      */
     data class UpdateThumbnailAction(val sessionId: String, val thumbnail: Bitmap) : ContentAction()
+
+    /**
+     * Updates the [DownloadState] of the [ContentState] with the given [sessionId].
+     */
+    data class UpdateDownloadAction(val sessionId: String, val download: DownloadState) : ContentAction()
+
+    /**
+     * Removes the [DownloadState] of the [ContentState] with the given [sessionId].
+     */
+    data class ConsumeDownloadAction(val sessionId: String, val download: DownloadState) : ContentAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -45,6 +45,16 @@ internal object ContentStateReducer {
             is ContentAction.UpdateThumbnailAction -> updateContentState(state, action.sessionId) {
                 it.copy(thumbnail = action.thumbnail)
             }
+            is ContentAction.UpdateDownloadAction -> updateContentState(state, action.sessionId) {
+                it.copy(download = action.download)
+            }
+            is ContentAction.ConsumeDownloadAction -> updateContentState(state, action.sessionId) {
+                if (action.download == it.download) {
+                    it.copy(download = null)
+                } else {
+                    it
+                }
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.state
 
 import android.graphics.Bitmap
+import mozilla.components.browser.state.state.content.DownloadState
 
 /**
  * Value type that represents the state of the content within a [SessionState].
@@ -21,6 +22,7 @@ import android.graphics.Bitmap
  * @property thumbnail the last generated [Bitmap] of this session's content, to
  * be used as a preview in e.g. a tab switcher.
  * @property icon the icon of the page currently loaded by this session.
+ * @property download Last unhandled download request.
  */
 data class ContentState(
     val url: String,
@@ -31,5 +33,6 @@ data class ContentState(
     val searchTerms: String = "",
     val securityInfo: SecurityInfoState = SecurityInfoState(),
     val thumbnail: Bitmap? = null,
-    val icon: Bitmap? = null
+    val icon: Bitmap? = null,
+    val download: DownloadState? = null
 )

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state.content
+
+import android.os.Environment
+
+/**
+ * Value type that represents a download request.
+ *
+ * @property url The full url to the content that should be downloaded.
+ * @property fileName A canonical filename for this download.
+ * @property contentType Content type (MIME type) to indicate the media type of the download.
+ * @property contentLength The file size reported by the server.
+ * @property userAgent The user agent to be used for the download.
+ * @property destinationDirectory The matching destination directory for this type of download.
+ * @property referrerUrl The site that linked to this download.
+ */
+data class DownloadState(
+    val url: String,
+    val fileName: String? = null,
+    val contentType: String? = null,
+    val contentLength: Long? = null,
+    val userAgent: String? = null,
+    val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
+    val referrerUrl: String? = null
+)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -9,10 +9,12 @@ import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -250,5 +252,43 @@ class ContentActionTest {
         assertNotEquals("I am a custom tab", updatedOtherCustomTab.content.title)
         assertNotEquals("I am a custom tab", tab.content.title)
         assertNotEquals("I am a custom tab", otherTab.content.title)
+    }
+
+    @Test
+    fun `UpdateDownloadAction updates download`() {
+        assertNull(tab.content.download)
+
+        val download1: DownloadState = mock()
+
+        store.dispatch(
+            ContentAction.UpdateDownloadAction(tab.id, download1)
+        ).joinBlocking()
+
+        assertEquals(download1, tab.content.download)
+
+        val download2: DownloadState = mock()
+
+        store.dispatch(
+            ContentAction.UpdateDownloadAction(tab.id, download2)
+        ).joinBlocking()
+
+        assertEquals(download2, tab.content.download)
+    }
+
+    @Test
+    fun `ConsumeDownloadAction removes download`() {
+        val download: DownloadState = mock()
+
+        store.dispatch(
+            ContentAction.UpdateDownloadAction(tab.id, download)
+        ).joinBlocking()
+
+        assertEquals(download, tab.content.download)
+
+        store.dispatch(
+            ContentAction.ConsumeDownloadAction(tab.id, download)
+        ).joinBlocking()
+
+        assertNull(tab.content.download)
     }
 }


### PR DESCRIPTION
First steps for #4284. State is not synchronized between `browser-state` and `browser-session` yet. I need to figure out how to deal with the `Consumable<Download>`in `Session`. We already did that when we prototyped this earlier this year. I think that's the reason we introduced `Consumable.onConsume`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
