### PR TITLE
Switch to regular set for Consumable listeners

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Consumable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Consumable.kt
@@ -4,9 +4,6 @@
 
 package mozilla.components.support.base.observer
 
-import java.util.Collections
-import java.util.WeakHashMap
-
 typealias ConsumableListener = () -> Unit
 
 /**
@@ -20,7 +17,7 @@ class Consumable<T> private constructor(
     onConsume: ConsumableListener? = null
 ) {
 
-    private val listeners = Collections.newSetFromMap(WeakHashMap<ConsumableListener, Boolean>()).also { listeners ->
+    private val listeners = mutableSetOf<ConsumableListener>().also { listeners ->
         if (onConsume != null) {
             listeners.add(onConsume)
         }


### PR DESCRIPTION
This was meant to prevent a footgun / accident leaks of session and context via the listeners, but of course, now that nothing else holds on to the listeners they could disappear (get gc'ed) and not be notified. 