### PR TITLE
Issue #4244: Add id of tab to intent launched from media notification.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/MediaFeature.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/MediaFeature.kt
@@ -65,4 +65,9 @@ class MediaFeature(
             }
         }
     }
+
+    companion object {
+        const val ACTION_SWITCH_TAB = "mozac.feature.media.SWITCH_TAB"
+        const val EXTRA_TAB_ID = "mozac.feature.media.TAB_ID"
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -109,6 +109,9 @@ permalink: /changelog/
 * **browser-session**, **feature-intent**
   * ⚠️ **This is a breaking change**: Moved `Intent` related code from `browser-session` to `feature-intent`.
 
+* **feature-media**
+  * The `Intent` launched from the media notification now has its action set to `MediaFeature.ACTION_SWITCH_TAB`. In addition to that the extra `MediaFeature.EXTRA_TAB_ID` contains the id of the tab the media notification is displayed for.
+
 # 10.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v10.0.0...v10.0.1)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
