### PR TITLE
Enable calling the Glean SDK General API from Java

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -91,6 +91,7 @@ open class GleanInternalAPI internal constructor () {
      * as shared preferences
      * @param configuration A Glean [Configuration] object with global settings.
      */
+    @JvmOverloads
     fun initialize(
         applicationContext: Context,
         configuration: Configuration = Configuration()
@@ -268,6 +269,7 @@ open class GleanInternalAPI internal constructor () {
      * @param branch The experiment branch (maximum 30 bytes)
      * @param extra Optional metadata to output with the ping
      */
+    @JvmOverloads
     fun setExperimentActive(
         experimentId: String,
         branch: String,

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -14,6 +14,8 @@ import mozilla.components.service.glean.net.PingUploader
  *
  * @property serverEndpoint the server pings are sent to. Please note that this is
  *           is only meant to be changed for tests.
+ * @property channel the release channel the application is on, if known. This will be
+ *           sent along with all the pings, in the `client_info` section.
  * @property userAgent the user agent used when sending pings, only to be used internally.
  * @property maxEvents the number of events to store before the events ping is sent
  * @property logPings whether to log ping contents to the console. This is only meant to be used
@@ -21,10 +23,10 @@ import mozilla.components.service.glean.net.PingUploader
  * @property httpClient The HTTP client implementation to use for uploading pings.
  * @property pingTag String tag to be applied to headers when uploading pings for debug view.
  *           This is only meant to be used internally by the `GleanDebugActivity`.
- * @property channel the release channel the application is on, if known. This will be
- *           sent along with all the pings, in the `client_info` section. */
+ */
 data class Configuration internal constructor(
     val serverEndpoint: String,
+    val channel: String? = null,
     val userAgent: String = DEFAULT_USER_AGENT,
     val maxEvents: Int = DEFAULT_MAX_EVENTS,
     val logPings: Boolean = DEFAULT_LOG_PINGS,
@@ -32,27 +34,27 @@ data class Configuration internal constructor(
     // default values for the lines below are ever changed, they are required
     // to change in the public constructor below.
     val httpClient: PingUploader = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() }),
-    val pingTag: String? = null,
-    val channel: String? = null
+    val pingTag: String? = null
 ) {
     // This is the only public constructor this class should have. It should only
     // expose things we want to allow external applications to change. Every test
     // only or internal configuration option should be added to the above primary internal
     // constructor and only initialized with a proper default when calling the primary
     // constructor from the secondary, public one, below.
+    @JvmOverloads
     constructor(
         serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
+        channel: String? = null,
         maxEvents: Int = DEFAULT_MAX_EVENTS,
-        httpClient: PingUploader = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() }),
-        channel: String? = null
+        httpClient: PingUploader = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() })
     ) : this (
         serverEndpoint = serverEndpoint,
+        channel = channel,
         userAgent = DEFAULT_USER_AGENT,
         maxEvents = maxEvents,
         logPings = DEFAULT_LOG_PINGS,
         httpClient = httpClient,
-        pingTag = null,
-        channel = channel
+        pingTag = null
     )
 
     companion object {


### PR DESCRIPTION
This changes the API in a few places:

- adds `@JvmOverloads` to public methods in Glean that  have default arguments;
- adds `@JvmOverloads` to the Configuration object's  public constructor.
- moves the `channel` parameter of the configuration object  earlier in the function signature, to make it more convenient  to call.

@pocmo does these changes make sense, or am I introducing footguns that might be obvious to you? I tested it by building locally and pointing FirefoxReality to that build, this seems to work. No compilation error, at least.

@mdboom for a sanity check :)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
