### PR TITLE
Proper 'matches' permission for webchannel extension manifest

### DIFF
--- a/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
+++ b/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "content_scripts": [
     {
-      "matches": ["https://acounts.firefox.com/*"],
+      "matches": ["https://accounts.firefox.com/*"],
       "js": ["fxawebchannel.js"],
       "run_at": "document_start"
     }


### PR DESCRIPTION
FxA URL was mistyped in #4221 :(

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
