### PR TITLE
Closes #4165: Add more logging for push

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -92,6 +92,8 @@ class AutoPushFeature(
         // If we have a token, initialize the rust component first.
         prefToken?.let { token ->
             scope.launch {
+                logger.debug("Initializing native component with the cached token.")
+
                 connection.updateToken(token)
             }
         }
@@ -126,6 +128,8 @@ class AutoPushFeature(
      */
     override fun onNewToken(newToken: String) {
         scope.launchAndTry {
+            logger.info("Received a new registration token from push service.")
+
             connection.updateToken(newToken)
 
             // Subscribe all only if this is the first time.
@@ -144,6 +148,7 @@ class AutoPushFeature(
         scope.launchAndTry {
             val type = DeliveryManager.serviceForChannelId(message.channelId)
             DeliveryManager.with(connection) {
+                logger.info("New push message decrypted.")
                 val decrypted = decrypt(
                     channelId = message.channelId,
                     body = message.body,
@@ -243,6 +248,8 @@ class AutoPushFeature(
      * [0]: https://github.com/mozilla-mobile/android-components/issues/3173
      */
     fun forceRegistrationRenewal() {
+        logger.warn("Forcing registration renewal by deleting our (cached) token.")
+
         // Remove the cached token we have.
         deleteToken(context)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,7 +50,10 @@ permalink: /changelog/
   * `begin*` OAuthAccount methods now return an `AuthFlowUrl`, which encapsulates an OAuth state identifier.
   * `AccountObserver:onAuthenticated` method now has `authType` parameter (instead of `newAccount`), which describes in detail what caused an authentication.
   * `GlobalSyncableStoreProvider.configureStore` now takes a pair of `Pair<SyncEngine, SyncableStore>`, instead of allowing arbitrary string names for engines.
-  * `GlobalSyncableStoreProvider.getStore` is no longer part of the public API.  
+  * `GlobalSyncableStoreProvider.getStore` is no longer part of the public API.
+
+* **feature-push**
+  * Added more logging into `AutoPushFeature` to aid in debugging in release builds.
 
 # 11.0.0
 


### PR DESCRIPTION
This adds different levels of logging to the AutoPushFeature since we're not always able to tell from a release build in an app that a consumer has initialized their `PushService` successfully; that's a bit of a blackbox for us when it comes to testing in release.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
