### PR TITLE
Closes #4290: Add PromptRequest to browser-state

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.state.action.ContentAction.ConsumeDownloadAction
 import mozilla.components.browser.state.action.ContentAction.ConsumeHitResultAction
+import mozilla.components.browser.state.action.ContentAction.ConsumePromptRequestAction
 import mozilla.components.browser.state.action.ContentAction.RemoveIconAction
 import mozilla.components.browser.state.action.ContentAction.RemoveThumbnailAction
 import mozilla.components.browser.state.action.ContentAction.UpdateDownloadAction
@@ -19,6 +20,7 @@ import mozilla.components.browser.state.action.ContentAction.UpdateHitResultActi
 import mozilla.components.browser.state.action.ContentAction.UpdateIconAction
 import mozilla.components.browser.state.action.ContentAction.UpdateLoadingStateAction
 import mozilla.components.browser.state.action.ContentAction.UpdateProgressAction
+import mozilla.components.browser.state.action.ContentAction.UpdatePromptRequestAction
 import mozilla.components.browser.state.action.ContentAction.UpdateSearchTermsAction
 import mozilla.components.browser.state.action.ContentAction.UpdateSecurityInfoAction
 import mozilla.components.browser.state.action.ContentAction.UpdateThumbnailAction
@@ -451,10 +453,19 @@ class Session(
     /**
      * [Consumable] State for a prompt request from web content.
      */
-    var promptRequest: Consumable<PromptRequest> by Delegates.vetoable(Consumable.empty()) {
-        _, _, request ->
-            val consumers = wrapConsumers<PromptRequest> { onPromptRequested(this@Session, it) }
-            !request.consumeBy(consumers)
+    var promptRequest: Consumable<PromptRequest> by Delegates.vetoable(Consumable.empty()) { _, _, request ->
+        store?.let {
+            val promptRequest = request.peek()
+            if (promptRequest == null) {
+                it.syncDispatch(ConsumePromptRequestAction(id))
+            } else {
+                it.syncDispatch(UpdatePromptRequestAction(id, promptRequest))
+                request.onConsume { it.syncDispatch(ConsumePromptRequestAction(id)) }
+            }
+        }
+
+        val consumers = wrapConsumers<PromptRequest> { onPromptRequested(this@Session, it) }
+        !request.consumeBy(consumers)
     }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
+import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -803,6 +804,32 @@ class SessionManagerMigrationTest {
 
         store.state.findTab("session2")!!.also { tab ->
             assertEquals(engineSession, tab.engineState.engineSession)
+        }
+    }
+
+    @Test
+    fun `Adding a prompt request`() {
+        val store = BrowserStore()
+        val manager = SessionManager(engine = mock(), store = store)
+
+        val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
+        manager.add(session)
+
+        assertNull(session.promptRequest.peek())
+        assertNull(store.state.findTab("session")!!.content.promptRequest)
+
+        val promptRequest: PromptRequest = mock()
+        session.promptRequest = Consumable.from(promptRequest)
+
+        assertEquals(promptRequest, session.promptRequest.peek())
+        store.state.findTab("session")!!.also { tab ->
+            assertNotNull(tab.content.promptRequest)
+            assertSame(promptRequest, tab.content.promptRequest)
+        }
+
+        session.promptRequest.consume { true }
+        store.state.findTab("session")!!.also { tab ->
+            assertNull(tab.content.promptRequest)
         }
     }
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -910,6 +910,25 @@ class SessionTest {
     }
 
     @Test
+    fun `action is dispatched when prompt request changes`() {
+        val store: BrowserStore = mock()
+        `when`(store.dispatch(any())).thenReturn(mock())
+
+        val session = Session("https://www.mozilla.org")
+        session.store = store
+
+        session.promptRequest = Consumable.empty()
+        verify(store).dispatch(ContentAction.ConsumePromptRequestAction(session.id))
+
+        val promptRequest: PromptRequest = mock()
+        session.promptRequest = Consumable.from(promptRequest)
+        verify(store).dispatch(ContentAction.UpdatePromptRequestAction(session.id, promptRequest))
+
+        session.promptRequest.consume { true }
+        verify(store, times(2)).dispatch(ContentAction.ConsumePromptRequestAction(session.id))
+    }
+
+    @Test
     fun `window requests will be set on session if no observer consumes them`() {
         val openWindowRequest: WindowRequest = mock()
         val closeWindowRequest: WindowRequest = mock()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
+import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.lib.state.Action
 
 /**
@@ -191,6 +192,16 @@ sealed class ContentAction : BrowserAction() {
      * Removes the [HitResult] of the [ContentState] with the given [sessionId].
      */
     data class ConsumeHitResultAction(val sessionId: String) : ContentAction()
+
+    /**
+     * Updates the [PromptRequest] of the [ContentState] with the given [sessionId].
+     */
+    data class UpdatePromptRequestAction(val sessionId: String, val promptRequest: PromptRequest) : ContentAction()
+
+    /**
+     * Removes the [PromptRequest] of the [ContentState] with the given [sessionId].
+     */
+    data class ConsumePromptRequestAction(val sessionId: String) : ContentAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -57,6 +57,12 @@ internal object ContentStateReducer {
             is ContentAction.ConsumeHitResultAction -> updateContentState(state, action.sessionId) {
                 it.copy(hitResult = null)
             }
+            is ContentAction.UpdatePromptRequestAction -> updateContentState(state, action.sessionId) {
+                it.copy(promptRequest = action.promptRequest)
+            }
+            is ContentAction.ConsumePromptRequestAction -> updateContentState(state, action.sessionId) {
+                it.copy(promptRequest = null)
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.state.state
 import android.graphics.Bitmap
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.prompt.PromptRequest
 
 /**
  * Value type that represents the state of the content within a [SessionState].
@@ -25,6 +26,7 @@ import mozilla.components.concept.engine.HitResult
  * @property icon the icon of the page currently loaded by this session.
  * @property download Last unhandled download request.
  * @property hitResult the target of the latest long click operation.
+ * @property promptRequest the last received [PromptRequest].
  */
 data class ContentState(
     val url: String,
@@ -37,5 +39,6 @@ data class ContentState(
     val thumbnail: Bitmap? = null,
     val icon: Bitmap? = null,
     val download: DownloadState? = null,
-    val hitResult: HitResult? = null
+    val hitResult: HitResult? = null,
+    val promptRequest: PromptRequest? = null
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -329,5 +330,43 @@ class ContentActionTest {
         ).joinBlocking()
 
         assertNull(tab.content.hitResult)
+    }
+
+    @Test
+    fun `UpdatePromptRequestAction updates request`() {
+        assertNull(tab.content.promptRequest)
+
+        val promptRequest1: PromptRequest = mock()
+
+        store.dispatch(
+            ContentAction.UpdatePromptRequestAction(tab.id, promptRequest1)
+        ).joinBlocking()
+
+        assertEquals(promptRequest1, tab.content.promptRequest)
+
+        val promptRequest2: PromptRequest = mock()
+
+        store.dispatch(
+            ContentAction.UpdatePromptRequestAction(tab.id, promptRequest2)
+        ).joinBlocking()
+
+        assertEquals(promptRequest2, tab.content.promptRequest)
+    }
+
+    @Test
+    fun `ConsumePromptRequestAction removes result`() {
+        val promptRequest: PromptRequest = mock()
+
+        store.dispatch(
+            ContentAction.UpdatePromptRequestAction(tab.id, promptRequest)
+        ).joinBlocking()
+
+        assertEquals(promptRequest, tab.content.promptRequest)
+
+        store.dispatch(
+            ContentAction.ConsumePromptRequestAction(tab.id)
+        ).joinBlocking()
+
+        assertNull(tab.content.promptRequest)
     }
 }


### PR DESCRIPTION
Same as for `Download` and `HitResult` consumables.