### PR TITLE
Fixes #4387, #4388 - Fix race in WebAppLauncherActivity

### DIFF
--- a/components/feature/pwa/src/main/AndroidManifest.xml
+++ b/components/feature/pwa/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <application>
 
         <activity android:name=".WebAppLauncherActivity"
-            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:theme="@style/Theme.AppCompat.Translucent"
             android:exported="true">
             <intent-filter>
                 <action android:name="mozilla.components.feature.pwa.PWA_LAUNCHER" />

--- a/components/feature/pwa/src/main/res/values/styles.xml
+++ b/components/feature/pwa/src/main/res/values/styles.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+
+    <style name="Theme.AppCompat.Translucent" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:background">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
Fixes #4387
Fixes #4388

WebAppLauncherActivity was sometimes destroyed before the routing could complete. `finish()` is now called after the routing is done. The activity has also been made transparent to deal with the flickering issue. (We may want to make the intent handler activity transparent too.)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
