### PR TITLE
Closes #4445: expose getCurrentDeviceID and getSessionToken FxA methods

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,7 +26,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.38.2"
+    const val mozilla_appservices = "0.39.1"
 
     const val material = "1.0.0"
 

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -35,6 +35,8 @@ data class AuthFlowUrl(val state: String, val url: String)
 interface OAuthAccount : AutoCloseable {
     fun beginOAuthFlowAsync(scopes: Set<String>): Deferred<AuthFlowUrl?>
     fun beginPairingFlowAsync(pairingUrl: String, scopes: Set<String>): Deferred<AuthFlowUrl?>
+    fun getCurrentDeviceId(): String?
+    fun getSessionToken(): String?
     fun getProfileAsync(ignoreCache: Boolean): Deferred<Profile?>
     fun getProfileAsync(): Deferred<Profile?>
     fun completeOAuthFlowAsync(code: String, state: String): Deferred<Boolean>

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -140,6 +140,28 @@ class FirefoxAccount internal constructor(
         }
     }
 
+    /**
+     * Returns current FxA Device ID for an authenticated account.
+     *
+     * @return Current device's FxA ID, if available. `null` otherwise.
+     */
+    override fun getCurrentDeviceId(): String? {
+        return handleFxaExceptions(logger, "getCurrentDeviceId", { null }) {
+            inner.getCurrentDeviceId()
+        }
+    }
+
+    /**
+     * Returns session token for an authenticated account.
+     *
+     * @return Current account's session token, if available. `null` otherwise.
+     */
+    override fun getSessionToken(): String? {
+        return handleFxaExceptions(logger, "getSessionToken", { null }) {
+            inner.getSessionToken()
+        }
+    }
+
     override fun migrateFromSessionTokenAsync(sessionToken: String, kSync: String, kXCS: String): Deferred<Boolean> {
         return scope.async {
             handleFxaExceptions(logger, "migrateFromSessionToken") {

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -778,6 +778,14 @@ class FxaAccountManagerTest {
             return CompletableDeferred(profile)
         }
 
+        override fun getCurrentDeviceId(): String? {
+            return null
+        }
+
+        override fun getSessionToken(): String? {
+            return null
+        }
+
         override fun completeOAuthFlowAsync(code: String, state: String): Deferred<Boolean> {
             return CompletableDeferred(true)
         }


### PR DESCRIPTION
This bumps A-S to 0.39.1, which exposes these methods, and comes with a Sync Manager!

We can use the session token to expand our WebChannel implementation, and we need current device FxA ID for the Rust sync manager, so that it may sync the 'clients' collection.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
