### PR TITLE
For #4284, 4285: HitResult and Download consumables for browser-state

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Download.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Download.kt
@@ -5,6 +5,8 @@
 package mozilla.components.browser.session
 
 import android.os.Environment
+import mozilla.components.browser.state.state.content.DownloadState
+import java.util.UUID
 
 /**
  * Value type that represents a Download.
@@ -16,6 +18,7 @@ import android.os.Environment
  * @property userAgent The user agent to be used for the download.
  * @property destinationDirectory The matching destination directory for this type of download.
  * @property referrerUrl The site that linked to this download.
+ * @property id a unique ID of this download.
  */
 data class Download(
     val url: String,
@@ -24,5 +27,17 @@ data class Download(
     val contentLength: Long? = null,
     val userAgent: String? = null,
     val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
-    val referrerUrl: String? = null
+    val referrerUrl: String? = null,
+    val id: String = UUID.randomUUID().toString()
+)
+
+internal fun Download.toDownloadState() = DownloadState(
+    url,
+    fileName,
+    contentType,
+    contentLength,
+    userAgent,
+    destinationDirectory,
+    referrerUrl,
+    id
 )

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -7,12 +7,15 @@ package mozilla.components.browser.session
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
+import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -669,6 +672,32 @@ class SessionManagerMigrationTest {
             assertFalse(tab.trackingProtection.enabled)
             assertEquals(0, tab.trackingProtection.blockedTrackers.size)
             assertEquals(0, tab.trackingProtection.loadedTrackers.size)
+        }
+    }
+
+    @Test
+    fun `Adding a hit result`() {
+        val store = BrowserStore()
+        val manager = SessionManager(engine = mock(), store = store)
+
+        val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
+        manager.add(session)
+
+        assertNull(session.hitResult.peek())
+        assertNull(store.state.findTab("session")!!.content.hitResult)
+
+        val hitResult: HitResult = HitResult.UNKNOWN("test")
+        session.hitResult = Consumable.from(hitResult)
+
+        assertEquals(hitResult, session.hitResult.peek())
+        store.state.findTab("session")!!.also { tab ->
+            assertNotNull(tab.content.hitResult)
+            assertSame(hitResult, tab.content.hitResult)
+        }
+
+        session.hitResult.consume { true }
+        store.state.findTab("session")!!.also { tab ->
+            assertNull(tab.content.hitResult)
         }
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -549,6 +549,28 @@ class SessionTest {
     }
 
     @Test
+    fun `action is dispatched when download changes`() {
+        val store: BrowserStore = mock()
+        `when`(store.dispatch(any())).thenReturn(mock())
+
+        val session = Session("https://www.mozilla.org")
+        session.store = store
+
+        session.download = Consumable.empty()
+        verify(store).dispatch(ContentAction.ConsumeDownloadAction(session.id))
+
+        val download: Download = mock()
+        `when`(download.id).thenReturn("1")
+        `when`(download.url).thenReturn("https://www.mozilla.org")
+        `when`(download.destinationDirectory).thenReturn("test")
+        session.download = Consumable.from(download)
+        verify(store).dispatch(ContentAction.UpdateDownloadAction(session.id, download.toDownloadState()))
+
+        session.download.consume { true }
+        verify(store, times(2)).dispatch(ContentAction.ConsumeDownloadAction(session.id))
+    }
+
+    @Test
     fun `observer is notified when title changes`() {
         val observer = mock(Session.Observer::class.java)
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -450,6 +450,25 @@ class SessionTest {
     }
 
     @Test
+    fun `action is dispatched when hit result changes`() {
+        val store: BrowserStore = mock()
+        `when`(store.dispatch(any())).thenReturn(mock())
+
+        val session = Session("https://www.mozilla.org")
+        session.store = store
+
+        session.hitResult = Consumable.empty()
+        verify(store).dispatch(ContentAction.ConsumeHitResultAction(session.id))
+
+        val hitResult = HitResult.UNKNOWN("test")
+        session.hitResult = Consumable.from(hitResult)
+        verify(store).dispatch(ContentAction.UpdateHitResultAction(session.id, hitResult))
+
+        session.hitResult.consume { true }
+        verify(store, times(2)).dispatch(ContentAction.ConsumeHitResultAction(session.id))
+    }
+
+    @Test
     fun `All observers will not be notified about a download`() {
         var firstCallbackExecuted = false
         var secondCallbackExecuted = false

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -177,7 +177,7 @@ sealed class ContentAction : BrowserAction() {
     /**
      * Removes the [DownloadState] of the [ContentState] with the given [sessionId].
      */
-    data class ConsumeDownloadAction(val sessionId: String, val download: DownloadState? = null) : ContentAction()
+    data class ConsumeDownloadAction(val sessionId: String) : ContentAction()
 
     /**
      * Updates the [HitResult] of the [ContentState] with the given [sessionId].

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
 import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.lib.state.Action
 
@@ -176,7 +177,17 @@ sealed class ContentAction : BrowserAction() {
     /**
      * Removes the [DownloadState] of the [ContentState] with the given [sessionId].
      */
-    data class ConsumeDownloadAction(val sessionId: String, val download: DownloadState) : ContentAction()
+    data class ConsumeDownloadAction(val sessionId: String, val download: DownloadState? = null) : ContentAction()
+
+    /**
+     * Updates the [HitResult] of the [ContentState] with the given [sessionId].
+     */
+    data class UpdateHitResultAction(val sessionId: String, val hitResult: HitResult) : ContentAction()
+
+    /**
+     * Removes the [HitResult] of the [ContentState] with the given [sessionId].
+     */
+    data class ConsumeHitResultAction(val sessionId: String) : ContentAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -49,11 +49,7 @@ internal object ContentStateReducer {
                 it.copy(download = action.download)
             }
             is ContentAction.ConsumeDownloadAction -> updateContentState(state, action.sessionId) {
-                if (action.download == it.download) {
-                    it.copy(download = null)
-                } else {
-                    it
-                }
+                it.copy(download = null)
             }
             is ContentAction.UpdateHitResultAction -> updateContentState(state, action.sessionId) {
                 it.copy(hitResult = action.hitResult)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -55,6 +55,12 @@ internal object ContentStateReducer {
                     it
                 }
             }
+            is ContentAction.UpdateHitResultAction -> updateContentState(state, action.sessionId) {
+                it.copy(hitResult = action.hitResult)
+            }
+            is ContentAction.ConsumeHitResultAction -> updateContentState(state, action.sessionId) {
+                it.copy(hitResult = null)
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.state.state
 
 import android.graphics.Bitmap
 import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.concept.engine.HitResult
 
 /**
  * Value type that represents the state of the content within a [SessionState].
@@ -23,6 +24,7 @@ import mozilla.components.browser.state.state.content.DownloadState
  * be used as a preview in e.g. a tab switcher.
  * @property icon the icon of the page currently loaded by this session.
  * @property download Last unhandled download request.
+ * @property hitResult the target of the latest long click operation.
  */
 data class ContentState(
     val url: String,
@@ -34,5 +36,6 @@ data class ContentState(
     val securityInfo: SecurityInfoState = SecurityInfoState(),
     val thumbnail: Bitmap? = null,
     val icon: Bitmap? = null,
-    val download: DownloadState? = null
+    val download: DownloadState? = null,
+    val hitResult: HitResult? = null
 )

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.state.content
 
 import android.os.Environment
+import java.util.UUID
 
 /**
  * Value type that represents a download request.
@@ -24,5 +25,6 @@ data class DownloadState(
     val contentLength: Long? = null,
     val userAgent: String? = null,
     val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
-    val referrerUrl: String? = null
+    val referrerUrl: String? = null,
+    val id: String = UUID.randomUUID().toString()
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.HitResult
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -290,5 +291,43 @@ class ContentActionTest {
         ).joinBlocking()
 
         assertNull(tab.content.download)
+    }
+
+    @Test
+    fun `UpdateHitResultAction updates hit result`() {
+        assertNull(tab.content.hitResult)
+
+        val hitResult1: HitResult = mock()
+
+        store.dispatch(
+            ContentAction.UpdateHitResultAction(tab.id, hitResult1)
+        ).joinBlocking()
+
+        assertEquals(hitResult1, tab.content.hitResult)
+
+        val hitResult2: HitResult = mock()
+
+        store.dispatch(
+            ContentAction.UpdateHitResultAction(tab.id, hitResult2)
+        ).joinBlocking()
+
+        assertEquals(hitResult2, tab.content.hitResult)
+    }
+
+    @Test
+    fun `ConsumeHitResultAction removes hit result`() {
+        val hitResult: HitResult = mock()
+
+        store.dispatch(
+            ContentAction.UpdateHitResultAction(tab.id, hitResult)
+        ).joinBlocking()
+
+        assertEquals(hitResult, tab.content.hitResult)
+
+        store.dispatch(
+            ContentAction.ConsumeHitResultAction(tab.id, hitResult)
+        ).joinBlocking()
+
+        assertNull(tab.content.hitResult)
     }
 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -287,7 +287,7 @@ class ContentActionTest {
         assertEquals(download, tab.content.download)
 
         store.dispatch(
-            ContentAction.ConsumeDownloadAction(tab.id, download)
+            ContentAction.ConsumeDownloadAction(tab.id)
         ).joinBlocking()
 
         assertNull(tab.content.download)
@@ -325,7 +325,7 @@ class ContentActionTest {
         assertEquals(hitResult, tab.content.hitResult)
 
         store.dispatch(
-            ContentAction.ConsumeHitResultAction(tab.id, hitResult)
+            ContentAction.ConsumeHitResultAction(tab.id)
         ).joinBlocking()
 
         assertNull(tab.content.hitResult)

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -16,9 +16,10 @@ import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
 import mozilla.components.feature.downloads.ext.putDownloadExtra
 import mozilla.components.support.test.any
-import mozilla.components.support.test.eq
+import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -56,7 +57,7 @@ class AbstractFetchDownloadServiceTest {
             Response.Body(mock())
         )
         doReturn(response).`when`(client).fetch(Request("https://example.com/file.txt"))
-        doNothing().`when`(service).useFileStream(eq(download), any())
+        doNothing().`when`(service).useFileStream(any(), any())
 
         val downloadIntent = Intent("ACTION_DOWNLOAD").apply {
             putExtra(EXTRA_DOWNLOAD_ID, 1L)
@@ -65,7 +66,11 @@ class AbstractFetchDownloadServiceTest {
 
         service.onStartCommand(downloadIntent, 0)
 
-        verify(service).useFileStream(eq(download), any())
+        val providedDownload = argumentCaptor<Download>()
+        verify(service).useFileStream(providedDownload.capture(), any())
+        assertEquals(download.url, providedDownload.value.url)
+        assertEquals(download.fileName, providedDownload.value.fileName)
+
         verify(broadcastManager).sendBroadcast(any())
         Unit
     }

--- a/components/support/base/src/test/java/mozilla/components/support/base/observer/ConsumableTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/observer/ConsumableTest.kt
@@ -119,7 +119,8 @@ class ConsumableTest {
         assertEquals(23, consumer3.callbackValue)
     }
 
-    fun `value will be consumed if at multiple lambdas return true`() {
+    @Test
+    fun `value will be consumed if multiple lambdas return true`() {
         val consumer1 = TestConsumer(shouldConsume = true)
         val consumer2 = TestConsumer(shouldConsume = false)
         val consumer3 = TestConsumer(shouldConsume = true)
@@ -143,6 +144,33 @@ class ConsumableTest {
 
         assertTrue(consumer3.callbackTriggered)
         assertEquals(23, consumer3.callbackValue)
+    }
+
+    @Test
+    fun `value can be read and not consumed`() {
+        val consumable = Consumable.from(42)
+
+        assertEquals(42, consumable.peek())
+        assertFalse(consumable.isConsumed())
+
+        consumable.consume { true }
+        assertNull(consumable.peek())
+    }
+
+    @Test
+    fun `listeners are notified when value is consumed`() {
+        var listener1Notified = false
+        var listener2Notified = false
+
+        val consumable = Consumable.from(42) { listener1Notified = true }
+        consumable.onConsume { listener2Notified = true }
+
+        assertFalse(listener1Notified)
+        assertFalse(listener2Notified)
+
+        consumable.consume { true }
+        assertTrue(listener1Notified)
+        assertTrue(listener2Notified)
     }
 
     @Test


### PR DESCRIPTION
@pocmo As discussed, there are 3 parts/commits here:

- Support for adding listeners to Consumables
- Add HitResult to browser-state (and sync from browser-session)
- Sync downloads between browser-session and browser-state