### PR TITLE
For #4444: Use AndroidX browser 1.2.0-alpha07

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     object AndroidX {
         const val annotation = "1.1.0"
         const val appcompat = "1.1.0"
-        const val browser = "1.0.0"
+        const val browser = "1.2.0-alpha07"
         const val cardview = "1.0.0"
         const val constraintlayout = "1.1.3"
         const val core = "1.1.0"

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
@@ -133,4 +133,8 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
     override fun updateVisuals(sessionToken: CustomTabsSessionToken, bundle: Bundle?): Boolean {
         return false
     }
+
+    override fun receiveFile(sessionToken: CustomTabsSessionToken, uri: Uri, purpose: Int, extras: Bundle?): Boolean {
+        return false
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **All components**
+  * Increased `androidx.browser` version to `1.2.0-alpha07`.
+
 * **feature-media**
   * Playback will now be stopped and the media notification will get removed if the app's task is getting removed (app is swiped away in task switcher).
 


### PR DESCRIPTION
[How to revert](https://docs.google.com/document/d/1IJBC929ntbTuwX7vJOnlFzqkzI-YL2HueelVQeKRPzA/edit)

This version is needed to support Trusted Web Activities.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
