### PR TITLE
Closes #4297: Make web extension feature logic reusable

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -276,6 +276,10 @@ projects:
     path: components/support/locale
     description: 'A component to allow apps to change the system defined language by their custom one'
     publish: true
+  support-webextensions:
+    path: components/support/webextensions
+    description: 'A component containing building blocks for features implemented as web extensions.'
+    publish: true
   lib-crash:
     path: components/lib/crash
     description: 'A generic crash reporter library that can report crashes to multiple services.'

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ _Supporting components with generic helper code._
 
 * 🔵 [**Utils**](components/support/utils/README.md) - Generic utility classes to be shared between projects.
 
+* 🔵 [**Webextensions**](components/support/webextensions/README.md) - A component containing building blocks for features implemented as web extensions.
+
 ## Standalone libraries
 
 * ⚪ [**Crash**](components/lib/crash/README.md) - A generic crash reporter component that can report crashes to multiple services.

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -51,11 +51,13 @@ class GeckoWebExtensionTest {
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(null))
 
-        // Verify connected port is forwarded to message handler
+        // Verify port is connected and forwarded to message handler
         val port: WebExtension.Port = mock()
         messageDelegateCaptor.value.onConnect(port)
         verify(messageHandler).onPortConnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertNotNull(extension.getConnectedPort("mozacTest"))
+        assertSame(port, (extension.getConnectedPort("mozacTest") as GeckoPort).nativePort)
 
         // Verify port messages are forwarded to message handler
         verify(port).setDelegate(portDelegateCaptor.capture())
@@ -69,6 +71,7 @@ class GeckoWebExtensionTest {
         portDelegate.onDisconnect(port)
         verify(messageHandler).onPortDisconnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertNull(extension.getConnectedPort("mozacTest"))
     }
 
     @Test
@@ -99,12 +102,14 @@ class GeckoWebExtensionTest {
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(session))
 
-        // Verify connected port is forwarded to message handler
+        // Verify port is connected and forwarded to message handler
         val port: WebExtension.Port = mock()
         messageDelegateCaptor.value.onConnect(port)
         verify(messageHandler).onPortConnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+        assertNotNull(extension.getConnectedPort("mozacTest", session))
+        assertSame(port, (extension.getConnectedPort("mozacTest", session) as GeckoPort).nativePort)
 
         // Verify port messages are forwarded to message handler
         verify(port).setDelegate(portDelegateCaptor.capture())
@@ -120,5 +125,52 @@ class GeckoWebExtensionTest {
         verify(messageHandler).onPortDisconnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+        assertNull(extension.getConnectedPort("mozacTest", session))
+    }
+
+    @Test
+    fun `disconnect port from content script`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val session: GeckoEngineSession = mock()
+        val geckoSession: GeckoSession = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+
+        whenever(session.geckoSession).thenReturn(geckoSession)
+
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
+        verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Connect port
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        assertNotNull(extension.getConnectedPort("mozacTest", session))
+
+        // Disconnect port
+        extension.disconnectPort("mozacTest", session)
+        verify(port).disconnect()
+        assertNull(extension.getConnectedPort("mozacTest", session))
+    }
+
+    @Test
+    fun `disconnect port from background script`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
+
+        verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Connect port
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        assertNotNull(extension.getConnectedPort("mozacTest"))
+
+        // Disconnect port
+        extension.disconnectPort("mozacTest")
+        verify(port).disconnect()
+        assertNull(extension.getConnectedPort("mozacTest"))
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -51,11 +51,13 @@ class GeckoWebExtensionTest {
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(null))
 
-        // Verify connected port is forwarded to message handler
+        // Verify port is connected and forwarded to message handler
         val port: WebExtension.Port = mock()
         messageDelegateCaptor.value.onConnect(port)
         verify(messageHandler).onPortConnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertNotNull(extension.getConnectedPort("mozacTest"))
+        assertSame(port, (extension.getConnectedPort("mozacTest") as GeckoPort).nativePort)
 
         // Verify port messages are forwarded to message handler
         verify(port).setDelegate(portDelegateCaptor.capture())
@@ -69,6 +71,7 @@ class GeckoWebExtensionTest {
         portDelegate.onDisconnect(port)
         verify(messageHandler).onPortDisconnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertNull(extension.getConnectedPort("mozacTest"))
     }
 
     @Test
@@ -99,12 +102,14 @@ class GeckoWebExtensionTest {
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(session))
 
-        // Verify connected port is forwarded to message handler
+        // Verify port is connected and forwarded to message handler
         val port: WebExtension.Port = mock()
         messageDelegateCaptor.value.onConnect(port)
         verify(messageHandler).onPortConnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+        assertNotNull(extension.getConnectedPort("mozacTest", session))
+        assertSame(port, (extension.getConnectedPort("mozacTest", session) as GeckoPort).nativePort)
 
         // Verify port messages are forwarded to message handler
         verify(port).setDelegate(portDelegateCaptor.capture())
@@ -120,5 +125,52 @@ class GeckoWebExtensionTest {
         verify(messageHandler).onPortDisconnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+        assertNull(extension.getConnectedPort("mozacTest", session))
+    }
+
+    @Test
+    fun `disconnect port from content script`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val session: GeckoEngineSession = mock()
+        val geckoSession: GeckoSession = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+
+        whenever(session.geckoSession).thenReturn(geckoSession)
+
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
+        verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Connect port
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        assertNotNull(extension.getConnectedPort("mozacTest", session))
+
+        // Disconnect port
+        extension.disconnectPort("mozacTest", session)
+        verify(port).disconnect()
+        assertNull(extension.getConnectedPort("mozacTest", session))
+    }
+
+    @Test
+    fun `disconnect port from background script`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
+
+        verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Connect port
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        assertNotNull(extension.getConnectedPort("mozacTest"))
+
+        // Disconnect port
+        extension.disconnectPort("mozacTest")
+        verify(port).disconnect()
+        assertNull(extension.getConnectedPort("mozacTest"))
     }
 }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -51,11 +51,13 @@ class GeckoWebExtensionTest {
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(null))
 
-        // Verify connected port is forwarded to message handler
+        // Verify port is connected and forwarded to message handler
         val port: WebExtension.Port = mock()
         messageDelegateCaptor.value.onConnect(port)
         verify(messageHandler).onPortConnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertNotNull(extension.getConnectedPort("mozacTest"))
+        assertSame(port, (extension.getConnectedPort("mozacTest") as GeckoPort).nativePort)
 
         // Verify port messages are forwarded to message handler
         verify(port).setDelegate(portDelegateCaptor.capture())
@@ -69,6 +71,7 @@ class GeckoWebExtensionTest {
         portDelegate.onDisconnect(port)
         verify(messageHandler).onPortDisconnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
+        assertNull(extension.getConnectedPort("mozacTest"))
     }
 
     @Test
@@ -99,12 +102,14 @@ class GeckoWebExtensionTest {
         assertNull(messageDelegateCaptor.value.onMessage(message, sender))
         verify(messageHandler, times(2)).onMessage(eq(message), eq(session))
 
-        // Verify connected port is forwarded to message handler
+        // Verify port is connected and forwarded to message handler
         val port: WebExtension.Port = mock()
         messageDelegateCaptor.value.onConnect(port)
         verify(messageHandler).onPortConnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+        assertNotNull(extension.getConnectedPort("mozacTest", session))
+        assertSame(port, (extension.getConnectedPort("mozacTest", session) as GeckoPort).nativePort)
 
         // Verify port messages are forwarded to message handler
         verify(port).setDelegate(portDelegateCaptor.capture())
@@ -120,5 +125,52 @@ class GeckoWebExtensionTest {
         verify(messageHandler).onPortDisconnected(portCaptor.capture())
         assertSame(port, (portCaptor.value as GeckoPort).nativePort)
         assertSame(session, (portCaptor.value as GeckoPort).engineSession)
+        assertNull(extension.getConnectedPort("mozacTest", session))
+    }
+
+    @Test
+    fun `disconnect port from content script`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val session: GeckoEngineSession = mock()
+        val geckoSession: GeckoSession = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+
+        whenever(session.geckoSession).thenReturn(geckoSession)
+
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
+        verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Connect port
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        assertNotNull(extension.getConnectedPort("mozacTest", session))
+
+        // Disconnect port
+        extension.disconnectPort("mozacTest", session)
+        verify(port).disconnect()
+        assertNull(extension.getConnectedPort("mozacTest", session))
+    }
+
+    @Test
+    fun `disconnect port from background script`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val messageHandler: MessageHandler = mock()
+        val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
+        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
+
+        verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
+
+        // Connect port
+        val port: WebExtension.Port = mock()
+        messageDelegateCaptor.value.onConnect(port)
+        assertNotNull(extension.getConnectedPort("mozacTest"))
+
+        // Disconnect port
+        extension.disconnectPort("mozacTest")
+        verify(port).disconnect()
+        assertNull(extension.getConnectedPort("mozacTest"))
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.engine.webextension
 
 import mozilla.components.concept.engine.EngineSession
+import org.json.JSONObject
 
 /**
  * Represents a browser extension based on the WebExtension API:
@@ -58,6 +59,28 @@ abstract class WebExtension(
      * @return true if a content message handler is active, otherwise false.
      */
     abstract fun hasContentMessageHandler(session: EngineSession, name: String): Boolean
+
+    /**
+     * Returns a connected port with the given name and for the provided
+     * [EngineSession], if one exists.
+     *
+     * @param name the name as provided to connectNative.
+     * @param session (optional) session to check for, null if port is from a
+     * background script.
+     * @return a matching port, or null if none is connected.
+     */
+    abstract fun getConnectedPort(name: String, session: EngineSession? = null): Port?
+
+    /**
+     * Disconnect a [Port] of the provided [EngineSession]. This method has
+     * no effect if there's no connected port with the given name.
+     *
+     * @param name the name as provided to connectNative, see
+     * [registerContentMessageHandler] and [registerBackgroundMessageHandler].
+     * @param session (options) session for which ports should disconnected,
+     * null if port is from a background script.
+     */
+    abstract fun disconnectPort(name: String, session: EngineSession? = null)
 }
 
 /**
@@ -120,8 +143,17 @@ abstract class Port(val engineSession: EngineSession? = null) {
     /**
      * Sends a message to this port.
      *
-     * @param message the message to send, either a primitive type
-     * or a org.json.JSONObject.
+     * @param message the message to send.
      */
-    abstract fun postMessage(message: Any)
+    abstract fun postMessage(message: JSONObject)
+
+    /**
+     * Returns the name of this port.
+     */
+    abstract fun name(): String
+
+    /**
+     * Disconnects this port.
+     */
+    abstract fun disconnect()
 }

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -2,6 +2,7 @@ package mozilla.components.concept.engine.webextension
 
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.mock
+import org.json.JSONObject
 import org.junit.Assert.assertSame
 import org.junit.Test
 
@@ -21,7 +22,13 @@ class WebExtensionTest {
     fun `port holds engine session`() {
         val engineSession: EngineSession = mock()
         val port = object : Port(engineSession) {
-            override fun postMessage(message: Any) { }
+            override fun name(): String {
+                return "test"
+            }
+
+            override fun disconnect() {}
+
+            override fun postMessage(message: JSONObject) { }
         }
 
         assertSame(engineSession, port.engineSession)

--- a/components/feature/readerview/build.gradle
+++ b/components/feature/readerview/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':support-base')
     implementation project(':support-ktx')
     implementation project(':support-utils')
+    implementation project(':support-webextensions')
     implementation project(':ui-icons')
 
     implementation Dependencies.androidx_core_ktx

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -11,10 +11,8 @@ import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
-import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.feature.readerview.internal.ReaderViewControlsInteractor
 import mozilla.components.feature.readerview.internal.ReaderViewControlsPresenter
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
@@ -22,22 +20,21 @@ import mozilla.components.feature.readerview.ReaderViewFeature.ColorScheme.LIGHT
 import mozilla.components.feature.readerview.ReaderViewFeature.FontType.SERIF
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.webextensions.WebExtensionController
 import org.json.JSONObject
 import java.lang.ref.WeakReference
-import java.util.WeakHashMap
 import kotlin.properties.Delegates.observable
 
 typealias OnReaderViewAvailableChange = (available: Boolean) -> Unit
 
 /**
  * Feature implementation that provides a reader view for the selected
- * session. This feature is implemented as a web extension and
- * needs to be installed prior to use (see [ReaderViewFeature.install]).
+ * session, based on a web extension.
  *
  * @property context a reference to the context.
  * @property engine a reference to the application's browser engine.
  * @property sessionManager a reference to the application's [SessionManager].
+ * @param controlsView the view to use to display reader mode controls.
  * @property onReaderViewAvailableChange a callback invoked to indicate whether
  * or not reader view is available for the page loaded by the currently selected
  * session. The callback will be invoked when a page is loaded or refreshed,
@@ -54,7 +51,12 @@ class ReaderViewFeature(
 ) : SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature, BackHandler {
 
     @VisibleForTesting
+    // This is an internal var to make it mutable for unit testing purposes only
+    internal var extensionController = WebExtensionController(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL)
+
+    @VisibleForTesting
     internal val config = Config(context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE))
+
     private val controlsPresenter = ReaderViewControlsPresenter(controlsView, config)
     private val controlsInteractor = ReaderViewControlsInteractor(controlsView, config)
 
@@ -66,7 +68,7 @@ class ReaderViewFeature(
         var colorScheme by observable(ColorScheme.valueOf(prefs.getString(COLOR_SCHEME_KEY, LIGHT.name)!!)) {
             _, old, new -> if (old != new) {
                 val message = JSONObject().put(ACTION_MESSAGE_KEY, ACTION_SET_COLOR_SCHEME).put(ACTION_VALUE, new.name)
-                sendContentMessage(message)
+                sendConfigMessage(message)
                 prefs.edit().putString(COLOR_SCHEME_KEY, new.name).apply()
             }
         }
@@ -74,7 +76,7 @@ class ReaderViewFeature(
         var fontType by observable(FontType.valueOf(prefs.getString(FONT_TYPE_KEY, SERIF.name)!!)) {
             _, old, new -> if (old != new) {
                 val message = JSONObject().put(ACTION_MESSAGE_KEY, ACTION_SET_FONT_TYPE).put(ACTION_VALUE, new.value)
-                sendContentMessage(message)
+                sendConfigMessage(message)
                 prefs.edit().putString(FONT_TYPE_KEY, new.name).apply()
             }
         }
@@ -82,22 +84,24 @@ class ReaderViewFeature(
         var fontSize by observable(prefs.getInt(FONT_SIZE_KEY, FONT_SIZE_DEFAULT)) {
             _, old, new -> if (old != new) {
                 val message = JSONObject().put(ACTION_MESSAGE_KEY, ACTION_CHANGE_FONT_SIZE).put(ACTION_VALUE, new - old)
-                sendContentMessage(message)
+                sendConfigMessage(message)
                 prefs.edit().putInt(FONT_SIZE_KEY, new).apply()
+            }
+        }
+
+        private fun sendConfigMessage(message: JSONObject, session: Session? = activeSession) {
+            session?.let {
+                extensionController.sendContentMessage(message, sessionManager.getEngineSession(it))
             }
         }
     }
 
     override fun start() {
         observeSelected()
+        registerReaderViewContentMessageHandler()
 
-        registerContentMessageHandler()
-
-        if (ReaderViewFeature.installedWebExt == null) {
-            ReaderViewFeature.install(engine)
-        }
-
-        if (portConnected()) {
+        extensionController.install(engine)
+        if (extensionController.portConnected(sessionManager.getOrCreateEngineSession())) {
             updateReaderViewState()
         }
 
@@ -129,17 +133,17 @@ class ReaderViewFeature(
     }
 
     override fun onSessionAdded(session: Session) {
-        registerContentMessageHandler(session)
+        registerReaderViewContentMessageHandler(session)
     }
 
     override fun onSessionRemoved(session: Session) {
-        ports.remove(sessionManager.getEngineSession(session))
+        extensionController.disconnectPort(sessionManager.getEngineSession(session))
     }
 
     override fun onUrlChanged(session: Session, url: String) {
         session.readerable = false
         session.readerMode = false
-        checkReaderable()
+        checkReaderable(session)
     }
 
     override fun onReaderableStateUpdated(session: Session, readerable: Boolean) {
@@ -150,8 +154,8 @@ class ReaderViewFeature(
      * Shows the reader view UI.
      */
     fun showReaderView(session: Session? = activeSession) {
-        session?.let {
-            showReaderView(sessionManager.getEngineSession(session), config)
+        session?.let { it ->
+            extensionController.sendContentMessage(createShowReaderMessage(config), sessionManager.getEngineSession(it))
             it.readerMode = true
         }
     }
@@ -160,11 +164,11 @@ class ReaderViewFeature(
      * Hides the reader view UI.
      */
     fun hideReaderView(session: Session? = activeSession) {
-        session?.let {
+        session?.let { it ->
             it.readerMode = false
             // We will re-determine if the original page is readerable when it's loaded.
             it.readerable = false
-            hideReaderView(sessionManager.getEngineSession(session))
+            extensionController.sendContentMessage(createHideReaderMessage(), sessionManager.getEngineSession(it))
         }
     }
 
@@ -185,26 +189,22 @@ class ReaderViewFeature(
     @VisibleForTesting
     internal fun checkReaderable(session: Session? = activeSession) {
         session?.let {
-            checkReaderable(sessionManager.getEngineSession(session))
+            val engineSession = sessionManager.getEngineSession(session)
+            if (extensionController.portConnected(engineSession)) {
+                extensionController.sendContentMessage(createCheckReaderableMessage(), engineSession)
+            }
         }
     }
 
     @VisibleForTesting
-    internal fun registerContentMessageHandler(session: Session? = activeSession) {
+    internal fun registerReaderViewContentMessageHandler(session: Session? = activeSession) {
         if (session == null) {
             return
         }
 
         val engineSession = sessionManager.getOrCreateEngineSession(session)
-        val messageHandler = ReaderViewContentMessageHandler(session, engineSession, WeakReference(config))
-        registerMessageHandler(engineSession, messageHandler)
-    }
-
-    @VisibleForTesting
-    internal fun sendContentMessage(msg: Any, session: Session? = activeSession) {
-        session?.let {
-            sendContentMessage(msg, sessionManager.getEngineSession(session))
-        }
+        val messageHandler = ReaderViewContentMessageHandler(session, WeakReference(config))
+        extensionController.registerContentMessageHandler(engineSession, messageHandler)
     }
 
     @VisibleForTesting
@@ -219,14 +219,8 @@ class ReaderViewFeature(
         }
     }
 
-    @VisibleForTesting
-    internal fun portConnected(session: Session? = activeSession): Boolean {
-        return session?.let { portConnected(sessionManager.getEngineSession(session)) } ?: false
-    }
-
     private class ReaderViewContentMessageHandler(
         private val session: Session,
-        private val engineSession: EngineSession,
         // This needs to be a weak reference because the engine session this message handler will be
         // attached to has a longer lifespan than the feature instance i.e. a tab can remain open,
         // but we don't want to prevent the feature (and therefore its context/fragment) from
@@ -236,16 +230,10 @@ class ReaderViewFeature(
         override fun onPortConnected(port: Port) {
             val config = config.get() ?: return
 
-            ports[port.engineSession] = port
-
-            checkReaderable(engineSession)
+            port.postMessage(createCheckReaderableMessage())
             if (session.readerMode) {
-                showReaderView(engineSession, config)
+                port.postMessage(createShowReaderMessage(config))
             }
-        }
-
-        override fun onPortDisconnected(port: Port) {
-            ports.remove(port.engineSession)
         }
 
         override fun onPortMessage(message: Any, port: Port) {
@@ -257,8 +245,6 @@ class ReaderViewFeature(
 
     @VisibleForTesting
     companion object {
-        private val logger = Logger("mozac-readerview")
-
         internal const val READER_VIEW_EXTENSION_ID = "mozacReaderview"
         internal const val READER_VIEW_EXTENSION_URL = "resource://android/assets/extensions/readerview/"
 
@@ -285,78 +271,23 @@ class ReaderViewFeature(
         internal const val FONT_SIZE_KEY = "mozac-readerview-fontsize"
         internal const val FONT_SIZE_DEFAULT = 3
 
-        @Volatile
-        internal var installedWebExt: WebExtension? = null
-
-        @Volatile
-        private var registerContentMessageHandler: (WebExtension) -> Unit? = { }
-
-        internal var ports = WeakHashMap<EngineSession, Port>()
-
-        /**
-         * Installs the readerview web extension in the provided engine.
-         *
-         * @param engine a reference to the application's browser engine.
-         */
-        fun install(engine: Engine) {
-            engine.installWebExtension(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL,
-                onSuccess = {
-                    logger.debug("Installed extension: ${it.id}")
-                    registerContentMessageHandler(it)
-                    installedWebExt = it
-                },
-                onError = { ext, throwable ->
-                    logger.error("Failed to install extension: $ext", throwable)
-                }
-            )
+        private fun createCheckReaderableMessage(): JSONObject {
+            return JSONObject().put(ACTION_MESSAGE_KEY, ACTION_CHECK_READERABLE)
         }
 
-        fun registerMessageHandler(session: EngineSession, messageHandler: MessageHandler) {
-            registerContentMessageHandler = {
-                it.registerContentMessageHandler(session, READER_VIEW_EXTENSION_ID, messageHandler)
-            }
+        private fun createShowReaderMessage(config: Config): JSONObject {
+            val configJson = JSONObject()
+                    .put(ACTION_VALUE_SHOW_FONT_SIZE, config.fontSize)
+                    .put(ACTION_VALUE_SHOW_FONT_TYPE, config.fontType.name.toLowerCase())
+                    .put(ACTION_VALUE_SHOW_COLOR_SCHEME, config.colorScheme.name.toLowerCase())
 
-            installedWebExt?.let { registerContentMessageHandler(it) }
+            return JSONObject()
+                    .put(ACTION_MESSAGE_KEY, ACTION_SHOW)
+                    .put(ACTION_VALUE, configJson)
         }
 
-        private fun checkReaderable(engineSession: EngineSession?) {
-            engineSession?.let {
-                if (portConnected(it)) {
-                    sendContentMessage(JSONObject().put(ACTION_MESSAGE_KEY, ACTION_CHECK_READERABLE), it)
-                }
-            }
-        }
-
-        private fun portConnected(engineSession: EngineSession?): Boolean {
-            return engineSession?.let { ports.containsKey(it) } ?: false
-        }
-
-        private fun sendContentMessage(msg: Any, engineSession: EngineSession?) {
-            engineSession?.let {
-                val port = ports[it]
-                port?.postMessage(msg) ?: logger.error("No port connected for provided session. Message $msg not sent.")
-            }
-        }
-
-        private fun showReaderView(engineSession: EngineSession?, config: Config) {
-            engineSession?.let {
-                val configJson = JSONObject()
-                        .put(ACTION_VALUE_SHOW_FONT_SIZE, config.fontSize)
-                        .put(ACTION_VALUE_SHOW_FONT_TYPE, config.fontType.name.toLowerCase())
-                        .put(ACTION_VALUE_SHOW_COLOR_SCHEME, config.colorScheme.name.toLowerCase())
-
-                val message = JSONObject()
-                        .put(ACTION_MESSAGE_KEY, ACTION_SHOW)
-                        .put(ACTION_VALUE, configJson)
-
-                sendContentMessage(message, engineSession)
-            }
-        }
-
-        private fun hideReaderView(engineSession: EngineSession?) {
-            engineSession?.let {
-                sendContentMessage(JSONObject().put(ACTION_MESSAGE_KEY, ACTION_HIDE), engineSession)
-            }
+        private fun createHideReaderMessage(): JSONObject {
+            return JSONObject().put(ACTION_MESSAGE_KEY, ACTION_HIDE)
         }
     }
 }

--- a/components/support/webextensions/README.md
+++ b/components/support/webextensions/README.md
@@ -1,0 +1,21 @@
+# [Android Components](../../../README.md) > Support > Webextensions
+
+A component containing building blocks for features implemented as web extensions.
+
+Usually this component never needs to be added to application projects manually. Other components may have a transitive dependency on some of the classes and interfaces in this component.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:support-webextensions:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/support/webextensions/build.gradle
+++ b/components/support/webextensions/build.gradle
@@ -16,24 +16,28 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
+    }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
     }
 }
 
+
 dependencies {
-    implementation Dependencies.kotlin_coroutines
-
     implementation project(':concept-engine')
-    implementation project(':feature-tabs')
-    implementation project(':service-firefox-accounts')
-    implementation project(':support-webextensions')
-
-    testImplementation Dependencies.androidx_test_junit
-    testImplementation Dependencies.testing_mockito
-    testImplementation Dependencies.testing_robolectric
+    implementation project(':support-base')
+    implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/webextensions/proguard-rules.pro
+++ b/components/support/webextensions/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/support/webextensions/src/main/AndroidManifest.xml
+++ b/components/support/webextensions/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.support.webextensions" />

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.webextensions
+
+import androidx.annotation.VisibleForTesting
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Provides functionality to feature modules that need to interact with a web extension.
+ *
+ * @property extensionId the unique ID of the web extension e.g. mozacReaderview.
+ * @property extensionUrl the url pointing to a resources path for locating the
+ * extension within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ */
+class WebExtensionController(
+    private val extensionId: String,
+    private val extensionUrl: String
+) {
+    private val logger = Logger("mozac-webextensions")
+    private var registerContentMessageHandler: (WebExtension) -> Unit? = { }
+
+    /**
+     * Makes sure the web extension is installed in the provided engine. If a
+     * content message handler was registered (see
+     * [registerContentMessageHandler]) before install completed, registration
+     * will happen upon successful installation.
+     *
+     * @param engine the [Engine] the web extension should be installed in.
+     */
+    fun install(engine: Engine) {
+        if (!installedExtensions.containsKey(extensionId)) {
+            engine.installWebExtension(extensionId, extensionUrl,
+                onSuccess = {
+                    logger.debug("Installed extension: ${it.id}")
+                    synchronized(this@WebExtensionController) {
+                        registerContentMessageHandler(it)
+                        installedExtensions[extensionId] = it
+                    }
+                },
+                onError = { ext, throwable ->
+                    logger.error("Failed to install extension: $ext", throwable)
+                }
+            )
+        }
+    }
+
+    /**
+     * Registers a content message handler for the provided session. Currently only one
+     * handler can be registered per session. An existing handler will be replaced and
+     * there is no need to unregister.
+     *
+     * @param engineSession the session the content message handler should be registered with.
+     * @param messageHandler the message handler to register.
+     * @param name (optional) name of the port, defaults to the provided extensionId.
+     */
+    fun registerContentMessageHandler(
+        engineSession: EngineSession,
+        messageHandler: MessageHandler,
+        name: String = extensionId
+    ) {
+        synchronized(this) {
+            registerContentMessageHandler = {
+                it.registerContentMessageHandler(engineSession, name, messageHandler)
+            }
+
+            installedExtensions[extensionId]?.let { registerContentMessageHandler(it) }
+        }
+    }
+
+    /**
+     * Sends a content message to the provided session.
+     *
+     * @param msg the message to send
+     * @param engineSession the session to send the content message to.
+     * @param name (optional) name of the port, defaults to the provided extensionId.
+     */
+    fun sendContentMessage(msg: JSONObject, engineSession: EngineSession?, name: String = extensionId) {
+        engineSession?.let { session ->
+            installedExtensions[extensionId]?.let { ext ->
+                val port = ext.getConnectedPort(name, session)
+                port?.postMessage(msg) ?: logger.error("No port connected for provided session. Message $msg not sent.")
+            }
+        }
+    }
+
+    /**
+     * Checks whether or not a port is connected for the provided session.
+     *
+     * @param engineSession the session the port should be connected to.
+     * @param name (optional) name of the port, defaults to the provided extensionId.
+     */
+    fun portConnected(engineSession: EngineSession?, name: String = extensionId): Boolean {
+        return engineSession?.let { session ->
+            installedExtensions[extensionId]?.let { ext ->
+                ext.getConnectedPort(name, session) != null
+            }
+        } ?: false
+    }
+
+    /**
+     * Disconnects the port of the provided session.
+     *
+     * @param engineSession the session the port is connected to.
+     * @param name (optional) name of the port, defaults to the provided extensionId.
+     */
+    fun disconnectPort(engineSession: EngineSession?, name: String = extensionId) {
+        engineSession?.let { session ->
+            installedExtensions[extensionId]?.let { ext ->
+                ext.disconnectPort(name, session)
+            }
+        }
+    }
+
+    companion object {
+        @VisibleForTesting
+        val installedExtensions = ConcurrentHashMap<String, WebExtension>()
+    }
+}

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.webextensions
+
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
+import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class WebExtensionControllerTest {
+    private val extensionId = "test-id"
+    private val extensionUrl = "test-url"
+
+    @Before
+    fun setup() {
+        WebExtensionController.installedExtensions.clear()
+    }
+
+    @Test
+    fun `install webextension`() {
+        val engine: Engine = mock()
+        val controller = WebExtensionController(extensionId, extensionUrl)
+        controller.install(engine)
+
+        val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
+        val onError = argumentCaptor<((String, Throwable) -> Unit)>()
+        verify(engine, times(1)).installWebExtension(
+            eq(extensionId),
+            eq(extensionUrl),
+            eq(true),
+            onSuccess.capture(),
+            onError.capture()
+        )
+        assertFalse(WebExtensionController.installedExtensions.containsKey(extensionId))
+
+        onSuccess.value.invoke(mock())
+        assertTrue(WebExtensionController.installedExtensions.containsKey(extensionId))
+
+        controller.install(engine)
+        verify(engine, times(1)).installWebExtension(
+            eq(extensionId),
+            eq(extensionUrl),
+            eq(true),
+            onSuccess.capture(),
+            onError.capture()
+        )
+    }
+
+    @Test
+    fun `register content message handler if extension installed`() {
+        val extension: WebExtension = mock()
+        val controller = WebExtensionController(extensionId, extensionUrl)
+        WebExtensionController.installedExtensions[extensionId] = extension
+
+        val session: EngineSession = mock()
+        val messageHandler: MessageHandler = mock()
+        controller.registerContentMessageHandler(session, messageHandler)
+        verify(extension).registerContentMessageHandler(session, extensionId, messageHandler)
+    }
+
+    @Test
+    fun `register content message handler before extension is installed`() {
+        val engine: Engine = mock()
+        val controller = WebExtensionController(extensionId, extensionUrl)
+        controller.install(engine)
+
+        val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
+        val onError = argumentCaptor<((String, Throwable) -> Unit)>()
+        verify(engine, times(1)).installWebExtension(
+            eq(extensionId),
+            eq(extensionUrl),
+            eq(true),
+            onSuccess.capture(),
+            onError.capture()
+        )
+
+        val session: EngineSession = mock()
+        val messageHandler: MessageHandler = mock()
+        controller.registerContentMessageHandler(session, messageHandler)
+
+        val extension: WebExtension = mock()
+        onSuccess.value.invoke(extension)
+        verify(extension).registerContentMessageHandler(session, extensionId, messageHandler)
+    }
+
+    @Test
+    fun `send content message`() {
+        val controller = WebExtensionController(extensionId, extensionUrl)
+
+        val message: JSONObject = mock()
+        val extension: WebExtension = mock()
+        val session: EngineSession = mock()
+        val port: Port = mock()
+        whenever(extension.getConnectedPort(extensionId, session)).thenReturn(port)
+
+        controller.sendContentMessage(message, null)
+        verify(port, never()).postMessage(message)
+
+        controller.sendContentMessage(message, session)
+        verify(port, never()).postMessage(message)
+
+        WebExtensionController.installedExtensions[extensionId] = extension
+
+        controller.sendContentMessage(message, session)
+        verify(port, times(1)).postMessage(message)
+    }
+
+    @Test
+    fun `check if port connected`() {
+        val controller = WebExtensionController(extensionId, extensionUrl)
+
+        val extension: WebExtension = mock()
+        val session: EngineSession = mock()
+        whenever(extension.getConnectedPort(extensionId, session)).thenReturn(mock())
+
+        assertFalse(controller.portConnected(null))
+        assertFalse(controller.portConnected(mock()))
+        assertFalse(controller.portConnected(session))
+
+        WebExtensionController.installedExtensions[extensionId] = extension
+
+        assertTrue(controller.portConnected(session))
+        assertFalse(controller.portConnected(session, "invalid"))
+    }
+
+    @Test
+    fun `disconnect port`() {
+        val extension: WebExtension = mock()
+        val controller = WebExtensionController(extensionId, extensionUrl)
+
+        controller.disconnectPort(null)
+        verify(extension, never()).disconnectPort(eq(extensionId), any())
+
+        val session: EngineSession = mock()
+        controller.disconnectPort(session)
+        verify(extension, never()).disconnectPort(eq(extensionId), eq(session))
+
+        WebExtensionController.installedExtensions[extensionId] = extension
+        controller.disconnectPort(session)
+        verify(extension, times(1)).disconnectPort(eq(extensionId), eq(session))
+    }
+}

--- a/components/support/webextensions/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/support/webextensions/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,9 @@ permalink: /changelog/
 * **engine-gecko-nightly**
   * Added the ability to exfiltrate Gecko categorical histograms.
 
+* **support-webextensions**
+  * 🆕 New component containing building blocks for features implemented as web extensions.
+
 # 13.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v12.0.0...v13.0.0)


### PR DESCRIPTION
This cleans up our web extension features (readerview, fxawebchannel) by making sure we have reusable logic for port management, message handler registration and installation. The features now have significantly less code (~70 lines less each) and more importantly only contain feature-specific logic.

The port management is now automatic and handled by the engine, which worked out nicely. For everything else, I've introduced a `WebExtensionController` in the new `support-webextensions`. This part I would like to revisit later e.g. by introducing some form of registry in the engine that knows/holds all installed extensions. For now I prefer to land this though as it solves the problem and is still fairly simple.