### PR TITLE
PWA: Don't use white nav bar below Oreo

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -8,6 +8,8 @@ import android.app.ActivityManager.TaskDescription
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 import androidx.core.net.toUri
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -26,11 +28,14 @@ fun WebAppManifest.toTaskDescription(icon: Bitmap?) =
 /**
  * Creates a [CustomTabConfig] that styles a custom tab toolbar to match the manifest theme.
  */
-fun WebAppManifest.toCustomTabConfig() =
-    CustomTabConfig(
+fun WebAppManifest.toCustomTabConfig(): CustomTabConfig {
+    val backgroundColor = this.backgroundColor
+    return CustomTabConfig(
         toolbarColor = themeColor,
-        navigationBarColor = backgroundColor?.let {
-            if (isDark(it)) Color.BLACK else Color.WHITE
+        navigationBarColor = if (SDK_INT >= Build.VERSION_CODES.O && backgroundColor != null) {
+            if (isDark(backgroundColor)) Color.BLACK else Color.WHITE
+        } else {
+            null
         },
         closeButtonIcon = null,
         enableUrlbarHiding = true,
@@ -38,6 +43,7 @@ fun WebAppManifest.toCustomTabConfig() =
         showShareMenuItem = true,
         menuItems = emptyList()
     )
+}
 
 /**
  * Returns the scope of the manifest as a [Uri] for use


### PR DESCRIPTION
Below Oreo, white navigation bars just look like a giant white rectangle since we can't darken the button colors.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
