### PR TITLE
Make BrowserAction names consistent

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -20,7 +20,7 @@ import mozilla.components.browser.state.action.ContentAction.UpdateIconAction
 import mozilla.components.browser.state.action.ContentAction.UpdateLoadingStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdateProgressAction
 import mozilla.components.browser.state.action.ContentAction.UpdateSearchTermsAction
-import mozilla.components.browser.state.action.ContentAction.UpdateSecurityInfo
+import mozilla.components.browser.state.action.ContentAction.UpdateSecurityInfoAction
 import mozilla.components.browser.state.action.ContentAction.UpdateThumbnailAction
 import mozilla.components.browser.state.action.ContentAction.UpdateTitleAction
 import mozilla.components.browser.state.action.ContentAction.UpdateUrlAction
@@ -257,7 +257,7 @@ class Session(
      */
     var securityInfo: SecurityInfo by Delegates.observable(SecurityInfo()) { _, old, new ->
         notifyObservers(old, new) { onSecurityChanged(this@Session, new) }
-        store?.syncDispatch(UpdateSecurityInfo(id, new.toSecurityInfoState()))
+        store?.syncDispatch(UpdateSecurityInfoAction(id, new.toSecurityInfoState()))
     }
 
     /**
@@ -332,10 +332,10 @@ class Session(
 
         if (new.isEmpty()) {
             // From `EngineObserver` we can assume that this means the trackers have been cleared.
-            // The `ClearTrackers` action will also clear the loaded trackers list. That is always
+            // The `ClearTrackersAction` will also clear the loaded trackers list. That is always
             // the case when this list is cleared from `EngineObserver`. For the sake of migrating
             // to browser-state we assume that no other code changes the tracking properties.
-            store?.syncDispatch(TrackingProtectionAction.ClearTrackers(id))
+            store?.syncDispatch(TrackingProtectionAction.ClearTrackersAction(id))
         } else {
             // `EngineObserver` always adds new trackers to the end of the list. So we just dispatch
             // an action for the last item in the list.

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -271,7 +271,7 @@ class SessionTest {
         session.store = store
         session.securityInfo = Session.SecurityInfo(true, "mozilla.org", "issuer")
 
-        verify(store).dispatch(ContentAction.UpdateSecurityInfo(session.id, session.securityInfo.toSecurityInfoState()))
+        verify(store).dispatch(ContentAction.UpdateSecurityInfoAction(session.id, session.securityInfo.toSecurityInfoState()))
         verifyNoMoreInteractions(store)
     }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -157,7 +157,7 @@ sealed class ContentAction : BrowserAction() {
     /**
      * Updates the [SecurityInfoState] of the [ContentState] with the given [sessionId].
      */
-    data class UpdateSecurityInfo(val sessionId: String, val securityInfo: SecurityInfoState) : ContentAction()
+    data class UpdateSecurityInfoAction(val sessionId: String, val securityInfo: SecurityInfoState) : ContentAction()
 
     /**
      * Updates the icon of the [ContentState] with the given [sessionId].
@@ -213,5 +213,5 @@ sealed class TrackingProtectionAction : BrowserAction() {
     /**
      * Clears the [TrackingProtectionState.blockedTrackers] and [TrackingProtectionState.blockedTrackers] lists.
      */
-    data class ClearTrackers(val tabId: String) : TrackingProtectionAction()
+    data class ClearTrackersAction(val tabId: String) : TrackingProtectionAction()
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -36,7 +36,7 @@ internal object ContentStateReducer {
             is ContentAction.UpdateSearchTermsAction -> updateContentState(state, action.sessionId) {
                 it.copy(searchTerms = action.searchTerms)
             }
-            is ContentAction.UpdateSecurityInfo -> updateContentState(state, action.sessionId) {
+            is ContentAction.UpdateSecurityInfoAction -> updateContentState(state, action.sessionId) {
                 it.copy(securityInfo = action.securityInfo)
             }
             is ContentAction.UpdateIconAction -> updateContentState(state, action.sessionId) {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TrackingProtectionStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TrackingProtectionStateReducer.kt
@@ -24,7 +24,7 @@ internal object TrackingProtectionStateReducer {
         is TrackingProtectionAction.TrackerLoadedAction -> state.copyWithTrackingProtectionState(action.tabId) {
             it.copy(loadedTrackers = it.loadedTrackers + action.tracker)
         }
-        is TrackingProtectionAction.ClearTrackers -> state.copyWithTrackingProtectionState(action.tabId) {
+        is TrackingProtectionAction.ClearTrackersAction -> state.copyWithTrackingProtectionState(action.tabId) {
             it.copy(loadedTrackers = emptyList(), blockedTrackers = emptyList())
         }
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -151,7 +151,7 @@ class ContentActionTest {
         assertNotEquals(newSecurityInfo, otherTab.content.securityInfo)
 
         store.dispatch(
-            ContentAction.UpdateSecurityInfo(tab.id, newSecurityInfo)
+            ContentAction.UpdateSecurityInfoAction(tab.id, newSecurityInfo)
         ).joinBlocking()
 
         assertEquals(newSecurityInfo, tab.content.securityInfo)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/TrackingProtectionActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/TrackingProtectionActionTest.kt
@@ -122,7 +122,7 @@ class TrackingProtectionActionTest {
         assertEquals(2, trackingProtectionState().blockedTrackers.size)
         assertEquals(3, trackingProtectionState().loadedTrackers.size)
 
-        store.dispatch(TrackingProtectionAction.ClearTrackers(tab.id)).joinBlocking()
+        store.dispatch(TrackingProtectionAction.ClearTrackersAction(tab.id)).joinBlocking()
 
         assertEquals(0, trackingProtectionState().blockedTrackers.size)
         assertEquals(0, trackingProtectionState().loadedTrackers.size)

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt
@@ -122,7 +122,7 @@ class ToolbarPresenterTest {
 
         verify(toolbar, never()).siteSecure = Toolbar.SiteSecurity.SECURE
 
-        store.dispatch(ContentAction.UpdateSecurityInfo("tab1", SecurityInfoState(
+        store.dispatch(ContentAction.UpdateSecurityInfoAction("tab1", SecurityInfoState(
             secure = true,
             host = "mozilla.org",
             issuer = "Mozilla"


### PR DESCRIPTION
Very minor refactoring, but since I just noticed. We could also decide to remove `Action` from all names, as they are usually prefixed with their type e.g. `TabListAction.AddTab`. Either way, I think we should keep them consistent.