### PR TITLE
Support the session token scope in the samples

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -185,6 +185,13 @@ class FirefoxAccount internal constructor(
     }
 
     /**
+     * Get the account session token.
+     */
+    fun getSessionToken(): String {
+        return inner.getSessionToken()
+    }
+
+    /**
      * Tries to fetch an access token for the given scope.
      *
      * @param singleScope Single OAuth scope (no spaces) for which the client wants access

--- a/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
+++ b/samples/firefox-accounts/src/main/java/org/mozilla/samples/fxa/MainActivity.kt
@@ -34,7 +34,7 @@ import kotlin.coroutines.CoroutineContext
 open class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener, CoroutineScope {
     private lateinit var account: FirefoxAccount
     private var scopesWithoutKeys: Set<String> = setOf("profile")
-    private var scopesWithKeys: Set<String> = setOf("profile", "https://identity.mozilla.com/apps/oldsync")
+    private var scopesWithKeys: Set<String> = setOf("profile", "https://identity.mozilla.com/apps/oldsync", "https://identity.mozilla.com/tokens/session")
     private var scopes: Set<String> = scopesWithoutKeys
 
     private lateinit var qrFeature: QrFeature


### PR DESCRIPTION
Requires https://github.com/mozilla/application-services/pull/1759 and **FxA 146** with these changes applied https://github.com/mozilla/fxa/issues/2523 

cc @grigoryk 