### PR TITLE
Closes #3558: browser-state: Add engine session state and sync w/ browser-session

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
@@ -20,6 +20,7 @@ import kotlin.math.min
 @Suppress("TooManyFunctions", "LargeClass")
 class LegacySessionManager(
     val engine: Engine,
+    private val engineSessionLinker: SessionManager.EngineSessionLinker,
     delegate: Observable<SessionManager.Observer> = ObserverRegistry()
 ) : Observable<SessionManager.Observer> by delegate {
     // It's important that any access to `values` is synchronized;
@@ -236,7 +237,7 @@ class LegacySessionManager(
      * - once snapshot has been restored, and appropriate session has been selected, onSessionsRestored
      *   notification will fire.
      *
-     * @param snapshot A [Snapshot] which may be produced by [createSnapshot].
+     * @param snapshot A [SessionManager.Snapshot] which may be produced by [createSnapshot].
      * @param updateSelection Whether the selected session should be updated from the restored snapshot.
      */
     fun restore(snapshot: SessionManager.Snapshot, updateSelection: Boolean = true) = synchronized(values) {
@@ -299,6 +300,7 @@ class LegacySessionManager(
                 engineSession.loadUrl(session.url)
             }
         }
+        engineSessionLinker.link(session, engineSession)
     }
 
     private fun unlink(session: Session) {
@@ -311,6 +313,7 @@ class LegacySessionManager(
                 engineObserver = null
             }
         }
+        engineSessionLinker.unlink(session)
     }
 
     /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -8,11 +8,14 @@ import android.graphics.Bitmap
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.CustomTabSessionState
+import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
 import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.lib.state.Action
@@ -214,4 +217,29 @@ sealed class TrackingProtectionAction : BrowserAction() {
      * Clears the [TrackingProtectionState.blockedTrackers] and [TrackingProtectionState.blockedTrackers] lists.
      */
     data class ClearTrackersAction(val tabId: String) : TrackingProtectionAction()
+}
+
+/**
+ * [BrowserAction] implementations related to updating the [EngineState] of a single [SessionState] inside
+ * [BrowserState].
+ */
+sealed class EngineAction : BrowserAction() {
+
+    /**
+     * Attaches the provided [EngineSession] to the session with the provided [sessionId].
+     */
+    data class LinkEngineSessionAction(val sessionId: String, val engineSession: EngineSession) : EngineAction()
+
+    /**
+     * Detaches the current [EngineSession] from the session with the provided [sessionId].
+     */
+    data class UnlinkEngineSessionAction(val sessionId: String) : EngineAction()
+
+    /**
+     * Updates the [EngineSessionState] of the session with the provided [sessionId].
+     */
+    data class UpdateEngineSessionStateAction(
+        val sessionId: String,
+        val engineSessionState: EngineSessionState
+    ) : EngineAction()
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.state.reducer
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CustomTabListAction
+import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
@@ -28,6 +29,7 @@ internal object BrowserStateReducer {
             is SystemAction -> SystemReducer.reduce(state, action)
             is TabListAction -> TabListReducer.reduce(state, action)
             is TrackingProtectionAction -> TrackingProtectionStateReducer.reduce(state, action)
+            is EngineAction -> EngineStateReducer.reduce(state, action)
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.EngineState
+import mozilla.components.browser.state.state.SessionState
+
+internal object EngineStateReducer {
+
+    /**
+     * [EngineAction] Reducer function for modifying a specific [EngineState]
+     * of a [SessionState].
+     */
+    fun reduce(state: BrowserState, action: EngineAction): BrowserState = when (action) {
+        is EngineAction.LinkEngineSessionAction -> state.copyWithEngineState(action.sessionId) {
+            it.copy(engineSession = action.engineSession)
+        }
+        is EngineAction.UnlinkEngineSessionAction -> state.copyWithEngineState(action.sessionId) {
+            it.copy(engineSession = null, engineSessionState = null)
+        }
+        is EngineAction.UpdateEngineSessionStateAction -> state.copyWithEngineState(action.sessionId) {
+            it.copy(engineSessionState = action.engineSessionState)
+        }
+    }
+}
+
+private fun BrowserState.copyWithEngineState(
+    tabId: String,
+    update: (EngineState) -> EngineState
+): BrowserState {
+    // Currently we map over both lists (tabs and customTabs). We could optimize this away later on if we know what
+    // type we want to modify.
+    return copy(
+        tabs = tabs.map { current ->
+            if (current.id == tabId) {
+                current.copy(engineState = update.invoke(current.engineState))
+            } else {
+                current
+            }
+        },
+        customTabs = customTabs.map { current ->
+            if (current.id == tabId) {
+                current.copy(engineState = update.invoke(current.engineState))
+            } else {
+                current
+            }
+        }
+    )
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -18,7 +18,8 @@ data class CustomTabSessionState(
     override val id: String = UUID.randomUUID().toString(),
     override val content: ContentState,
     override val trackingProtection: TrackingProtectionState = TrackingProtectionState(),
-    val config: CustomTabConfig
+    val config: CustomTabConfig,
+    override val engineState: EngineState = EngineState()
 ) : SessionState
 
 fun createCustomTab(

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/EngineState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/EngineState.kt
@@ -1,0 +1,16 @@
+package mozilla.components.browser.state.state
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
+
+/**
+ * Value type that holds the browser engine state of a session.
+ *
+ * @property engineSession the engine's representation of this session.
+ * @property engineSessionState serializable and restorable state of an engine session, see
+ * [EngineSession.saveState] and [EngineSession.restoreState].
+ */
+data class EngineState(
+    val engineSession: EngineSession? = null,
+    val engineSessionState: EngineSessionState? = null
+)

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/SessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/SessionState.kt
@@ -10,9 +10,11 @@ package mozilla.components.browser.state.state
  * @property id the unique id of the session.
  * @property content the [ContentState] of this session.
  * @property trackingProtection the [TrackingProtectionState] of this session.
+ * @property engineState the [EngineState] of this session.
  */
 interface SessionState {
     val id: String
     val content: ContentState
     val trackingProtection: TrackingProtectionState
+    val engineState: EngineState
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -21,6 +21,7 @@ data class TabSessionState(
     override val id: String = UUID.randomUUID().toString(),
     override val content: ContentState,
     override val trackingProtection: TrackingProtectionState = TrackingProtectionState(),
+    override val engineState: EngineState = EngineState(),
     val parentId: String? = null
 ) : SessionState
 

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class EngineActionTest {
+    private lateinit var tab: TabSessionState
+    private lateinit var store: BrowserStore
+
+    @Before
+    fun setUp() {
+        tab = createTab("https://www.mozilla.org")
+
+        store = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(tab)
+            )
+        )
+    }
+
+    private fun engineState() = store.state.findTab(tab.id)!!.engineState
+
+    @Test
+    fun `LinkEngineSessionAction - Attaches engine session`() {
+        assertNull(engineState().engineSession)
+
+        val engineSession: EngineSession = mock()
+        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
+
+        assertNotNull(engineState().engineSession)
+        assertEquals(engineSession, engineState().engineSession)
+    }
+
+    @Test
+    fun `UnlinkEngineSessionAction - Detaches engine session`() {
+        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, mock())).joinBlocking()
+        assertNotNull(engineState().engineSession)
+
+        store.dispatch(EngineAction.UnlinkEngineSessionAction(tab.id)).joinBlocking()
+        assertNull(engineState().engineSession)
+    }
+
+    @Test
+    fun `UpdateEngineSessionStateAction - Updates engine session state`() {
+        assertNull(engineState().engineSessionState)
+
+        val engineSessionState: EngineSessionState = mock()
+        store.dispatch(EngineAction.UpdateEngineSessionStateAction(tab.id, engineSessionState)).joinBlocking()
+        assertNotNull(engineState().engineSessionState)
+        assertEquals(engineSessionState, engineState().engineSessionState)
+    }
+}


### PR DESCRIPTION
Interestingly, we could live without an action for unlinking, as that only happens when the session is removed and since our new session state is immutable there's nothing to update, but for consistency/readability I've introduced it, plus there may be more use cases later.

There's some special handling here for `restore`, as we first have to dispatch the restore action (which happens in the outer manager) before dispatching the link action (otherwise we won't find the session). Otherwise, all as discussed. I've named the object passed down to the legacy session manager "EngineSessionLinker", but better name suggestions welcome :)