### PR TITLE
Issue #4353: MediaStateMachine: Lower state update delay to 100ms.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaStateMachine.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/state/MediaStateMachine.kt
@@ -21,7 +21,7 @@ import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import kotlin.coroutines.EmptyCoroutineContext
 
-private const val DELAY_STATE_UPDATE_MS = 250L
+private const val DELAY_STATE_UPDATE_MS = 100L
 
 /**
  * A state machine that subscribes to all [Session] instances and watches changes to their [Media] to create an


### PR DESCRIPTION
A quick fix that makes it feel less laggy. I did some measurements on various devices. See issue #4353.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
