### PR TITLE
Allow products to specify a custom path for Glean-generated docs

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "1.4.0"
+String GLEAN_PARSER_VERSION = "1.4.2"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"
@@ -285,7 +285,12 @@ if (project.ext.has("gleanGenerateMarkdownDocs")) {
     task gleanGenerateMetricsDocs(type: Exec) {
         description = "Generate the Markdown docs for the collected metrics"
 
-        outputs.dir "$projectDir/docs"
+        def gleanDocsDirectory = "$projectDir/docs"
+        if (project.ext.has("gleanDocsDirectory")) {
+            gleanDocsDirectory = project.ext.get("gleanDocsDirectory")
+        }
+
+        outputs.dir gleanDocsDirectory
         workingDir rootDir
         commandLine gleanGetPythonCommand()
 
@@ -297,13 +302,13 @@ if (project.ext.has("gleanGenerateMarkdownDocs")) {
         args "-f"
         args "markdown"
         args "-o"
-        args "$projectDir/docs"
+        args gleanDocsDirectory
         args "$projectDir/metrics.yaml"
         args "$projectDir/pings.yaml"
 
         doFirst {
             inputs.files.forEach{ file ->
-                project.logger.lifecycle("Glean SDK - generating docs for ${file.path} in $projectDir/docs")
+                project.logger.lifecycle("Glean SDK - generating docs for ${file.path} in $gleanDocsDirectory")
             }
         }
 


### PR DESCRIPTION
This is required by Fenix, since their docs are in `$rootDir/docs` not in `$projectDir/docs`

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
