### PR TITLE
Rename isPWA to isInstallable

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -61,7 +61,7 @@ class WebAppShortcutManager(
      * Request to create a new shortcut on the home screen.
      * @param context The current context.
      * @param session The session to create the shortcut for.
-     * @param overrideShortcutName (optional) The name of the shortcut
+     * @param overrideShortcutName (optional) The name of the shortcut. Ignored for PWAs.
      */
     suspend fun requestPinShortcut(
         context: Context,

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
@@ -17,25 +17,28 @@ class WebAppUseCases(
     private val applicationContext: Context,
     private val sessionManager: SessionManager,
     httpClient: Client,
-    supportWebApps: Boolean = true
+    private val supportWebApps: Boolean = true
 ) {
+
+    private val shortcutManager by lazy {
+        WebAppShortcutManager(
+            applicationContext,
+            httpClient,
+            supportWebApps = supportWebApps
+        )
+    }
+
+    /**
+     * Checks if the launcher supports adding shortcuts.
+     */
     fun isPinningSupported() =
         ShortcutManagerCompat.isRequestPinShortcutSupported(applicationContext)
 
     /**
-     * Checks to see if the current session is a Progressive Web App.
+     * Checks to see if the current session can be installed as a Progressive Web App.
      */
-    fun isPWA(): Boolean {
-        return sessionManager.selectedSession?.installableManifest() != null
-    }
-
-    private val shortcutManager by lazy {
-        WebAppShortcutManager(
-                applicationContext,
-                httpClient,
-                supportWebApps = supportWebApps
-        )
-    }
+    fun isInstallable() =
+        sessionManager.selectedSession?.installableManifest() != null && supportWebApps
 
     /**
      * Let the user add the selected session to the homescreen.

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
@@ -11,15 +11,17 @@ import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 
 @RunWith(AndroidJUnit4::class)
 class WebAppUseCasesTest {
+
     @Test
-    fun `isPWA returns false if currentSession has no manifest`() {
+    fun `isInstallable returns false if currentSession has no manifest`() {
         val session: Session = mock()
         `when`(session.securityInfo).thenReturn(Session.SecurityInfo(secure = true))
         `when`(session.webAppManifest).thenReturn(null)
@@ -27,12 +29,12 @@ class WebAppUseCasesTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.selectedSession).thenReturn(session)
 
-        val webAppUseCases = WebAppUseCases(testContext, sessionManager, mock(), true)
-        Assert.assertFalse(webAppUseCases.isPWA())
+        val webAppUseCases = WebAppUseCases(testContext, sessionManager, mock())
+        assertFalse(webAppUseCases.isInstallable())
     }
 
     @Test
-    fun `isPWA returns true if currentSession has a manifest`() {
+    fun `isInstallable returns true if currentSession has a manifest`() {
         val manifest = WebAppManifest(
                 name = "Demo",
                 startUrl = "https://example.com",
@@ -49,7 +51,29 @@ class WebAppUseCasesTest {
         val sessionManager: SessionManager = mock()
         `when`(sessionManager.selectedSession).thenReturn(session)
 
-        val webAppUseCases = WebAppUseCases(testContext, sessionManager, mock(), true)
-        Assert.assertTrue(webAppUseCases.isPWA())
+        val webAppUseCases = WebAppUseCases(testContext, sessionManager, mock())
+        assertTrue(webAppUseCases.isInstallable())
+    }
+
+    @Test
+    fun `isInstallable returns false if supportWebApps is false`() {
+        val manifest = WebAppManifest(
+            name = "Demo",
+            startUrl = "https://example.com",
+            icons = listOf(WebAppManifest.Icon(
+                src = "https://example.com/icon.png",
+                sizes = listOf(Size(192, 192))
+            ))
+        )
+
+        val session: Session = mock()
+        `when`(session.webAppManifest).thenReturn(manifest)
+        `when`(session.securityInfo).thenReturn(Session.SecurityInfo(secure = true))
+
+        val sessionManager: SessionManager = mock()
+        `when`(sessionManager.selectedSession).thenReturn(session)
+
+        val webAppUseCases = WebAppUseCases(testContext, sessionManager, mock(), supportWebApps = false)
+        assertFalse(webAppUseCases.isInstallable())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-pwa**
+  * Adds `WebAppUseCases.isInstallable` to check if the current session can be installed as a Progressive Web App.
+
 # 12.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v11.0.0...v12.0.0)
@@ -30,7 +33,7 @@ permalink: /changelog/
     strictSocialTrackingProtection = true
   )
   ```
-  
+
 * **context-menu**
   * Exposed title tag from GV in HitResult. Fixes [#1444]. If title is null or blank the src value is returned for title.
 
@@ -82,7 +85,7 @@ permalink: /changelog/
 
 * **feature-pwa**
   * Adds the ability to create a basic shortcut with a custom label
-  
+
 * **browser-engine-gecko-nightly**
   * Adds support for exposing Gecko scalars through the Glean SDK. See [bug 1579365](https://bugzilla.mozilla.org/show_bug.cgi?id=1579365) for details.
 


### PR DESCRIPTION
I'm worried about confusion between a tab that can be installed as a web app vs a session opened as a PWA inside `ExternalAppBrowserFragment`. This hasn't been integrated into Fenix just yet so let's rename it.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
