### PR TITLE
Closes #4161: Make MediaState extension methods visible for consuming apps.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/ext/MediaState.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/ext/MediaState.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.media.ext
 
 import android.support.v4.media.session.PlaybackStateCompat
+import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.feature.media.state.MediaState
 
@@ -21,6 +22,17 @@ internal fun MediaState.getMedia(): List<Media> {
         is MediaState.Playing -> media
         is MediaState.Paused -> media
         else -> emptyList()
+    }
+}
+
+/**
+ * Get the [Session] that caused this [MediaState] (if any).
+ */
+fun MediaState.getSession(): Session? {
+    return when (this) {
+        is MediaState.Playing -> session
+        is MediaState.Paused -> session
+        else -> null
     }
 }
 
@@ -53,16 +65,16 @@ internal fun MediaState.toPlaybackState() =
 /**
  * If this state is [MediaState.Playing] then pause all playing [Media].
  */
-internal fun MediaState.pauseIfPlaying() {
+fun MediaState.pauseIfPlaying() {
     if (this is MediaState.Playing) {
         media.pause()
     }
 }
 
 /**
- * If this state is [MediaState.Paused] then resume playing all paused media.
+ * If this state is [MediaState.Paused] then resume playing all paused [Media].
  */
-internal fun MediaState.playIfPaused() {
+fun MediaState.playIfPaused() {
     if (this is MediaState.Paused) {
         media.play()
     }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/ext/MediaStateKtTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/ext/MediaStateKtTest.kt
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.media.ext
+
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.engine.media.Media
+import mozilla.components.feature.media.MockMedia
+import mozilla.components.feature.media.state.MediaState
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+class MediaStateKtTest {
+    @Test
+    fun `getSession() extension method`() {
+        val noneState = MediaState.None
+        assertNull(noneState.getSession())
+
+        val playingState = MediaState.Playing(
+            Session(id = "test1", initialUrl = "https://www.mozilla.org"),
+            emptyList())
+        assertNotNull(playingState.getSession())
+        assertEquals("test1", playingState.getSession()!!.id)
+
+        val pausedState = MediaState.Paused(
+            Session(id = "test2", initialUrl = "https://www.mozilla.org"),
+            emptyList())
+        assertNotNull(pausedState.getSession())
+        assertEquals("test2", pausedState.getSession()!!.id)
+    }
+
+    @Test
+    fun `pauseIfPlaying() extension method`() {
+        val noneState = MediaState.None
+        noneState.pauseIfPlaying() // Does nothing and has no media -> nothing to verify/assert.
+
+        val playingMedia: Media = MockMedia(Media.PlaybackState.PLAYING)
+        val playingState = MediaState.Playing(session = mock(), media = listOf(playingMedia))
+        playingState.pauseIfPlaying()
+        verify(playingMedia.controller).pause()
+
+        val pausedMedia: Media = MockMedia(Media.PlaybackState.PAUSE)
+        val pausedState = MediaState.Paused(session = mock(), media = listOf(pausedMedia))
+        pausedState.pauseIfPlaying()
+        verify(pausedMedia.controller, never()).pause()
+    }
+
+    @Test
+    fun `playIfPaused() extension method`() {
+        val noneState = MediaState.None
+        noneState.playIfPaused() // Does nothing and has no media -> nothing to verify/assert.
+
+        val playingMedia: Media = MockMedia(Media.PlaybackState.PLAYING)
+        val playingState = MediaState.Playing(session = mock(), media = listOf(playingMedia))
+        playingState.playIfPaused()
+        verify(playingMedia.controller, never()).play()
+
+        val pausedMedia: Media = MockMedia(Media.PlaybackState.PAUSE)
+        val pausedState = MediaState.Paused(session = mock(), media = listOf(pausedMedia))
+        pausedState.playIfPaused()
+        verify(pausedMedia.controller).play()
+    }
+}


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
