### PR TITLE
Closes #4391: Adapt the color of the tracking protection icon on custom tabs.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -232,6 +232,15 @@ class BrowserToolbar @JvmOverloads constructor(
         }
 
     /**
+     * Sets the colour of the tracking protection icon.
+     */
+    var trackingProtectionColor: Int
+        get() = displayToolbar.trackingProtectionViewColor
+        set(value) {
+            displayToolbar.trackingProtectionViewColor = value
+        }
+
+    /**
      * Sets the different icons that the tracking protection icon could has depending of its
      * [Toolbar.siteTrackingProtection]
      * @param iconOnNoTrackersBlocked icon for when the site is on the state

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -147,6 +147,12 @@ internal class DisplayToolbar(
             menuView.setColorFilter(value)
         }
 
+    internal var trackingProtectionViewColor = defaultColor
+        set(value) {
+            field = value
+            trackingProtectionIconView.setColorFilter(value)
+        }
+
     internal val trackingProtectionIconView = TrackingProtectionIconView(context).apply {
         id = R.id.mozac_browser_toolbar_tracking_protection_icon_view
         isVisible = false

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -1011,6 +1011,16 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `trackingProtectionColor changes will forward calls to display toolbar`() {
+        val toolbar = BrowserToolbar(testContext)
+        toolbar.displayToolbar = spy(toolbar.displayToolbar)
+
+        toolbar.trackingProtectionColor = Color.BLUE
+        verify(toolbar.displayToolbar).trackingProtectionViewColor = Color.BLUE
+        assertEquals(toolbar.trackingProtectionColor, Color.BLUE)
+    }
+
+    @Test
     fun `setOnTrackingProtectionClickedListener will forward events to display toolbar`() {
         val toolbar = BrowserToolbar(testContext)
         val displayToolbar = toolbar.displayToolbar

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -80,6 +80,17 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `trackingProtectionViewColor will change the color of the trackingProtectionIconView`() {
+        val displayToolbar = DisplayToolbar(testContext, BrowserToolbar(testContext))
+
+        assertNull(displayToolbar.trackingProtectionIconView.colorFilter)
+
+        displayToolbar.trackingProtectionViewColor = Color.BLUE
+
+        assertNotNull(displayToolbar.trackingProtectionIconView.colorFilter)
+    }
+
+    @Test
     fun `tracking protection indicator view will use square size`() {
         val toolbar = mock(BrowserToolbar::class.java)
         val displayToolbar = DisplayToolbar(testContext, toolbar)

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -100,6 +100,7 @@ class CustomTabsToolbarFeature(
             toolbar.textColor = readableColor
             toolbar.titleColor = readableColor
             toolbar.siteSecurityColor = readableColor to readableColor
+            toolbar.trackingProtectionColor = readableColor
             toolbar.menuViewColor = readableColor
 
             window?.setStatusBarTheme(color)

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -149,10 +149,12 @@ class CustomTabsToolbarFeatureTest {
 
         verify(toolbar, never()).setBackgroundColor(anyInt())
         verify(toolbar, never()).textColor = anyInt()
+        verify(toolbar, never()).trackingProtectionColor = anyInt()
 
         feature.updateToolbarColor(123, 456)
 
         verify(toolbar).setBackgroundColor(anyInt())
+        verify(toolbar).trackingProtectionColor = anyInt()
         verify(toolbar).textColor = anyInt()
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,16 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-customtabs**
+  * Now the color of the tracking protection icon adapts to color of the toolbar.
+
+* **browser-toolbar**
+  * Added a way to customize the color of the tracking protection icon via BrowserToolbar.
+  ```kotlin
+  val toolbar = BrowserToolbar(context)
+  toolbar.trackingProtectionColor = Color.BLUE
+  ``
+
 * **All components**
   * Increased `androidx.browser` version to `1.2.0-alpha07`.
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
