### PR TITLE
Add support for Gecko categorical histograms in the Glean SDK

### DIFF
--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "1.5.1"
+String GLEAN_PARSER_VERSION = "1.6.1"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/LabeledMetricType.kt
@@ -213,4 +213,25 @@ data class LabeledMetricType<T>(
 
         return getMetricWithNewName(newMetricName)
     }
+
+    /**
+     * Get the specific metric for a given label index.
+     *
+     * This only works if a set of acceptable labels were specified in the
+     * metrics.yaml file. If static labels were not defined in that file or
+     * the index of the given label is not in the set, it will be recorded under
+     * the special [OTHER_LABEL].
+     *
+     * @param labelIndex The label
+     * @return The specific metric for that label
+     */
+    operator fun get(labelIndex: Int): T {
+        val actualLabel = if (labels != null && labelIndex < labels.size) {
+            labels.elementAt(labelIndex)
+        } else {
+            OTHER_LABEL
+        }
+
+        return this[actualLabel]
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,9 @@ permalink: /changelog/
 * **feature-pwa**
   * Adds `WebAppHideToolbarFeature.onToolbarVisibilityChange` to be notified when the toolbar is shown or hidden.
 
+* **engine-gecko-nightly**
+  * Added the ability to exfiltrate Gecko categorical histograms.
+
 # 13.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v12.0.0...v13.0.0)


### PR DESCRIPTION
This changes:

- the `GleanAdapter` in engine-gecko-nightly to increment labeled counters when a categorical histogram is bubbled up (@pocmo flagged as a component owner and @chutten flagged for double checking my understanding of categoricals);
- adds a new getter to `LabeledMetricType` that allows to get the label by its index, required for categoricals (@mdboom to review);
- updates the changelog.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
