### PR TITLE
Add WebCompat Addon as feature-webcompat

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -120,6 +120,10 @@ projects:
     path: components/feature/qr
     description: 'A feature that provides functionality for scanning QR codes.'
     publish: true
+  feature-webcompat:
+    path: components/feature/webcompat
+    description: 'Feature that provides hotfixes for websites from Mozillas Web Compatibility team'
+    publish: true
   browser-awesomebar:
     path: components/browser/awesomebar
     description: 'A customizable awesomebar component for browsers.'

--- a/components/feature/webcompat/README.md
+++ b/components/feature/webcompat/README.md
@@ -1,0 +1,32 @@
+# [Android Components](../../../README.md) > Feature > WebCompat
+
+Feature to enable website-hotfixing via the Web Compatibility System-Addon. More details are available at:
+
+* [`github.com/mozilla/webcompat-addon`](https://github.com/mozilla/webcompat-addon), where the Web-Extension sources are tracked.
+* [The Mozilla Wiki](https://wiki.mozilla.org/Compatibility/Go_Faster_Addon), where more information about the background of this extensions are available and our processes for authoring site patches are outlined.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-webcompat:{latest-version}"
+```
+
+### Install WebExtension
+
+To install the WebExtension, run
+
+```kotlin
+WebCompatFeature.install(engine)
+```
+
+Please make sure to only run this once, as the feature itself does not check if the extension is already installed.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/webcompat/build.gradle
+++ b/components/feature/webcompat/build.gradle
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':concept-engine')
+
+    implementation Dependencies.androidx_core_ktx
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/feature/webcompat/proguard-rules.pro
+++ b/components/feature/webcompat/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/webcompat/src/main/AndroidManifest.xml
+++ b/components/feature/webcompat/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.webcompat" >
+
+    <application android:supportsRtl="true" />
+</manifest>

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/AboutCompat.jsm
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/AboutCompat.jsm
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["AboutCompat"];
+
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+const addonID = "webcompat@mozilla.org";
+const addonPageRelativeURL = "/about-compat/aboutCompat.html";
+
+function AboutCompat() {
+  this.chromeURL = WebExtensionPolicy.getByID(addonID).getURL(
+    addonPageRelativeURL
+  );
+}
+AboutCompat.prototype = {
+  QueryInterface: ChromeUtils.generateQI([Ci.nsIAboutModule]),
+  getURIFlags() {
+    return Ci.nsIAboutModule.URI_MUST_LOAD_IN_EXTENSION_PROCESS;
+  },
+
+  newChannel(aURI, aLoadInfo) {
+    const uri = Services.io.newURI(this.chromeURL);
+    const channel = Services.io.newChannelFromURIWithLoadInfo(uri, aLoadInfo);
+    channel.originalURI = aURI;
+
+    channel.owner = (Services.scriptSecurityManager.createContentPrincipal ||
+      Services.scriptSecurityManager.createCodebasePrincipal)(
+      uri,
+      aLoadInfo.originAttributes
+    );
+    return channel;
+  },
+};

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutCompat.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutCompat.css
@@ -1,0 +1,202 @@
+@media (any-pointer: fine) {
+  :root {
+    font-family: sans-serif;
+    margin: 40px auto;
+    min-width: 30em;
+    max-width: 60em;
+  }
+
+  table {
+    width: 100%;
+    padding-bottom: 2em;
+  }
+
+  .float-right {
+    float: right;
+  }
+
+  .hidden {
+    display: none;
+  }
+
+  .table-title-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .wide-button {
+    display: block;
+    min-height: 32px;
+    padding-left: 30px;
+    padding-right: 30px;
+  }
+
+  .submitting {
+    background-image: url(chrome://global/skin/icons/loading.png);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 16px;
+  }
+
+  .submitting .submit-crash-button-label {
+    display: none;
+  }
+
+  .failed-to-submit {
+    color: #ca8695;
+  }
+
+  a.button-as-link {
+    -moz-appearance: none;
+    min-height: 30px;
+    color: var(--in-content-text-color) !important;
+    border: 1px solid var(--in-content-box-border-color) !important;
+    border-radius: 2px;
+    background-color: var(--in-content-page-background);
+    line-height: 30px;
+    margin: 4px 8px;
+    /* Ensure font-size isn't overridden by widget styling (e.g. in forms.css) */
+    font-size: 1em;
+  }
+
+  a.button-as-link:hover {
+    background-color: var(--in-content-box-background-hover) !important;
+    text-decoration: none;
+  }
+
+  h2.lighter-font-weight {
+    font-weight: lighter;
+  }
+
+  html[dir="ltr"] th {
+    text-align: left;
+  }
+
+  html[dir="rtl"] th {
+    text-align: right;
+  }
+}
+
+@media (any-pointer: coarse), (any-pointer: none) {
+  * {
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    font-family: sans-serif;
+    font-size: 14px;
+    -moz-text-size-adjust: none;
+    background-color: #f5f5f5;
+  }
+
+  table,
+  tr,
+  p {
+    display: block;
+    background: #fff;
+  }
+
+  table {
+    border-top: 2px solid #0a84ff;
+    margin-top: -2px;
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+    display: none;
+  }
+
+  tr {
+    position: relative;
+    border-bottom: 1px solid #d7d9db;
+    padding: 1em;
+  }
+
+  a {
+    color: #000;
+    font-size: 94%;
+  }
+
+  .tab {
+    cursor: pointer;
+    position: relative;
+    z-index: 2;
+    display: inline-block;
+    text-align: left;
+    padding: 1em;
+    font-weight: bold;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    border: 1px solid #d7d9db;
+    border-bottom: 0;
+    margin-bottom: 2px;
+    background: #f5f5f5;
+    color: #363b40;
+    font-size: 1em;
+    font-weight: bold;
+    padding: 1em;
+  }
+
+  .tab.active {
+    border-bottom-color: #fff;
+    background: #fff;
+    margin-bottom: 0;
+    padding-bottom: calc(1em + 2px);
+  }
+
+  .tab.active + table {
+    display: block;
+  }
+
+  td {
+    display: block;
+    position: relative;
+  }
+  td:dir(ltr) {
+    padding-right: 6.5em;
+  }
+  td:dir(rtl) {
+    padding-left: 6.5em;
+  }
+
+  td[colspan="4"] {
+    padding: 1em;
+    font-style: italic;
+    text-align: center;
+  }
+
+  td:not([colspan]):nth-child(1) {
+    font-weight: bold;
+  }
+
+  td:not([colspan]):nth-child(1) {
+    padding-bottom: 0.25em;
+  }
+
+  td:nth-child(3) {
+    display: contents;
+  }
+
+  button {
+    background: #e8e8e7;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 6em;
+    border: 0;
+    border-left: 1px solid #d7d9db;
+    -moz-appearance: none;
+    color: #000;
+  }
+  button:dir(ltr) {
+    right: 0;
+  }
+  button:dir(rtl) {
+    left: 0;
+  }
+
+  button::-moz-focus-inner {
+    border: 0;
+  }
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutCompat.html
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutCompat.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <base/>
+
+  <!-- If you change this script tag you must update the hash in the extension's
+         `content_security_policy` 'sha256-MmZkN2QaIHhfRWPZ8TVRjijTn5Ci1iEabtTEWrt9CCo=' -->
+  <script>/* globals browser */ document.head.firstElementChild.href = browser.runtime.getURL("");</script>
+
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="about-compat/aboutCompat.css" />
+  <link rel="stylesheet" media="screen and (pointer:fine), projection" type="text/css"
+          href="chrome://global/skin/in-content/common.css"/>
+  <link rel="localization" href="toolkit/about/aboutCompat.ftl"/>
+  <title data-l10n-id="text-title"></title>
+  <script src="about-compat/aboutCompat.js"></script>
+  </head>
+<body>
+  <h2 class="tab active" data-l10n-id="label-overrides"></h2>
+  <table id="overrides">
+    <col/>
+    <col/>
+    <col/>
+  </table>
+  <h2 class="tab" data-l10n-id="label-interventions"></h2>
+  <table id="interventions">
+    <col/>
+    <col/>
+    <col/>
+  </table>
+</body>
+</html>

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutCompat.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutCompat.js
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals browser */
+
+let availablePatches;
+
+const portToAddon = (function() {
+  let port;
+
+  function connect() {
+    port = browser.runtime.connect({ name: "AboutCompatTab" });
+    port.onMessage.addListener(onMessageFromAddon);
+    port.onDisconnect.addListener(e => {
+      port = undefined;
+    });
+  }
+
+  connect();
+
+  async function send(message) {
+    if (port) {
+      return port.postMessage(message);
+    }
+    return Promise.reject("background script port disconnected");
+  }
+
+  return { send };
+})();
+
+const $ = function(sel) {
+  return document.querySelector(sel);
+};
+
+const DOMContentLoadedPromise = new Promise(resolve => {
+  document.addEventListener(
+    "DOMContentLoaded",
+    () => {
+      resolve();
+    },
+    { once: true }
+  );
+});
+
+Promise.all([
+  browser.runtime.sendMessage("getOverridesAndInterventions"),
+  DOMContentLoadedPromise,
+]).then(([info]) => {
+  document.body.addEventListener("click", async evt => {
+    const ele = evt.target;
+    if (ele.nodeName === "BUTTON") {
+      const row = ele.closest("[data-id]");
+      if (row) {
+        evt.preventDefault();
+        ele.disabled = true;
+        const id = row.getAttribute("data-id");
+        try {
+          await browser.runtime.sendMessage({ command: "toggle", id });
+        } catch (_) {
+          ele.disabled = false;
+        }
+      }
+    } else if (ele.classList.contains("tab")) {
+      document.querySelectorAll(".tab").forEach(tab => {
+        tab.classList.remove("active");
+      });
+      ele.classList.add("active");
+    }
+  });
+
+  availablePatches = info;
+  redraw();
+});
+
+function onMessageFromAddon(msg) {
+  if ("interventionsChanged" in msg) {
+    redrawTable($("#interventions"), msg.interventionsChanged);
+  }
+
+  if ("overridesChanged" in msg) {
+    redrawTable($("#overrides"), msg.overridesChanged);
+  }
+
+  const id = msg.toggling || msg.toggled;
+  const button = $(`[data-id="${id}"] button`);
+  if (!button) {
+    return;
+  }
+  const active = msg.active;
+  document.l10n.setAttributes(
+    button,
+    active ? "label-disable" : "label-enable"
+  );
+  button.disabled = !!msg.toggling;
+}
+
+function redraw() {
+  if (!availablePatches) {
+    return;
+  }
+  const { overrides, interventions } = availablePatches;
+  const showHidden = location.hash === "#all";
+  redrawTable($("#overrides"), overrides, showHidden);
+  redrawTable($("#interventions"), interventions, showHidden);
+}
+
+function redrawTable(table, data, showHidden = false) {
+  const df = document.createDocumentFragment();
+  table.querySelectorAll("tr").forEach(tr => {
+    tr.remove();
+  });
+
+  let noEntriesMessage;
+  if (data === false) {
+    noEntriesMessage = "text-disabled-in-about-config";
+  } else if (data.length === 0) {
+    noEntriesMessage =
+      table.id === "overrides" ? "text-no-overrides" : "text-no-interventions";
+  }
+
+  if (noEntriesMessage) {
+    const tr = document.createElement("tr");
+    df.appendChild(tr);
+
+    const td = document.createElement("td");
+    td.setAttribute("colspan", "3");
+    document.l10n.setAttributes(td, noEntriesMessage);
+    tr.appendChild(td);
+
+    table.appendChild(df);
+    return;
+  }
+
+  for (const row of data) {
+    if (row.hidden && !showHidden) {
+      continue;
+    }
+
+    const tr = document.createElement("tr");
+    tr.setAttribute("data-id", row.id);
+    df.appendChild(tr);
+
+    let td = document.createElement("td");
+    td.innerText = row.domain;
+    tr.appendChild(td);
+
+    td = document.createElement("td");
+    const a = document.createElement("a");
+    const bug = row.bug;
+    a.href = `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug}`;
+    document.l10n.setAttributes(a, "label-more-information", { bug });
+    a.target = "_blank";
+    td.appendChild(a);
+    tr.appendChild(td);
+
+    td = document.createElement("td");
+    tr.appendChild(td);
+    const button = document.createElement("button");
+    document.l10n.setAttributes(
+      button,
+      row.active ? "label-disable" : "label-enable"
+    );
+    td.appendChild(button);
+  }
+  table.appendChild(df);
+}
+
+window.onhashchange = redraw;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPage.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPage.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* global ExtensionAPI, Services, XPCOMUtils */
+
+ChromeUtils.defineModuleGetter(
+  this,
+  "Services",
+  "resource://gre/modules/Services.jsm"
+);
+
+XPCOMUtils.defineLazyServiceGetter(
+  this,
+  "resProto",
+  "@mozilla.org/network/protocol;1?name=resource",
+  "nsISubstitutingProtocolHandler"
+);
+
+const ResourceSubstitution = "webcompat";
+const ProcessScriptURL = "resource://webcompat/aboutPageProcessScript.js";
+
+this.aboutPage = class extends ExtensionAPI {
+  onStartup() {
+    const { rootURI } = this.extension;
+
+    resProto.setSubstitution(
+      ResourceSubstitution,
+      Services.io.newURI("about-compat/", null, rootURI)
+    );
+
+    Services.ppmm.loadProcessScript(ProcessScriptURL, true);
+  }
+
+  onShutdown() {
+    resProto.setSubstitution(ResourceSubstitution, null);
+
+    Services.ppmm.removeDelayedProcessScript(ProcessScriptURL);
+  }
+};

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPage.json
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPage.json
@@ -1,0 +1,4 @@
+[{
+    "namespace": "aboutCompat",
+    "description": "Enables the about:compat page"
+}]

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPageProcessScript.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPageProcessScript.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const Cm = Components.manager.QueryInterface(Ci.nsIComponentRegistrar);
+
+const classID = Components.ID("{97bf9550-2a7b-11e9-b56e-0800200c9a66}");
+
+if (!Cm.isCIDRegistered(classID)) {
+  const { XPCOMUtils } = ChromeUtils.import(
+    "resource://gre/modules/XPCOMUtils.jsm"
+  );
+
+  const factory = XPCOMUtils.generateSingletonFactory(function() {
+    const { AboutCompat } = ChromeUtils.import(
+      "resource://webcompat/AboutCompat.jsm"
+    );
+    return new AboutCompat();
+  });
+
+  Cm.registerFactory(
+    classID,
+    "about:compat",
+    "@mozilla.org/network/protocol/about;1?what=compat",
+    factory
+  );
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/data/injections.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/data/injections.js
@@ -1,0 +1,450 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals module */
+
+/**
+ * For detailed information on our policies, and a documention on this format
+ * and its possibilites, please check the Mozilla-Wiki at
+ *
+ * https://wiki.mozilla.org/Compatibility/Go_Faster_Addon/Override_Policies_and_Workflows#User_Agent_overrides
+ */
+const AVAILABLE_INJECTIONS = [
+  {
+    id: "testbed-injection",
+    platform: "all",
+    domain: "webcompat-addon-testbed.herokuapp.com",
+    bug: "0000000",
+    hidden: true,
+    contentScripts: {
+      matches: ["*://webcompat-addon-testbed.herokuapp.com/*"],
+      css: [
+        {
+          file: "injections/css/bug0000000-testbed-css-injection.css",
+        },
+      ],
+      js: [
+        {
+          file: "injections/js/bug0000000-testbed-js-injection.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1452707",
+    platform: "desktop",
+    domain: "ib.absa.co.za",
+    bug: "1452707",
+    contentScripts: {
+      matches: ["https://ib.absa.co.za/*"],
+      js: [
+        {
+          file:
+            "injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1457335",
+    platform: "desktop",
+    domain: "histography.io",
+    bug: "1457335",
+    contentScripts: {
+      matches: ["*://histography.io/*"],
+      js: [
+        {
+          file: "injections/js/bug1457335-histography.io-ua-change.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1472075",
+    platform: "desktop",
+    domain: "bankofamerica.com",
+    bug: "1472075",
+    contentScripts: {
+      matches: ["*://*.bankofamerica.com/*"],
+      js: [
+        {
+          file: "injections/js/bug1472075-bankofamerica.com-ua-change.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1472081",
+    platform: "desktop",
+    domain: "election.gov.np",
+    bug: "1472081",
+    contentScripts: {
+      matches: ["http://202.166.205.141/bbvrs/*"],
+      allFrames: true,
+      js: [
+        {
+          file:
+            "injections/js/bug1472081-election.gov.np-window.sidebar-shim.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1482066",
+    platform: "desktop",
+    domain: "portalminasnet.com",
+    bug: "1482066",
+    contentScripts: {
+      matches: ["*://portalminasnet.com/*"],
+      allFrames: true,
+      js: [
+        {
+          file:
+            "injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1570856",
+    platform: "android",
+    domain: "medium.com",
+    bug: "1570856",
+    contentScripts: {
+      matches: ["*://medium.com/*"],
+      js: [
+        {
+          file: "injections/js/bug1570856-medium.com-menu-isTier1.js",
+        },
+      ],
+      allFrames: true,
+    },
+  },
+  {
+    id: "bug1579159",
+    platform: "android",
+    domain: "m.tailieu.vn",
+    bug: "1579159",
+    contentScripts: {
+      matches: ["*://m.tailieu.vn/*", "*://m.elib.vn/*"],
+      js: [
+        {
+          file: "injections/js/bug1579159-m.tailieu.vn-pdfjs-worker-disable.js",
+        },
+      ],
+      allFrames: true,
+    },
+  },
+  {
+    id: "bug1577245",
+    platform: "android",
+    domain: "help.pandora.com",
+    bug: "1577245",
+    contentScripts: {
+      matches: [
+        "https://faq.usps.com/*",
+        "https://help.duo.com/*",
+        "https://help.hulu.com/*",
+        "https://help.pandora.com/*",
+        "https://my211.force.com/*",
+        "https://support.paypay.ne.jp/*",
+        "https://usps.force.com/*",
+      ],
+      js: [
+        {
+          file:
+            "injections/js/bug1577245-salesforce-communities-hide-unsupported.js",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1526977",
+    platform: "desktop",
+    domain: "sreedharscce.in",
+    bug: "1526977",
+    contentScripts: {
+      matches: ["*://*.sreedharscce.in/authenticate"],
+      css: [
+        {
+          file: "injections/css/bug1526977-sreedharscce.in-login-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1518781",
+    platform: "desktop",
+    domain: "twitch.tv",
+    bug: "1518781",
+    contentScripts: {
+      matches: ["*://*.twitch.tv/*"],
+      css: [
+        {
+          file: "injections/css/bug1518781-twitch.tv-webkit-scrollbar.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1551672",
+    platform: "android",
+    domain: "Sites using PDK 5 video",
+    bug: "1551672",
+    data: {
+      urls: ["https://*/*/tpPdk.js", "https://*/*/pdk/js/*/*.js"],
+      types: ["script"],
+    },
+    customFunc: "pdk5fix",
+  },
+  {
+    id: "bug1577870",
+    platform: "desktop",
+    domain: "slideshare.net",
+    bug: "1577870",
+    data: {
+      urls: ["https://*.linkedin.com/tscp-serving/dtag*"],
+      contentType: {
+        name: "content-type",
+        value: "text/html; charset=utf-8",
+      },
+    },
+    customFunc: "dtagFix",
+  },
+  {
+    id: "bug1305028",
+    platform: "desktop",
+    domain: "gaming.youtube.com",
+    bug: "1305028",
+    contentScripts: {
+      matches: ["*://gaming.youtube.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1305028-gaming.youtube.com-webkit-scrollbar.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1432935-discord",
+    platform: "desktop",
+    domain: "discordapp.com",
+    bug: "1432935",
+    contentScripts: {
+      matches: ["*://discordapp.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1432935-discordapp.com-webkit-scorllbar-white-line.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1432935-breitbart",
+    platform: "desktop",
+    domain: "breitbart.com",
+    bug: "1432935",
+    contentScripts: {
+      matches: ["*://*.breitbart.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1432935-breitbart.com-webkit-scrollbar.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1561371",
+    platform: "android",
+    domain: "mail.google.com",
+    bug: "1561371",
+    contentScripts: {
+      matches: ["*://mail.google.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1561371-mail.google.com-allow-horizontal-scrolling.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1567610",
+    platform: "all",
+    domain: "dns.google.com",
+    bug: "1567610",
+    contentScripts: {
+      matches: ["*://dns.google.com/*", "*://dns.google/*"],
+      css: [
+        {
+          file: "injections/css/bug1567610-dns.google.com-moz-fit-content.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1568256",
+    platform: "android",
+    domain: "zertifikate.commerzbank.de",
+    bug: "1568256",
+    contentScripts: {
+      matches: ["*://*.zertifikate.commerzbank.de/webforms/mobile/*"],
+      css: [
+        {
+          file: "injections/css/bug1568256-zertifikate.commerzbank.de-flex.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1568908",
+    platform: "desktop",
+    domain: "console.cloud.google.com",
+    bug: "1568908",
+    contentScripts: {
+      matches: ["*://*.console.cloud.google.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1568908-console.cloud.google.com-scrollbar-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1570119",
+    platform: "desktop",
+    domain: "teamcoco.com",
+    bug: "1570119",
+    contentScripts: {
+      matches: ["*://teamcoco.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1570119-teamcoco.com-scrollbar-width.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1570328",
+    platform: "android",
+    domain: "developer.apple.com",
+    bug: "1570328",
+    contentScripts: {
+      matches: ["*://developer.apple.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1570328-developer-apple.com-transform-scale.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1571036",
+    platform: "all",
+    domain: "mobile.aireuropa.com",
+    bug: "1571036",
+    contentScripts: {
+      matches: ["*://mobile.aireuropa.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1571036-mobile.aireuropa.com-menu-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1574973",
+    platform: "android",
+    domain: "patch.com",
+    bug: "1574973",
+    contentScripts: {
+      matches: ["*://patch.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1574973-patch.com-dropdown-menu-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1575000",
+    platform: "all",
+    domain: "apply.lloydsbank.co.uk",
+    bug: "1575000",
+    contentScripts: {
+      matches: ["*://apply.lloydsbank.co.uk/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1575000-apply.lloydsbank.co.uk-radio-buttons-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1575011",
+    platform: "android",
+    domain: "holiday-weather.com",
+    bug: "1575011",
+    contentScripts: {
+      matches: ["*://*.holiday-weather.com/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1575011-holiday-weather.com-scrolling-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1575017",
+    platform: "desktop",
+    domain: "dunkindonuts.com",
+    bug: "1575017",
+    contentScripts: {
+      matches: ["*://*.dunkindonuts.com/en/sign-in*"],
+      css: [
+        {
+          file: "injections/css/bug1575017-dunkindonuts.com-flex-basis.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1577270",
+    platform: "android",
+    domain: "binance.com",
+    bug: "1577270",
+    contentScripts: {
+      matches: ["*://*.binance.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1577270-binance.com-calc-height-fix.css",
+        },
+      ],
+    },
+  },
+  {
+    id: "bug1577297",
+    platform: "android",
+    domain: "kitkat.com.au",
+    bug: "1577297",
+    contentScripts: {
+      matches: ["*://*.kitkat.com.au/*"],
+      css: [
+        {
+          file: "injections/css/bug1577297-kitkat.com.au-slider-width-fix.css",
+        },
+      ],
+    },
+  },
+];
+
+module.exports = AVAILABLE_INJECTIONS;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
@@ -1,0 +1,552 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals module */
+
+/**
+ * For detailed information on our policies, and a documention on this format
+ * and its possibilites, please check the Mozilla-Wiki at
+ *
+ * https://wiki.mozilla.org/Compatibility/Go_Faster_Addon/Override_Policies_and_Workflows#User_Agent_overrides
+ */
+const AVAILABLE_UA_OVERRIDES = [
+  {
+    id: "testbed-override",
+    platform: "all",
+    domain: "webcompat-addon-testbed.herokuapp.com",
+    bug: "0000000",
+    hidden: true,
+    config: {
+      matches: ["*://webcompat-addon-testbed.herokuapp.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36 for WebCompat"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1563839 - rolb.santanderbank.com - Build UA override
+     * WebCompat issue #33462 - https://webcompat.com/issues/33462
+     *
+     * santanderbank expects UA to have 'like Gecko', otherwise it runs
+     * xmlDoc.onload whose support has been dropped. It results in missing labels in forms
+     * and some other issues.  Adding 'like Gecko' fixes those issues.
+     */
+    id: "bug1563839",
+    platform: "all",
+    domain: "rolb.santanderbank.com",
+    bug: "1563839",
+    config: {
+      matches: [
+        "*://*.santander.co.uk/*",
+        "*://bob.santanderbank.com/*",
+        "*://rolb.santanderbank.com/*",
+      ],
+      uaTransformer: originalUA => {
+        return originalUA.replace("Gecko", "like Gecko");
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1577179 - UA override for supportforms.embarcadero.com
+     * WebCompat issue #34682 - https://webcompat.com/issues/34682
+     *
+     * supportforms.embarcadero.com has a constant onchange event on a product selector
+     * which makes it unusable. Spoofing as Chrome allows to stop event from firing
+     */
+    id: "bug1577179",
+    platform: "all",
+    domain: "supportforms.embarcadero.com",
+    bug: "1577179",
+    config: {
+      matches: ["*://supportforms.embarcadero.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1577519 - att.tv - Create a UA override for att.tv for playback on desktop
+     * WebCompat issue #3846 - https://webcompat.com/issues/3846
+     *
+     * att.tv (atttvnow.com) is blocking Firefox via UA sniffing. Spoofing as Chrome allows
+     * to access the site and playback works fine. This is former directvnow.com
+     */
+    id: "bug1577519",
+    platform: "desktop",
+    domain: "att.tv",
+    bug: "1577519",
+    config: {
+      matches: ["*://*.att.tv/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1570108 - steamcommunity.com - UA override for steamcommunity.com
+     * WebCompat issue #34171 - https://webcompat.com/issues/34171
+     *
+     * steamcommunity.com blocks chat feature for Firefox users showing unsupported browser message.
+     * When spoofing as Chrome the chat works fine
+     */
+    id: "bug1570108",
+    platform: "desktop",
+    domain: "steamcommunity.com",
+    bug: "1570108",
+    config: {
+      matches: ["*://steamcommunity.com/chat*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1579453 - UA override for www.thule.com
+     * WebCompat issue #35022 - https://webcompat.com/issues/35022
+     *
+     * www.thule.com continuously requesting for location permission
+     * due to the UA detection making the site unusable. Spoofing as Chrome
+     * allows to interact with the page normally
+     */
+    id: "bug1579453",
+    platform: "all",
+    domain: "thule.com",
+    bug: "1579453",
+    config: {
+      matches: ["https://*.thule.com/*/*/dealer-locator*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1480710 - m.imgur.com - Build UA override
+     * WebCompat issue #13154 - https://webcompat.com/issues/13154
+     *
+     * imgur returns a 404 for requests to CSS and JS file if requested with a Fennec
+     * User Agent. By removing the Fennec identifies and adding Chrome Mobile's, we
+     * receive the correct CSS and JS files.
+     */
+    id: "bug1480710",
+    platform: "android",
+    domain: "m.imgur.com",
+    bug: "1480710",
+    config: {
+      matches: ["*://m.imgur.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 945963 - tieba.baidu.com serves simplified mobile content to Firefox Android
+     * WebCompat issue #18455 - https://webcompat.com/issues/18455
+     *
+     * tieba.baidu.com and tiebac.baidu.com serve a heavily simplified and less functional
+     * mobile experience to Firefox for Android users. Adding the AppleWebKit indicator
+     * to the User Agent gets us the same experience.
+     */
+    id: "bug945963",
+    platform: "android",
+    domain: "tieba.baidu.com",
+    bug: "945963",
+    config: {
+      matches: [
+        "*://tieba.baidu.com/*",
+        "*://tiebac.baidu.com/*",
+        "*://zhidao.baidu.com/*",
+      ],
+      uaTransformer: originalUA => {
+        return originalUA + " AppleWebKit/537.36 (KHTML, like Gecko)";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1177298 - Write UA overrides for top Japanese Sites
+     * (Imported from ua-update.json.in)
+     *
+     * To receive the proper mobile version instead of the desktop version or
+     * a lower grade mobile experience, the UA is spoofed.
+     */
+    id: "bug1177298-2",
+    platform: "android",
+    domain: "lohaco.jp",
+    bug: "1177298",
+    config: {
+      matches: ["*://*.lohaco.jp/*"],
+      uaTransformer: _ => {
+        return "Mozilla/5.0 (Linux; Android 5.0.2; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1177298 - Write UA overrides for top Japanese Sites
+     * (Imported from ua-update.json.in)
+     *
+     * To receive the proper mobile version instead of the desktop version or
+     * a lower grade mobile experience, the UA is spoofed.
+     */
+    id: "bug1177298-3",
+    platform: "android",
+    domain: "nhk.or.jp",
+    bug: "1177298",
+    config: {
+      matches: ["*://*.nhk.or.jp/*"],
+      uaTransformer: originalUA => {
+        return originalUA + " AppleWebKit";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1338260 - Add UA override for directTV
+     * (Imported from ua-update.json.in)
+     *
+     * DirectTV has issues with scrolling and cut-off images. Pretending to be
+     * Chrome for Android fixes those issues.
+     */
+    id: "bug1338260",
+    platform: "android",
+    domain: "directv.com",
+    bug: "1338260",
+    config: {
+      matches: ["*://*.directv.com/*"],
+      uaTransformer: _ => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1385206 - Create UA override for rakuten.co.jp on Firefox Android
+     * (Imported from ua-update.json.in)
+     *
+     * rakuten.co.jp serves a Desktop version if Firefox is included in the UA.
+     */
+    id: "bug1385206",
+    platform: "android",
+    domain: "rakuten.co.jp",
+    bug: "1385206",
+    config: {
+      matches: ["*://*.rakuten.co.jp/*"],
+      uaTransformer: originalUA => {
+        return originalUA.replace(/Firefox.+$/, "");
+      },
+    },
+  },
+  {
+    /*
+     * Bug 969844 - mobile.de sends desktop site to Firefox on Android
+     *
+     * mobile.de sends the desktop site to Fennec. Spooing as Chrome works fine.
+     */
+    id: "bug969844",
+    platform: "android",
+    domain: "mobile.de",
+    bug: "969844",
+    config: {
+      matches: ["*://*.mobile.de/*"],
+      uaTransformer: _ => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1509831 - cc.com - Add UA override for CC.com
+     * WebCompat issue #329 - https://webcompat.com/issues/329
+     *
+     * ComedyCentral blocks Firefox for not being able to play HLS, which was
+     * true in previous versions, but no longer is. With a spoofed Chrome UA,
+     * the site works just fine.
+     */
+    id: "bug1509831",
+    platform: "android",
+    domain: "cc.com",
+    bug: "1509831",
+    config: {
+      matches: ["*://*.cc.com/*"],
+      uaTransformer: _ => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1508516 - cineflix.com.br - Add UA override for cineflix.com.br/m/
+     * WebCompat issue #21553 - https://webcompat.com/issues/21553
+     *
+     * The site renders a blank page with any Firefox snipped in the UA as it
+     * is running into an exception. Spoofing as Chrome makes the site work
+     * fine.
+     */
+    id: "bug1508516",
+    platform: "android",
+    domain: "cineflix.com.br",
+    bug: "1508516",
+    config: {
+      matches: ["*://*.cineflix.com.br/m/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1509852 - redbull.com - Add UA override for redbull.com
+     * WebCompat issue #21439 - https://webcompat.com/issues/21439
+     *
+     * Redbull.com blocks some features, for example the live video player, for
+     * Fennec. Spoofing as Chrome results in us rendering the video just fine,
+     * and everything else works as well.
+     */
+    id: "bug1509852",
+    platform: "android",
+    domain: "redbull.com",
+    bug: "1509852",
+    config: {
+      matches: ["*://*.redbull.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1509873 - zmags.com - Add UA override for secure.viewer.zmags.com
+     * WebCompat issue #21576 - https://webcompat.com/issues/21576
+     *
+     * The zmags viewer locks out Fennec with a "Browser unsupported" message,
+     * but tests showed that it works just fine with a Chrome UA. Outreach
+     * attempts were unsuccessful, and as the site has a relatively high rank,
+     * we alter the UA.
+     */
+    id: "bug1509873",
+    platform: "android",
+    domain: "zmags.com",
+    bug: "1509873",
+    config: {
+      matches: ["*://*.viewer.zmags.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1566253 - posts.google.com - Add UA override for posts.google.com
+     * WebCompat issue #17870 - https://webcompat.com/issues/17870
+     *
+     * posts.google.com displaying "Your browser doesn't support this page".
+     * Spoofing as Chrome works fine.
+     */
+    id: "bug1566253",
+    platform: "android",
+    domain: "posts.google.com",
+    bug: "1566253",
+    config: {
+      matches: ["*://posts.google.com/*"],
+      uaTransformer: _ => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G900M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1567945 - Create UA override for beeg.com on Firefox Android
+     * WebCompat issue #16648 - https://webcompat.com/issues/16648
+     *
+     * beeg.com is hiding content of a page with video if Firefox exists in UA,
+     * replacing "Firefox" with an empty string makes the page load
+     */
+    id: "bug1567945",
+    platform: "android",
+    domain: "beeg.com",
+    bug: "1567945",
+    config: {
+      matches: ["*://beeg.com/*"],
+      uaTransformer: originalUA => {
+        return originalUA.replace(/Firefox.+$/, "");
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1571036 - UA override for mobile.aireuropa.com on Firefox for Android
+     * WebCompat issue #34760 - https://webcompat.com/issues/34760
+     *
+     * mobile.aireuropa.com has a UA detection which prevents Firefox for Android
+     * from opening main menu. Spoofing as Chrome allows to open it.
+     */
+    id: "bug1571036",
+    platform: "android",
+    domain: "mobile.aireuropa.com",
+    bug: "1571036",
+    config: {
+      matches: ["*://mobile.aireuropa.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1574522 - UA override for enuri.com on Firefox for Android
+     * WebCompat issue #37139 - https://webcompat.com/issues/37139
+     *
+     * enuri.com returns a different template for Firefox on Android
+     * based on server side UA detection. This results in page content cut offs.
+     * Spoofing as Chrome fixes the issue
+     */
+    id: "bug1574522",
+    platform: "android",
+    domain: "enuri.com",
+    bug: "1574522",
+    config: {
+      matches: ["*://enuri.com/*"],
+      uaTransformer: _ => {
+        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G900M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1574564 - UA override for ceskatelevize.cz on Firefox for Android
+     * WebCompat issue #15467 - https://webcompat.com/issues/15467
+     *
+     * ceskatelevize sets streamingProtocol depending on the User-Agent it sees
+     * in the request headers, returning DASH for Chrome, HLS for iOS,
+     * and Flash for Fennec. Since Fennec has no Flash, the video doesn't work.
+     * Spoofing as Chrome makes the video play
+     */
+    id: "bug1574564",
+    platform: "android",
+    domain: "ceskatelevize.cz",
+    bug: "1574564",
+    config: {
+      matches: ["*://*.ceskatelevize.cz/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1577240 - UA override for heb.com on Firefox for Android
+     * WebCompat issue #33613 - https://webcompat.com/issues/33613
+     *
+     * heb.com shows desktop site on Firefox for Android for some pages based on
+     * UA detection. Spoofing as Chrome allows to get mobile site.
+     */
+    id: "bug1577240",
+    platform: "android",
+    domain: "heb.com",
+    bug: "1577240",
+    config: {
+      matches: ["*://*.heb.com/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1577250 - UA override for homebook.pl on Firefox for Android
+     * WebCompat issue #24044 - https://webcompat.com/issues/24044
+     *
+     * homebook.pl shows desktop site on Firefox for Android based on
+     * UA detection. Spoofing as Chrome allows to get mobile site.
+     */
+    id: "bug1577250",
+    platform: "android",
+    domain: "homebook.pl",
+    bug: "1577250",
+    config: {
+      matches: ["*://*.homebook.pl/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1577267 - UA override for metfone.com.kh on Firefox for Android
+     * WebCompat issue #16363 - https://webcompat.com/issues/16363
+     *
+     * metfone.com.kh has a server side UA detection which returns desktop site
+     * for Firefox for Android. Spoofing as Chrome allows to receive mobile version
+     */
+    id: "bug1577267",
+    platform: "android",
+    domain: "metfone.com.kh",
+    bug: "1577267",
+    config: {
+      matches: ["*://*.metfone.com.kh/*"],
+      uaTransformer: originalUA => {
+        return (
+          UAHelpers.getPrefix(originalUA) +
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36"
+        );
+      },
+    },
+  },
+];
+
+const UAHelpers = {
+  getPrefix(originalUA) {
+    return originalUA.substr(0, originalUA.indexOf(")") + 1);
+  },
+};
+
+module.exports = AVAILABLE_UA_OVERRIDES;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/experiment-apis/aboutConfigPrefs.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/experiment-apis/aboutConfigPrefs.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* global ExtensionAPI, ExtensionCommon, Services, XPCOMUtils */
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+  Services: "resource://gre/modules/Services.jsm",
+});
+
+this.aboutConfigPrefs = class extends ExtensionAPI {
+  getAPI(context) {
+    const EventManager = ExtensionCommon.EventManager;
+    const extensionIDBase = context.extension.id.split("@")[0];
+    const extensionPrefNameBase = `extensions.${extensionIDBase}.`;
+
+    return {
+      aboutConfigPrefs: {
+        onPrefChange: new EventManager({
+          context,
+          name: "aboutConfigPrefs.onUAOverridesPrefChange",
+          register: (fire, name) => {
+            const prefName = `${extensionPrefNameBase}${name}`;
+            const callback = () => {
+              fire.async(name).catch(() => {}); // ignore Message Manager disconnects
+            };
+            Services.prefs.addObserver(prefName, callback);
+            return () => {
+              Services.prefs.removeObserver(prefName, callback);
+            };
+          },
+        }).api(),
+        async getPref(name) {
+          try {
+            return Services.prefs.getBoolPref(
+              `${extensionPrefNameBase}${name}`
+            );
+          } catch (_) {
+            return undefined;
+          }
+        },
+        async setPref(name, value) {
+          Services.prefs.setBoolPref(`${extensionPrefNameBase}${name}`, value);
+        },
+      },
+    };
+  }
+};

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/experiment-apis/aboutConfigPrefs.json
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/experiment-apis/aboutConfigPrefs.json
@@ -1,0 +1,53 @@
+[
+  {
+    "namespace": "aboutConfigPrefs",
+    "description": "experimental API extension to allow access to about:config preferences",
+    "events": [
+      {
+        "name": "onPrefChange",
+        "type": "function",
+        "parameters": [{
+          "name": "name",
+          "type": "string",
+          "description": "The preference which changed"
+        }],
+        "extraParameters": [{
+          "name": "name",
+          "type": "string",
+          "description": "The preference to monitor"
+        }]
+      }
+    ],
+    "functions": [
+      {
+        "name": "getPref",
+        "type": "function",
+        "description": "Get a preference's value",
+        "parameters": [{
+          "name": "name",
+          "type": "string",
+          "description": "The preference name"
+        }],
+        "async": true
+      },
+      {
+        "name": "setPref",
+        "type": "function",
+        "description": "Set a preference's value",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          },
+          {
+            "name": "value",
+            "type": "boolean",
+            "description": "The new value"
+          }
+        ],
+        "async": true
+      }
+    ]
+  }
+]

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug0000000-testbed-css-injection.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug0000000-testbed-css-injection.css
@@ -1,0 +1,3 @@
+#css-injection.red {
+  background-color: #0f0;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1305028-gaming.youtube.com-webkit-scrollbar.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1305028-gaming.youtube.com-webkit-scrollbar.css
@@ -1,0 +1,14 @@
+/**
+ * gaming.youtube.com - The vertical scrollbar displayed for the main pane is
+ * partially overlapped by the video itself
+ * Bug #1305028 - https://bugzilla.mozilla.org/show_bug.cgi?id=1305028
+ *
+ * The scrollbar in the main player area is overlapped by the player, making the
+ * design look broken. In Chrome, YouTube is using ::-webkit-scrollbar to style
+ * the bar to match their expectations, but this doesn't work in Firefox.
+ * To make it look less broken, we hide the scrollbar for the main video pane
+ * entirely.
+ */
+ytg-scroll-pane.ytg-watch-page {
+  scrollbar-width: none;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1432935-breitbart.com-webkit-scrollbar.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1432935-breitbart.com-webkit-scrollbar.css
@@ -1,0 +1,13 @@
+/**
+ * breitbart.com - -webkit-scrollbar dependency causes scrollbar in the header
+ * Part of Bug #1432935 - https://bugzilla.mozilla.org/show_bug.cgi?id=1432935
+ * WebCompat issue #25156 - https://webcompat.com/issues/25156
+ *
+ * This site is using -webkit-scrollbar to hide a header in ther "scrollable
+ * via JS" header navigation. This breaks in Firefox, and causes a visible
+ * scrollbar to appear which overlaps large portions of the navigation content.
+ * While we wait for an outreach response, let's fix it ourselves.
+ */
+#HWT ul {
+  scrollbar-width: none;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1432935-discordapp.com-webkit-scorllbar-white-line.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1432935-discordapp.com-webkit-scorllbar-white-line.css
@@ -1,0 +1,16 @@
+/**
+ * discordapp.com - -webkit-scrollbar dependency causes visible white line
+ * Part of Bug #1432935 - https://bugzilla.mozilla.org/show_bug.cgi?id=1432935
+ * WebCompat issue #7919 - https://webcompat.com/issues/7919
+ *
+ * Discord depends on -webkit-scrollbar for styling and hiding their scrollbars
+ * in the UI. Previously, the scrollbars overlapped content permanently.
+ * However, this issue seems to be addressed now, but a small white line
+ * still remains. While Discord is working on this, let's get rid of these
+ * lines.
+ */
+.themeGhostHairline-DBD-2d .pad-29zQak,
+.themeGhostHairlineChannels-3G0x9_ .pad-29zQak {
+  width: 3px !important;
+  left: -3px !important;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1518781-twitch.tv-webkit-scrollbar.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1518781-twitch.tv-webkit-scrollbar.css
@@ -1,0 +1,14 @@
+/**
+ * twitch.tv - Comment interaction button is overlayed by scrollbar
+ * Bug #1518781 - https://bugzilla.mozilla.org/show_bug.cgi?id=1518781
+ *
+ * The interaction buttons in Twitch' chat are partly overlayed by the
+ * scrollbar, which makes them hard to use. Twitch uses
+ * ::-webkit-scrollbar to make the scrollbar thinner, which isn't working in
+ * Firefox.
+ * Given that even scrollbar-width: thin; is not enough (see Bugzilla), let's
+ * remove it entirely.
+ */
+.video-chat__message-list-wrapper {
+  scrollbar-width: none;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1526977-sreedharscce.in-login-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1526977-sreedharscce.in-login-fix.css
@@ -1,0 +1,12 @@
+/**
+ * sreedharscce.in - Fix login form with CSS intervention
+ * Bug #1526977 - https://bugzilla.mozilla.org/show_bug.cgi?id=1526977
+ * WebCompat issue #21505 - https://webcompat.com/issues/21505
+ *
+ * The login form is partly moved out of the screen on sreedharscce.in in
+ * Firefox. Enforcing the body height to the full viewport fixes this issue,
+ * as the login form itself is posititoned with `position: absolute;`.
+ */
+body {
+  height: 100vh;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1561371-mail.google.com-allow-horizontal-scrolling.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1561371-mail.google.com-allow-horizontal-scrolling.css
@@ -1,0 +1,12 @@
+/**
+ * mail.google.com - The HTML email view does not allow horizontal scrolling
+ * on Fennec due to a missing CSS rule which is only served to Chrome.
+ * Bug #1561371 - https://bugzilla.mozilla.org/show_bug.cgi?id=1561371
+ *
+ * HTML emails may sometimes contain content that does not wrap, yet the
+ * CSS served to Fennec does not permit scrolling horizontally. To prevent
+ * this UX frustration, we enable horizontal scrolling.
+ */
+body > #views > div {
+  overflow: auto;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1567610-dns.google.com-moz-fit-content.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1567610-dns.google.com-moz-fit-content.css
@@ -1,0 +1,12 @@
+/**
+ * dns.google.com - Page content is shifted to the left side of the page
+ * Bug #1567610 - https://bugzilla.mozilla.org/show_bug.cgi?id=1567610
+ * WebCompat issue #22494 - https://webcompat.com/issues/22494
+ *
+ * Affected element is styled with width:fit-content; which is not
+ * supported by Firefox yet, see https://bugzilla.mozilla.org/show_bug.cgi?id=1495868
+ * Adding -moz-fit-content fixes the issue
+ */
+main > .ng-star-inserted > .centered {
+  width: -moz-fit-content;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1568256-zertifikate.commerzbank.de-flex.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1568256-zertifikate.commerzbank.de-flex.css
@@ -1,0 +1,12 @@
+/**
+ * zertifikate.commerzbank.de - clickable elements on the page are collapsed
+ * Bug #1568256 - https://bugzilla.mozilla.org/show_bug.cgi?id=1568256
+ * WebCompat issue #9102 - https://webcompat.com/issues/9102
+ *
+ * Affected elements have display:-webkit-box and display:flex applied, however,
+ * listed in wrong order, so display:-webkit-box is becoming the final say.
+ * Adding display: flex for those elements fixes the issue
+ */
+.x-layout-box {
+  display: flex !important;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1568908-console.cloud.google.com-scrollbar-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1568908-console.cloud.google.com-scrollbar-fix.css
@@ -1,0 +1,16 @@
+/**
+ * console.cloud.google.com - Double scrollbar visisible on long pages
+ * Bug #1568908 - https://bugzilla.mozilla.org/show_bug.cgi?id=1568908
+ * WebCompat issue #33164 - https://webcompat.com/issues/33164
+ *
+ * For pages that have contents heigher than the page's height, a secondary
+ * scrollbar outside the scrollable content area is visible. This is caused
+ * by a difference in Flexbox behavior, which is being addressed in
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=981134
+ *
+ * Until this fix hits release and Google has updated their UI properly,
+ * this intervention addresses the differences.
+ */
+central-page-area {
+  min-height: 0;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1570119-teamcoco.com-scrollbar-width.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1570119-teamcoco.com-scrollbar-width.css
@@ -1,0 +1,11 @@
+/**
+ * teamcoco.com - a scrollbar at the top covering navigation menu
+ * Bug #1570119 - https://bugzilla.mozilla.org/show_bug.cgi?id=1570119
+ *
+ * The scrollbar is covering navigation items making them unusable.
+ * There are ::-webkit-scrollbar css rules already applied to the scrollbar,
+ * hiding it in Chrome. Adding the scrollbar-width: none fixes the issue in Firefox.
+ */
+.css-bdnz85 {
+  scrollbar-width: none;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1570328-developer-apple.com-transform-scale.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1570328-developer-apple.com-transform-scale.css
@@ -1,0 +1,17 @@
+/**
+ * developer.apple.com - content of the page is shifted to the left
+ * Bug #1570328 - https://bugzilla.mozilla.org/show_bug.cgi?id=1570328
+ * WebCompat issue #4070 - https://webcompat.com/issues/4070
+ *
+ * The site is relying on zoom property which is not supported by Mozilla,
+ * see https://bugzilla.mozilla.org/show_bug.cgi?id=390936. Adding a combination
+ * of transform: scale(1.4), transform-origin and width fixes the issue
+ */
+@media only screen and (min-device-width: 320px) and (max-device-width: 980px),
+  (min-device-width: 1024px) and (max-device-width: 1024px) and (min-device-height: 1366px) and (max-device-height: 1366px) and (min-width: 320px) and (max-width: 980px) {
+  #tocContainer {
+    transform-origin: 0 0;
+    transform: scale(1.4);
+    width: 71.4%;
+  }
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1571036-mobile.aireuropa.com-menu-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1571036-mobile.aireuropa.com-menu-fix.css
@@ -1,0 +1,15 @@
+/**
+ * mobile.aireuropa.com - menu is shifted to the left
+ * Bug #1571036 - https://bugzilla.mozilla.org/show_bug.cgi?id=1571036
+ * WebCompat issue #34760 - https://webcompat.com/issues/34760
+ *
+ * Menu element is shifted to the left and menu links max-height is not working since
+ * they are table elements. More information https://bugzilla.mozilla.org/show_bug.cgi?id=307866
+ */
+.main-header-inner .main-menu-button {
+  max-width: 60px;
+}
+
+.links-list.with-icons li > a {
+  height: 50px;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1574973-patch.com-dropdown-menu-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1574973-patch.com-dropdown-menu-fix.css
@@ -1,0 +1,13 @@
+/**
+ * patch.com - sub-menu expands at the bottom of the page and overlaps other elements.
+ * Bug #1574973 - https://bugzilla.mozilla.org/show_bug.cgi?id=1574973
+ * WebCompat issue #25384 - https://webcompat.com/issues/25384
+ *
+ * patch.con has a top:100% style on the relatively-positioned element
+ * with class="dropdown-menu", and Firefox is incorrectly honoring that
+ * style (resolving it to something nonzero), whereas Chrome just treats it as "auto"
+ * see https://bugzilla.mozilla.org/show_bug.cgi?id=1092007
+ */
+#patch-nav-secondary .dropdown-menu {
+  top: auto;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1575000-apply.lloydsbank.co.uk-radio-buttons-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1575000-apply.lloydsbank.co.uk-radio-buttons-fix.css
@@ -1,0 +1,11 @@
+/**
+ * apply.lloydsbank.co.uk - radio buttons are misplaced
+ * Bug #1575000 - https://bugzilla.mozilla.org/show_bug.cgi?id=1575000
+ * WebCompat issue #34969 - https://webcompat.com/issues/34969
+ *
+ * Radio buttons are displaced to the left due to positioning issue of ::before
+ * pseudo element, adding position relative to it's parent fixes the issue.
+ */
+.radio-content-field .radio.inline label span.text {
+  position: relative;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1575011-holiday-weather.com-scrolling-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1575011-holiday-weather.com-scrolling-fix.css
@@ -1,0 +1,15 @@
+/**
+ * holiday-weather.com - page is not scrollable
+ * Bug #1575011 - https://bugzilla.mozilla.org/show_bug.cgi?id=1575011
+ * WebCompat issue #18478 - https://webcompat.com/issues/18478
+ *
+ * the page won't scroll since the flex container is too high,
+ * adding min height to parent containers fixes the issue
+ */
+.page-container-style__pageContent {
+  min-height: 0;
+}
+
+.widgets-style__root {
+  min-height: 0;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1575017-dunkindonuts.com-flex-basis.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1575017-dunkindonuts.com-flex-basis.css
@@ -1,0 +1,11 @@
+/**
+ * dunkindonuts.com - form input fields are small and misaligned
+ * Bug #1575017 - https://bugzilla.mozilla.org/show_bug.cgi?id=1575017
+ * WebCompat issue #28742 - https://webcompat.com/issues/28742
+ *
+ * Form input fields are small and misaligned due to flex-basis: min-content;
+ * applied on their parent element. Setting it to auto fixes the issue
+ */
+.grid__item {
+  flex-basis: auto;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1577270-binance.com-calc-height-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1577270-binance.com-calc-height-fix.css
@@ -1,0 +1,12 @@
+/**
+ * binance.com - can't see the full site
+ * Bug #1577270 - https://bugzilla.mozilla.org/show_bug.cgi?id=1577270
+ * WebCompat issue #17810 - https://webcompat.com/issues/17810
+ *
+ * The site does not have a doctype and is rendered in quirks mode. The calc() percentage
+ * height is applied on the .main-page .viewWrap element, but its parent does not have
+ * a specified height property. Adding a height of 100% to the parent fixes the issue.
+ */
+#tradeDiv {
+  height: 100%;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1577297-kitkat.com.au-slider-width-fix.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1577297-kitkat.com.au-slider-width-fix.css
@@ -1,0 +1,11 @@
+/**
+ * kitkat.com.au - can't see the content
+ * Bug #1577297 - https://bugzilla.mozilla.org/show_bug.cgi?id=1577297
+ * WebCompat issue #28992 - https://webcompat.com/issues/28992
+ *
+ * Affected element is too wide due to https://bugzilla.mozilla.org/show_bug.cgi?id=1316534.
+ * Adding min-width: 0; fixes the issue
+ */
+.columns .column.main {
+  min-width: 0;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug0000000-testbed-js-injection.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug0000000-testbed-js-injection.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/* globals exportFunction */
+
+Object.defineProperty(window.wrappedJSObject, "isTestFeatureSupported", {
+  get: exportFunction(function() {
+    return true;
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/**
+ * Bug 1452707 - Build site patch for ib.absa.co.za
+ * WebCompat issue #16401 - https://webcompat.com/issues/16401
+ *
+ * The online banking at ib.absa.co.za detect if window.controllers is a
+ * non-falsy value to detect if the current browser is Firefox or something
+ * else. In bug 1448045, this shim has been disabled for Firefox Nightly 61+,
+ * which breaks the UA detection on this site and results in a "Browser
+ * unsuppored" error message.
+ *
+ * This site patch simply sets window.controllers to a string, resulting in
+ * their check to work again.
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "window.controllers has been shimmed for compatibility reasons. See https://webcompat.com/issues/16401 for details."
+);
+
+Object.defineProperty(window.wrappedJSObject, "controllers", {
+  get: exportFunction(function() {
+    return true;
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1457335-histography.io-ua-change.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1457335-histography.io-ua-change.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/**
+ * Bug 1457335 - histography.io - Override UA & navigator.vendor
+ * WebCompat issue #1804 - https://webcompat.com/issues/1804
+ *
+ * This site is using a strict matching of navigator.userAgent and
+ * navigator.vendor to allow access for Safari or Chrome. Here, we set the
+ * values appropriately so we get recognized as Chrome.
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/1804 for details."
+);
+
+const CHROME_UA = navigator.userAgent + " Chrome for WebCompat";
+
+Object.defineProperty(window.navigator.wrappedJSObject, "userAgent", {
+  get: exportFunction(function() {
+    return CHROME_UA;
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});
+
+Object.defineProperty(window.navigator.wrappedJSObject, "vendor", {
+  get: exportFunction(function() {
+    return "Google Inc.";
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1472075-bankofamerica.com-ua-change.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1472075-bankofamerica.com-ua-change.js
@@ -1,0 +1,48 @@
+"use strict";
+
+/**
+ * Bug 1472075 - Build UA override for Bank of America for OSX & Linux
+ * WebCompat issue #2787 - https://webcompat.com/issues/2787
+ *
+ * BoA is showing a red warning to Linux and macOS users, while accepting
+ * Windows users without warning. From our side, there is no difference here
+ * and we receive a lot of user complains about the warnings, so we spoof
+ * as Firefox on Windows in those cases.
+ */
+
+/* globals exportFunction */
+
+if (!navigator.platform.includes("Win")) {
+  console.info(
+    "The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/2787 for details."
+  );
+
+  const WINDOWS_UA = navigator.userAgent.replace(
+    /\(.*; rv:/i,
+    "(Windows NT 10.0; Win64; x64; rv:"
+  );
+
+  Object.defineProperty(window.navigator.wrappedJSObject, "userAgent", {
+    get: exportFunction(function() {
+      return WINDOWS_UA;
+    }, window),
+
+    set: exportFunction(function() {}, window),
+  });
+
+  Object.defineProperty(window.navigator.wrappedJSObject, "appVersion", {
+    get: exportFunction(function() {
+      return "appVersion";
+    }, window),
+
+    set: exportFunction(function() {}, window),
+  });
+
+  Object.defineProperty(window.navigator.wrappedJSObject, "platform", {
+    get: exportFunction(function() {
+      return "Win64";
+    }, window),
+
+    set: exportFunction(function() {}, window),
+  });
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1472081-election.gov.np-window.sidebar-shim.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1472081-election.gov.np-window.sidebar-shim.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/**
+ * Bug 1472081 - election.gov.np - Override window.sidebar with something falsey
+ * WebCompat issue #11622 - https://webcompat.com/issues/11622
+ *
+ * This site is blocking onmousedown and onclick if window.sidebar is something
+ * that evaluates to true, rendering the form fields unusable. This patch
+ * overrides window.sidebar with false, so the blocking event handlers won't
+ * get registered.
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "window.sidebar has been shimmed for compatibility reasons. See https://webcompat.com/issues/11622 for details."
+);
+
+Object.defineProperty(window.wrappedJSObject, "sidebar", {
+  get: exportFunction(function() {
+    return false;
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1482066-portalminasnet.com-window.sidebar-shim.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/**
+ * portalminasnet.com - Override window.sidebar with something falsey
+ * WebCompat issue #18143 - https://webcompat.com/issues/18143
+ *
+ * This site is blocking onmousedown and onclick if window.sidebar is something
+ * that evaluates to true, rendering the login unusable. This patch overrides
+ * window.sidebar with false, so the blocking event handlers won't get
+ * registered.
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "window.sidebar has been shimmed for compatibility reasons. See https://webcompat.com/issues/18143 for details."
+);
+
+Object.defineProperty(window.wrappedJSObject, "sidebar", {
+  get: exportFunction(function() {
+    return false;
+  }, window),
+
+  set: exportFunction(function() {}, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1570856-medium.com-menu-isTier1.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1570856-medium.com-menu-isTier1.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/**
+ * medium.com - Override window.GLOBALS.useragent.isTier1 to be true
+ * WebCompat issue #25844 - https://webcompat.com/issues/25844
+ *
+ * This site is not showing main menu when scrolling. There is a GLOBALS variable
+ * at the bottom of the template being defined based on a server side UA detection.
+ * Setting window.GLOBALS.useragent.isTier1 to true makes the menu appear when scrolling
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "window.GLOBALS.useragent.isTier1 has been set to true for compatibility reasons. See https://webcompat.com/issues/25844 for details."
+);
+
+let globals = {};
+
+Object.defineProperty(window.wrappedJSObject, "GLOBALS", {
+  get: exportFunction(function() {
+    return globals;
+  }, window),
+
+  set: exportFunction(function(value = {}) {
+    globals = value;
+
+    if (!globals.useragent) {
+      globals.useragent = {};
+    }
+
+    globals.useragent.isTier1 = true;
+  }, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1577245-salesforce-communities-hide-unsupported.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1577245-salesforce-communities-hide-unsupported.js
@@ -1,0 +1,49 @@
+"use strict";
+
+/**
+ * help.pandora.com - Hide unsupported message in Firefox for Android
+ * WebCompat issue #38433 - https://webcompat.com/issues/38433
+ *
+ * SalesForce Communities are showing unsupported message
+ * for help.pandora.com and some more sites. See the full list here:
+ * https://github.com/webcompat/web-bugs/issues?utf8=%E2%9C%93&q=doNotShowUnsupportedBrowserModal
+ */
+
+console.info(
+  "Unsupported message has been hidden for compatibility reasons. See https://webcompat.com/issues/38433 for details."
+);
+
+const NOTIFICATIONS_LIMIT = 20;
+
+const createObserver = callback => {
+  return new MutationObserver(callback).observe(document, {
+    childList: true,
+    subtree: true,
+  });
+};
+
+const removeElementWhenReady = elementId => {
+  const element = document.getElementById(elementId);
+  if (element) {
+    element.remove();
+    return;
+  }
+
+  let n = 0;
+  createObserver(function(records, observer) {
+    const element = document.getElementById(elementId);
+    if (element) {
+      element.remove();
+      observer.disconnect();
+      return;
+    }
+
+    if (n > NOTIFICATIONS_LIMIT) {
+      observer.disconnect();
+    }
+
+    n++;
+  });
+};
+
+removeElementWhenReady("community-browser-not-support-message");

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1579159-m.tailieu.vn-pdfjs-worker-disable.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/js/bug1579159-m.tailieu.vn-pdfjs-worker-disable.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/**
+ * m.tailieu.vn - Override PDFJS.disableWorker to be true
+ * WebCompat issue #39057 - https://webcompat.com/issues/39057
+ *
+ * Custom viewer built with PDF.js is not working in Firefox for Android
+ * Disabling worker to match Chrome behavior fixes the issue
+ */
+
+/* globals exportFunction */
+
+console.info(
+  "window.PDFJS.disableWorker has been set to true for compatibility reasons. See https://webcompat.com/issues/39057 for details."
+);
+
+let globals = {};
+
+Object.defineProperty(window.wrappedJSObject, "PDFJS", {
+  get: exportFunction(function() {
+    return globals;
+  }, window),
+
+  set: exportFunction(function(value = {}) {
+    globals = value;
+    globals.disableWorker = true;
+  }, window),
+});

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/about_compat_broker.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/about_compat_broker.js
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* global browser, module */
+
+class AboutCompatBroker {
+  constructor(bindings) {
+    this.portsToAboutCompatTabs = this.buildPorts();
+
+    this._injections = bindings.injections;
+    this._injections.bindAboutCompatBroker(this);
+
+    this._uaOverrides = bindings.uaOverrides;
+    this._uaOverrides.bindAboutCompatBroker(this);
+  }
+
+  buildPorts() {
+    const ports = new Set();
+
+    browser.runtime.onConnect.addListener(port => {
+      ports.add(port);
+      port.onDisconnect.addListener(function() {
+        ports.delete(port);
+      });
+    });
+
+    async function broadcast(message) {
+      for (const port of ports) {
+        port.postMessage(message);
+      }
+    }
+
+    return { broadcast };
+  }
+
+  filterOverrides(overrides) {
+    return overrides
+      .filter(override => override.availableOnPlatform)
+      .map(override => {
+        const { id, active, bug, domain, hidden } = override;
+        return { id, active, bug, domain, hidden };
+      });
+  }
+
+  getOverrideOrInterventionById(id) {
+    for (const [type, things] of Object.entries({
+      overrides: this._uaOverrides.getAvailableOverrides(),
+      interventions: this._injections.getAvailableInjections(),
+    })) {
+      for (const what of things) {
+        if (what.id === id) {
+          return { type, what };
+        }
+      }
+    }
+    return {};
+  }
+
+  bootup() {
+    browser.runtime.onMessage.addListener(msg => {
+      switch (msg.command || msg) {
+        case "toggle": {
+          const id = msg.id;
+          const { type, what } = this.getOverrideOrInterventionById(id);
+          if (!what) {
+            return Promise.reject(
+              `No such override or intervention to toggle: ${id}`
+            );
+          }
+          this.portsToAboutCompatTabs
+            .broadcast({ toggling: id, active: what.active })
+            .then(async () => {
+              switch (type) {
+                case "interventions": {
+                  if (what.active) {
+                    await this._injections.disableInjection(what);
+                  } else {
+                    await this._injections.enableInjection(what);
+                  }
+                  break;
+                }
+                case "overrides": {
+                  if (what.active) {
+                    await this._uaOverrides.disableOverride(what);
+                  } else {
+                    await this._uaOverrides.enableOverride(what);
+                  }
+                  break;
+                }
+              }
+              this.portsToAboutCompatTabs.broadcast({
+                toggled: id,
+                active: what.active,
+              });
+            });
+          break;
+        }
+        case "getOverridesAndInterventions": {
+          return Promise.resolve({
+            overrides:
+              (this._uaOverrides.isEnabled() &&
+                this.filterOverrides(
+                  this._uaOverrides.getAvailableOverrides()
+                )) ||
+              false,
+            interventions:
+              (this._injections.isEnabled() &&
+                this.filterOverrides(
+                  this._injections.getAvailableInjections()
+                )) ||
+              false,
+          });
+        }
+      }
+      return undefined;
+    });
+  }
+}
+
+module.exports = AboutCompatBroker;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/custom_functions.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/custom_functions.js
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals module */
+
+const replaceStringInRequest = (
+  requestId,
+  inString,
+  outString,
+  inEncoding = "utf-8"
+) => {
+  const filter = browser.webRequest.filterResponseData(requestId);
+  const decoder = new TextDecoder(inEncoding);
+  const encoder = new TextEncoder();
+  const RE = new RegExp(inString, "g");
+  const carryoverLength = inString.length;
+  let carryover = "";
+
+  filter.ondata = event => {
+    const replaced = (
+      carryover + decoder.decode(event.data, { stream: true })
+    ).replace(RE, outString);
+    filter.write(encoder.encode(replaced.slice(0, -carryoverLength)));
+    carryover = replaced.slice(-carryoverLength);
+  };
+
+  filter.onstop = event => {
+    if (carryover.length) {
+      filter.write(encoder.encode(carryover));
+    }
+    filter.close();
+  };
+};
+
+const CUSTOM_FUNCTIONS = {
+  dtagFix: injection => {
+    const { urls, contentType } = injection.data;
+    const listener = (injection.data.listener = e => {
+      e.responseHeaders.push(contentType);
+      return { responseHeaders: e.responseHeaders };
+    });
+
+    browser.webRequest.onHeadersReceived.addListener(listener, { urls }, [
+      "blocking",
+      "responseHeaders",
+    ]);
+  },
+  dtagFixDisable: injection => {
+    const { listener } = injection.data;
+    browser.webRequest.onHeadersReceived.removeListener(listener);
+    delete injection.data.listener;
+  },
+  pdk5fix: injection => {
+    const { urls, types } = injection.data;
+    const listener = (injection.data.listener = ({ requestId }) => {
+      replaceStringInRequest(
+        requestId,
+        "VideoContextChromeAndroid",
+        "VideoContextAndroid"
+      );
+      return {};
+    });
+    browser.webRequest.onBeforeRequest.addListener(listener, { urls, types }, [
+      "blocking",
+    ]);
+  },
+  pdk5fixDisable: injection => {
+    const { listener } = injection.data;
+    browser.webRequest.onBeforeRequest.removeListener(listener);
+    delete injection.data.listener;
+  },
+};
+
+module.exports = CUSTOM_FUNCTIONS;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/injections.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/injections.js
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals browser, module */
+
+class Injections {
+  constructor(availableInjections, customFunctions) {
+    this.INJECTION_PREF = "perform_injections";
+
+    this._injectionsEnabled = true;
+
+    this._availableInjections = availableInjections;
+    this._activeInjections = new Map();
+    this._customFunctions = customFunctions;
+  }
+
+  bindAboutCompatBroker(broker) {
+    this._aboutCompatBroker = broker;
+  }
+
+  bootup() {
+    browser.aboutConfigPrefs.onPrefChange.addListener(() => {
+      this.checkInjectionPref();
+    }, this.INJECTION_PREF);
+    this.checkInjectionPref();
+  }
+
+  checkInjectionPref() {
+    browser.aboutConfigPrefs.getPref(this.INJECTION_PREF).then(value => {
+      if (value === undefined) {
+        browser.aboutConfigPrefs.setPref(this.INJECTION_PREF, true);
+      } else if (value === false) {
+        this.unregisterContentScripts();
+      } else {
+        this.registerContentScripts();
+      }
+    });
+  }
+
+  getAvailableInjections() {
+    return this._availableInjections;
+  }
+
+  isEnabled() {
+    return this._injectionsEnabled;
+  }
+
+  async registerContentScripts() {
+    const platformMatches = ["all"];
+    let platformInfo = await browser.runtime.getPlatformInfo();
+    platformMatches.push(platformInfo.os == "android" ? "android" : "desktop");
+
+    for (const injection of this._availableInjections) {
+      if (platformMatches.includes(injection.platform)) {
+        injection.availableOnPlatform = true;
+        await this.enableInjection(injection);
+      }
+    }
+
+    this._injectionsEnabled = true;
+    this._aboutCompatBroker.portsToAboutCompatTabs.broadcast({
+      interventionsChanged: this._aboutCompatBroker.filterOverrides(
+        this._availableInjections
+      ),
+    });
+  }
+
+  assignContentScriptDefaults(contentScripts) {
+    let finalConfig = Object.assign({}, contentScripts);
+
+    if (!finalConfig.runAt) {
+      finalConfig.runAt = "document_start";
+    }
+
+    return finalConfig;
+  }
+
+  async enableInjection(injection) {
+    if (injection.active) {
+      return;
+    }
+
+    if (injection.customFunc) {
+      return this.enableCustomInjection(injection);
+    }
+
+    return this.enableContentScripts(injection);
+  }
+
+  enableCustomInjection(injection) {
+    if (injection.customFunc in this._customFunctions) {
+      this._customFunctions[injection.customFunc](injection);
+      injection.active = true;
+    } else {
+      console.error(
+        `Provided function ${injection.customFunc} wasn't found in functions list`
+      );
+    }
+  }
+
+  async enableContentScripts(injection) {
+    try {
+      const handle = await browser.contentScripts.register(
+        this.assignContentScriptDefaults(injection.contentScripts)
+      );
+      this._activeInjections.set(injection, handle);
+      injection.active = true;
+    } catch (ex) {
+      console.error(
+        "Registering WebCompat GoFaster content scripts failed: ",
+        ex
+      );
+    }
+  }
+
+  unregisterContentScripts() {
+    for (const injection of this._availableInjections) {
+      this.disableInjection(injection);
+    }
+
+    this._injectionsEnabled = false;
+    this._aboutCompatBroker.portsToAboutCompatTabs.broadcast({
+      interventionsChanged: false,
+    });
+  }
+
+  async disableInjection(injection) {
+    if (!injection.active) {
+      return;
+    }
+
+    if (injection.customFunc) {
+      return this.disableCustomInjections(injection);
+    }
+
+    return this.disableContentScripts(injection);
+  }
+
+  disableCustomInjections(injection) {
+    const disableFunc = injection.customFunc + "Disable";
+
+    if (disableFunc in this._customFunctions) {
+      this._customFunctions[disableFunc](injection);
+      injection.active = false;
+    } else {
+      console.error(
+        `Provided function ${disableFunc} for disabling injection wasn't found in functions list`
+      );
+    }
+  }
+
+  async disableContentScripts(injection) {
+    const contentScript = this._activeInjections.get(injection);
+    await contentScript.unregister();
+    this._activeInjections.delete(injection);
+    injection.active = false;
+  }
+}
+
+module.exports = Injections;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/module_shim.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/module_shim.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/**
+ * We cannot yet use proper JS modules within webextensions, as support for them
+ * is highly experimental and highly instable. So we end up just including all
+ * the JS files we need as separate background scripts, and since they all are
+ * executed within the same context, this works for our in-browser deployment.
+ *
+ * However, this code is tracked outside of mozilla-central, and we work on
+ * shipping this code in other products, like android-components as well.
+ * Because of that, we have automated tests running within that repository. To
+ * make our lives easier, we add `module.exports` statements to the JS source
+ * files, so we can easily import their contents into our NodeJS-based test
+ * suite.
+ *
+ * This works fine, but obviously, `module` is not defined when running
+ * in-browser. So let's use this empty object as a shim, so we don't run into
+ * runtime exceptions because of that.
+ */
+var module = {};

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/ua_overrides.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/lib/ua_overrides.js
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals browser, module */
+
+class UAOverrides {
+  constructor(availableOverrides) {
+    this.OVERRIDE_PREF = "perform_ua_overrides";
+
+    this._overridesEnabled = true;
+
+    this._availableOverrides = availableOverrides;
+    this._activeListeners = new Map();
+  }
+
+  bindAboutCompatBroker(broker) {
+    this._aboutCompatBroker = broker;
+  }
+
+  bootup() {
+    browser.aboutConfigPrefs.onPrefChange.addListener(() => {
+      this.checkOverridePref();
+    }, this.OVERRIDE_PREF);
+    this.checkOverridePref();
+  }
+
+  checkOverridePref() {
+    browser.aboutConfigPrefs.getPref(this.OVERRIDE_PREF).then(value => {
+      if (value === undefined) {
+        browser.aboutConfigPrefs.setPref(this.OVERRIDE_PREF, true);
+      } else if (value === false) {
+        this.unregisterUAOverrides();
+      } else {
+        this.registerUAOverrides();
+      }
+    });
+  }
+
+  getAvailableOverrides() {
+    return this._availableOverrides;
+  }
+
+  isEnabled() {
+    return this._overridesEnabled;
+  }
+
+  enableOverride(override) {
+    if (override.active) {
+      return;
+    }
+
+    const { matches, uaTransformer } = override.config;
+    const listener = details => {
+      for (const header of details.requestHeaders) {
+        if (header.name.toLowerCase() === "user-agent") {
+          header.value = uaTransformer(header.value);
+        }
+      }
+      return { requestHeaders: details.requestHeaders };
+    };
+
+    browser.webRequest.onBeforeSendHeaders.addListener(
+      listener,
+      { urls: matches },
+      ["blocking", "requestHeaders"]
+    );
+
+    this._activeListeners.set(override, listener);
+    override.active = true;
+  }
+
+  async registerUAOverrides() {
+    const platformMatches = ["all"];
+    let platformInfo = await browser.runtime.getPlatformInfo();
+    platformMatches.push(platformInfo.os == "android" ? "android" : "desktop");
+
+    for (const override of this._availableOverrides) {
+      if (platformMatches.includes(override.platform)) {
+        override.availableOnPlatform = true;
+        this.enableOverride(override);
+      }
+    }
+
+    this._overridesEnabled = true;
+    this._aboutCompatBroker.portsToAboutCompatTabs.broadcast({
+      overridesChanged: this._aboutCompatBroker.filterOverrides(
+        this._availableOverrides
+      ),
+    });
+  }
+
+  unregisterUAOverrides() {
+    for (const override of this._availableOverrides) {
+      this.disableOverride(override);
+    }
+
+    this._overridesEnabled = false;
+    this._aboutCompatBroker.portsToAboutCompatTabs.broadcast({
+      overridesChanged: false,
+    });
+  }
+
+  disableOverride(override) {
+    if (!override.active) {
+      return;
+    }
+
+    browser.webRequest.onBeforeSendHeaders.removeListener(
+      this._activeListeners.get(override)
+    );
+    override.active = false;
+    this._activeListeners.delete(override);
+  }
+}
+
+module.exports = UAOverrides;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -1,0 +1,53 @@
+{
+  "manifest_version": 2,
+  "name": "Web Compat",
+  "description": "Urgent post-release fixes for web compatibility.",
+  "version": "5.0.2",
+
+  "applications": {
+    "gecko": {
+      "id": "webcompat@mozilla.org",
+      "strict_min_version": "59.0b5"
+    }
+  },
+
+  "experiment_apis": {
+    "aboutConfigPrefs": {
+      "schema": "experiment-apis/aboutConfigPrefs.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experiment-apis/aboutConfigPrefs.js",
+        "paths": [["aboutConfigPrefs"]]
+      }
+    },
+    "aboutPage": {
+      "schema": "about-compat/aboutPage.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "about-compat/aboutPage.js",
+        "events": ["startup"]
+      }
+    }
+  },
+
+  "content_security_policy": "script-src 'self' 'sha256-MmZkN2QaIHhfRWPZ8TVRjijTn5Ci1iEabtTEWrt9CCo='; default-src 'self'; base-uri moz-extension://*;",
+
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>"
+  ],
+
+  "background": {
+    "scripts": [
+      "lib/module_shim.js",
+      "data/injections.js",
+      "data/ua_overrides.js",
+      "lib/about_compat_broker.js",
+      "lib/custom_functions.js",
+      "lib/injections.js",
+      "lib/ua_overrides.js",
+      "run.js"
+    ]
+  }
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/run.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/run.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals AVAILABLE_INJECTIONS, AVAILABLE_UA_OVERRIDES, AboutCompatBroker,
+           Injections, UAOverrides, CUSTOM_FUNCTIONS */
+
+const injections = new Injections(AVAILABLE_INJECTIONS, CUSTOM_FUNCTIONS);
+const uaOverrides = new UAOverrides(AVAILABLE_UA_OVERRIDES);
+
+const aboutCompatBroker = new AboutCompatBroker({
+  injections,
+  uaOverrides,
+});
+
+aboutCompatBroker.bootup();
+injections.bootup();
+uaOverrides.bootup();

--- a/components/feature/webcompat/src/main/java/mozilla/components/feature/webcompat/WebCompatFeature.kt
+++ b/components/feature/webcompat/src/main/java/mozilla/components/feature/webcompat/WebCompatFeature.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.webcompat
+
+import mozilla.components.concept.engine.Engine
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * Feature to enable website-hotfixing via the Web Compatibility System-Addon.
+ */
+object WebCompatFeature {
+    private val logger = Logger("mozac-webcompat")
+
+    internal const val WEBCOMPAT_EXTENSION_ID = "webcompat@mozilla.com"
+    internal const val WEBCOMPAT_EXTENSION_URL = "resource://android/assets/extensions/webcompat/"
+
+    fun install(engine: Engine) {
+        engine.installWebExtension(WEBCOMPAT_EXTENSION_ID, WEBCOMPAT_EXTENSION_URL,
+            onSuccess = {
+                logger.debug("Installed WebCompat webextension: ${it.id}")
+            },
+            onError = { ext, throwable ->
+                logger.error("Failed to install WebCompat webextension: $ext", throwable)
+            }
+        )
+    }
+}


### PR DESCRIPTION
This imports the sources for the WebCompat System Addon, hosted at https://github.com/mozilla/webcompat-addon, as an Android Component, in preparation for shipping it in Fenix, see https://github.com/mozilla-mobile/fenix/issues/1174.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Now, this looks a bit larger than it actually is. The sources inside `components/feature/webcompat/src/main/assets/extensions/webcompat/` are imported from our GitHub and are, with the exception of some fresh interventions, already merged into mozilla-central and/or already released to the Firefox Desktop and Fennec population. This does not mean you *can't* review them, it just means you don't *have to*. :)

For everything else, please keep in mind that my Kotlin and A-C knowledge-levels are pretty much at 0, so pick apart everything. There are some points I wanted to have additional clarification on:

* I'm a bit torn if this is a `feature` or a `service`. Right now, there is no real user-visible impact besides websites getting fixed, but there will be one. From my understanding of the existing code, `service`s are mainly used for shipping background tasks and helpers for other things. However, I'm happy to move things around!
* This PR has no tests (yet). I'm unsure what exactly to test here, given the extension is only registering a webextension. The WebExt-registering has test coverage in a-c, and our system addon has test-coverage in our repository. Do you suggest just adding a test that checks if the extension is loaded correctly, or do you want something more advanced?
* I used `samples-browser` as a test vehicle, but did not include that change in this PR. I don't know if you actually want this inside the sample browser, given the addon can and will change websites in a way that's maybe unexpected by developers. However, we as the webcompat team, would really like an easy test method for development and manual tests, so the sample browser would be somewhat convenient. What do you suggest here, should I add it to the sample-browser, keep testing with my local patch, or spin another sample that just loads the WebCompat feature?

Also, although this is working for me, I'm sure I missed some things here. Sorry in advance. :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
