### PR TITLE
Closes #4458: Use cached registration token from ADM if available

### DIFF
--- a/components/lib/push-amazon/src/main/java/mozilla/components/lib/push/amazon/AbstractAmazonPushService.kt
+++ b/components/lib/push-amazon/src/main/java/mozilla/components/lib/push/amazon/AbstractAmazonPushService.kt
@@ -28,8 +28,12 @@ abstract class AbstractAmazonPushService : ADMMessageHandlerBase("AbstractAmazon
 
     override fun start(context: Context) {
         adm = ADM(context)
-        if (adm.registrationId == null) {
+
+        val registrationId = adm.registrationId
+        if (registrationId == null) {
             adm.startRegister()
+        } else {
+            PushProcessor.requireInstance.onNewToken(registrationId)
         }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ permalink: /changelog/
 * **support-webextensions**
   * 🆕 New component containing building blocks for features implemented as web extensions.
 
+* **lib-push-amazon**
+  * Fixed usage of cache version of registration ID in situations when app data is deleted.
+
 # 13.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v12.0.0...v13.0.0)


### PR DESCRIPTION
Since the ADM instance does not live in the app itself, clearing app
data doesn't remove the registration ID for it. This means that we never
initialize the native PushManager with the cached code.

Our fix is straight-forward: if we have a cached registration ID, invoke
the `PushProcessor#onNewToken` and follow the regular flow.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
