### PR TITLE
Closes #4450: Support for 'signedInUser' fxa_status WebChannel response

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -84,8 +84,12 @@ private interface OAuthObserver {
     fun onError()
 }
 
+// Necessary to fetch a profile.
 const val SCOPE_PROFILE = "profile"
+// Necessary to obtain sync keys.
 const val SCOPE_SYNC = "https://identity.mozilla.com/apps/oldsync"
+// Necessary to obtain a sessionToken, which gives full access to the account.
+const val SCOPE_SESSION = "https://identity.mozilla.com/tokens/session"
 
 /**
  * An account manager which encapsulates various internal details of an account lifecycle and provides


### PR DESCRIPTION
Currently built on top of #4449, so rebase this once that PR lands. 

In testing this, for some reason accounts.firefox.com isn't sending an `fxa_status` message, so I wasn't able to confirm this works yet. cc @vladikoff 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
