### PR TITLE
Enable Gecko scalars exfiltration in engine-gecko

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/glean/GeckoAdapter.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/glean/GeckoAdapter.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.browser.engine.gecko.glean
 
-import mozilla.components.browser.engine.gecko.GleanMetrics.GleanGeckoHistogramMapping
+import mozilla.components.browser.engine.gecko.GleanMetrics.GleanGeckoMetricsMapping
 import org.mozilla.geckoview.RuntimeTelemetry
 
 /**
@@ -20,8 +20,8 @@ import org.mozilla.geckoview.RuntimeTelemetry
  */
 class GeckoAdapter : RuntimeTelemetry.Delegate {
     override fun onTelemetryReceived(metric: RuntimeTelemetry.Metric) {
-        // Note that the `GleanGeckoHistogramMapping` is automatically generated at
+        // Note that the `GleanGeckoMetricsMapping` is automatically generated at
         // build time by the Glean SDK parsers.
-        GleanGeckoHistogramMapping[metric.name]?.accumulateSamples(metric.values)
+        GleanGeckoMetricsMapping.getHistogram(metric.name)?.accumulateSamples(metric.values)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/glean/GeckoAdapter.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/glean/GeckoAdapter.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.browser.engine.gecko.glean
 
-import mozilla.components.browser.engine.gecko.GleanMetrics.GleanGeckoHistogramMapping
+import mozilla.components.browser.engine.gecko.GleanMetrics.GleanGeckoMetricsMapping
 import org.mozilla.geckoview.RuntimeTelemetry
 
 /**
@@ -22,6 +22,18 @@ class GeckoAdapter : RuntimeTelemetry.Delegate {
     override fun onHistogram(metric: RuntimeTelemetry.Metric<LongArray>) {
         // Note that the `GleanGeckoHistogramMapping` is automatically generated at
         // build time by the Glean SDK parsers.
-        GleanGeckoHistogramMapping[metric.name]?.accumulateSamples(metric.value)
+        GleanGeckoMetricsMapping.getHistogram(metric.name)?.accumulateSamples(metric.value)
+    }
+
+    override fun onBooleanScalar(metric: RuntimeTelemetry.Metric<Boolean>) {
+        GleanGeckoMetricsMapping.getBooleanScalar(metric.name)?.set(metric.value)
+    }
+
+    override fun onStringScalar(metric: RuntimeTelemetry.Metric<String>) {
+        GleanGeckoMetricsMapping.getStringScalar(metric.name)?.set(metric.value)
+    }
+
+    override fun onLongScalar(metric: RuntimeTelemetry.Metric<Long>) {
+        GleanGeckoMetricsMapping.getQuantityScalar(metric.name)?.set(metric.value)
     }
 }

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "1.4.2"
+String GLEAN_PARSER_VERSION = "1.5.1"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,6 +71,9 @@ permalink: /changelog/
 
 * **feature-pwa**
   * Adds the ability to create a basic shortcut with a custom label
+  
+* **browser-engine-gecko-nightly**
+  * Adds support for exposing Gecko scalars through the Glean SDK. See [bug 1579365](https://bugzilla.mozilla.org/show_bug.cgi?id=1579365) for details.
 
 # 11.0.0
 


### PR DESCRIPTION
This enables exfiltrating Gecko scalars defined in Gecko in products using both engine-gecko and the
Glean SDK.

This needs the new parsers from mozilla/glean_parser#96

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
