### PR TITLE
Add an abstraction layer between Glean and concept-fetch

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -19,6 +19,7 @@ import java.util.UUID
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.GleanMetrics.GleanInternalMetrics
 import mozilla.components.service.glean.GleanMetrics.Pings
+import mozilla.components.service.glean.net.BaseUploader
 import mozilla.components.service.glean.ping.PingMaker
 import mozilla.components.service.glean.private.PingType
 import mozilla.components.service.glean.scheduler.GleanLifecycleObserver
@@ -48,6 +49,11 @@ open class GleanInternalAPI internal constructor () {
     private lateinit var storageEngineManager: StorageEngineManager
     internal lateinit var pingMaker: PingMaker
     internal lateinit var configuration: Configuration
+
+    // This is the wrapped http uploading mechanism: provides base functionalities
+    // for logging and delegates the actual upload to the implementation in
+    // the `Configuration`.
+    internal val httpClient by lazy { BaseUploader(configuration.httpClient) }
 
     private val gleanLifecycleObserver by lazy { GleanLifecycleObserver() }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -4,9 +4,10 @@
 
 package mozilla.components.service.glean.config
 
-import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.net.ConceptFetchHttpUploader
+import mozilla.components.service.glean.net.PingUploader
 
 /**
  * The Configuration class describes how to configure the Glean.
@@ -14,10 +15,6 @@ import mozilla.components.service.glean.BuildConfig
  * @property serverEndpoint the server pings are sent to. Please note that this is
  *           is only meant to be changed for tests.
  * @property userAgent the user agent used when sending pings, only to be used internally.
- * @property connectionTimeout the timeout, in milliseconds, to use when connecting to
- *           the [serverEndpoint]
- * @property readTimeout the timeout, in milliseconds, to use when connecting to
- *           the [serverEndpoint]
  * @property maxEvents the number of events to store before the events ping is sent
  * @property logPings whether to log ping contents to the console. This is only meant to be used
  *           internally by the `GleanDebugActivity`.
@@ -29,14 +26,12 @@ import mozilla.components.service.glean.BuildConfig
 data class Configuration internal constructor(
     val serverEndpoint: String,
     val userAgent: String = DEFAULT_USER_AGENT,
-    val connectionTimeout: Long = DEFAULT_CONNECTION_TIMEOUT,
-    val readTimeout: Long = DEFAULT_READ_TIMEOUT,
     val maxEvents: Int = DEFAULT_MAX_EVENTS,
     val logPings: Boolean = DEFAULT_LOG_PINGS,
     // NOTE: since only simple object or strings can be made `const val`s, if the
     // default values for the lines below are ever changed, they are required
     // to change in the public constructor below.
-    val httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() },
+    val httpClient: PingUploader = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() }),
     val pingTag: String? = null,
     val channel: String? = null
 ) {
@@ -47,16 +42,12 @@ data class Configuration internal constructor(
     // constructor from the secondary, public one, below.
     constructor(
         serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
-        connectionTimeout: Long = DEFAULT_CONNECTION_TIMEOUT,
-        readTimeout: Long = DEFAULT_READ_TIMEOUT,
         maxEvents: Int = DEFAULT_MAX_EVENTS,
-        httpClient: Lazy<Client> = lazy { HttpURLConnectionClient() },
+        httpClient: PingUploader = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() }),
         channel: String? = null
     ) : this (
         serverEndpoint = serverEndpoint,
         userAgent = DEFAULT_USER_AGENT,
-        connectionTimeout = connectionTimeout,
-        readTimeout = readTimeout,
         maxEvents = maxEvents,
         logPings = DEFAULT_LOG_PINGS,
         httpClient = httpClient,
@@ -67,8 +58,6 @@ data class Configuration internal constructor(
     companion object {
         const val DEFAULT_TELEMETRY_ENDPOINT = "https://incoming.telemetry.mozilla.org"
         const val DEFAULT_USER_AGENT = "Glean/${BuildConfig.LIBRARY_VERSION} (Android)"
-        const val DEFAULT_CONNECTION_TIMEOUT = 10000L
-        const val DEFAULT_READ_TIMEOUT = 30000L
         const val DEFAULT_MAX_EVENTS = 500
         const val DEFAULT_LOG_PINGS = false
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/BaseUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/BaseUploader.kt
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import androidx.annotation.VisibleForTesting
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONException
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * The logic for uploading pings: this leaves the actual upload implementation
+ * to the user-provided delegate.
+ */
+class BaseUploader(d: PingUploader) : PingUploader by d {
+    private val logger = Logger("glean/BaseUploader")
+
+    /**
+     * Log the contents of a ping to the console, if configured to do so in
+     * [Configuration.logPings].
+     *
+     * @param path the URL path to append to the server address
+     * @param data the serialized text data to send
+     * @param config the Glean configuration object
+     */
+    private fun logPing(path: String, data: String, config: Configuration) {
+        if (config.logPings) {
+            // Parse and reserialize the JSON so it has indentation and is human-readable.
+            try {
+                val json = JSONObject(data)
+                val indented = json.toString(2)
+
+                logger.debug("Glean ping to URL: $path\n$indented")
+            } catch (e: JSONException) {
+                logger.debug("Exception parsing ping as JSON: $e") // $COVERAGE-IGNORE$
+            }
+        }
+    }
+
+    /**
+     * TEST-ONLY. Allows to set specific dates for testing.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getCalendarInstance(): Calendar { return Calendar.getInstance() }
+
+    /**
+     * Generate a date string to be used in the Date header.
+     */
+    private fun createDateHeaderValue(): String {
+        val calendar = getCalendarInstance()
+        val dateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
+        dateFormat.timeZone = TimeZone.getTimeZone("GMT")
+        return dateFormat.format(calendar.time)
+    }
+
+    /**
+     * Generate a list of headers to send with the request.
+     *
+     * @param config the Glean configuration object
+     * @return a [HeadersList] containing String to String [Pair] with the first
+     *         entry being the header name and the second its value.
+     */
+    private fun getHeadersToSend(config: Configuration): HeadersList {
+        val headers = mutableListOf(
+            Pair("Content-Type", "application/json; charset=utf-8"),
+            Pair("User-Agent", config.userAgent),
+            Pair("Date", createDateHeaderValue()),
+            // Add headers for supporting the legacy pipeline.
+            Pair("X-Client-Type", "Glean"),
+            Pair("X-Client-Version", BuildConfig.LIBRARY_VERSION)
+        )
+
+        // If there is a pingTag set, then this header needs to be added in order to flag pings
+        // for "debug view" use.
+        config.pingTag?.let {
+            headers.add(Pair("X-Debug-ID", it))
+        }
+
+        return headers
+    }
+
+    /**
+     * This function triggers the actual upload: logs the ping and calls the implementation
+     * specific upload function.
+     *
+     * @param path the URL path to append to the server address
+     * @param data the serialized text data to send
+     * @param config the Glean configuration object
+     *
+     * @return true if the ping was correctly dealt with (sent successfully
+     *         or faced an unrecoverable error), false if there was a recoverable
+     *         error callers can deal with.
+     */
+    internal fun doUpload(path: String, data: String, config: Configuration): Boolean {
+        logPing(path, data, config)
+
+        return upload(
+            url = config.serverEndpoint + path,
+            data = data,
+            headers = getHeadersToSend(config)
+        )
+    }
+}

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/net/PingUploader.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/net/PingUploader.kt
@@ -4,22 +4,23 @@
 
 package mozilla.components.service.glean.net
 
-import mozilla.components.service.glean.config.Configuration
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Locale
-import java.util.TimeZone
+typealias HeadersList = List<Pair<String, String>>
 
 /**
  * The interface defining how to send pings.
  */
-internal interface PingUploader {
-    fun upload(path: String, data: String, config: Configuration): Boolean
-
-    fun createDateHeaderValue(): String {
-        val calendar = Calendar.getInstance()
-        val dateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
-        dateFormat.timeZone = TimeZone.getTimeZone("GMT")
-        return dateFormat.format(calendar.time)
-    }
+interface PingUploader {
+    /**
+     * Synchronously upload a ping to a server.
+     *
+     * @param url the URL path to upload the data to
+     * @param data the serialized text data to send
+     * @param headers a [HeadersList] containing String to String [Pair] with
+     *        the first entry being the header name and the second its value.
+     *
+     * @return true if the ping was correctly dealt with (sent successfully
+     *         or faced an unrecoverable error), false if there was a recoverable
+     *         error callers can deal with.
+     */
+    fun upload(url: String, data: String, headers: HeadersList): Boolean
 }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/PingUploadWorker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/PingUploadWorker.kt
@@ -15,7 +15,6 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import mozilla.components.service.glean.Glean
-import mozilla.components.service.glean.net.HttpPingUploader
 
 /**
  * This class is the worker class used by [WorkManager] to handle uploading the ping to the server.
@@ -38,7 +37,7 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
 
         /**
          * Build the [OneTimeWorkRequest] for enqueueing in the [WorkManager].  This also adds a tag
-         * by which [isWorkScheduled] can tell if the worker object has been enqueued.
+         * by which enqueued requests can be identified.
          *
          * @return [OneTimeWorkRequest] representing the task for the [WorkManager] to enqueue and run
          */
@@ -64,8 +63,8 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
          * @return true if process was successful
          */
         private fun uploadPings(): Boolean {
-            val httpPingUploader = HttpPingUploader()
-            return Glean.pingStorageEngine.process(httpPingUploader::upload)
+            val httpPingUploader = Glean.httpClient
+            return Glean.pingStorageEngine.process(httpPingUploader::doUpload)
         }
 
         /**

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/storages/PingStorageEngine.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/storages/PingStorageEngine.kt
@@ -77,7 +77,7 @@ internal class PingStorageEngine(context: Context) {
      * the ping storage directory.
      *
      * @param processingCallback Callback function to do the actual process action on the ping.
-     *                           Typically this will be the [HttpPingUploader.upload] function.
+     *                           Typically this will be a [PingUploader.upload] function.
      * @return Boolean representing the success of the upload task. This may be the value bubbled up
      *         from the callback, or if there was an error reading the files.
      */

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -22,6 +22,7 @@ import mozilla.components.service.glean.resetGlean
 import mozilla.components.service.glean.triggerWorkManager
 import mozilla.components.service.glean.TestPingTagClient
 import mozilla.components.service.glean.getMockWebServer
+import mozilla.components.service.glean.net.ConceptFetchHttpUploader
 import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Rule
 import org.robolectric.Shadows.shadowOf
@@ -210,7 +211,7 @@ class GleanDebugActivityTest {
 
         // Use the test client in the Glean configuration
         resetGlean(config = Glean.configuration.copy(
-            httpClient = lazy { testClient }
+            httpClient = ConceptFetchHttpUploader(lazy { testClient })
         ))
 
         // Put some metric data in the store, otherwise we won't get a ping out

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/BaseUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/BaseUploaderTest.kt
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean.net
+
+import mozilla.components.service.glean.BuildConfig
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+import java.util.TimeZone
+
+@RunWith(RobolectricTestRunner::class)
+class BaseUploaderTest {
+    private val testPath: String = "/some/random/path/not/important"
+    private val testPing: String = "{ 'ping': 'test' }"
+    private val testDefaultConfig = Configuration().copy(
+        userAgent = "Glean/Test 25.0.2"
+    )
+
+    /**
+     * A stub uploader class that does not upload anything.
+     */
+    private class TestUploader : PingUploader {
+        override fun upload(url: String, data: String, headers: HeadersList): Boolean {
+            return false
+        }
+    }
+
+    @Test
+    fun `upload() must get called with the full submission path`() {
+        val uploader = spy<BaseUploader>(BaseUploader(TestUploader()))
+
+        val expectedUrl = testDefaultConfig.serverEndpoint + testPath
+        uploader.doUpload(testPath, testPing, testDefaultConfig)
+        verify(uploader).upload(eq(expectedUrl), any(), any())
+    }
+
+    @Test
+    fun `All headers are correctly reported for upload`() {
+        val uploader = spy<BaseUploader>(BaseUploader(TestUploader()))
+        `when`(uploader.getCalendarInstance()).thenAnswer {
+            val fakeNow = Calendar.getInstance()
+            fakeNow.clear()
+            fakeNow.timeZone = TimeZone.getTimeZone("GMT")
+            fakeNow.set(2015, 6, 11, 11, 0, 0)
+            fakeNow
+        }
+
+        uploader.doUpload(testPath, testPing, testDefaultConfig)
+        val headersCaptor = argumentCaptor<HeadersList>()
+
+        val expectedUrl = testDefaultConfig.serverEndpoint + testPath
+        verify(uploader).upload(eq(expectedUrl), eq(testPing), headersCaptor.capture())
+
+        val expectedHeaders = mapOf(
+            "Content-Type" to "application/json; charset=utf-8",
+            "Date" to "Sat, 11 Jul 2015 11:00:00 GMT",
+            "User-Agent" to "Glean/Test 25.0.2",
+            "X-Client-Type" to "Glean",
+            "X-Client-Version" to BuildConfig.LIBRARY_VERSION
+        )
+
+        expectedHeaders.forEach { (headerName, headerValue) ->
+            assertEquals(
+                headerValue,
+                headersCaptor.value.find { it.first == headerName }!!.second
+            )
+        }
+    }
+
+    @Test
+    fun `X-Debug-ID header is correctly added when pingTag is not null`() {
+        val uploader = spy<BaseUploader>(BaseUploader(TestUploader()))
+
+        val debugConfig = testDefaultConfig.copy(
+            pingTag = "this-ping-is-tagged"
+        )
+
+        uploader.doUpload(testPath, testPing, debugConfig)
+        val headersCaptor = argumentCaptor<HeadersList>()
+        verify(uploader).upload(any(), any(), headersCaptor.capture())
+
+        assertEquals(
+            "this-ping-is-tagged",
+            headersCaptor.value.find { it.first == "X-Debug-ID" }!!.second
+        )
+    }
+}

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -99,8 +99,8 @@
     <ID>LongMethod:Glean.kt$GleanInternalAPI$ private fun initializeCoreMetrics(applicationContext: Context)</ID>
     <ID>LongMethod:GleanDebugActivity.kt$GleanDebugActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:HttpIconLoader.kt$HttpIconLoader$override fun load(context: Context, request: IconRequest, resource: IconRequest.Resource): IconLoader.Result</ID>
-    <ID>LongMethod:HttpPingUploader.kt$HttpPingUploader$@Throws(IOException::class) internal fun performUpload(client: Client, request: Request): Boolean</ID>
-    <ID>LongMethod:HttpPingUploader.kt$HttpPingUploader$@VisibleForTesting(otherwise = PRIVATE) internal fun buildRequest(path: String, data: String, config: Configuration): Request</ID>
+    <ID>LongMethod:ConceptFetchHttpUploader.kt$HttpPingUploader$@Throws(IOException::class) internal fun performUpload(client: Client, request: Request): Boolean</ID>
+    <ID>LongMethod:ConceptFetchHttpUploader.kt$HttpPingUploader$@VisibleForTesting(otherwise = PRIVATE) internal fun buildRequest(path: String, data: String, config: Configuration): Request</ID>
     <ID>LongMethod:HttpURLConnectionClient.kt$private fun createBody(connection: HttpURLConnection, contentType: String?): Response.Body</ID>
     <ID>LongMethod:ICOIconDecoderTest.kt$ICOIconDecoderTest$@Test fun testIconSizesOfGolemFavicon()</ID>
     <ID>LongMethod:ICOIconDecoderTest.kt$ICOIconDecoderTest$@Test fun testIconSizesOfMicrosoftFavicon()</ID>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,9 @@ permalink: /changelog/
 * **feature-downloads**
   *  ⚠️ **This is a breaking change**: The `feature-downloads` component has been migrated to `browser-state` from `browser-session`. Therefore creating a `DownloadsFeature` requires a `BrowserStore` instance (instead of a `SessionManager` instance) and a `DownloadsUseCases` instance now.
 
+* **service-glean**
+  * ⚠️ **This is a breaking change**: applications need to use `ConceptFetchHttpUploader` for overriding the ping uploading mechanism instead of directly using `concept-fetch` implementations.
+
 # 12.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v11.0.0...v12.0.0)


### PR DESCRIPTION
This additionally works around a [compiler bug](https://youtrack.jetbrains.com/issue/KT-33799) in `ConceptFetchHttpUploaderTest.kt` by removing the `'*'` in the test function name. Moreover, it splits
test coverage by moving upload logic tests from `ConceptFetchHttpUploader` to `PingUploaderTest`.

**What happens when moving to glean-core?**
- `ConceptFetchHttpUploader` will live in Android Components, together with its test file.
- The Glean SDK repo will provide its own basic uploader using the http Android API (not used by A-C).

**Reviewers**

@pocmo any chance you could take a look to the overall design and to the changelog entry? This is for fixing [the megazording blocker you mentioned](https://bugzilla.mozilla.org/show_bug.cgi?id=1576773).
@badboy and @mdboom does the overall design make sense to you? Does the strategy for moving to glean-core sound ok?

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
