### PR TITLE
Closes #4282: Migrate feature-downloads to use browser-state.

### DIFF
--- a/components/feature/downloads/build.gradle
+++ b/components/feature/downloads/build.gradle
@@ -22,6 +22,12 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
 
     implementation project(':browser-session')

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -22,7 +22,7 @@ import androidx.core.net.toUri
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Header
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_LENGTH
@@ -83,7 +83,7 @@ abstract class AbstractFetchDownloadService : CoroutineService() {
         sendDownloadCompleteBroadcast(downloadID)
     }
 
-    private suspend fun performDownload(download: Download) = withContext(IO) {
+    private suspend fun performDownload(download: DownloadState) = withContext(IO) {
         val headers = listOf(
             CONTENT_TYPE to download.contentType,
             CONTENT_LENGTH to download.contentLength?.toString(),
@@ -120,7 +120,7 @@ abstract class AbstractFetchDownloadService : CoroutineService() {
      * Encapsulates different behaviour depending on the SDK version.
      */
     internal fun useFileStream(
-        download: Download,
+        download: DownloadState,
         block: (OutputStream) -> Unit
     ) {
         if (SDK_INT >= Build.VERSION_CODES.Q) {
@@ -131,7 +131,7 @@ abstract class AbstractFetchDownloadService : CoroutineService() {
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
-    private fun useFileStreamScopedStorage(download: Download, block: (OutputStream) -> Unit) {
+    private fun useFileStreamScopedStorage(download: DownloadState, block: (OutputStream) -> Unit) {
         val values = ContentValues().apply {
             put(MediaStore.Downloads.DISPLAY_NAME, download.fileName)
             put(MediaStore.Downloads.MIME_TYPE, download.contentType ?: "*/*")
@@ -153,7 +153,7 @@ abstract class AbstractFetchDownloadService : CoroutineService() {
 
     @TargetApi(Build.VERSION_CODES.P)
     @Suppress("Deprecation")
-    private fun useFileStreamLegacy(download: Download, block: (OutputStream) -> Unit) {
+    private fun useFileStreamLegacy(download: DownloadState, block: (OutputStream) -> Unit) {
         val dir = Environment.getExternalStoragePublicDirectory(download.destinationDirectory)
         val file = File(dir, download.fileName!!)
         FileOutputStream(file).use(block)

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadDialogFragment.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadDialogFragment.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.downloads
 
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.support.utils.DownloadUtils
 
 /**
@@ -24,10 +24,12 @@ abstract class DownloadDialogFragment : DialogFragment() {
      */
     var onStartDownload: () -> Unit = {}
 
+    var onCancelDownload: () -> Unit = {}
+
     /**
      * add the metadata of this download object to the arguments of this fragment.
      */
-    fun setDownload(download: Download) {
+    fun setDownload(download: DownloadState) {
         val args = arguments ?: Bundle()
         args.putString(KEY_FILE_NAME, download.fileName
             ?: DownloadUtils.guessFileName(null, download.url, download.contentType))

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsUseCases.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsUseCases.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads
+
+import mozilla.components.browser.session.Download
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+
+/**
+ * Contains use cases related to the downloads feature.
+ *
+ * @param sessionManager the application's [SessionManager].
+ */
+class DownloadsUseCases(
+    sessionManager: SessionManager
+) {
+    class ConsumeDownloadUseCase(
+        private val sessionManager: SessionManager
+    ) {
+        /**
+         * Consumes the [Download] with the given [downloadId] from the [Session] with the given
+         * [tabId].
+         */
+        operator fun invoke(tabId: String, downloadId: String) {
+            sessionManager.findSessionById(tabId)?.let { session ->
+                session.download.consume {
+                    it.id == downloadId
+                }
+            }
+        }
+    }
+
+    val consumeDownload = ConsumeDownloadUseCase(sessionManager)
+}

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragment.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragment.kt
@@ -49,8 +49,10 @@ class SimpleDownloadDialogFragment : DownloadDialogFragment() {
                     onStartDownload()
                 }
                 .setNegativeButton(negativeButtonText) { _, _ ->
+                    onCancelDownload()
                     dismiss()
                 }
+                .setOnCancelListener { onCancelDownload() }
                 .setCancelable(cancelable)
                 .create()
         }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/DownloadState.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/DownloadState.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.downloads.ext
 
 import androidx.core.net.toUri
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.fetch.Headers
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_DISPOSITION
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_LENGTH
@@ -14,7 +14,7 @@ import mozilla.components.support.utils.DownloadUtils
 import java.io.InputStream
 import java.net.URLConnection
 
-fun Download.isScheme(protocols: Iterable<String>): Boolean {
+internal fun DownloadState.isScheme(protocols: Iterable<String>): Boolean {
     val scheme = url.trim().toUri().scheme ?: return false
     return protocols.contains(scheme)
 }
@@ -25,7 +25,7 @@ fun Download.isScheme(protocols: Iterable<String>): Boolean {
  * @param headers Headers from the response.
  * @param stream Stream of the response body.
  */
-fun Download.withResponse(headers: Headers, stream: InputStream?): Download {
+internal fun DownloadState.withResponse(headers: Headers, stream: InputStream?): DownloadState {
     val contentDisposition = headers[CONTENT_DISPOSITION]
     var contentType = this.contentType
     if (contentType == null && stream != null) {

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/Intent.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/ext/Intent.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.downloads.ext
 
 import android.content.Intent
 import androidx.core.os.bundleOf
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_LENGTH
 import mozilla.components.concept.fetch.Headers.Names.CONTENT_TYPE
 import mozilla.components.concept.fetch.Headers.Names.REFERRER
@@ -17,7 +17,7 @@ private const val INTENT_URL = "mozilla.components.feature.downloads.URL"
 private const val INTENT_FILE_NAME = "mozilla.components.feature.downloads.FILE_NAME"
 private const val INTENT_DESTINATION = "mozilla.components.feature.downloads.DESTINATION"
 
-fun Intent.putDownloadExtra(download: Download) {
+fun Intent.putDownloadExtra(download: DownloadState) {
     download.apply {
         putExtra(INTENT_DOWNLOAD, bundleOf(
             INTENT_URL to url,
@@ -31,14 +31,14 @@ fun Intent.putDownloadExtra(download: Download) {
     }
 }
 
-fun Intent.getDownloadExtra(): Download? =
+fun Intent.getDownloadExtra(): DownloadState? =
     getBundleExtra(INTENT_DOWNLOAD)?.run {
         val url = getString(INTENT_URL)
         val fileName = getString(INTENT_FILE_NAME)
         val destination = getString(INTENT_DESTINATION)
         if (url == null || destination == null) return null
 
-        Download(
+        DownloadState(
             url = url,
             fileName = fileName,
             contentType = getString(CONTENT_TYPE),

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/AndroidDownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/AndroidDownloadManager.kt
@@ -19,7 +19,7 @@ import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.core.util.isEmpty
 import androidx.core.util.set
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.fetch.Headers.Names.COOKIE
 import mozilla.components.concept.fetch.Headers.Names.REFERRER
 import mozilla.components.concept.fetch.Headers.Names.USER_AGENT
@@ -39,7 +39,7 @@ class AndroidDownloadManager(
     override var onDownloadCompleted: OnDownloadCompleted = noop
 ) : BroadcastReceiver(), DownloadManager {
 
-    private val queuedDownloads = LongSparseArray<Download>()
+    private val queuedDownloads = LongSparseArray<DownloadState>()
     private var isSubscribedReceiver = false
 
     override val permissions = arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
@@ -51,7 +51,7 @@ class AndroidDownloadManager(
      * @return the id reference of the scheduled download.
      */
     @RequiresPermission(allOf = [INTERNET, WRITE_EXTERNAL_STORAGE])
-    override fun download(download: Download, cookie: String): Long? {
+    override fun download(download: DownloadState, cookie: String): Long? {
 
         val androidDownloadManager: SystemDownloadManager = applicationContext.getSystemService()!!
 
@@ -112,7 +112,7 @@ class AndroidDownloadManager(
     }
 }
 
-private fun Download.toAndroidRequest(cookie: String): SystemRequest {
+private fun DownloadState.toAndroidRequest(cookie: String): SystemRequest {
     val request = SystemRequest(url.toUri())
         .setNotificationVisibility(VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
 

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/DownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/DownloadManager.kt
@@ -5,10 +5,10 @@
 package mozilla.components.feature.downloads.manager
 
 import android.content.Context
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.support.ktx.android.content.isPermissionGranted
 
-typealias OnDownloadCompleted = (Download, Long) -> Unit
+typealias OnDownloadCompleted = (DownloadState, Long) -> Unit
 
 interface DownloadManager {
 
@@ -23,7 +23,7 @@ interface DownloadManager {
      * @return the id reference of the scheduled download.
      */
     fun download(
-        download: Download,
+        download: DownloadState,
         cookie: String = ""
     ): Long?
 

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
@@ -19,7 +19,7 @@ import android.util.LongSparseArray
 import androidx.core.util.isEmpty
 import androidx.core.util.set
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import mozilla.components.feature.downloads.ext.isScheme
 import mozilla.components.feature.downloads.ext.putDownloadExtra
@@ -39,7 +39,7 @@ class FetchDownloadManager<T : AbstractFetchDownloadService>(
     override var onDownloadCompleted: OnDownloadCompleted = noop
 ) : BroadcastReceiver(), DownloadManager {
 
-    private val queuedDownloads = LongSparseArray<Download>()
+    private val queuedDownloads = LongSparseArray<DownloadState>()
     private var isSubscribedReceiver = false
 
     override val permissions = if (SDK_INT >= P) {
@@ -54,7 +54,7 @@ class FetchDownloadManager<T : AbstractFetchDownloadService>(
      * @param cookie any additional cookie to add as part of the download request.
      * @return the id reference of the scheduled download.
      */
-    override fun download(download: Download, cookie: String): Long? {
+    override fun download(download: DownloadState, cookie: String): Long? {
         if (!download.isScheme(listOf("http", "https"))) {
             // We are ignoring everything that is not http or https. This is a limitation of
             // GeckoView: https://bugzilla.mozilla.org/show_bug.cgi?id=1501735 and

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -9,7 +9,7 @@ import android.content.Intent
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
@@ -49,7 +49,7 @@ class AbstractFetchDownloadServiceTest {
 
     @Test
     fun `begins download when started`() = runBlocking {
-        val download = Download("https://example.com/file.txt", "file.txt")
+        val download = DownloadState("https://example.com/file.txt", "file.txt")
         val response = Response(
             "https://example.com/file.txt",
             200,
@@ -66,7 +66,7 @@ class AbstractFetchDownloadServiceTest {
 
         service.onStartCommand(downloadIntent, 0)
 
-        val providedDownload = argumentCaptor<Download>()
+        val providedDownload = argumentCaptor<DownloadState>()
         verify(service).useFileStream(providedDownload.capture(), any())
         assertEquals(download.url, providedDownload.value.url)
         assertEquals(download.fileName, providedDownload.value.fileName)

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.downloads
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.KEY_FILE_NAME
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -17,12 +17,12 @@ import org.junit.runner.RunWith
 class DownloadDialogFragmentTest {
 
     private lateinit var dialog: DownloadDialogFragment
-    private lateinit var download: Download
+    private lateinit var download: DownloadState
 
     @Before
     fun setup() {
         dialog = object : DownloadDialogFragment() {}
-        download = Download(
+        download = DownloadState(
             "http://ipv4.download.thinkbroadband.com/5MB.zip",
             "5MB.zip", "application/zip", 5242880,
             "Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -6,20 +6,36 @@ package mozilla.components.feature.downloads
 
 import android.Manifest.permission.INTERNET
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-import androidx.core.content.PermissionChecker
+import android.content.pm.PackageManager
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.concept.engine.Engine
-import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.FRAGMENT_TAG
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.manager.DownloadManager
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -27,300 +43,308 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoMoreInteractions
+import org.robolectric.shadows.ShadowToast
 
 @RunWith(AndroidJUnit4::class)
 class DownloadsFeatureTest {
+    private val testDispatcher = TestCoroutineDispatcher()
 
-    private lateinit var feature: DownloadsFeature
-    private lateinit var mockDownloadManager: DownloadManager
-    private lateinit var mockSessionManager: SessionManager
+    private lateinit var store: BrowserStore
 
     @Before
-    fun setup() {
-        val engine = mock<Engine>()
-        mockSessionManager = spy(SessionManager(engine))
-        mockDownloadManager = mock()
-        `when`(mockDownloadManager.permissions).thenReturn(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE))
-        feature = DownloadsFeature(testContext,
-            downloadManager = mockDownloadManager,
-            sessionManager = mockSessionManager)
-    }
+    @ExperimentalCoroutinesApi
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
 
-    @Test
-    fun `when valid sessionId is provided, observe it's session`() {
-        feature = spy(DownloadsFeature(
-            testContext,
-            downloadManager = mockDownloadManager,
-            sessionManager = mockSessionManager,
-            sessionId = "123"
+        store = BrowserStore(BrowserState(
+            tabs = listOf(createTab("https://www.mozilla.org", id = "test-tab")),
+            selectedTabId = "test-tab"
         ))
-        `when`(mockSessionManager.findSessionById(anyString())).thenReturn(mock())
+    }
 
-        feature.start()
-
-        verify(feature).observeIdOrSelected(anyString())
-        verify(feature).observeFixed(any())
+    @After
+    @ExperimentalCoroutinesApi
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test
-    fun `when sessionId is NOT provided, observe selected session`() {
-        feature = spy(DownloadsFeature(
+    fun `Adding a download object will request permissions if needed`() {
+        val fragmentManager: FragmentManager = mock()
+
+        var requestedPermissions = false
+
+        val feature = DownloadsFeature(
             testContext,
-            downloadManager = mockDownloadManager,
-            sessionManager = mockSessionManager
+            store,
+            useCases = mock(),
+            onNeedToRequestPermissions = { requestedPermissions = true },
+            fragmentManager = mockFragmentManager()
+        )
+
+        feature.start()
+
+        assertFalse(requestedPermissions)
+
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download = mock()))
+            .joinBlocking()
+
+        testDispatcher.advanceUntilIdle()
+
+        assertTrue(requestedPermissions)
+        verify(fragmentManager, never()).beginTransaction()
+    }
+
+    @Test
+    fun `Adding a download when permissions are granted will show dialog`() {
+        val fragmentManager: FragmentManager = mockFragmentManager()
+
+        grantPermissions()
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            fragmentManager = fragmentManager
+        )
+
+        feature.start()
+
+        verify(fragmentManager, never()).beginTransaction()
+
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download = mock()))
+            .joinBlocking()
+
+        testDispatcher.advanceUntilIdle()
+
+        verify(fragmentManager).beginTransaction()
+    }
+
+    @Test
+    fun `Adding a download without a fragment manager will start download immediately`() {
+        grantPermissions()
+
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = downloadManager
+        )
+
+        feature.start()
+
+        verify(downloadManager, never()).download(any(), anyString())
+
+        val download: DownloadState = mock()
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
+            .joinBlocking()
+
+        testDispatcher.advanceUntilIdle()
+
+        verify(downloadManager).download(eq(download), anyString())
+    }
+
+    @Test
+    fun `When starting the feature will reattach to already existing dialog`() {
+        grantPermissions()
+
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download = mock()))
+            .joinBlocking()
+
+        val dialogFragment: DownloadDialogFragment = mock()
+        val fragmentManager: FragmentManager = mock()
+        doReturn(dialogFragment).`when`(fragmentManager).findFragmentByTag(DownloadDialogFragment.FRAGMENT_TAG)
+
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = downloadManager,
+            fragmentManager = fragmentManager
+        )
+
+        assertNotEquals(dialogFragment, feature.dialog)
+
+        feature.start()
+
+        assertEquals(dialogFragment, feature.dialog)
+        verify(dialogFragment).onStartDownload = any()
+        verify(dialogFragment).onCancelDownload = any()
+    }
+
+    @Test
+    fun `onPermissionsResult will start download if permissions were granted`() {
+        val download: DownloadState = mock()
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download = download))
+            .joinBlocking()
+
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = downloadManager
+        )
+
+        feature.start()
+
+        verify(downloadManager, never()).download(download)
+
+        grantPermissions()
+
+        feature.onPermissionsResult(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
+            arrayOf(PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED).toIntArray())
+
+        verify(downloadManager).download(download)
+    }
+
+    @Test
+    fun `onPermissionsResult will consume download if permissions were not granted`() {
+        val store = BrowserStore()
+        val sessionManager = SessionManager(engine = mock(), store = store)
+
+        val session = Session("https://www.mozilla.org", id = "test-tab")
+        sessionManager.add(session)
+        session.download = Consumable.from(Download("https://www.mozilla.org"))
+
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = DownloadsUseCases(sessionManager),
+            downloadManager = downloadManager
+        )
+
+        feature.start()
+
+        println(store.state.findTab("test-tab"))
+        assertNotNull(store.state.findTab("test-tab")!!.content.download)
+
+        feature.onPermissionsResult(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
+            arrayOf(PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED).toIntArray())
+
+        assertNull(store.state.findTab("test-tab")!!.content.download)
+
+        verify(downloadManager, never()).download(any(), anyString())
+    }
+
+    @Test
+    fun `Calling stop() will unregister listeners from download manager`() {
+        val downloadManager: DownloadManager = mock()
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = downloadManager
+        )
+
+        feature.start()
+
+        verify(downloadManager, never()).unregisterListeners()
+
+        feature.stop()
+
+        verify(downloadManager).unregisterListeners()
+    }
+
+    @Test
+    fun `DownloadManager failing to start download will cause error toast to be displayed`() {
+        grantPermissions()
+
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
+
+        doReturn(null).`when`(downloadManager).download(any(), anyString())
+
+        val feature = spy(DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = downloadManager
         ))
 
-        feature.start()
-
-        verify(feature).observeIdOrSelected(null)
-        verify(feature).observeSelected()
-    }
-
-    @Test
-    fun `when start is called must register SessionManager observers `() {
-        feature.start()
-        verify(mockSessionManager).register(feature)
-    }
-
-    @Test
-    fun `when stop is called must unregister SessionManager observers `() {
-        feature.stop()
-        verify(mockSessionManager).unregister(feature)
-    }
-
-    @Test
-    fun `when a download is notify must pass it to the download manager`() {
-        val session = Session("https://mozilla.com")
-        val download = mock<Download>()
-        grantPermissions()
-
-        mockSessionManager.add(session)
-        mockSessionManager.select(session)
-        feature.start()
-
-        session.download = Consumable.from(download)
-
-        verify(mockDownloadManager).download(download)
-    }
-
-    @Test
-    fun `when new session is select must register an observer on it `() {
-        val session = mock<Session>()
-        val download = mock<Download>()
+        doNothing().`when`(feature).showDownloadNotSupportedError()
 
         feature.start()
-        session.notifyObservers {
-            onDownload(session, download)
-        }
-        with(mockSessionManager) {
-            add(session)
-            select(session)
-        }
 
-        verify(session, times(2)).register(any())
+        verify(downloadManager, never()).download(any(), anyString())
+        verify(feature, never()).showDownloadNotSupportedError()
+
+        val download: DownloadState = mock()
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
+            .joinBlocking()
+
+        testDispatcher.advanceUntilIdle()
+
+        verify(downloadManager).download(eq(download), anyString())
+        verify(feature).showDownloadNotSupportedError()
     }
 
     @Test
-    fun `after stop is called, new download must not pass to the download manager `() {
-        val session = Session("https://mozilla.com")
-        val download = mock<Download>()
+    fun `showDownloadNotSupportedError shows toast`() {
+        // We need to create a Toast on the actual main thread (with a Looper) and therefore reset
+        // the main dispatcher that was set to a TestDispatcher in setUp().
+        Dispatchers.resetMain()
 
         grantPermissions()
 
-        feature.start()
-        mockSessionManager.add(session)
-        mockSessionManager.select(session)
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
 
-        verify(mockDownloadManager).onDownloadCompleted = any()
+        doReturn(null).`when`(downloadManager).download(any(), anyString())
 
-        session.notifyObservers {
-            onDownload(session, download)
-        }
+        val feature = spy(DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = downloadManager
+        ))
 
-        verify(mockDownloadManager).permissions
-        verify(mockDownloadManager).download(download)
-        feature.stop()
+        feature.showDownloadNotSupportedError()
 
-        verify(mockDownloadManager).unregisterListeners()
-
-        session.download = Consumable.from(download)
-
-        verifyNoMoreInteractions(mockDownloadManager)
+        val toast = ShadowToast.getTextOfLatestToast()
+        assertNotNull(toast)
+        assertTrue(toast.contains("can’t download this file type"))
     }
+}
 
-    @Test
-    fun `when a download came and permissions aren't granted needToRequestPermissions must be called `() {
-        var needToRequestPermissionCalled = false
+private fun grantPermissions() {
+    grantPermission(INTERNET, WRITE_EXTERNAL_STORAGE)
+}
 
-        feature.onNeedToRequestPermissions = { needToRequestPermissionCalled = true }
-
-        feature.start()
-        val download = startDownload()
-
-        verify(mockDownloadManager, never()).download(download)
-        assertTrue(needToRequestPermissionCalled)
-    }
-
-    @Test
-    fun `when a downloading & permissions aren't granted needToRequestPermissions, after onPermissionsGranted the download must be triggered`() {
-        var needToRequestPermissionCalled = false
-
-        feature.onNeedToRequestPermissions = { needToRequestPermissionCalled = true }
-
-        feature.start()
-
-        val download = startDownload()
-
-        verify(mockDownloadManager, times(0)).download(download)
-        assertTrue(needToRequestPermissionCalled)
-
-        grantPermissions()
-
-        feature.onPermissionsResult(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
-                intArrayOf(PermissionChecker.PERMISSION_GRANTED, PermissionChecker.PERMISSION_GRANTED))
-        verify(mockDownloadManager).download(download)
-    }
-
-    @Test
-    fun `when fragmentManager is not null a confirmation dialog must be show before starting a download`() {
-        val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock<FragmentManager>()
-
-        `when`(mockFragmentManager.beginTransaction()).thenReturn(mock())
-
-        val featureWithDialog =
-            DownloadsFeature(
-                testContext,
-                downloadManager = mockDownloadManager,
-                sessionManager = mockSessionManager,
-                fragmentManager = mockFragmentManager,
-                dialog = mockDialog
-            )
-
-        grantPermissions()
-
-        featureWithDialog.start()
-
-        val download = startDownload()
-
-        verify(mockDialog).show(mockFragmentManager, FRAGMENT_TAG)
-        mockDialog.onStartDownload()
-        verify(mockDownloadManager).download(download)
-    }
-
-    @Test
-    fun `feature with a sessionId will re-attach to already existing fragment`() {
-        val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock<FragmentManager>()
-        val mockDownload: Consumable<Download> = mock()
-        val mockSession: Session = mock()
-
-        doReturn(mockDownload).`when`(mockSession).download
-        doReturn("sessionId").`when`(mockSession).id
-        doReturn(mockDialog).`when`(mockFragmentManager).findFragmentByTag(any())
-
-        mockSessionManager.add(mockSession)
-
-        val feature =
-            DownloadsFeature(
-                testContext,
-                downloadManager = mockDownloadManager,
-                sessionId = "sessionId",
-                sessionManager = mockSessionManager,
-                fragmentManager = mockFragmentManager
-            )
-
-        feature.start()
-        assertTrue(feature.dialog !is SimpleDownloadDialogFragment)
-        verify(mockSession).download
-    }
-
-    @Test
-    fun `feature with a selected session will re-attach to already existing fragment`() {
-        val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock<FragmentManager>()
-        val mockDownload: Consumable<Download> = mock()
-        val mockSession: Session = mock()
-
-        doReturn(mockDownload).`when`(mockSession).download
-        doReturn("sessionId").`when`(mockSession).id
-        doReturn(mockDialog).`when`(mockFragmentManager).findFragmentByTag(any())
-
-        mockSessionManager.add(mockSession)
-        mockSessionManager.select(mockSession)
-
-        val feature =
-            DownloadsFeature(
-                testContext,
-                downloadManager = mockDownloadManager,
-                sessionId = "sessionId",
-                sessionManager = mockSessionManager,
-                fragmentManager = mockFragmentManager
-            )
-
-        feature.start()
-        assertTrue(feature.dialog !is SimpleDownloadDialogFragment)
-        verify(mockSession).download
-    }
-
-    @Test
-    fun `shouldn't show twice a dialog if is already created`() {
-        val mockDialog = spy(DownloadDialogFragment::class.java)
-        val mockFragmentManager = mock<FragmentManager>()
-
-        `when`(mockFragmentManager.findFragmentByTag(FRAGMENT_TAG)).thenReturn(mockDialog)
-
-        val featureWithDialog =
-            DownloadsFeature(
-                testContext,
-                downloadManager = mockDownloadManager,
-                sessionManager = mockSessionManager,
-                fragmentManager = mockFragmentManager
-            )
-
-        grantPermissions()
-
-        featureWithDialog.start()
-
-        startDownload()
-
-        verify(mockDialog, times(0)).show(mockFragmentManager, FRAGMENT_TAG)
-    }
-
-    @Test
-    fun `download is cleared when permissions denied`() {
-        feature.start()
-        feature.onPermissionsResult(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
-                intArrayOf(PermissionChecker.PERMISSION_GRANTED, PermissionChecker.PERMISSION_GRANTED))
-        assertNull(mockSessionManager.selectedSession)
-
-        val download = startDownload()
-        feature.onPermissionsResult(arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
-                intArrayOf(PermissionChecker.PERMISSION_GRANTED, PermissionChecker.PERMISSION_DENIED))
-
-        verify(mockDownloadManager, never()).download(download)
-        assertNotNull(mockSessionManager.selectedSession)
-        assertTrue(mockSessionManager.selectedSession!!.download.isConsumed())
-    }
-
-    private fun startDownload(): Download {
-        val session = Session("https://mozilla.com")
-        val download = mock<Download>()
-
-        mockSessionManager.add(session)
-        mockSessionManager.select(session)
-        session.download = Consumable.from(download)
-        return download
-    }
-
-    private fun grantPermissions() {
-        grantPermission(INTERNET, WRITE_EXTERNAL_STORAGE)
-    }
+private fun mockFragmentManager(): FragmentManager {
+    val fragmentManager: FragmentManager = mock()
+    doReturn(mock<FragmentTransaction>()).`when`(fragmentManager).beginTransaction()
+    return fragmentManager
 }

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt
@@ -10,7 +10,7 @@ import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
 import android.app.DownloadManager.Request
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.robolectric.testContext
@@ -27,12 +27,12 @@ import org.mockito.Mockito.verifyZeroInteractions
 @RunWith(AndroidJUnit4::class)
 class AndroidDownloadManagerTest {
 
-    private lateinit var download: Download
+    private lateinit var download: DownloadState
     private lateinit var downloadManager: AndroidDownloadManager
 
     @Before
     fun setup() {
-        download = Download(
+        download = DownloadState(
             "http://ipv4.download.thinkbroadband.com/5MB.zip",
             "", "application/zip", 5242880,
             "Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/FetchDownloadManagerTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/FetchDownloadManagerTest.kt
@@ -13,7 +13,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Download
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import mozilla.components.support.test.any
@@ -33,14 +33,14 @@ class FetchDownloadManagerTest {
 
     private lateinit var broadcastManager: LocalBroadcastManager
     private lateinit var service: MockDownloadService
-    private lateinit var download: Download
+    private lateinit var download: DownloadState
     private lateinit var downloadManager: FetchDownloadManager<MockDownloadService>
 
     @Before
     fun setup() {
         broadcastManager = LocalBroadcastManager.getInstance(testContext)
         service = MockDownloadService()
-        download = Download(
+        download = DownloadState(
             "http://ipv4.download.thinkbroadband.com/5MB.zip",
             "", "application/zip", 5242880,
             "Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-pwa**
   * Adds `WebAppUseCases.isInstallable` to check if the current session can be installed as a Progressive Web App.
 
+* **feature-downloads**
+  *  ⚠️ **This is a breaking change**: The `feature-downloads` component has been migrated to `browser-state` from `browser-session`. Therefore creating a `DownloadsFeature` requires a `BrowserStore` instance (instead of a `SessionManager` instance) and a `DownloadsUseCases` instance now.
+
 # 12.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v11.0.0...v12.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -106,7 +106,8 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler {
         downloadsFeature.set(
             feature = DownloadsFeature(
                 requireContext().applicationContext,
-                sessionManager = components.sessionManager,
+                store = components.store,
+                useCases = components.downloadsUseCases,
                 fragmentManager = childFragmentManager,
                 onDownloadCompleted = { download, id ->
                     Logger.debug("Download done. ID#$id $download")

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -30,6 +30,7 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
+import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.intent.processing.TabIntentProcessor
 import mozilla.components.feature.media.MediaFeature
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
@@ -224,4 +225,6 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     // Tabs
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(sessionManager) }
+
+    val downloadsUseCases: DownloadsUseCases by lazy { DownloadsUseCases(sessionManager) }
 }


### PR DESCRIPTION
As discussed before this migrates everything in `feature-downloads` from `browser-session` to `browser-state`. The last part using `browser-session` is the newly introduced `DownloadsUseCases` for now.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
