### PR TITLE
 Closes #3173: Check push subscriptions on an interval 

### DIFF
--- a/components/feature/push/README.md
+++ b/components/feature/push/README.md
@@ -4,7 +4,7 @@ A component that implements push notifications with a supported push service.
 
 ## Usage
 
-Add a supported push service for providing the encrypted messages (for example Firebase Cloud Messaging via `lib-push-firebase`):
+Add a supported push service for providing the encrypted messages (for example, Firebase Cloud Messaging via `lib-push-firebase`):
 ```kotlin
 class FirebasePush : AbstractFirebasePushService()
 ```
@@ -14,7 +14,7 @@ Create a push configuration with the project info and also place the required se
 ```kotlin
 PushConfig(
   senderId = "push-test-f408f",
-  serverHost = "push.service.mozilla.com",
+  serverHost = "updates.push.services.mozilla.com",
   serviceType = ServiceType.FCM,
   protocol = Protocol.HTTPS
 )
@@ -62,8 +62,25 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:feature-push:{latest-version}"
 ```
 
+## Implementation Notes
+
+Why do we need to verify connections, and what happens when we do?
+- Various services may need to communicate with us via push messages. Examples: FxA events (send tab, etc), WebPush (a web app receives a push message from its server).
+- To send these push messages, services (FxA, random internet servers talking to their web apps) post an HTTP request to a "push endpoint" maintained by [Mozilla's Autopush service][0]. This push endpoint is specific to its recipient - so one instance of an app may have many endpoints associated with it: one for the current FxA device, a few for web apps, etc.
+- Important point here: servers (FxA, services behind web apps, etc.) need to be told about subscription info we get from Autopush.
+- Here is where things start to get complicated: client (us) and server (Autopush) may disagree on which channels are associated with the current UAID (remember: our subscriptions are per-channel). Channels may expire (TTL'd) or may be deleted by some server's Cron job if they're unused. For example, if this happens, services that use this subscription info (e.g. FxA servers) to communication with their clients (FxA devices) will fail to deliver push messages.
+- So the client needs to be able to find out that this is the case, re-create channel subscriptions on Autopush, and update any dependent services with new subscription info (e.g. update the FxA device record for `PushType.Services`, or notify the JS code with a `pushsubscriptionchanged` event for WebPush).
+- The Autopush side of this is `verify_connection` API - we're expected to call this periodically, and that library will compare channel registrations that the server knows about vs those that the client knows about.
+- If those are misaligned, we need to re-register affected (or, all?) channels, and notify related services so that they may update their own server-side records.
+- For FxA, this means that we need to have an instance of the rust FirefoxAccount object around in order to call `setDevicePushSubscriptionAsync` once we re-generate our push subscription.
+- For consumers such as Fenix, easiest way to access that method is via an `account manager`.
+- However, neither account object itself, nor the account manager, aren't available from within a Worker. It's possible to "re-hydrate" (instantiate rust object from the locally persisted state) a FirefoxAccount instance, but that's a separate can of worms, and needs to be carefully considered.
+- Similarly for WebPush (in the future), we will need to have Gecko around in order to fire `pushsubscriptionchanged` javascript events.
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+[0]: https://github.com/mozilla-services/autopush

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,9 @@ permalink: /changelog/
     * `browser-engine-gecko-beta`: GeckoView 71.0
     * `browser-engine-gecko-nightly`: GeckoView 72.0
 
+* **feature-push**
+  * The `AutoPushFeature` now checks (once every 24 hours) to verify and renew push subscriptions if expired after a cold boot.
+  
 # 18.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v17.0.0...v18.0.0)


### PR DESCRIPTION
We start a CoroutineWorker that is enqueued when the application starts, but only checks for verifications after 24 hours since the last attempt.

Our implementation uses a timestamp to do this check since the Worker can actually run when the app is force-closed, but because it is no longer alive, invocations of `PushProcessors.requireInstance` will throw exceptions and fail silently. This can happen repeatedly if the worker is started, when a user typically doesn't have the app in-memory, without any verification ever happening.

Since it's a Coroutine, starting a worker is cheap even if we do no real work (because our last check was less than 24 hours).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Closes #3173 

cc: @Dexterp37 , @travis79 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
