### PR TITLE
Closes #846. Add detekt rule to check license header in kotlin files.

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -320,6 +320,10 @@ projects:
     path: components/lib/state
     description: 'A library for maintaining application state.'
     publish: true
+  tooling-detekt:
+    path: components/tooling/detekt
+    description: 'Custom Detekt rules.'
+    publish: false
   tooling-lint:
     path: components/tooling/lint
     description: 'Custom Lint checks for using and writing components.'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("1.0.1")
+    id("io.gitlab.arturbosch.detekt").version("1.0.1")  // Check version number in `Versions.detekt`
 }
 
 allprojects {
@@ -214,7 +214,6 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-
 detekt {
     input = files("$projectDir/components", "$projectDir/buildSrc", "$projectDir/samples")
     config = files("$projectDir/config/detekt.yml")
@@ -232,6 +231,10 @@ detekt {
 }
 
 tasks.withType(io.gitlab.arturbosch.detekt.Detekt) {
+    // Custom detekt rules should be build before
+    // See https://arturbosch.github.io/detekt/extensions.html#pitfalls
+    dependsOn(":tooling-detekt:assemble")
+
     autoCorrect = true
 
     exclude "**/src/androidTest/**"
@@ -250,6 +253,7 @@ configurations {
 
 dependencies {
     ktlint "com.github.shyiko:ktlint:0.31.0"
+    detektPlugins project(":tooling-detekt")
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -18,6 +18,7 @@ object Versions {
     const val android_gradle_plugin = "3.4.1"
     const val android_maven_publish_plugin = "3.6.2"
     const val lint = "26.3.2"
+    const val detekt = "1.0.1"
 
     const val sentry = "1.7.21"
     const val okhttp = "3.13.1"
@@ -113,6 +114,9 @@ object Dependencies {
     const val tools_lint = "com.android.tools.lint:lint:${Versions.lint}"
     const val tools_lintapi = "com.android.tools.lint:lint-api:${Versions.lint}"
     const val tools_linttests = "com.android.tools.lint:lint-tests:${Versions.lint}"
+
+    const val tools_detekt_api = "io.gitlab.arturbosch.detekt:detekt-api:${Versions.detekt}"
+    const val tools_detekt_test = "io.gitlab.arturbosch.detekt:detekt-test:${Versions.detekt}"
 
     const val mozilla_fxa = "org.mozilla.appservices:fxaclient:${Versions.mozilla_appservices}"
 

--- a/components/tooling/detekt/README.md
+++ b/components/tooling/detekt/README.md
@@ -1,0 +1,11 @@
+# [Android Components](../../../README.md) > Tooling > Detekt
+
+Custom Detekt rules for the components repository.
+
+These additional detekt rules are run as part of the _Android Components_ build pipeline. Currently we do not publish packaged versions of these detekt rules for consumption outside of the _Android Components_ repository.
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/tooling/detekt/build.gradle
+++ b/components/tooling/detekt/build.gradle
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.tools_detekt_api
+
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.tools_detekt_api
+    testImplementation Dependencies.tools_detekt_test
+}
+
+task lintRelease {
+    doLast {
+        // Do nothing. We execute the same set of tasks for all our modules in parallel on taskcluster.
+        // This project doesn't have a lint task.
+    }
+}
+
+task assembleAndroidTest {
+    doLast {
+        // Do nothing. Like the `lint` task above this is just a dummy task so that this module
+        // behaves like our others and we do not need to special case it in automation.
+    }
+}

--- a/components/tooling/detekt/src/main/kotlin/mozilla/components/tooling/detekt/MozillaRuleSetProvider.kt
+++ b/components/tooling/detekt/src/main/kotlin/mozilla/components/tooling/detekt/MozillaRuleSetProvider.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+/**
+ * Set of custom mozilla rules to be loaded in detekt utility.
+ */
+class MozillaRuleSetProvider : RuleSetProvider {
+
+    override val ruleSetId = "mozilla-rules"
+
+    override fun instance(config: Config) = RuleSet(
+        ruleSetId,
+        listOf(
+            ProjectLicenseRule(config)
+        )
+    )
+}

--- a/components/tooling/detekt/src/main/kotlin/mozilla/components/tooling/detekt/ProjectLicenseRule.kt
+++ b/components/tooling/detekt/src/main/kotlin/mozilla/components/tooling/detekt/ProjectLicenseRule.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.detekt
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtFile
+
+/**
+ * Check header license in Kotlin files.
+ */
+class ProjectLicenseRule(config: Config = Config.empty) : Rule(config) {
+
+    private val expectedLicense = """
+        |/* This Source Code Form is subject to the terms of the Mozilla Public
+        | * License, v. 2.0. If a copy of the MPL was not distributed with this
+        | * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+    """.trimMargin()
+
+    override val issue = Issue(
+        id = "AbsentOrWrongFileLicense",
+        severity = Severity.Style,
+        description = "License text is absent or incorrect in the file.",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitKtFile(file: KtFile) {
+        if (!file.hasValidLicense) {
+            reportCodeSmell(file)
+        }
+    }
+
+    private val KtFile.hasValidLicense: Boolean
+        get() = text.startsWith(expectedLicense)
+
+    private fun reportCodeSmell(file: KtFile) {
+        report(CodeSmell(
+            issue, Entity.from(file),
+            "Expected license not found or incorrect in the file: ${file.name}."
+        ))
+    }
+}

--- a/components/tooling/detekt/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/components/tooling/detekt/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+mozilla.components.tooling.detekt.MozillaRuleSetProvider

--- a/components/tooling/detekt/src/test/kotlin/ProjectLicenseRuleTest.kt
+++ b/components/tooling/detekt/src/test/kotlin/ProjectLicenseRuleTest.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.detekt
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProjectLicenseRuleTest {
+
+    @Test
+    fun testAbsentLicense() {
+        val findings = ProjectLicenseRule().lint(fileContent)
+
+        assertEquals(1, findings.size)
+        assertEquals("Expected license not found or incorrect in the file: Test.kt.",
+            findings.first().message)
+    }
+
+    @Test
+    fun testInvalidLicense() {
+        val file = """
+            |/* This Source Code Form is subject to the terms of the Mozilla Public License.
+            | * You can obtain one at http://mozilla.org/MPL/2.0/. */
+            |
+            $fileContent
+        """.trimMargin()
+        val findings = ProjectLicenseRule().lint(file)
+
+        assertEquals(1, findings.size)
+        assertEquals("Expected license not found or incorrect in the file: Test.kt.",
+            findings.first().message)
+    }
+
+    @Test
+    fun testValidLicense() {
+        val file = """
+            |/* This Source Code Form is subject to the terms of the Mozilla Public
+            | * License, v. 2.0. If a copy of the MPL was not distributed with this
+            | * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+            |
+            $fileContent
+        """.trimMargin()
+        val findings = ProjectLicenseRule().lint(file)
+
+        assertEquals(0, findings.size)
+    }
+}
+
+private val fileContent = """
+    |package my.package
+    |
+    |/** My awesome class */
+    |class MyClass () {
+    |    fun foo () {}
+    |}
+""".trimMargin()

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -1,218 +1,1966 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <Blacklist timestamp="1521663963552"></Blacklist>
-  <Whitelist timestamp="1561988617766">
-    <ID>LargeClass:BrowserFragment.kt$BrowserFragment : FragmentBackHandler</ID>
+  <Blacklist></Blacklist>
+  <Whitelist>
+    <ID>AbsentOrWrongFileLicense:AbstractAmazonPushService.kt$mozilla.components.lib.push.amazon.AbstractAmazonPushService.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AbstractAmazonPushServiceTest.kt$mozilla.components.lib.push.amazon.AbstractAmazonPushServiceTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AbstractFirebasePushService.kt$mozilla.components.lib.push.firebase.AbstractFirebasePushService.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AbstractFirebasePushServiceTest.kt$mozilla.components.lib.push.firebase.AbstractFirebasePushServiceTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AccountObserverTest.kt$mozilla.components.feature.sendtab.AccountObserverTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ActionImageTest.kt$mozilla.components.concept.toolbar.ActionImageTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Activity.kt$mozilla.components.support.ktx.android.view.Activity.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ActivityTest.kt$mozilla.components.support.ktx.android.view.ActivityTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AppLinkRedirect.kt$mozilla.components.feature.app.links.AppLinkRedirect.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AppLinksFeature.kt$mozilla.components.feature.app.links.AppLinksFeature.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AppLinksFeatureTest.kt$mozilla.components.feature.app.links.AppLinksFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AppLinksUseCases.kt$mozilla.components.feature.app.links.AppLinksUseCases.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AppLinksUseCasesTest.kt$mozilla.components.feature.app.links.AppLinksUseCasesTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AutoFitTextureView.kt$mozilla.components.support.base.android.view.AutoFitTextureView.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AutoPushFeature.kt$mozilla.components.feature.push.AutoPushFeature.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AutoPushFeatureKtTest.kt$mozilla.components.feature.push.AutoPushFeatureKtTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AutoPushFeatureTest.kt$mozilla.components.feature.push.AutoPushFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:AutoSave.kt$mozilla.components.browser.session.storage.AutoSave.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Base64.kt$mozilla.components.support.ktx.android.util.Base64.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Base64Test.kt$mozilla.components.support.ktx.android.util.Base64Test.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BaseDomainAutocompleteProviderTest.kt$mozilla.components.browser.domains.BaseDomainAutocompleteProviderTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BooleanMetricTypeTest.kt$mozilla.components.service.glean.private.BooleanMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BooleansStorageEngineTest.kt$mozilla.components.service.glean.storages.BooleansStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BreadcrumbPriorityQueue.kt$mozilla.components.lib.crash.BreadcrumbPriorityQueue.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuCheckboxTest.kt$mozilla.components.browser.menu.item.BrowserMenuCheckboxTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuCompoundButton.kt$mozilla.components.browser.menu.item.BrowserMenuCompoundButton.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuCompoundButtonTest.kt$mozilla.components.browser.menu.item.BrowserMenuCompoundButtonTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuDividerTest.kt$mozilla.components.browser.menu.item.BrowserMenuDividerTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuHighlightableItemTest.kt$mozilla.components.browser.menu.item.BrowserMenuHighlightableItemTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuImageSwitch.kt$mozilla.components.browser.menu.item.BrowserMenuImageSwitch.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuImageTextTest.kt$mozilla.components.browser.menu.item.BrowserMenuImageTextTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuSwitch.kt$mozilla.components.browser.menu.item.BrowserMenuSwitch.kt</ID>
+    <ID>AbsentOrWrongFileLicense:BrowserMenuSwitchTest.kt$mozilla.components.browser.menu.item.BrowserMenuSwitchTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Bus.kt$mozilla.components.concept.push.Bus.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ChoiceAdapter.kt$mozilla.components.feature.prompts.ChoiceAdapter.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ChoiceDialogFragmentTest.kt$mozilla.components.feature.prompts.ChoiceDialogFragmentTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Collection.kt$mozilla.components.support.ktx.kotlin.Collection.kt</ID>
+    <ID>AbsentOrWrongFileLicense:CollectionKtTest.kt$mozilla.components.support.ktx.kotlin.CollectionKtTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:CommonMetricData.kt$mozilla.components.service.glean.private.CommonMetricData.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Connection.kt$mozilla.components.feature.push.Connection.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ConnectionKtTest.kt$mozilla.components.feature.push.ConnectionKtTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:CustomDistributionMetricTypeTest.kt$mozilla.components.service.glean.private.CustomDistributionMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:CustomTabsToolbarFeatureTest.kt$mozilla.components.feature.customtabs.CustomTabsToolbarFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DatePickerDialogFragmentTest.kt$.DatePickerDialogFragmentTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DatetimeMetricTypeTest.kt$mozilla.components.service.glean.private.DatetimeMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DatetimesStorageEngineTest.kt$mozilla.components.service.glean.storages.DatetimesStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DeliveryManagerTest.kt$mozilla.components.feature.push.DeliveryManagerTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DeviceFragment.kt$org.mozilla.samples.sync.DeviceFragment.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DeviceObserverTest.kt$mozilla.components.feature.sendtab.DeviceObserverTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DeviceRecyclerViewAdapter.kt$org.mozilla.samples.sync.DeviceRecyclerViewAdapter.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DisplayMetricsTest.kt$mozilla.components.support.ktx.android.util.DisplayMetricsTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:DownloadUtils.kt$mozilla.components.support.utils.DownloadUtils.kt</ID>
+    <ID>AbsentOrWrongFileLicense:EncryptedPushMessageTest.kt$mozilla.components.concept.push.EncryptedPushMessageTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:EngineState.kt$mozilla.components.browser.state.state.EngineState.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ErrorPages.kt$mozilla.components.browser.errorpages.ErrorPages.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ErrorPagesTest.kt$mozilla.components.browser.errorpages.ErrorPagesTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ErrorRecordingTest.kt$mozilla.components.service.glean.error.ErrorRecordingTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:EventMetricType.kt$mozilla.components.service.glean.private.EventMetricType.kt</ID>
+    <ID>AbsentOrWrongFileLicense:EventMetricTypeTest.kt$mozilla.components.service.glean.private.EventMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:EventsStorageEngineTest.kt$mozilla.components.service.glean.storages.EventsStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ExperimentsStorageEngineTest.kt$mozilla.components.service.glean.storages.ExperimentsStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ExperimentsUpdaterTest.kt$mozilla.components.service.experiments.ExperimentsUpdaterTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Extensions.kt$mozilla.components.support.test.robolectric.Extensions.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ExtensionsTest.kt$mozilla.components.support.test.robolectric.ExtensionsTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:FileUtils.kt$mozilla.components.service.glean.utils.FileUtils.kt</ID>
+    <ID>AbsentOrWrongFileLicense:FullScreenFeature.kt$mozilla.components.feature.session.FullScreenFeature.kt</ID>
+    <ID>AbsentOrWrongFileLicense:FullScreenFeatureTest.kt$mozilla.components.feature.session.FullScreenFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:GeckoMediaDelegateTest.kt$mozilla.components.browser.engine.gecko.media.GeckoMediaDelegateTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:GeckoWebExtension.kt$mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension.kt</ID>
+    <ID>AbsentOrWrongFileLicense:GeckoWindowRequestTest.kt$mozilla.components.browser.engine.gecko.window.GeckoWindowRequestTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:GleanDebugActivityTest.kt$mozilla.components.service.glean.debug.GleanDebugActivityTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:GleanLifecycleObserver.kt$mozilla.components.service.glean.scheduler.GleanLifecycleObserver.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Helpers.kt$mozilla.components.lib.state.helpers.Helpers.kt</ID>
+    <ID>AbsentOrWrongFileLicense:HistogramMetricBase.kt$mozilla.components.service.glean.private.HistogramMetricBase.kt</ID>
+    <ID>AbsentOrWrongFileLicense:HitResultTest.kt$mozilla.components.concept.engine.HitResultTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:IconDirectoryEntry.kt$mozilla.components.browser.icons.decoder.ico.IconDirectoryEntry.kt</ID>
+    <ID>AbsentOrWrongFileLicense:JSONExperimentParserTest.kt$mozilla.components.service.experiments.JSONExperimentParserTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:JSONExperimentParserTest.kt$mozilla.components.service.fretboard.JSONExperimentParserTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:JSONObjectTest.kt$mozilla.components.support.ktx.android.org.json.JSONObjectTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:KArgumentCaptor.kt$mozilla.components.support.test.KArgumentCaptor.kt</ID>
+    <ID>AbsentOrWrongFileLicense:LexerTest.kt$mozilla.components.lib.jexl.lexer.LexerTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Lifecycle.kt$mozilla.components.support.ktx.android.arch.lifecycle.Lifecycle.kt</ID>
+    <ID>AbsentOrWrongFileLicense:LifecycleAwareFeature.kt$mozilla.components.support.base.feature.LifecycleAwareFeature.kt</ID>
+    <ID>AbsentOrWrongFileLicense:LifecycleTest.kt$mozilla.components.support.ktx.android.arch.lifecycle.LifecycleTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:LoadRequestMetadata.kt$mozilla.components.browser.session.engine.request.LoadRequestMetadata.kt</ID>
+    <ID>AbsentOrWrongFileLicense:MemoryDistributionMetricTypeTest.kt$mozilla.components.service.glean.private.MemoryDistributionMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:MessageBus.kt$mozilla.components.feature.push.MessageBus.kt</ID>
+    <ID>AbsentOrWrongFileLicense:MessageBusTest.kt$mozilla.components.feature.push.MessageBusTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:MockMedia.kt$mozilla.components.feature.media.MockMedia.kt</ID>
+    <ID>AbsentOrWrongFileLicense:MonthAndYearPickerTest.kt$mozilla.components.feature.prompts.widget.MonthAndYearPickerTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Observable.kt$mozilla.components.support.base.observer.Observable.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ObserverRegistry.kt$mozilla.components.support.base.observer.ObserverRegistry.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ObserverRegistryTest.kt$mozilla.components.support.base.observer.ObserverRegistryTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PictureInPictureFeature.kt$mozilla.components.feature.session.PictureInPictureFeature.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PictureInPictureFeatureTest.kt$mozilla.components.feature.session.PictureInPictureFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PingType.kt$mozilla.components.service.glean.private.PingType.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PingTypeTest.kt$mozilla.components.service.glean.private.PingTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PingUploadWorker.kt$mozilla.components.service.glean.scheduler.PingUploadWorker.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PingUploadWorkerTest.kt$mozilla.components.service.glean.scheduler.PingUploadWorkerTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PlacesBookmarksStorageTest.kt$mozilla.components.browser.storage.sync.PlacesBookmarksStorageTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PreferredColorScheme.kt$mozilla.components.concept.engine.mediaquery.PreferredColorScheme.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PublicSuffixListTest.kt$mozilla.components.lib.publicsuffixlist.PublicSuffixListTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PushErrorTest.kt$mozilla.components.concept.push.PushErrorTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PushObserverTest.kt$mozilla.components.feature.sendtab.PushObserverTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PushProcessor.kt$mozilla.components.concept.push.PushProcessor.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PushProcessorTest.kt$mozilla.components.concept.push.PushProcessorTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PushService.kt$mozilla.components.concept.push.PushService.kt</ID>
+    <ID>AbsentOrWrongFileLicense:PushTypeTest.kt$mozilla.components.feature.push.PushTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:QrFragment.kt$mozilla.components.feature.qr.QrFragment.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsBar.kt$mozilla.components.feature.readerview.view.ReaderViewControlsBar.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsBarTest.kt$mozilla.components.feature.readerview.view.ReaderViewControlsBarTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsInteractor.kt$mozilla.components.feature.readerview.internal.ReaderViewControlsInteractor.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsInteractorTest.kt$mozilla.components.feature.readerview.internal.ReaderViewControlsInteractorTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsPresenter.kt$mozilla.components.feature.readerview.internal.ReaderViewControlsPresenter.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsPresenterTest.kt$mozilla.components.feature.readerview.internal.ReaderViewControlsPresenterTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewControlsView.kt$mozilla.components.feature.readerview.view.ReaderViewControlsView.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ReaderViewIntegration.kt$org.mozilla.samples.browser.integration.ReaderViewIntegration.kt</ID>
+    <ID>AbsentOrWrongFileLicense:RedirectDialogFragment.kt$mozilla.components.feature.app.links.RedirectDialogFragment.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ResizingProcessorTest.kt$mozilla.components.browser.icons.processor.ResizingProcessorTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:RustPushConnectionTest.kt$mozilla.components.feature.push.RustPushConnectionTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SafeBundle.kt$mozilla.components.support.utils.SafeBundle.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SampleToolbarHelpers.kt$org.mozilla.samples.toolbar.SampleToolbarHelpers.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SamplesGleanLibrary.kt$org.mozilla.samples.glean.library.SamplesGleanLibrary.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SendTabFeature.kt$mozilla.components.feature.sendtab.SendTabFeature.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SendTabFeatureKtTest.kt$mozilla.components.feature.sendtab.SendTabFeatureKtTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SendTabUseCases.kt$mozilla.components.feature.sendtab.SendTabUseCases.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SendTabUseCasesTest.kt$mozilla.components.feature.sendtab.SendTabUseCasesTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SessionExtensionsTest.kt$mozilla.components.browser.session.ext.SessionExtensionsTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SettingUpdater.kt$mozilla.components.browser.engine.gecko.integration.SettingUpdater.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SettingUpdaterTest.kt$mozilla.components.browser.engine.gecko.integration.SettingUpdaterTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SettingsUseCasesTest.kt$mozilla.components.feature.session.SettingsUseCasesTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SimpleRedirectDialogFragment.kt$mozilla.components.feature.app.links.SimpleRedirectDialogFragment.kt</ID>
+    <ID>AbsentOrWrongFileLicense:StateMachine.kt$mozilla.components.lib.jexl.parser.StateMachine.kt</ID>
+    <ID>AbsentOrWrongFileLicense:StorageUtilsTest.kt$mozilla.components.support.utils.StorageUtilsTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:StringListMetricTypeTest.kt$mozilla.components.service.glean.private.StringListMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:StringListsStorageEngineTest.kt$mozilla.components.service.glean.storages.StringListsStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:StringMetricTypeTest.kt$mozilla.components.service.glean.private.StringMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:StringsStorageEngineTest.kt$mozilla.components.service.glean.storages.StringsStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SuggestionViewHolder.kt$mozilla.components.browser.awesomebar.layout.SuggestionViewHolder.kt</ID>
+    <ID>AbsentOrWrongFileLicense:SystemEngineSessionTest.kt$mozilla.components.browser.engine.system.SystemEngineSessionTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TabThumbnailView.kt$mozilla.components.browser.tabstray.thumbnail.TabThumbnailView.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TabThumbnailViewTest.kt$mozilla.components.browser.tabstray.thumbnail.TabThumbnailViewTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TabTouchCallback.kt$mozilla.components.browser.tabstray.TabTouchCallback.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TabTouchCallbackTest.kt$mozilla.components.browser.tabstray.TabTouchCallbackTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TabsFeatureTest.kt$mozilla.components.feature.tabs.tabstray.TabsFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TestUtil.kt$mozilla.components.service.experiments.TestUtil.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TestUtil.kt$mozilla.components.service.glean.TestUtil.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TextViewTest.kt$mozilla.components.support.ktx.android.widget.TextViewTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TimeUtils.kt$mozilla.components.service.glean.utils.TimeUtils.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TimespanMetricTypeTest.kt$mozilla.components.service.glean.private.TimespanMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TimespansStorageEngineTest.kt$mozilla.components.service.glean.storages.TimespansStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:TimingDistributionMetricTypeTest.kt$mozilla.components.service.glean.private.TimingDistributionMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ToolbarFeatureTest.kt$mozilla.components.feature.toolbar.ToolbarFeatureTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ToolbarInteractorTest.kt$mozilla.components.feature.toolbar.ToolbarInteractorTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:ToolbarPresenterTest.kt$mozilla.components.feature.toolbar.ToolbarPresenterTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:UuidMetricTypeTest.kt$mozilla.components.service.glean.private.UuidMetricTypeTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:UuidsStorageEngineTest.kt$mozilla.components.service.glean.storages.UuidsStorageEngineTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:VersionString.kt$mozilla.components.service.experiments.util.VersionString.kt</ID>
+    <ID>AbsentOrWrongFileLicense:VersionStringTest.kt$mozilla.components.service.experiments.util.VersionStringTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:WebExtensionTest.kt$mozilla.components.concept.engine.webextension.WebExtensionTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:Window.kt$mozilla.components.support.ktx.android.view.Window.kt</ID>
+    <ID>AbsentOrWrongFileLicense:WindowTest.kt$mozilla.components.support.ktx.android.view.WindowTest.kt</ID>
+    <ID>AbsentOrWrongFileLicense:context.kt$mozilla.ext.context.kt</ID>
+    <ID>AbsentOrWrongFileLicense:coroutines.kt$mozilla.utils.coroutines.kt</ID>
+    <ID>AbsentOrWrongFileLicense:intents.kt$mozilla.components.support.utils.intents.kt</ID>
+    <ID>ClassNaming:BookmarksStorageSuggestionProviderTest.kt$BookmarksStorageSuggestionProviderTest$testableBookmarksStorage : BookmarksStorage</ID>
+    <ID>ClassNaming:EventMetricTypeTest.kt$clickKeys</ID>
+    <ID>ClassNaming:EventMetricTypeTest.kt$testNameKeys</ID>
+    <ID>ComplexMethod:HistoryDelegateTest.kt$HistoryDelegateTest$@Test fun `history delegate passes through getVisited calls`()</ID>
+    <ID>ComplexMethod:IconMessageHandlerTest.kt$IconMessageHandlerTest$@Test fun `Complex message (TheVerge) is transformed into IconRequest and loaded`()</ID>
+    <ID>ComplexMethod:UrlMatcherTest.kt$UrlMatcherTest$ @Test fun enableDisableCategories()</ID>
+    <ID>EmptyCatchBlock:EventMetricTypeTest.kt$EventMetricTypeTest${ }</ID>
+    <ID>EmptyCatchBlock:FetchTestCases.kt$FetchTestCases${}</ID>
+    <ID>EmptyCatchBlock:FxaAccountManagerTest.kt$FxaAccountManagerTest${}</ID>
+    <ID>EmptyCatchBlock:GeckoEngineTest.kt$GeckoEngineTest${ }</ID>
+    <ID>EmptyCatchBlock:SystemEngineSessionTest.kt$SystemEngineSessionTest${}</ID>
+    <ID>EmptyCatchBlock:SystemEngineTest.kt$SystemEngineTest${ }</ID>
+    <ID>EmptyCatchBlock:WhiteListTest.kt$WhiteListTest${ }</ID>
+    <ID>EmptyFunctionBlock:AbstractAmazonPushServiceTest.kt$ShadowADM${}</ID>
+    <ID>EmptyFunctionBlock:AbstractAmazonPushServiceTest.kt$ShadowADMMessageHandlerBase${}</ID>
+    <ID>EmptyFunctionBlock:AutoPushFeatureTest.kt$AutoPushFeatureTest.TestPushConnection${}</ID>
+    <ID>EmptyFunctionBlock:BrowserMenuAdapterTest.kt$BrowserMenuAdapterTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:BrowserMenuBuilderTest.kt$BrowserMenuBuilderTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:EngineObserverTest.kt$EngineObserverTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:EngineSessionTest.kt$DummyEngineSession${}</ID>
+    <ID>EmptyFunctionBlock:EngineViewBottomBehaviorTest.kt$FakeEngineView${}</ID>
+    <ID>EmptyFunctionBlock:EngineViewTest.kt$EngineViewTest.BrokenEngineView${}</ID>
+    <ID>EmptyFunctionBlock:EngineViewTest.kt$EngineViewTest.DummyEngineView${}</ID>
+    <ID>EmptyFunctionBlock:ExceptionHandlerTest.kt$ExceptionHandlerTest.&lt;no name provided&gt;${ }</ID>
+    <ID>EmptyFunctionBlock:GeckoPromptDelegateTest.kt$GeckoPromptDelegateTest.DefaultGeckoChoiceCallback${}</ID>
+    <ID>EmptyFunctionBlock:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:PushProcessorTest.kt$PushProcessorTest.TestPushProcessor${}</ID>
+    <ID>EmptyFunctionBlock:SendCrashReportServiceTest.kt$SendCrashReportServiceTest.&lt;no name provided&gt;${ }</ID>
+    <ID>EmptyFunctionBlock:SwipeRefreshFeatureTest.kt$SwipeRefreshFeatureTest.DummyEngineView${}</ID>
+    <ID>EmptyFunctionBlock:TabsTrayPresenterTest.kt$MockedTabsTray${}</ID>
+    <ID>EmptyFunctionBlock:WebExtensionTest.kt$WebExtensionTest.&lt;no name provided&gt;${ }</ID>
+    <ID>EmptyFunctionBlock:WebExtensionTest.kt$WebExtensionTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyKtFile:DatePickerDialogFragmentTest.kt$.DatePickerDialogFragmentTest.kt</ID>
+    <ID>EmptyWhileBlock:EngineSessionHolderTest.kt$EngineSessionHolderTest${ }</ID>
+    <ID>EnumNaming:EventMetricTypeTest.kt$clickKeys$objectId</ID>
+    <ID>EnumNaming:EventMetricTypeTest.kt$testNameKeys$testName</ID>
+    <ID>ForbiddenComment:BaselinePingTest.kt$BaselinePingTest$// FIXME: for some reason, without this, WorkManager won't find the job</ID>
+    <ID>ForbiddenComment:BitmapKtTest.kt$BitmapKtTest$// TODO: convert to integration test. Robolectric's shadows are incomplete and cause this to fail.</ID>
+    <ID>FunctionNaming:AbstractAmazonPushServiceTest.kt$ShadowADM$@Implementation @Suppress("UNUSED_PARAMETER") fun __constructor__(context: Context)</ID>
+    <ID>FunctionNaming:AbstractAmazonPushServiceTest.kt$ShadowADMMessageHandlerBase$ @Implementation @Suppress("UNUSED_PARAMETER") fun __constructor__(name: String)</ID>
+    <ID>FunctionNaming:DownloadUtilsTest.kt$DownloadUtilsTest$@Test fun guessFileName_contentDisposition()</ID>
+    <ID>FunctionNaming:DownloadUtilsTest.kt$DownloadUtilsTest$@Test fun guessFileName_mimeType()</ID>
+    <ID>FunctionNaming:DownloadUtilsTest.kt$DownloadUtilsTest$@Test fun guessFileName_url()</ID>
+    <ID>LargeClass:AppLinksFeatureTest.kt$AppLinksFeatureTest</ID>
+    <ID>LargeClass:BrowserAwesomeBarTest.kt$BrowserAwesomeBarTest</ID>
+    <ID>LargeClass:BrowserIconsTest.kt$BrowserIconsTest</ID>
+    <ID>LargeClass:BrowserMenuItemToolbarTest.kt$BrowserMenuItemToolbarTest</ID>
+    <ID>LargeClass:BrowserMenuTest.kt$BrowserMenuTest</ID>
     <ID>LargeClass:BrowserToolbar.kt$BrowserToolbar : ViewGroupToolbar</ID>
+    <ID>LargeClass:BrowserToolbarTest.kt$BrowserToolbarTest</ID>
+    <ID>LargeClass:BrowsersTest.kt$BrowsersTest</ID>
+    <ID>LargeClass:ChoiceDialogFragmentTest.kt$ChoiceDialogFragmentTest</ID>
+    <ID>LargeClass:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest</ID>
+    <ID>LargeClass:ConsumableTest.kt$ConsumableTest</ID>
+    <ID>LargeClass:ContentActionTest.kt$ContentActionTest</ID>
     <ID>LargeClass:ContextMenuCandidate.kt$ContextMenuCandidate$Companion</ID>
+    <ID>LargeClass:ContextMenuCandidateTest.kt$ContextMenuCandidateTest</ID>
+    <ID>LargeClass:ContextMenuFeatureTest.kt$ContextMenuFeatureTest</ID>
+    <ID>LargeClass:ContextMenuFragmentTest.kt$ContextMenuFragmentTest</ID>
+    <ID>LargeClass:CrashReporterTest.kt$CrashReporterTest</ID>
+    <ID>LargeClass:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest</ID>
+    <ID>LargeClass:CustomTabConfigHelperTest.kt$CustomTabConfigHelperTest</ID>
     <ID>LargeClass:CustomTabsToolbarFeature.kt$CustomTabsToolbarFeature : LifecycleAwareFeatureBackHandler</ID>
+    <ID>LargeClass:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest</ID>
+    <ID>LargeClass:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest</ID>
+    <ID>LargeClass:DisplayToolbarTest.kt$DisplayToolbarTest</ID>
+    <ID>LargeClass:DownloadsFeatureTest.kt$DownloadsFeatureTest</ID>
+    <ID>LargeClass:EditToolbarTest.kt$EditToolbarTest</ID>
+    <ID>LargeClass:EngineObserverTest.kt$EngineObserverTest</ID>
+    <ID>LargeClass:EngineSessionTest.kt$EngineSessionTest</ID>
+    <ID>LargeClass:EvaluatorTest.kt$EvaluatorTest</ID>
     <ID>LargeClass:EventsStorageEngine.kt$EventsStorageEngine : StorageEngine</ID>
+    <ID>LargeClass:EventsStorageEngineTest.kt$EventsStorageEngineTest</ID>
     <ID>LargeClass:ExperimentEvaluator.kt$ExperimentEvaluator</ID>
+    <ID>LargeClass:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest</ID>
     <ID>LargeClass:Experiments.kt$ExperimentsInternalAPI</ID>
-    <ID>LargeClass:FxaAccountManager.kt$FxaAccountManager : CloseableObservable</ID>
+    <ID>LargeClass:ExperimentsDebugActivityTest.kt$ExperimentsDebugActivityTest</ID>
+    <ID>LargeClass:ExperimentsSerializerTest.kt$ExperimentsSerializerTest</ID>
+    <ID>LargeClass:ExperimentsTest.kt$ExperimentsTest</ID>
+    <ID>LargeClass:FetchTestCases.kt$FetchTestCases</ID>
+    <ID>LargeClass:FilePickerTest.kt$FilePickerTest</ID>
+    <ID>LargeClass:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest</ID>
+    <ID>LargeClass:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest</ID>
+    <ID>LargeClass:FretboardTest.kt$FretboardTest</ID>
+    <ID>LargeClass:FxaAccountManagerTest.kt$FxaAccountManagerTest</ID>
+    <ID>LargeClass:FxaDeviceConstellationTest.kt$FxaDeviceConstellationTest</ID>
+    <ID>LargeClass:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest</ID>
+    <ID>LargeClass:GeckoEngineSessionTest.kt$GeckoEngineSessionTest</ID>
+    <ID>LargeClass:GeckoEngineTest.kt$GeckoEngineTest</ID>
     <ID>LargeClass:GeckoPromptDelegate.kt$GeckoPromptDelegate : PromptDelegate</ID>
-    <ID>LargeClass:Lexer.kt$Lexer</ID>
+    <ID>LargeClass:GeckoPromptDelegateTest.kt$GeckoPromptDelegateTest</ID>
+    <ID>LargeClass:GeckoViewFetchUnitTestCases.kt$GeckoViewFetchUnitTestCases : FetchTestCases</ID>
+    <ID>LargeClass:GenericStorageEngineTest.kt$GenericStorageEngineTest</ID>
+    <ID>LargeClass:GleanTest.kt$GleanTest</ID>
+    <ID>LargeClass:HeadersTest.kt$HeadersTest</ID>
+    <ID>LargeClass:IconResourceComparatorTest.kt$IconResourceComparatorTest</ID>
+    <ID>LargeClass:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest</ID>
+    <ID>LargeClass:InlineAutocompleteEditTextTest.kt$InlineAutocompleteEditTextTest</ID>
+    <ID>LargeClass:JSONExperimentParserTest.kt$JSONExperimentParserTest</ID>
+    <ID>LargeClass:KintoExperimentSourceTest.kt$KintoExperimentSourceTest</ID>
+    <ID>LargeClass:LabeledMetricTypeTest.kt$LabeledMetricTypeTest</ID>
+    <ID>LargeClass:LexerTest.kt$LexerTest</ID>
     <ID>LargeClass:MainActivity.kt$MainActivity : AppCompatActivityOnLoginCompleteListenerCoroutineScope</ID>
+    <ID>LargeClass:MediaStateMachineTest.kt$MediaStateMachineTest</ID>
+    <ID>LargeClass:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest</ID>
+    <ID>LargeClass:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest</ID>
+    <ID>LargeClass:MimeTypeTest.kt$MimeTypeTest</ID>
+    <ID>LargeClass:MozillaLocationServiceTest.kt$MozillaLocationServiceTest</ID>
+    <ID>LargeClass:MultiButtonDialogFragmentTest.kt$MultiButtonDialogFragmentTest</ID>
+    <ID>LargeClass:ObserverRegistryTest.kt$ObserverRegistryTest</ID>
+    <ID>LargeClass:ParserTest.kt$ParserTest</ID>
+    <ID>LargeClass:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest</ID>
+    <ID>LargeClass:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest</ID>
     <ID>LargeClass:PromptFeature.kt$PromptFeature : LifecycleAwareFeaturePermissionsFeature</ID>
+    <ID>LargeClass:PromptFeatureTest.kt$PromptFeatureTest</ID>
+    <ID>LargeClass:PublicSuffixListTest.kt$PublicSuffixListTest</ID>
+    <ID>LargeClass:QrFragmentTest.kt$QrFragmentTest</ID>
+    <ID>LargeClass:QuantitiesStorageEngineTest.kt$QuantitiesStorageEngineTest</ID>
+    <ID>LargeClass:ReaderViewFeatureTest.kt$ReaderViewFeatureTest</ID>
+    <ID>LargeClass:ResponseTest.kt$ResponseTest</ID>
+    <ID>LargeClass:SafeIntentTest.kt$SafeIntentTest</ID>
+    <ID>LargeClass:SearchEngineManagerTest.kt$SearchEngineManagerTest</ID>
+    <ID>LargeClass:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest</ID>
+    <ID>LargeClass:SendTabUseCasesTest.kt$SendTabUseCasesTest</ID>
     <ID>LargeClass:Session.kt$Session : Observable</ID>
+    <ID>LargeClass:SessionManagerMigrationTest.kt$SessionManagerMigrationTest</ID>
+    <ID>LargeClass:SessionManagerTest.kt$SessionManagerTest</ID>
+    <ID>LargeClass:SessionStorageTest.kt$SessionStorageTest</ID>
+    <ID>LargeClass:SessionTest.kt$SessionTest</ID>
+    <ID>LargeClass:SessionUseCasesTest.kt$SessionUseCasesTest</ID>
+    <ID>LargeClass:SettingsTest.kt$SettingsTest</ID>
+    <ID>LargeClass:SharedPreferencesTest.kt$SharedPreferencesTest</ID>
+    <ID>LargeClass:SignatureVerifierTest.kt$SignatureVerifierTest</ID>
+    <ID>LargeClass:SitePermissionsDialogFragmentTest.kt$SitePermissionsDialogFragmentTest</ID>
+    <ID>LargeClass:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest</ID>
+    <ID>LargeClass:StoreExtensionsKtTest.kt$StoreExtensionsKtTest</ID>
+    <ID>LargeClass:StringListsStorageEngineTest.kt$StringListsStorageEngineTest</ID>
+    <ID>LargeClass:SuggestionsAdapterTest.kt$SuggestionsAdapterTest</ID>
     <ID>LargeClass:SystemEngineSession.kt$SystemEngineSession : EngineSession</ID>
+    <ID>LargeClass:SystemEngineSessionTest.kt$SystemEngineSessionTest</ID>
     <ID>LargeClass:SystemEngineView.kt$SystemEngineView : FrameLayoutEngineViewOnLongClickListener</ID>
     <ID>LargeClass:SystemEngineView.kt$SystemEngineView$&lt;no name provided&gt; : WebChromeClient</ID>
     <ID>LargeClass:SystemEngineView.kt$SystemEngineView$&lt;no name provided&gt; : WebViewClient</ID>
-    <ID>LongMethod:Activity.kt$ fun Activity.applyOrientation(manifest: WebAppManifest)</ID>
-    <ID>LongMethod:AndroidDownloadManager.kt$AndroidDownloadManager$ @RequiresPermission(allOf = [INTERNET, WRITE_EXTERNAL_STORAGE]) override fun download( download: Download, refererUrl: String, cookie: String ): Long</ID>
-    <ID>LongMethod:AndroidIconDecoder.kt$AndroidIconDecoder$override fun decode(data: ByteArray, desiredSize: DesiredSize): Bitmap?</ID>
-    <ID>LongMethod:AppLinksFeature.kt$AppLinksFeature$@SuppressLint("MissingPermission") @VisibleForTesting internal fun handleRedirect(redirect: AppLinkRedirect, session: Session)</ID>
-    <ID>LongMethod:AppLinksUseCases.kt$AppLinksUseCases.GetAppLinkRedirect$operator fun invoke(url: String): AppLinkRedirect</ID>
-    <ID>LongMethod:AppLinksUseCases.kt$AppLinksUseCases.GetAppLinkRedirect$private fun createBrowsableIntents(url: String): List&lt;Intent&gt;</ID>
-    <ID>LongMethod:AssetsSearchEngineProvider.kt$AssetsSearchEngineProvider$ override suspend fun loadSearchEngines(context: Context): SearchEngineList</ID>
-    <ID>LongMethod:AssetsSearchEngineProvider.kt$AssetsSearchEngineProvider$private suspend fun loadSearchEnginesFromList( context: Context, searchEngineIdentifiers: List&lt;String&gt; ): List&lt;SearchEngine&gt;</ID>
-    <ID>LongMethod:AstNode.kt$AstNode$@Suppress("ComplexMethod") // Yes, this method is long and complex. We should split AstNode into multiple types. private fun toString(level: Int): String</ID>
-    <ID>LongMethod:AuthenticationDialogFragment.kt$AuthenticationDialogFragment.Companion$ @Suppress("LongParameterList") fun newInstance( sessionId: String, title: String, message: String, username: String, password: String, onlyShowPassword: Boolean ): AuthenticationDialogFragment</ID>
-    <ID>LongMethod:AutoSave.kt$AutoSave$ @Synchronized internal fun triggerSave(delaySave: Boolean = true): Job</ID>
-    <ID>LongMethod:BrowserMenu.kt$@VisibleForTesting internal fun PopupWindow.displayPopup( containerView: View, anchor: View, preferredOrientation: BrowserMenu.Orientation )</ID>
-    <ID>LongMethod:BrowserMenu.kt$BrowserMenu$ @SuppressLint("InflateParams") fun show( anchor: View, orientation: Orientation = DOWN, endOfMenuAlwaysVisible: Boolean = false, onDismiss: () -&gt; Unit = {} ): PopupWindow</ID>
-    <ID>LongMethod:BrowserMenuItemToolbar.kt$BrowserMenuItemToolbar$override fun bind(menu: BrowserMenu, view: View)</ID>
-    <ID>LongMethod:Browsers.kt$Browsers$private fun findKnownBrowsers( packageManager: PackageManager, browsers: MutableMap&lt;String, ActivityInfo&gt;, uri: Uri )</ID>
+    <ID>LargeClass:SystemEngineViewTest.kt$SystemEngineViewTest</ID>
+    <ID>LargeClass:TabListActionTest.kt$TabListActionTest</ID>
+    <ID>LargeClass:TabsTrayPresenterTest.kt$TabsTrayPresenterTest</ID>
+    <ID>LargeClass:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest</ID>
+    <ID>LargeClass:TimespanMetricTypeTest.kt$TimespanMetricTypeTest</ID>
+    <ID>LargeClass:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest</ID>
+    <ID>LargeClass:ToolbarPresenterTest.kt$ToolbarPresenterTest</ID>
+    <ID>LargeClass:UrlMatcherTest.kt$UrlMatcherTest</ID>
+    <ID>LargeClass:UuidsStorageEngineTest.kt$UuidsStorageEngineTest</ID>
+    <ID>LargeClass:ViewBoundFeatureWrapperTest.kt$ViewBoundFeatureWrapperTest</ID>
+    <ID>LargeClass:WebAppManifestParserTest.kt$WebAppManifestParserTest</ID>
+    <ID>LargeClass:WebAppShortcutManagerTest.kt$WebAppShortcutManagerTest</ID>
     <ID>LongMethod:ByteArray.kt$ @Suppress("ComplexMethod", "NestedBlockDepth") internal fun ByteArray.binarySearch(labels: List&lt;ByteArray&gt;, labelIndex: Int): String?</ID>
-    <ID>LongMethod:ByteArray.kt$fun ByteArray.toBitmap( offset: Int, length: Int, opts: BitmapFactory.Options? = null ): Bitmap?</ID>
-    <ID>LongMethod:Connection.kt$Connection$// These are implemented as default methods on `Connection` instead of // `RustPlacesConnection` to make testing easier. @Suppress("ComplexMethod", "NestedBlockDepth") fun assembleHistoryPing(ping: SyncTelemetryPing)</ID>
-    <ID>LongMethod:Connection.kt$Connection$// This function is almost identical to `recordHistoryPing`, with additional // reporting for validation problems. Unfortunately, since the // `BookmarksSync` and `HistorySync` metrics are two separate objects, we // can't factor this out into a generic function. @Suppress("ComplexMethod", "NestedBlockDepth") fun assembleBookmarksPing(ping: SyncTelemetryPing)</ID>
-    <ID>LongMethod:ContentStateReducer.kt$ContentStateReducer$ fun reduce(state: BrowserState, action: ContentAction): BrowserState</ID>
-    <ID>LongMethod:ContentStateReducer.kt$private fun updateContentState( state: BrowserState, tabId: String, update: (ContentState) -&gt; ContentState ): BrowserState</ID>
-    <ID>LongMethod:ContextMenuCandidate.kt$ContextMenuCandidate.Companion$ fun createOpenImageInNewTabCandidate( context: Context, tabsUseCases: TabsUseCases, snackBarParentView: View, snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate() )</ID>
-    <ID>LongMethod:ContextMenuCandidate.kt$ContextMenuCandidate.Companion$ fun createOpenInNewTabCandidate( context: Context, tabsUseCases: TabsUseCases, snackBarParentView: View, snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate() )</ID>
-    <ID>LongMethod:ContextMenuCandidate.kt$ContextMenuCandidate.Companion$ fun createOpenInPrivateTabCandidate( context: Context, tabsUseCases: TabsUseCases, snackBarParentView: View, snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate() )</ID>
-    <ID>LongMethod:CrashActivity.kt$CrashActivity$@Suppress("TooGenericExceptionThrown") override fun onClick(view: View)</ID>
-    <ID>LongMethod:CustomTabConfig.kt$CustomTabConfig.Companion$ @Suppress("ComplexMethod") fun createFromIntent(intent: SafeIntent, displayMetrics: DisplayMetrics? = null): CustomTabConfig</ID>
-    <ID>LongMethod:CustomTabsToolbarFeature.kt$CustomTabsToolbarFeature$@VisibleForTesting internal fun addMenuItems( session: Session, menuItems: List&lt;CustomTabMenuItem&gt;, index: Int )</ID>
-    <ID>LongMethod:CustomTabsToolbarFeature.kt$CustomTabsToolbarFeature$@VisibleForTesting internal fun initialize(session: Session): Boolean</ID>
-    <ID>LongMethod:DefaultIconGenerator.kt$DefaultIconGenerator$@Suppress("MagicNumber") override fun generate(context: Context, request: IconRequest): Icon</ID>
-    <ID>LongMethod:DefaultSuggestionViewHolder.kt$DefaultSuggestionViewHolder.Chips$override fun bind(suggestion: AwesomeBar.Suggestion, selectionListener: () -&gt; Unit)</ID>
+    <ID>LongMethod:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$@Test fun `test that truncation works`()</ID>
     <ID>LongMethod:DisplayToolbar.kt$DisplayToolbar$// We layout the toolbar ourselves to avoid the overhead from using complex ViewGroup implementations @Suppress("ComplexMethod") override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int)</ID>
-    <ID>LongMethod:DisplayToolbar.kt$DisplayToolbar$// We measure the views manually to avoid overhead by using complex ViewGroup implementations override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int)</ID>
-    <ID>LongMethod:DomainAutoCompleteProvider.kt$DomainAutoCompleteProvider$ fun initialize( context: Context, useShippedDomains: Boolean = true, useCustomDomains: Boolean = false, loadDomainsFromDisk: Boolean = true )</ID>
-    <ID>LongMethod:DomainMatcher.kt$@SuppressWarnings("ReturnCount") private fun basicMatch(query: String, urls: Sequence&lt;String&gt;): String?</ID>
-    <ID>LongMethod:EngineVersion.kt$EngineVersion.Companion$ @Suppress("MagicNumber", "ReturnCount") fun parse(version: String): EngineVersion?</ID>
-    <ID>LongMethod:ErrorPages.kt$ErrorPages$ fun createErrorPage( context: Context, errorType: ErrorType, uri: String? = null, @RawRes htmlResource: Int = R.raw.error_pages, @RawRes cssResource: Int = R.raw.error_style ): String</ID>
-    <ID>LongMethod:ErrorRecording.kt$ErrorRecording$ @VisibleForTesting(otherwise = VisibleForTesting.NONE) internal fun testGetNumRecordedErrors( metricData: CommonMetricData, errorType: ErrorType, pingName: String? = null ): Int</ID>
-    <ID>LongMethod:ErrorRecording.kt$ErrorRecording$ internal fun recordError( metricData: CommonMetricData, errorType: ErrorType, message: String, logger: Logger )</ID>
-    <ID>LongMethod:EventsStorageEngine.kt$EventsStorageEngine$ @Synchronized fun getSnapshot(storeName: String, clearStore: Boolean): List&lt;RecordedEventData&gt;?</ID>
-    <ID>LongMethod:EventsStorageEngine.kt$EventsStorageEngine$ fun &lt;ExtraKeysEnum : Enum&lt;ExtraKeysEnum&gt;&gt; record( metricData: EventMetricType&lt;ExtraKeysEnum&gt;, monotonicElapsedMs: Long, extra: Map&lt;String, String&gt;? = null )</ID>
-    <ID>LongMethod:ExperimentEvaluator.kt$ExperimentEvaluator$ internal fun evaluate( context: Context, experimentDescriptor: ExperimentDescriptor, experiments: List&lt;Experiment&gt;, userBucket: Int = getUserBucket(context) ): ActiveExperiment?</ID>
-    <ID>LongMethod:ExperimentEvaluator.kt$ExperimentEvaluator$private fun matches(context: Context, experiment: Experiment): Boolean</ID>
-    <ID>LongMethod:Experiments.kt$ExperimentsInternalAPI$ fun initialize( applicationContext: Context, configuration: Configuration = Configuration() )</ID>
-    <ID>LongMethod:ExperimentsDebugActivity.kt$ExperimentsDebugActivity$@Suppress("ComplexMethod") override fun onCreate(savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:ExperimentsStorageEngine.kt$ExperimentsStorageEngine$ fun setExperimentActive( experimentId: String, branch: String, extra: Map&lt;String, String&gt;? = null )</ID>
-    <ID>LongMethod:FindInPageBar.kt$FindInPageBar$private fun createStyling( context: Context, attrs: AttributeSet?, defStyleAttr: Int ): FindInPageBarStyling</ID>
-    <ID>LongMethod:FlowLayout.kt$FlowLayout$override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int)</ID>
-    <ID>LongMethod:FlowLayout.kt$FlowLayout$override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int)</ID>
+    <ID>LongMethod:DomainMatcherTest.kt$DomainMatcherTest$@Test fun `should perform basic domain matching for a given query`()</ID>
+    <ID>LongMethod:EngineSessionTest.kt$EngineSessionTest$@Test fun `observer will not be notified after calling unregister`()</ID>
+    <ID>LongMethod:EngineSessionTest.kt$EngineSessionTest$@Test fun `observer will not be notified after session is closed`()</ID>
+    <ID>LongMethod:EngineSessionTest.kt$EngineSessionTest$@Test fun `observers will not be notified after calling unregisterObservers`()</ID>
+    <ID>LongMethod:EngineSessionTest.kt$EngineSessionTest$@Test fun `registered observers are instance specific`()</ID>
+    <ID>LongMethod:EngineSessionTest.kt$EngineSessionTest$@Test fun `registered observers will be notified`()</ID>
+    <ID>LongMethod:ExperimentsDebugActivityTest.kt$ExperimentsDebugActivityTest$@Test fun `command line extra overrideExperiment updates experiments`()</ID>
+    <ID>LongMethod:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$@Test fun toJsonValid()</ID>
+    <ID>LongMethod:ExperimentsTest.kt$ExperimentsTest$@Test fun withExperiment()</ID>
     <ID>LongMethod:FxaAccountManager.kt$FxaAccountManager$ @Suppress("ComplexMethod", "ReturnCount", "ThrowsCount") private suspend fun stateActions(forState: AccountState, via: Event): Event?</ID>
-    <ID>LongMethod:FxaAccountManager.kt$FxaAccountManager.Companion$ internal fun nextState(state: AccountState, event: Event): AccountState?</ID>
-    <ID>LongMethod:FxaDeviceManager.kt$PollingDeviceManager$fun refreshDevicesAsync(): Deferred&lt;Boolean&gt;</ID>
-    <ID>LongMethod:GVVersionVerifierPlugin.kt$GVVersionVerifierPlugin$override fun apply(project: Project)</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession$ override fun toggleDesktopMode(enable: Boolean, reload: Boolean)</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession$@Suppress("ComplexMethod") fun handleLongClick(elementSrc: String?, elementType: Int, uri: String? = null): HitResult?</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession$private fun createGeckoSession()</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession.&lt;no name provided&gt;$@SuppressWarnings("ReturnCount") override fun onVisited( session: GeckoSession, url: String, lastVisitedURL: String?, flags: Int ): GeckoResult&lt;Boolean&gt;?</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession.&lt;no name provided&gt;$override fun onLoadRequest( session: GeckoSession, request: NavigationDelegate.LoadRequest ): GeckoResult&lt;AllowOrDeny&gt;</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession.Companion$ @Suppress("ComplexMethod") internal fun geckoErrorToErrorType(@WebRequestError.Error errorCode: Int)</ID>
-    <ID>LongMethod:GeckoEngineSession.kt$GeckoEngineSession.Companion$ @Suppress("ComplexMethod") internal fun geckoErrorToErrorType(errorCode: Int)</ID>
-    <ID>LongMethod:GeckoPermissionRequest.kt$GeckoPermissionRequest.Media.Companion$@Suppress("ComplexMethod", "SwitchIntDef") fun mapPermission(mediaSource: MediaSource): Permission</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$@Suppress("LongParameterList") private fun notifyDatePromptRequest( title: String, initialDateString: String, minDateString: String?, maxDateString: String?, onClear: () -&gt; Unit, format: String, geckoCallback: TextCallback )</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$override fun onAuthPrompt( session: GeckoSession, title: String?, message: String?, options: AuthOptions, geckoCallback: AuthCallback )</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$override fun onButtonPrompt( session: GeckoSession, title: String?, message: String?, buttonTitles: Array&lt;out String?&gt;?, callback: ButtonCallback )</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$override fun onChoicePrompt( session: GeckoSession, title: String?, msg: String?, type: Int, geckoChoices: Array&lt;out GeckoChoice&gt;, callback: ChoiceCallback )</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$override fun onDateTimePrompt( session: GeckoSession, title: String?, type: Int, value: String?, minDate: String?, maxDate: String?, geckoCallback: TextCallback )</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$override fun onFilePrompt( session: GeckoSession, title: String?, selectionType: Int, mimeTypes: Array&lt;out String&gt;?, callback: FileCallback )</ID>
-    <ID>LongMethod:GeckoPromptDelegate.kt$GeckoPromptDelegate$override fun onTextPrompt( session: GeckoSession, title: String?, inputLabel: String?, inputValue: String?, callback: TextCallback )</ID>
-    <ID>LongMethod:GeckoViewFetchClient.kt$GeckoViewFetchClient$@Throws(IOException::class) @Suppress("ComplexMethod") override fun fetch(request: Request): Response</ID>
-    <ID>LongMethod:GeckoViewFetchClient.kt$GeckoViewFetchClient$@Throws(IOException::class) override fun fetch(request: Request): Response</ID>
-    <ID>LongMethod:GenericStorageEngine.kt$GenericStorageEngine$ @Suppress("TooGenericExceptionCaught", "ComplexMethod") open fun deserializeLifetime(lifetime: Lifetime): SharedPreferences</ID>
-    <ID>LongMethod:GenericStorageEngine.kt$GenericStorageEngine$ @Synchronized protected fun recordMetric( metricData: CommonMetricData, value: MetricType, extraSerializationData: Any? = null, combine: MetricsCombiner&lt;MetricType&gt; )</ID>
-    <ID>LongMethod:GitHubClient.kt$GitHubClient$@Suppress("TooGenericExceptionCaught") private fun httpPOST(urlString: String, json: String, vararg headers: Pair&lt;String, String&gt;): Pair&lt;Boolean, String&gt;</ID>
-    <ID>LongMethod:GitHubPlugin.kt$GitHubPlugin$@Suppress("TooGenericExceptionThrown", "LongParameterList") private fun createPullRequest( title: String, body: String, branchName: String, baseBranch: String, owner: String, repoName: String, user: String )</ID>
-    <ID>LongMethod:GitHubPlugin.kt$GitHubPlugin$override fun apply(project: Project)</ID>
-    <ID>LongMethod:Glean.kt$GleanInternalAPI$ @Suppress("EXPERIMENTAL_API_USAGE") internal fun sendPings(pings: List&lt;PingType&gt;)</ID>
-    <ID>LongMethod:Glean.kt$GleanInternalAPI$ fun initialize( applicationContext: Context, configuration: Configuration = Configuration() )</ID>
-    <ID>LongMethod:Glean.kt$GleanInternalAPI$ private fun fixLegacyPingInfoMetrics()</ID>
-    <ID>LongMethod:Glean.kt$GleanInternalAPI$ private fun initializeCoreMetrics(applicationContext: Context)</ID>
-    <ID>LongMethod:GleanDebugActivity.kt$GleanDebugActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:HttpIconLoader.kt$HttpIconLoader$override fun load(context: Context, request: IconRequest, resource: IconRequest.Resource): IconLoader.Result</ID>
-    <ID>LongMethod:ConceptFetchHttpUploader.kt$HttpPingUploader$@Throws(IOException::class) internal fun performUpload(client: Client, request: Request): Boolean</ID>
-    <ID>LongMethod:ConceptFetchHttpUploader.kt$HttpPingUploader$@VisibleForTesting(otherwise = PRIVATE) internal fun buildRequest(path: String, data: String, config: Configuration): Request</ID>
-    <ID>LongMethod:HttpURLConnectionClient.kt$private fun createBody(connection: HttpURLConnection, contentType: String?): Response.Body</ID>
-    <ID>LongMethod:ICOIconDecoderTest.kt$ICOIconDecoderTest$@Test fun testIconSizesOfGolemFavicon()</ID>
-    <ID>LongMethod:ICOIconDecoderTest.kt$ICOIconDecoderTest$@Test fun testIconSizesOfMicrosoftFavicon()</ID>
-    <ID>LongMethod:IconDirectoryEntry.kt$ @Suppress("MagicNumber", "ReturnCount", "ComplexMethod", "NestedBlockDepth", "ComplexCondition") internal fun decodeDirectoryEntries(data: ByteArray, maxSize: Int): List&lt;IconDirectoryEntry&gt;</ID>
-    <ID>LongMethod:IconDirectoryEntry.kt$@Suppress("MagicNumber") internal fun createIconDirectoryEntry( data: ByteArray, entryOffset: Int, directoryIndex: Int ): IconDirectoryEntry?</ID>
-    <ID>LongMethod:InMemoryHistoryStorage.kt$InMemoryHistoryStorage$override fun getSuggestions(query: String, limit: Int): List&lt;SearchResult&gt;</ID>
-    <ID>LongMethod:InMemoryHistoryStorage.kt$InMemoryHistoryStorage$override suspend fun getDetailedVisits( start: Long, end: Long, excludeTypes: List&lt;VisitType&gt; ): List&lt;VisitInfo&gt;</ID>
-    <ID>LongMethod:JSONExperimentParser.kt$JSONExperimentParser$ fun fromJson(jsonObject: JSONObject): Experiment</ID>
-    <ID>LongMethod:JSONExperimentParser.kt$JSONExperimentParser$ fun toJson(experiment: Experiment): JSONObject</ID>
-    <ID>LongMethod:Jexl.kt$Jexl$ fun evaluateBooleanExpression( expression: String, context: JexlContext = JexlContext(), defaultValue: Boolean? = null ): Boolean</ID>
-    <ID>LongMethod:KintoClient.kt$KintoClient$@Suppress("TooGenericExceptionCaught", "ThrowsCount") internal fun fetch(url: String): String</ID>
-    <ID>LongMethod:KintoExperimentSource.kt$KintoExperimentSource$private fun mergeExperimentsFromDiff(experimentsDiff: String, snapshot: ExperimentsSnapshot): ExperimentsSnapshot</ID>
-    <ID>LongMethod:LabeledMetricType.kt$LabeledMetricType$ @Suppress("ReturnCount") private fun getFinalDynamicLabel(label: String): String</ID>
-    <ID>LongMethod:LegacySessionManager.kt$LegacySessionManager$ @Suppress("ComplexMethod") private fun recalculateSelectionIndex( indexToRemove: Int, selectParentIfExists: Boolean, private: Boolean, parentId: String? ): Boolean</ID>
-    <ID>LongMethod:LegacySessionManager.kt$LegacySessionManager$ fun createSnapshot(): SessionManager.Snapshot</ID>
-    <ID>LongMethod:LegacySessionManager.kt$LegacySessionManager$ fun remove( session: Session = selectedSessionOrThrow, selectParentIfExists: Boolean = false )</ID>
-    <ID>LongMethod:LegacySessionManager.kt$LegacySessionManager$ fun restore(snapshot: SessionManager.Snapshot, updateSelection: Boolean = true)</ID>
-    <ID>LongMethod:LegacySessionManager.kt$LegacySessionManager$@Suppress("LongParameterList", "ComplexMethod") private fun addInternal( session: Session, selected: Boolean = false, engineSession: EngineSession? = null, engineSessionState: EngineSessionState? = null, parent: Session? = null, viaRestore: Boolean = false )</ID>
-    <ID>LongMethod:Lexer.kt$Lexer$ @Suppress("ComplexMethod") @Throws(LexerException::class) fun tokenize(raw: String): List&lt;Token&gt;</ID>
-    <ID>LongMethod:Lexer.kt$Lexer$@Suppress("ComplexMethod") private fun readDigit(input: LexerInput, negate: Boolean): Token</ID>
-    <ID>LongMethod:MainActivity.kt$MainActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:MainActivity.kt$MainActivity.&lt;no name provided&gt;$override fun onIdle()</ID>
-    <ID>LongMethod:MainActivity.kt$MainActivity.&lt;no name provided&gt;$override fun onLoggedOut()</ID>
-    <ID>LongMethod:Map.kt$private fun &lt;V&gt; Bundle.put(key: String, value: V)</ID>
-    <ID>LongMethod:MediaStateMachine.kt$MediaSessionObserver$@Suppress("ReturnCount") private fun determineNewState(): MediaState</ID>
-    <ID>LongMethod:MetricsPingScheduler.kt$MetricsPingScheduler$ @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal fun getMillisecondsUntilDueTime( sendTheNextCalendarDay: Boolean, now: Calendar, dueHourOfTheDay: Int = DUE_HOUR_OF_THE_DAY ): Long</ID>
-    <ID>LongMethod:MetricsPingScheduler.kt$MetricsPingScheduler$ fun startupCheck()</ID>
-    <ID>LongMethod:MultiButtonDialogFragment.kt$MultiButtonDialogFragment.Companion$@Suppress("LongParameterList") fun newInstance( sessionId: String, title: String, message: String, hasShownManyDialogs: Boolean, positiveButton: String = "", negativeButton: String = "", neutralButton: String = "" ): MultiButtonDialogFragment</ID>
-    <ID>LongMethod:NestedGeckoView.kt$NestedGeckoView$@SuppressLint("ClickableViewAccessibility") override fun onTouchEvent(ev: MotionEvent): Boolean</ID>
-    <ID>LongMethod:NestedWebView.kt$NestedWebView$@SuppressLint("ClickableViewAccessibility") override fun onTouchEvent(ev: MotionEvent): Boolean</ID>
-    <ID>LongMethod:OkHttpClient.kt$private fun OkHttpClient.rebuildFor(request: Request, context: Context?): OkHttpClient</ID>
-    <ID>LongMethod:OnDeviceBrowserIconsTest.kt$OnDeviceBrowserIconsTest$@Test fun dataUriLoad()</ID>
-    <ID>LongMethod:OnDeviceSitePermissionsStorageTest.kt$OnDeviceSitePermissionsStorageTest$@Test fun migrate1to2()</ID>
-    <ID>LongMethod:Parser.kt$Parser$@Suppress("ComplexMethod", "ThrowsCount") private fun parseToken(token: Token): State?</ID>
-    <ID>LongMethod:PingStorageEngine.kt$PingStorageEngine$ private fun processFile( file: File, processingCallback: (String, String, Configuration) -&gt; Boolean ): Boolean</ID>
-    <ID>LongMethod:PromptFeature.kt$PromptFeature$ @Suppress("UNCHECKED_CAST", "ComplexMethod") internal fun onConfirm(sessionId: String, value: Any? = null)</ID>
+    <ID>LongMethod:FxaAccountManagerTest.kt$FxaAccountManagerTest$@Test fun `state transitions`()</ID>
+    <ID>LongMethod:FxaAccountManagerTest.kt$FxaAccountManagerTest$@Test fun `updating sync config, with one to begin with`()</ID>
+    <ID>LongMethod:FxaAccountManagerTest.kt$FxaAccountManagerTest$@Test fun `updating sync config, without it at first`()</ID>
+    <ID>LongMethod:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$@Test fun geckoErrorMappingToErrorType()</ID>
+    <ID>LongMethod:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$@Test fun trackingProtectionDelegateNotifiesObservers()</ID>
+    <ID>LongMethod:GeckoEngineTest.kt$GeckoEngineTest$@Test fun defaultSettings()</ID>
+    <ID>LongMethod:GeckoEngineTest.kt$GeckoEngineTest$@Test fun settings()</ID>
+    <ID>LongMethod:IconMessageHandlerTest.kt$IconMessageHandlerTest$@Test fun `Complex message (TheVerge) is transformed into IconRequest and loaded`()</ID>
+    <ID>LongMethod:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$@Test fun getExperimentsDiffAdd()</ID>
+    <ID>LongMethod:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$@Test fun getExperimentsDiffUpdate()</ID>
+    <ID>LongMethod:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$override fun syncBookmarks(syncInfo: SyncAuthInfo)</ID>
+    <ID>LongMethod:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$@Test fun `storage allows recording and querying visits of different types`()</ID>
+    <ID>LongMethod:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$override fun syncHistory(syncInfo: SyncAuthInfo)</ID>
     <ID>LongMethod:PromptFeature.kt$PromptFeature$@Suppress("ComplexMethod") @VisibleForTesting(otherwise = PRIVATE) internal fun handleDialogsRequest( promptRequest: PromptRequest, session: Session )</ID>
-    <ID>LongMethod:Providers.kt$BaseDomainAutocompleteProvider$ override fun getAutocompleteSuggestion(query: String): DomainAutocompleteResult?</ID>
-    <ID>LongMethod:PublicSuffixListData.kt$PublicSuffixListData$@Suppress("ReturnCount") fun getPublicSuffixOffset(domain: String): PublicSuffixOffset?</ID>
-    <ID>LongMethod:PublicSuffixListPlugin.kt$PublicSuffixListPlugin$private fun fetchPublicSuffixList(): PublicSuffixListData</ID>
-    <ID>LongMethod:QrFragment.kt$QrFragment$ @Suppress("ComplexMethod") internal fun createCameraPreviewSession()</ID>
-    <ID>LongMethod:QrFragment.kt$QrFragment$ @Suppress("ComplexMethod", "MagicNumber") internal fun setUpCameraOutputs(width: Int, height: Int)</ID>
-    <ID>LongMethod:QrFragment.kt$QrFragment$ @Suppress("MagicNumber") private fun configureTransform(viewWidth: Int, viewHeight: Int)</ID>
-    <ID>LongMethod:QrFragment.kt$QrFragment$ @SuppressLint("MissingPermission") @Suppress("ThrowsCount") internal fun openCamera(width: Int, height: Int)</ID>
-    <ID>LongMethod:QrFragment.kt$QrFragment.&lt;no name provided&gt;$override fun onImageAvailable(reader: ImageReader)</ID>
-    <ID>LongMethod:QrFragment.kt$QrFragment.Companion$ @Suppress("LongParameterList") internal fun chooseOptimalSize( choices: Array&lt;Size&gt;, textureViewWidth: Int, textureViewHeight: Int, maxWidth: Int, maxHeight: Int, aspectRatio: Size ): Size</ID>
-    <ID>LongMethod:ReaderViewControlsBar.kt$ReaderViewControlsBar$@Suppress("ComplexMethod") private fun bindViews()</ID>
-    <ID>LongMethod:ResizingProcessor.kt$ResizingProcessor$override fun process( context: Context, request: IconRequest, resource: IconRequest.Resource?, icon: Icon, desiredSize: DesiredSize ): Icon?</ID>
-    <ID>LongMethod:SearchEngineParser.kt$SearchEngineParser$@Throws(XmlPullParserException::class, IOException::class) private fun readSearchPlugin(parser: XmlPullParser, builder: SearchEngineBuilder)</ID>
-    <ID>LongMethod:SearchSuggestionProvider.kt$SearchSuggestionProvider$private fun createMultipleSuggestions(text: String, result: List&lt;String&gt;?): List&lt;AwesomeBar.Suggestion&gt;</ID>
-    <ID>LongMethod:SearchSuggestionProvider.kt$SearchSuggestionProvider$private fun createSingleSearchSuggestion(text: String, result: List&lt;String&gt;?): List&lt;AwesomeBar.Suggestion&gt;</ID>
-    <ID>LongMethod:SessionManager.kt$SessionManager$ fun add( session: Session, selected: Boolean = false, engineSession: EngineSession? = null, parent: Session? = null )</ID>
-    <ID>LongMethod:SessionManager.kt$SessionManager$ fun restore(snapshot: Snapshot, updateSelection: Boolean = true)</ID>
-    <ID>LongMethod:SessionSuggestionProvider.kt$SessionSuggestionProvider$override suspend fun onInputChanged(text: String): List&lt;AwesomeBar.Suggestion&gt;</ID>
-    <ID>LongMethod:SharedIds.kt$SharedIds$ @Synchronized fun getIdForTag(context: Context, tag: String): Int</ID>
-    <ID>LongMethod:SignatureVerifier.kt$SignatureVerifier$ private fun getX5U(url: String): PublicKey</ID>
-    <ID>LongMethod:SignatureVerifier.kt$SignatureVerifier$ private fun signatureToASN1(signatureBytes: ByteArray): ByteArray</ID>
-    <ID>LongMethod:SimpleDownloadDialogFragment.kt$SimpleDownloadDialogFragment$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:SimpleRedirectDialogFragment.kt$SimpleRedirectDialogFragment$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:SitePermissionsDialogFragment.kt$SitePermissionsDialogFragment$@SuppressLint("InflateParams") private fun createContainer(): View</ID>
-    <ID>LongMethod:SitePermissionsDialogFragment.kt$SitePermissionsDialogFragment.Companion$@Suppress("LongParameterList") fun newInstance( sessionId: String, title: String, titleIcon: Int, feature: SitePermissionsFeature, shouldShowDoNotAskAgainCheckBox: Boolean, shouldSelectDoNotAskAgainCheckBox: Boolean = false, isNotificationRequest: Boolean = false ): SitePermissionsDialogFragment</ID>
-    <ID>LongMethod:SitePermissionsFeature.kt$SitePermissionsFeature$@Suppress("LongParameterList") @SuppressLint("VisibleForTests") private fun createSinglePermissionPrompt( context: Context, sessionId: String, host: String, @StringRes titleId: Int, @DrawableRes iconId: Int, showDoNotAskAgainCheckBox: Boolean, shouldSelectRememberChoice: Boolean, isNotificationRequest: Boolean = false ): SitePermissionsDialogFragment</ID>
-    <ID>LongMethod:SitePermissionsFeature.kt$SitePermissionsFeature$@Synchronized internal fun storeSitePermissions( session: Session, request: PermissionRequest, permissions: List&lt;Permission&gt; = request.permissions, status: SitePermissions.Status )</ID>
-    <ID>LongMethod:SitePermissionsFeature.kt$SitePermissionsFeature$private fun createPrompt( permissionRequest: PermissionRequest, session: Session ): SitePermissionsDialogFragment</ID>
-    <ID>LongMethod:SitePermissionsFeature.kt$SitePermissionsFeature$private fun handlingSingleContentPermissions( sessionId: String, permission: Permission, host: String ): SitePermissionsDialogFragment</ID>
-    <ID>LongMethod:SitePermissionsFeature.kt$SitePermissionsFeature$private fun updateSitePermissionsStatus( status: SitePermissions.Status, permission: Permission, sitePermissions: SitePermissions ): SitePermissions</ID>
-    <ID>LongMethod:SitePermissionsFeature.kt$private fun isPermissionGranted( permission: Permission, permissionFromStorage: SitePermissions ): Boolean</ID>
-    <ID>LongMethod:SnapshotSerializer.kt$@Throws(JSONException::class) @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal fun deserializeSession(json: JSONObject, restoreId: Boolean): Session</ID>
-    <ID>LongMethod:StorageSync.kt$StorageSync$private suspend fun syncStore( store: SyncableStore, storeName: String, auth: AuthInfo ): StoreSyncStatus</ID>
-    <ID>LongMethod:StorageUtils.kt$StorageUtils$// Borrowed from https://gist.github.com/ademar111190/34d3de41308389a0d0d8 fun levenshteinDistance(a: String, b: String): Int</ID>
-    <ID>LongMethod:StringListsStorageEngine.kt$StringListsStorageEngineImplementation$ fun add( metricData: CommonMetricData, value: String )</ID>
-    <ID>LongMethod:StringListsStorageEngine.kt$StringListsStorageEngineImplementation$ fun set( metricData: CommonMetricData, value: List&lt;String&gt; )</ID>
-    <ID>LongMethod:SystemEngineSession.kt$SystemEngineSession$ @Suppress("TooGenericExceptionCaught") override fun clearData(data: BrowsingData, host: String?, onSuccess: () -&gt; Unit, onError: (Throwable) -&gt; Unit)</ID>
+    <ID>LongMethod:PromptRequestTest.kt$PromptRequestTest$@Test fun `Create prompt requests`()</ID>
+    <ID>LongMethod:PublicSuffixListTest.kt$PublicSuffixListTest$ @Test fun `Verify getPublicSuffixPlusOne against official test data`()</ID>
+    <ID>LongMethod:SessionKtTest.kt$SessionKtTest$@Test fun `web app must have 192x192 icons to be installable`()</ID>
+    <ID>LongMethod:SettingsTest.kt$SettingsTest$@Test fun defaultSettings()</ID>
+    <ID>LongMethod:SettingsTest.kt$SettingsTest$@Test fun settingsThrowByDefault()</ID>
+    <ID>LongMethod:SignatureVerifierTest.kt$SignatureVerifierTest$@Test fun validSignatureCorrect()</ID>
+    <ID>LongMethod:SignatureVerifierTest.kt$SignatureVerifierTest$@Test fun validSignatureIncorrect()</ID>
+    <ID>LongMethod:SignatureVerifierTest.kt$SignatureVerifierTest$@Test(expected = ExperimentDownloadException::class) fun validSignatureCertificateNotYetValid()</ID>
+    <ID>LongMethod:SignatureVerifierTest.kt$SignatureVerifierTest$@Test(expected = ExperimentDownloadException::class) fun validSignatureExpiredCertificate()</ID>
+    <ID>LongMethod:SignatureVerifierTest.kt$SignatureVerifierTest$@Test(expected = ExperimentDownloadException::class) fun validSignatureInvalidChainOrder()</ID>
+    <ID>LongMethod:SignatureVerifierTest.kt$SignatureVerifierTest$private fun testSignature(metadataBody: String, certChainBody: String, expected: Boolean, currentDate: Date = defaultDate())</ID>
     <ID>LongMethod:SystemEngineSession.kt$SystemEngineSession$private fun initSettings(webView: WebView, s: WebSettings)</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView$internal fun handleLongClick(type: Int, extra: String): Boolean</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView.&lt;no name provided&gt;$@Suppress("ReturnCount", "NestedBlockDepth") override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse?</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView.&lt;no name provided&gt;$override fun onJsAlert(view: WebView, url: String?, message: String?, result: JsResult): Boolean</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView.&lt;no name provided&gt;$override fun onJsConfirm(view: WebView?, url: String?, message: String?, result: JsResult): Boolean</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView.&lt;no name provided&gt;$override fun onJsPrompt( view: WebView?, url: String?, message: String?, defaultValue: String?, result: JsPromptResult ): Boolean</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView.&lt;no name provided&gt;$override fun onReceivedHttpAuthRequest(view: WebView, handler: HttpAuthHandler, host: String, realm: String)</ID>
-    <ID>LongMethod:SystemEngineView.kt$SystemEngineView.&lt;no name provided&gt;$override fun onShowFileChooser( webView: WebView?, filePathCallback: ValueCallback&lt;Array&lt;Uri&gt;&gt;?, fileChooserParams: FileChooserParams? ): Boolean</ID>
+    <ID>LongMethod:SystemEngineSessionTest.kt$SystemEngineSessionTest$@Test @Suppress("Deprecation") fun initSettings()</ID>
+    <ID>LongMethod:SystemEngineSessionTest.kt$SystemEngineSessionTest$@Test fun clearDataMakingExpectedCalls()</ID>
+    <ID>LongMethod:SystemEngineViewTest.kt$SystemEngineViewTest$@Test @Suppress("Deprecation") fun `WebViewClient calls interceptor from deprecated onReceivedError API`()</ID>
+    <ID>LongMethod:SystemEngineViewTest.kt$SystemEngineViewTest$@Test fun `blocked trackers are reported with correct categories`()</ID>
     <ID>LongMethod:TabCollectionStorageTest.kt$TabCollectionStorageTest$@Test @Suppress("ComplexMethod") fun testGettingCollectionsWithLimit()</ID>
-    <ID>LongMethod:TabCollectionStorageTest.kt$TabCollectionStorageTest$@Test fun testAddingTabsToExistingCollection()</ID>
-    <ID>LongMethod:TabCollectionStorageTest.kt$TabCollectionStorageTest$@Test fun testCreatingCollectionAndRestoringState()</ID>
-    <ID>LongMethod:TabCollectionStorageTest.kt$TabCollectionStorageTest$@Test fun testGettingTabCollectionCount()</ID>
-    <ID>LongMethod:TabDaoTest.kt$TabDaoTest$@Test fun testAddingTabsToCollection()</ID>
-    <ID>LongMethod:TabDaoTest.kt$TabDaoTest$@Test fun testRemovingTabFromCollection()</ID>
     <ID>LongMethod:TabListReducer.kt$TabListReducer$ fun reduce(state: BrowserState, action: TabListAction): BrowserState</ID>
-    <ID>LongMethod:TabViewHolder.kt$TabViewHolder$ fun bind(session: Session, isSelected: Boolean, observable: Observable&lt;TabsTray.Observer&gt;)</ID>
-    <ID>LongMethod:TabsTrayFragment.kt$TabsTrayFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:TelemetryClient.kt$TelemetryClient$@Suppress("MagicNumber", "ReturnCount") fun uploadPing(configuration: TelemetryConfiguration, path: String, serializedPing: String): Boolean</ID>
-    <ID>LongMethod:TimePickerDialogFragment.kt$TimePickerDialogFragment$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:TimePickerDialogFragment.kt$TimePickerDialogFragment.Companion$ @Suppress("LongParameterList") fun newInstance( sessionId: String, initialDate: Date, minDate: Date?, maxDate: Date?, selectionType: Int = SELECTION_TYPE_DATE ): TimePickerDialogFragment</ID>
-    <ID>LongMethod:TimespanMetricType.kt$TimespanMetricType$ fun stop()</ID>
-    <ID>LongMethod:TimespansStorageEngine.kt$TimespansStorageEngineImplementation$override fun deserializeSingleMetric(metricName: String, value: Any?): Long?</ID>
-    <ID>LongMethod:TimingDistributionsStorageEngine.kt$TimingDistributionData$ private fun getBuckets(): List&lt;Long&gt;</ID>
-    <ID>LongMethod:TimingDistributionsStorageEngine.kt$TimingDistributionData.Companion$ @Suppress("ReturnCount", "ComplexMethod") internal fun fromJsonString(json: String): TimingDistributionData?</ID>
-    <ID>LongMethod:TimingDistributionsStorageEngine.kt$TimingDistributionsStorageEngineImplementation$ @Synchronized fun accumulate( metricData: CommonMetricData, sample: Long, timeUnit: TimeUnit )</ID>
-    <ID>LongMethod:TimingManager.kt$TimingManager$ fun start(metricData: CommonMetricData): GleanTimerId?</ID>
-    <ID>LongMethod:ToolbarActivity.kt$ToolbarActivity$ private fun setupFocusPhoneToolbar()</ID>
-    <ID>LongMethod:ToolbarActivity.kt$ToolbarActivity$ private fun setupFocusTabletToolbar()</ID>
-    <ID>LongMethod:ToolbarActivity.kt$ToolbarActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:Types.kt$BaseGleanSyncPing.Companion$fun fromEngineInfo(uid: String, info: EngineInfo): BaseGleanSyncPing</ID>
-    <ID>LongMethod:UrlMatcher.kt$UrlMatcher$ @Suppress("ReturnCount", "ComplexMethod") fun matches(resourceURI: Uri, pageURI: Uri): Boolean</ID>
-    <ID>LongMethod:UrlMatcher.kt$UrlMatcher.Companion$@Suppress("ThrowsCount", "ComplexMethod", "NestedBlockDepth") private fun extractCategories(reader: JsonReader, categoryMap: MutableMap&lt;String, Trie&gt;, override: Boolean)</ID>
-    <ID>LongMethod:UrlMatcher.kt$UrlMatcher.Companion$private fun extractSite(reader: JsonReader, callback: (String, String) -&gt; Unit)</ID>
-    <ID>LongMethod:Utils.kt$ @Suppress("ReturnCount") internal fun List&lt;Pair&lt;Int, Int&gt;&gt;.findBestSize(targetSize: Int, maxSize: Int, maxScaleFactor: Float): Pair&lt;Int, Int&gt;?</ID>
-    <ID>LongMethod:Utils.kt$ fun &lt;T&gt; handleFxaExceptions( logger: Logger, operation: String, block: () -&gt; T, postHandleAuthErrorBlock: (e: FxaUnauthorizedException) -&gt; T, handleErrorBlock: (e: FxaException) -&gt; T ): T</ID>
-    <ID>LongMethod:VersionString.kt$VersionString$@Suppress("ComplexMethod") override fun compareTo(other: VersionString): Int</ID>
-    <ID>LongMethod:View.kt$ShowKeyboard$override fun run()</ID>
-    <ID>LongMethod:WebAppManifestParser.kt$WebAppManifestParser$ fun parse(json: JSONObject): Result</ID>
-    <ID>LongMethod:WhiteList.kt$WhiteList.Companion$ @Suppress("NestedBlockDepth") fun fromJson(reader: JsonReader): WhiteList</ID>
-    <ID>LongMethod:WorkManagerSyncDispatcher.kt$WorkManagerSyncWorker$@Suppress("ReturnCount", "ComplexMethod") override suspend fun doWork(): Result</ID>
+    <ID>LongMethod:ToolbarAutocompleteFeatureTest.kt$ToolbarAutocompleteFeatureTest$@Test fun `feature can be configured with providers`()</ID>
+    <ID>LongMethod:WebAppManifestParserTest.kt$WebAppManifestParserTest$@Test fun `Parsing typical manifest from W3 spec`()</ID>
+    <ID>LongParameterList:BaseDomainAutocompleteProviderTest.kt$( provider: DomainAutocompleteProvider, domainSource: DomainList, sourceSize: Int, input: String, expectedInput: String, completion: String, expectedUrl: String )</ID>
+    <ID>LongParameterList:DomainAutoCompleteProviderTest.kt$DomainAutoCompleteProviderTest$( provider: DomainAutoCompleteProvider, text: String, domainSource: String, sourceSize: Int, completion: String, expectedUrl: String )</ID>
+    <ID>LongParameterList:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest$(action: String, expectedAuthType: AuthType, code: String, state: String, messageHandler: MessageHandler, accountManager: FxaAccountManager)</ID>
+    <ID>LongParameterList:Mock.kt$( action: Int, downTime: Long = System.currentTimeMillis(), eventTime: Long = System.currentTimeMillis(), x: Float = 0f, y: Float = 0f, metaState: Int = 0 )</ID>
+    <ID>LongParameterList:ProvidersTest.kt$ProvidersTest$( provider: BaseDomainAutocompleteProvider, text: String, domainSource: DomainList, sourceSize: Int, completion: String, expectedUrl: String )</ID>
+    <ID>LongParameterList:ResizingProcessorTest.kt$ResizingProcessorTest$( p: ResizingProcessor = processor, context: Context = mockContext(2f), request: IconRequest = IconRequest("https://mozilla.org"), resource: IconRequest.Resource = mock(), icon: Icon = Icon(mockBitmap(64), source = Icon.Source.DISK), desiredSize: DesiredSize = DesiredSize(96, 1000, 3f) )</ID>
+    <ID>LongParameterList:TestUtil.kt$( appId: String? = null, appDisplayVersion: String? = null, appMinVersion: String? = null, appMaxVersion: String? = null, localeLanguage: String? = null, localeCountry: String? = null, deviceManufacturer: String? = null, deviceModel: String? = null, regions: List&lt;String&gt;? = null, debugTags: List&lt;String&gt;? = null )</ID>
+    <ID>LongParameterList:TestUtil.kt$( id: String = "testid", description: String = "description", lastModified: Long? = null, schemaModified: Long? = null, buckets: Experiment.Buckets = Experiment.Buckets(0, ExperimentEvaluator.MAX_USER_BUCKET), branches: List&lt;Experiment.Branch&gt; = createSingleBranchList(), match: Experiment.Matcher = createDefaultMatcher() )</ID>
+    <ID>MagicNumber:AbstractCustomTabsServiceTest.kt$AbstractCustomTabsServiceTest$123</ID>
+    <ID>MagicNumber:AbstractCustomTabsServiceTest.kt$AbstractCustomTabsServiceTest$42</ID>
+    <ID>MagicNumber:AbstractFetchDownloadServiceTest.kt$AbstractFetchDownloadServiceTest$200</ID>
+    <ID>MagicNumber:AccountSharingTest.kt$AccountSharingTest$3</ID>
+    <ID>MagicNumber:ActionButtonTest.kt$ActionButtonTest$16</ID>
+    <ID>MagicNumber:ActionButtonTest.kt$ActionButtonTest$20</ID>
+    <ID>MagicNumber:ActionButtonTest.kt$ActionButtonTest$24</ID>
+    <ID>MagicNumber:ActionButtonTest.kt$ActionButtonTest$28</ID>
+    <ID>MagicNumber:ActionImageTest.kt$ActionImageTest$16</ID>
+    <ID>MagicNumber:ActionImageTest.kt$ActionImageTest$20</ID>
+    <ID>MagicNumber:ActionImageTest.kt$ActionImageTest$24</ID>
+    <ID>MagicNumber:ActionImageTest.kt$ActionImageTest$28</ID>
+    <ID>MagicNumber:ActionImageTest.kt$ActionImageTest$5</ID>
+    <ID>MagicNumber:ActionSpaceTest.kt$ActionSpaceTest$16</ID>
+    <ID>MagicNumber:ActionSpaceTest.kt$ActionSpaceTest$20</ID>
+    <ID>MagicNumber:ActionSpaceTest.kt$ActionSpaceTest$24</ID>
+    <ID>MagicNumber:ActionSpaceTest.kt$ActionSpaceTest$28</ID>
+    <ID>MagicNumber:ActionToggleButtonTest.kt$ActionToggleButtonTest$16</ID>
+    <ID>MagicNumber:ActionToggleButtonTest.kt$ActionToggleButtonTest$20</ID>
+    <ID>MagicNumber:ActionToggleButtonTest.kt$ActionToggleButtonTest$24</ID>
+    <ID>MagicNumber:ActionToggleButtonTest.kt$ActionToggleButtonTest$28</ID>
+    <ID>MagicNumber:ActiveExperimentTest.kt$ActiveExperimentTest$3</ID>
+    <ID>MagicNumber:AdaptiveIconProcessorTest.kt$AdaptiveIconProcessorTest$128</ID>
+    <ID>MagicNumber:AdaptiveIconProcessorTest.kt$AdaptiveIconProcessorTest$228</ID>
+    <ID>MagicNumber:AdaptiveIconProcessorTest.kt$AdaptiveIconProcessorTest$256</ID>
+    <ID>MagicNumber:AdaptiveIconProcessorTest.kt$AdaptiveIconProcessorTest$334</ID>
+    <ID>MagicNumber:AndroidDownloadManagerTest.kt$AndroidDownloadManagerTest$5242880</ID>
+    <ID>MagicNumber:AndroidIconDecoderTest.kt$AndroidIconDecoderTest$2000</ID>
+    <ID>MagicNumber:AndroidIconDecoderTest.kt$AndroidIconDecoderTest$250</ID>
+    <ID>MagicNumber:AndroidIconDecoderTest.kt$AndroidIconDecoderTest$50</ID>
+    <ID>MagicNumber:AndroidIconDecoderTest.kt$AndroidIconDecoderTest$512</ID>
+    <ID>MagicNumber:AndroidLogSinkTest.kt$AndroidLogSinkTest$21</ID>
+    <ID>MagicNumber:AndroidLogSinkTest.kt$AndroidLogSinkTest$24</ID>
+    <ID>MagicNumber:Assert.kt$200</ID>
+    <ID>MagicNumber:AssetsSearchEngineProviderTest.kt$AssetsSearchEngineProviderTest$4</ID>
+    <ID>MagicNumber:AssetsSearchEngineProviderTest.kt$AssetsSearchEngineProviderTest$6</ID>
+    <ID>MagicNumber:AssetsSearchEngineProviderTest.kt$AssetsSearchEngineProviderTest$7</ID>
+    <ID>MagicNumber:AsyncFilterListenerTest.kt$AsyncFilterListenerTest$4</ID>
+    <ID>MagicNumber:AsyncFilterListenerTest.kt$AsyncFilterListenerTest$8</ID>
+    <ID>MagicNumber:AtomicFileKtTest.kt$AtomicFileKtTest$3</ID>
+    <ID>MagicNumber:AudioFocusTest.kt$AudioFocusTest$999</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$16</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$3</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$360</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$4</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$480</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$640</ID>
+    <ID>MagicNumber:AutoFitTextureViewTest.kt$AutoFitTextureViewTest$9</ID>
+    <ID>MagicNumber:BaseUploaderTest.kt$BaseUploaderTest$11</ID>
+    <ID>MagicNumber:BaseUploaderTest.kt$BaseUploaderTest$2015</ID>
+    <ID>MagicNumber:BaseUploaderTest.kt$BaseUploaderTest$6</ID>
+    <ID>MagicNumber:BaselinePingTest.kt$BaselinePingTest$1000</ID>
+    <ID>MagicNumber:BaselinePingTest.kt$BaselinePingTest$20L</ID>
+    <ID>MagicNumber:BaselinePingTest.kt$BaselinePingTest$3</ID>
+    <ID>MagicNumber:BaselinePingTest.kt$BaselinePingTest$5000L</ID>
+    <ID>MagicNumber:BitmapKtTest.kt$BitmapKtTest$10</ID>
+    <ID>MagicNumber:BitmapKtTest.kt$BitmapKtTest$200</ID>
+    <ID>MagicNumber:BitmapKtTest.kt$BitmapKtTest$244</ID>
+    <ID>MagicNumber:BitmapKtTest.kt$BitmapKtTest$40f</ID>
+    <ID>MagicNumber:BookmarksStorageSuggestionProviderTest.kt$BookmarksStorageSuggestionProviderTest$100</ID>
+    <ID>MagicNumber:BookmarksStorageSuggestionProviderTest.kt$BookmarksStorageSuggestionProviderTest$20</ID>
+    <ID>MagicNumber:BreadcrumbPriorityQueueTest.kt$BreadcrumbPriorityQueueTest$10</ID>
+    <ID>MagicNumber:BreadcrumbPriorityQueueTest.kt$BreadcrumbPriorityQueueTest$100</ID>
+    <ID>MagicNumber:BreadcrumbPriorityQueueTest.kt$BreadcrumbPriorityQueueTest$15</ID>
+    <ID>MagicNumber:BreadcrumbPriorityQueueTest.kt$BreadcrumbPriorityQueueTest$5</ID>
+    <ID>MagicNumber:BreadcrumbTest.kt$BreadcrumbTest$100</ID>
+    <ID>MagicNumber:BreadcrumbTest.kt$BreadcrumbTest$3</ID>
+    <ID>MagicNumber:BrowserAwesomeBarTest.kt$BrowserAwesomeBarTest$3</ID>
+    <ID>MagicNumber:BrowserAwesomeBarTest.kt$BrowserAwesomeBarTest.&lt;no name provided&gt;$10</ID>
+    <ID>MagicNumber:BrowserIconsTest.kt$BrowserIconsTest$128</ID>
+    <ID>MagicNumber:BrowserIconsTest.kt$BrowserIconsTest$180</ID>
+    <ID>MagicNumber:BrowserIconsTest.kt$BrowserIconsTest$64</ID>
+    <ID>MagicNumber:BrowserMenuAdapterTest.kt$BrowserMenuAdapterTest$23</ID>
+    <ID>MagicNumber:BrowserMenuAdapterTest.kt$BrowserMenuAdapterTest$3</ID>
+    <ID>MagicNumber:BrowserMenuAdapterTest.kt$BrowserMenuAdapterTest$4</ID>
+    <ID>MagicNumber:BrowserMenuAdapterTest.kt$BrowserMenuAdapterTest$42</ID>
+    <ID>MagicNumber:BrowserMenuAdapterTest.kt$BrowserMenuAdapterTest$5</ID>
+    <ID>MagicNumber:BrowserMenuItemToolbarTest.kt$BrowserMenuItemToolbarTest$3</ID>
+    <ID>MagicNumber:BrowserMenuTest.kt$BrowserMenuTest$10</ID>
+    <ID>MagicNumber:BrowserMenuTest.kt$BrowserMenuTest$100</ID>
+    <ID>MagicNumber:BrowserMenuTest.kt$BrowserMenuTest$11</ID>
+    <ID>MagicNumber:BrowserMenuTest.kt$BrowserMenuTest$200</ID>
+    <ID>MagicNumber:BrowserMenuTest.kt$BrowserMenuTest$9</ID>
+    <ID>MagicNumber:BrowserTabsTrayTest.kt$BrowserTabsTrayTest$2</ID>
+    <ID>MagicNumber:BrowserTabsTrayTest.kt$BrowserTabsTrayTest$4</ID>
+    <ID>MagicNumber:BrowserTabsTrayTest.kt$BrowserTabsTrayTest$5</ID>
+    <ID>MagicNumber:BrowserTabsTrayTest.kt$BrowserTabsTrayTest$7</ID>
+    <ID>MagicNumber:BrowserToolbarBottomBehaviorTest.kt$BrowserToolbarBottomBehaviorTest$100</ID>
+    <ID>MagicNumber:BrowserToolbarBottomBehaviorTest.kt$BrowserToolbarBottomBehaviorTest$10f</ID>
+    <ID>MagicNumber:BrowserToolbarBottomBehaviorTest.kt$BrowserToolbarBottomBehaviorTest$25f</ID>
+    <ID>MagicNumber:BrowserToolbarBottomBehaviorTest.kt$BrowserToolbarBottomBehaviorTest$4223</ID>
+    <ID>MagicNumber:BrowserToolbarBottomBehaviorTest.kt$BrowserToolbarBottomBehaviorTest$90f</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$10</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$100</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$1000</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$1024</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$1100</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$12</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$12f</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$15</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$16</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$165</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$185</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$20</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$200</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$23</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$24</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$28</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$3</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$300</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$4</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$42</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$5</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$50</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$56</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$60</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$75</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$800</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$890</ID>
+    <ID>MagicNumber:BrowserToolbarTest.kt$BrowserToolbarTest$940</ID>
+    <ID>MagicNumber:BrowsersTest.kt$BrowsersTest$6</ID>
+    <ID>MagicNumber:ByteArrayTest.kt$ByteArrayTest$36</ID>
+    <ID>MagicNumber:ByteArrayTest.kt$ByteArrayTest$38</ID>
+    <ID>MagicNumber:ChoiceDialogFragmentTest.kt$ChoiceDialogFragmentTest$3</ID>
+    <ID>MagicNumber:ChoiceDialogFragmentTest.kt$ChoiceDialogFragmentTest$4</ID>
+    <ID>MagicNumber:CollectionKtTest.kt$CollectionKtTest$3</ID>
+    <ID>MagicNumber:ColorProcessorTest.kt$ColorProcessorTest$3</ID>
+    <ID>MagicNumber:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest$200</ID>
+    <ID>MagicNumber:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest$226</ID>
+    <ID>MagicNumber:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest$400</ID>
+    <ID>MagicNumber:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest$451</ID>
+    <ID>MagicNumber:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest$500</ID>
+    <ID>MagicNumber:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest$527</ID>
+    <ID>MagicNumber:ConceptFetchKtTest.kt$ConceptFetchKtTest$200</ID>
+    <ID>MagicNumber:ConceptFetchKtTest.kt$ConceptFetchKtTest$404</ID>
+    <ID>MagicNumber:ConsumableTest.kt$ConsumableTest$23</ID>
+    <ID>MagicNumber:ConsumableTest.kt$ConsumableTest$3</ID>
+    <ID>MagicNumber:ConsumableTest.kt$ConsumableTest$4</ID>
+    <ID>MagicNumber:ConsumableTest.kt$ConsumableTest$42</ID>
+    <ID>MagicNumber:ContentActionTest.kt$ContentActionTest$25</ID>
+    <ID>MagicNumber:ContentActionTest.kt$ContentActionTest$75</ID>
+    <ID>MagicNumber:ContentActionTest.kt$ContentActionTest$85</ID>
+    <ID>MagicNumber:ContextMenuCandidateTest.kt$ContextMenuCandidateTest$7</ID>
+    <ID>MagicNumber:ContextMenuFragmentTest.kt$ContextMenuFragmentTest$3</ID>
+    <ID>MagicNumber:CoordinateScrollingFeatureTest.kt$CoordinateScrollingFeatureTest$12</ID>
+    <ID>MagicNumber:CounterMetricTypeTest.kt$CounterMetricTypeTest$10</ID>
+    <ID>MagicNumber:CounterMetricTypeTest.kt$CounterMetricTypeTest$11</ID>
+    <ID>MagicNumber:CustomDistributionMetricTypeTest.kt$CustomDistributionMetricTypeTest$3</ID>
+    <ID>MagicNumber:CustomDistributionMetricTypeTest.kt$CustomDistributionMetricTypeTest$3L</ID>
+    <ID>MagicNumber:CustomDistributionMetricTypeTest.kt$CustomDistributionMetricTypeTest$6L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$10</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$100</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1000000</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1000000L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$10000L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1000L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$100L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$101</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$10219</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1064</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$10L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$11</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$111</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$11111</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$11275</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1174</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$12</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$122</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$12440</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1295</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$13</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$135</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$13726</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$14</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1429</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$149</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$15</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$15144</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1577</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$164</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$16709</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$17</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1740</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$18</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$181</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$18436</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$19</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$1920</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$200</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$20341</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$21</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$2118</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$221</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$22443</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$23</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$2337</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$244</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$24762</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$25</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$2579</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$269</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$27321</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$28</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$2846</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$297</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$3</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$30144</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$31</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$3140</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$328</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$33259</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$34</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$3464</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$362</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$36696</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$38</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$3822</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$399</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$3L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$4</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$40488</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$42</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$4217</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$440</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$44672</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$46</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$4653</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$485</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$49288</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$5</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$51</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$5134</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$535</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$54381</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$56</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$5665</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$590</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$6</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$60000</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$60000L</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$612</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$62</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$6250</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$651</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$68</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$6896</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$7</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$718</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$75</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$7609</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$792</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$8</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$83</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$8395</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$874</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$9</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$92</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$9262</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$964</ID>
+    <ID>MagicNumber:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$9796</ID>
+    <ID>MagicNumber:CustomDomainsTest.kt$CustomDomainsTest$3</ID>
+    <ID>MagicNumber:CustomTabConfigHelperTest.kt$CustomTabConfigHelperTest$24</ID>
+    <ID>MagicNumber:CustomTabConfigHelperTest.kt$CustomTabConfigHelperTest$64</ID>
+    <ID>MagicNumber:CustomTabConfigHelperTest.kt$CustomTabConfigHelperTest$64f</ID>
+    <ID>MagicNumber:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest$123</ID>
+    <ID>MagicNumber:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest$24</ID>
+    <ID>MagicNumber:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest$3</ID>
+    <ID>MagicNumber:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest$4</ID>
+    <ID>MagicNumber:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest$456</ID>
+    <ID>MagicNumber:DataUriIconLoaderTest.kt$DataUriIconLoaderTest$75</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$11</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$17</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$1969</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$1993</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$20</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$2004</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$23</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$29</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$3</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$43</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$5</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$7</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$8</ID>
+    <ID>MagicNumber:DatetimeMetricTypeTest.kt$DatetimeMetricTypeTest$9</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$11</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$1993</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$2004</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$23</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$29</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$3</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$320</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$5</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$8</ID>
+    <ID>MagicNumber:DatetimesStorageEngineTest.kt$DatetimesStorageEngineTest$9</ID>
+    <ID>MagicNumber:DefaultIconGeneratorTest.kt$DefaultIconGeneratorTest$32</ID>
+    <ID>MagicNumber:DefaultIconGeneratorTest.kt$DefaultIconGeneratorTest$99</ID>
+    <ID>MagicNumber:DefaultSuggestionViewHolderTest.kt$DefaultSuggestionViewHolderTest$3</ID>
+    <ID>MagicNumber:DigitalAssetLinksHandlerTest.kt$DigitalAssetLinksHandlerTest$200</ID>
+    <ID>MagicNumber:DigitalAssetLinksHandlerTest.kt$DigitalAssetLinksHandlerTest$400</ID>
+    <ID>MagicNumber:DispatchersTest.kt$DispatchersTest$3</ID>
+    <ID>MagicNumber:DisplayMetricsTest.kt$DisplayMetricsTest$500</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$10</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$100</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$1024</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$200</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$24</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$3</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$50</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$500</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$56</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$624</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest$75</ID>
+    <ID>MagicNumber:DisplayToolbarTest.kt$DisplayToolbarTest.&lt;no name provided&gt;$500</ID>
+    <ID>MagicNumber:DownloadDialogFragmentTest.kt$DownloadDialogFragmentTest$5242880</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$1024</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$16</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$56</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$8</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$856</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$912</ID>
+    <ID>MagicNumber:EditToolbarTest.kt$EditToolbarTest$968</ID>
+    <ID>MagicNumber:EngineObserverTest.kt$EngineObserverTest$100</ID>
+    <ID>MagicNumber:EngineObserverTest.kt$EngineObserverTest.&lt;no name provided&gt;$100</ID>
+    <ID>MagicNumber:EngineSessionHolderTest.kt$EngineSessionHolderTest$10</ID>
+    <ID>MagicNumber:EngineSessionTest.kt$EngineSessionTest$100</ID>
+    <ID>MagicNumber:EngineSessionTest.kt$EngineSessionTest$123</ID>
+    <ID>MagicNumber:EngineSessionTest.kt$EngineSessionTest$25</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$10</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$25</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$3</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$3770</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$3808</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$3809</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$3810</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$67</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$68</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$69</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$7</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$70</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$75</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$76</ID>
+    <ID>MagicNumber:EngineVersionTest.kt$EngineVersionTest$77</ID>
+    <ID>MagicNumber:EngineViewBottomBehaviorTest.kt$EngineViewBottomBehaviorTest$100</ID>
+    <ID>MagicNumber:EngineViewBottomBehaviorTest.kt$EngineViewBottomBehaviorTest$42f</ID>
+    <ID>MagicNumber:EngineViewBottomBehaviorTest.kt$EngineViewBottomBehaviorTest$58</ID>
+    <ID>MagicNumber:ErrorPagesTest.kt$ErrorPagesTest$4</ID>
+    <ID>MagicNumber:EvaluatorTest.kt$EvaluatorTest$10</ID>
+    <ID>MagicNumber:EvaluatorTest.kt$EvaluatorTest$20</ID>
+    <ID>MagicNumber:EvaluatorTest.kt$EvaluatorTest$3</ID>
+    <ID>MagicNumber:EvaluatorTest.kt$EvaluatorTest$42</ID>
+    <ID>MagicNumber:EvaluatorTest.kt$EvaluatorTest$8</ID>
+    <ID>MagicNumber:EventMetricTypeTest.kt$EventMetricTypeTest$37</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$10</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$20L</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$37</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$499</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$500</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$509</ID>
+    <ID>MagicNumber:EventsStorageEngineTest.kt$EventsStorageEngineTest$9</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$10</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$100</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$1000</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$150</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$1528916183</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$19</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$20</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$21</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$29</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$3</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$350</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$355</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$4</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$5</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$50</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$500</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$55</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$6</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$650</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$69</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$70</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$71</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$779</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$79</ID>
+    <ID>MagicNumber:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$9</ID>
+    <ID>MagicNumber:ExperimentPayloadTest.kt$ExperimentPayloadTest$2.5</ID>
+    <ID>MagicNumber:ExperimentTest.kt$ExperimentTest$100</ID>
+    <ID>MagicNumber:ExperimentTest.kt$ExperimentTest$1000</ID>
+    <ID>MagicNumber:ExperimentTest.kt$ExperimentTest$12345</ID>
+    <ID>MagicNumber:ExperimentTest.kt$ExperimentTest$3</ID>
+    <ID>MagicNumber:ExperimentsMapMeasurementTest.kt$ExperimentsMapMeasurementTest$4</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$10</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$100</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$1000</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$1523549895713</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$1523549895749</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$21</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$5</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$7</ID>
+    <ID>MagicNumber:ExperimentsSerializerTest.kt$ExperimentsSerializerTest$70</ID>
+    <ID>MagicNumber:ExperimentsTest.kt$ExperimentsTest$355</ID>
+    <ID>MagicNumber:ExperimentsTest.kt$ExperimentsTest$779</ID>
+    <ID>MagicNumber:ExperimentsTest.kt$ExperimentsTest$954</ID>
+    <ID>MagicNumber:FailureCacheTest.kt$FailureCacheTest$1000</ID>
+    <ID>MagicNumber:FailureCacheTest.kt$FailureCacheTest$15</ID>
+    <ID>MagicNumber:FailureCacheTest.kt$FailureCacheTest$40</ID>
+    <ID>MagicNumber:FailureCacheTest.kt$FailureCacheTest$50</ID>
+    <ID>MagicNumber:FailureCacheTest.kt$FailureCacheTest$60</ID>
+    <ID>MagicNumber:FetchDownloadManagerTest.kt$FetchDownloadManagerTest$5242880</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$10</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$200</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$201</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$3</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$302</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$404</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$5</ID>
+    <ID>MagicNumber:FetchTestCases.kt$FetchTestCases$6</ID>
+    <ID>MagicNumber:FileKtTest.kt$FileKtTest$4</ID>
+    <ID>MagicNumber:FindInPageBarTest.kt$FindInPageBarTest$100</ID>
+    <ID>MagicNumber:FindInPageInteractorTest.kt$FindInPageInteractorTest$3</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$10</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$100</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$1000</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$1526991669</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$1526991669L</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$1526991700</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$1526991700L</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$20</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$42</ID>
+    <ID>MagicNumber:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$5</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$10</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$100</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$1024</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$110</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$120</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$170</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$200</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$210</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$300</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$310</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$50</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$510</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$60</ID>
+    <ID>MagicNumber:FlowLayoutTest.kt$FlowLayoutTest$600</ID>
+    <ID>MagicNumber:FragmentKtTest.kt$FragmentKtTest$100</ID>
+    <ID>MagicNumber:FragmentKtTest.kt$FragmentKtTest$23</ID>
+    <ID>MagicNumber:FragmentKtTest.kt$FragmentKtTest$24</ID>
+    <ID>MagicNumber:FragmentKtTest.kt$FragmentKtTest$25</ID>
+    <ID>MagicNumber:FragmentKtTest.kt$FragmentKtTest$26</ID>
+    <ID>MagicNumber:FragmentKtTest.kt$FragmentKtTest$28</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$10</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$1000</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$150</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$25</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$3</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$350</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$50</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$54</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$55</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$650</ID>
+    <ID>MagicNumber:FretboardTest.kt$FretboardTest$79</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$1.5</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$100</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$11</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$3</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$3L</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$500</ID>
+    <ID>MagicNumber:FunctionalHistogramTest.kt$FunctionalHistogramTest$8.0</ID>
+    <ID>MagicNumber:FxaAccountManagerTest.kt$FxaAccountManagerTest$10</ID>
+    <ID>MagicNumber:FxaAccountManagerTest.kt$FxaAccountManagerTest$1000L</ID>
+    <ID>MagicNumber:FxaAccountManagerTest.kt$FxaAccountManagerTest$60</ID>
+    <ID>MagicNumber:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$0x800000</ID>
+    <ID>MagicNumber:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$3</ID>
+    <ID>MagicNumber:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$4</ID>
+    <ID>MagicNumber:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$500</ID>
+    <ID>MagicNumber:GeckoEngineTest.kt$GeckoEngineTest$69</ID>
+    <ID>MagicNumber:GeckoEngineViewTest.kt$GeckoEngineViewTest$42</ID>
+    <ID>MagicNumber:GeckoMediaControllerTest.kt$GeckoMediaControllerTest$1337.42</ID>
+    <ID>MagicNumber:GeckoMediaTest.kt$GeckoMediaTest$0.0001</ID>
+    <ID>MagicNumber:GeckoMediaTest.kt$GeckoMediaTest$5.0</ID>
+    <ID>MagicNumber:GeckoMediaTest.kt$GeckoMediaTest$572.0</ID>
+    <ID>MagicNumber:GeckoPermissionRequestTest.kt$GeckoPermissionRequestTest$1234</ID>
+    <ID>MagicNumber:GeckoPromptDelegateTest.kt$GeckoPromptDelegateTest$13223</ID>
+    <ID>MagicNumber:GeckoPromptDelegateTest.kt$GeckoPromptDelegateTest$2423</ID>
+    <ID>MagicNumber:GeckoResultTest.kt$GeckoResultTest$42</ID>
+    <ID>MagicNumber:GeckoViewFetchUnitTestCases.kt$GeckoViewFetchUnitTestCases$200</ID>
+    <ID>MagicNumber:GeckoViewFetchUnitTestCases.kt$GeckoViewFetchUnitTestCases$201</ID>
+    <ID>MagicNumber:GeckoViewFetchUnitTestCases.kt$GeckoViewFetchUnitTestCases$404</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$11</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$15</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$2015</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$3</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$37</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$7</ID>
+    <ID>MagicNumber:GenericStorageEngineTest.kt$GenericStorageEngineTest$85</ID>
+    <ID>MagicNumber:GleanCrashReporterServiceTest.kt$GleanCrashReporterServiceTest$3</ID>
+    <ID>MagicNumber:GleanCrashReporterServiceTest.kt$GleanCrashReporterServiceTest$4</ID>
+    <ID>MagicNumber:GleanDebugActivityTest.kt$GleanDebugActivityTest$10L</ID>
+    <ID>MagicNumber:GleanTest.kt$GleanTest$20L</ID>
+    <ID>MagicNumber:GleanTest.kt$GleanTest$3</ID>
+    <ID>MagicNumber:HeadersTest.kt$HeadersTest$3</ID>
+    <ID>MagicNumber:HeadersTest.kt$HeadersTest$4</ID>
+    <ID>MagicNumber:HeadersTest.kt$HeadersTest$5</ID>
+    <ID>MagicNumber:HeadersTest.kt$HeadersTest$6</ID>
+    <ID>MagicNumber:HeadersTest.kt$HeadersTest$7</ID>
+    <ID>MagicNumber:HelpersKtTest.kt$HelpersKtTest$21</ID>
+    <ID>MagicNumber:HelpersKtTest.kt$HelpersKtTest$22</ID>
+    <ID>MagicNumber:HistoryStorageSuggestionProviderTest.kt$HistoryStorageSuggestionProviderTest$100</ID>
+    <ID>MagicNumber:HistoryStorageSuggestionProviderTest.kt$HistoryStorageSuggestionProviderTest$20</ID>
+    <ID>MagicNumber:HistoryStorageSuggestionProviderTest.kt$HistoryStorageSuggestionProviderTest$3</ID>
+    <ID>MagicNumber:HistoryStorageSuggestionProviderTest.kt$HistoryStorageSuggestionProviderTest$5</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$10182</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$102</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$1024</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$10344</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$10446</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$1128</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$120</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$128</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$14006</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$15646</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$16</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$16390</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$1640</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$16878</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$192</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$19822</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$22722</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$22808</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$24</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$24086</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$2488</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$256</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$296</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$3</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$32</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$32640</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$3560</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$37032</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$39520</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$4</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$4264</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$4392</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$48</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$488</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$5</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$6</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$64</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$7</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$72</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$744</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$8</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$86</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$96</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$9640</ID>
+    <ID>MagicNumber:ICOIconDecoderTest.kt$ICOIconDecoderTest$9832</ID>
+    <ID>MagicNumber:IconDiskCacheTest.kt$IconDiskCacheTest$128</ID>
+    <ID>MagicNumber:IconDiskCacheTest.kt$IconDiskCacheTest$180</ID>
+    <ID>MagicNumber:IconDiskCacheTest.kt$IconDiskCacheTest$3</ID>
+    <ID>MagicNumber:IconDiskCacheTest.kt$IconDiskCacheTest$64</ID>
+    <ID>MagicNumber:IconDiskCacheTest.kt$IconDiskCacheTest$90</ID>
+    <ID>MagicNumber:IconLoaderTest.kt$IconLoaderTest$10</ID>
+    <ID>MagicNumber:IconLoaderTest.kt$IconLoaderTest$100</ID>
+    <ID>MagicNumber:IconLoaderTest.kt$IconLoaderTest$5000</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$16</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$180</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$192</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$3</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$32</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$4</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$5</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$6</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$7</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$8</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$9</ID>
+    <ID>MagicNumber:IconMessageHandlerTest.kt$IconMessageHandlerTest$96</ID>
+    <ID>MagicNumber:IconMessageKtTest.kt$IconMessageKtTest$128</ID>
+    <ID>MagicNumber:IconMessageKtTest.kt$IconMessageKtTest$180</ID>
+    <ID>MagicNumber:IconMessageKtTest.kt$IconMessageKtTest$3</ID>
+    <ID>MagicNumber:IconMessageKtTest.kt$IconMessageKtTest$64</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$1024</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$114</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$120</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$144</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$152</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$16</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$180</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$192</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$196</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$32</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$57</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$72</ID>
+    <ID>MagicNumber:IconResourceComparatorTest.kt$IconResourceComparatorTest$96</ID>
+    <ID>MagicNumber:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$10</ID>
+    <ID>MagicNumber:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$100</ID>
+    <ID>MagicNumber:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$111</ID>
+    <ID>MagicNumber:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$3</ID>
+    <ID>MagicNumber:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$4</ID>
+    <ID>MagicNumber:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$5</ID>
+    <ID>MagicNumber:InlineAutocompleteEditTextTest.kt$InlineAutocompleteEditTextTest$14</ID>
+    <ID>MagicNumber:InlineAutocompleteEditTextTest.kt$InlineAutocompleteEditTextTest$3</ID>
+    <ID>MagicNumber:InlineAutocompleteEditTextTest.kt$InlineAutocompleteEditTextTest$4</ID>
+    <ID>MagicNumber:InterceptorTest.kt$InterceptorTest$203</ID>
+    <ID>MagicNumber:InterceptorTest.kt$InterceptorTest.&lt;no name provided&gt;$203</ID>
+    <ID>MagicNumber:JSONArrayTest.kt$JSONArrayTest$10</ID>
+    <ID>MagicNumber:JSONArrayTest.kt$JSONArrayTest$3</ID>
+    <ID>MagicNumber:JSONArrayTest.kt$JSONArrayTest$4</ID>
+    <ID>MagicNumber:JSONArrayTest.kt$JSONArrayTest$404</ID>
+    <ID>MagicNumber:JSONArrayTest.kt$JSONArrayTest$6</ID>
+    <ID>MagicNumber:JSONArrayTest.kt$JSONArrayTest$8</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$0.01</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$1000</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$1526991669</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$20</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$3</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$3.5</ID>
+    <ID>MagicNumber:JSONExperimentParserTest.kt$JSONExperimentParserTest$4</ID>
+    <ID>MagicNumber:JSONObjectTest.kt$JSONObjectTest$218728173837192717</ID>
+    <ID>MagicNumber:JSONObjectTest.kt$JSONObjectTest$3</ID>
+    <ID>MagicNumber:JSONObjectTest.kt$JSONObjectTest$5</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$0.00001</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$2.0</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$23</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$23.0</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$2f</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$3</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$4</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$52.0</ID>
+    <ID>MagicNumber:JexlExtensionsTest.kt$JexlExtensionsTest$52.0f</ID>
+    <ID>MagicNumber:JexlTest.kt$JexlTest$33</ID>
+    <ID>MagicNumber:JexlTest.kt$JexlTest$36</ID>
+    <ID>MagicNumber:JexlTest.kt$JexlTest$75</ID>
+    <ID>MagicNumber:JexlValueTest.kt$JexlValueTest$3</ID>
+    <ID>MagicNumber:JexlValueTest.kt$JexlValueTest$3.0</ID>
+    <ID>MagicNumber:JexlValueTest.kt$JexlValueTest$4</ID>
+    <ID>MagicNumber:JexlValueTest.kt$JexlValueTest$4.0</ID>
+    <ID>MagicNumber:JexlValueTest.kt$JexlValueTest$6.0</ID>
+    <ID>MagicNumber:JexlValueTest.kt$JexlValueTest$9.0</ID>
+    <ID>MagicNumber:KeystoreTest.kt$KeystoreTest$12</ID>
+    <ID>MagicNumber:KeystoreTest.kt$MockStoreWrapper$256</ID>
+    <ID>MagicNumber:KintoClientTest.kt$KintoClientTest$1527179995</ID>
+    <ID>MagicNumber:KintoClientTest.kt$KintoClientTest$200</ID>
+    <ID>MagicNumber:KintoClientTest.kt$KintoClientTest$404</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$10</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$100</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$1000</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$1523549800000</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$1523549890000</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$1523549895713</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$1523549899999</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$180</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$20</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$200</ID>
+    <ID>MagicNumber:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$5</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$100</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$15</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$17</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$20</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$3</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$4</ID>
+    <ID>MagicNumber:LabeledMetricTypeTest.kt$LabeledMetricTypeTest$5</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$1.337</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$12</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$1234</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$17.55</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$2</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$2.42</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$20</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$3</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$6</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$7.6</ID>
+    <ID>MagicNumber:LexerTest.kt$LexerTest$782</ID>
+    <ID>MagicNumber:LoggerTest.kt$LoggerTest$10</ID>
+    <ID>MagicNumber:MatchersTest.kt$MatchersTest$4</ID>
+    <ID>MagicNumber:MediaFeatureTest.kt$MediaFeatureTest$30.0</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$1023</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$1024</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$1024L</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$2047</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$2048L</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$3</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$3024</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$3L</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$40</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$6144L</ID>
+    <ID>MagicNumber:MemoryDistributionMetricTypeTest.kt$MemoryDistributionMetricTypeTest$6L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$1000000L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$100000L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$10000L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$1000L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$100L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$1023</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$1024</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$1024L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$10L</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$11110</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$154</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$4</ID>
+    <ID>MagicNumber:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$41</ID>
+    <ID>MagicNumber:MenuButtonTest.kt$MenuButtonTest$0xffffff</ID>
+    <ID>MagicNumber:MenuButtonTest.kt$MenuButtonTest$100</ID>
+    <ID>MagicNumber:MessageBusTest.kt$MessageBusTest$3</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$1000</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$11</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$123L</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$2015</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$20L</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$23</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$3</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$4</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$5</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$55</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$6</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$60</ID>
+    <ID>MagicNumber:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest$7</ID>
+    <ID>MagicNumber:MimeTypeTest.kt$MimeTypeTest$3</ID>
+    <ID>MagicNumber:MockResponses.kt$MockResponses$200</ID>
+    <ID>MagicNumber:MockResponses.kt$MockResponses$404</ID>
+    <ID>MagicNumber:MotionEventKtTest.kt$MotionEventKtTest$100</ID>
+    <ID>MagicNumber:MotionEventKtTest.kt$MotionEventKtTest$47</ID>
+    <ID>MagicNumber:NativeNotificationBridgeTest.kt$NativeNotificationBridgeTest$1234567890</ID>
+    <ID>MagicNumber:NativeNotificationBridgeTest.kt$NativeNotificationBridgeTest$3</ID>
+    <ID>MagicNumber:NestedGeckoViewTest.kt$NestedGeckoViewTest$6</ID>
+    <ID>MagicNumber:NestedGeckoViewTest.kt$NestedGeckoViewTest$8</ID>
+    <ID>MagicNumber:NestedWebViewTest.kt$NestedWebViewTest$6</ID>
+    <ID>MagicNumber:NestedWebViewTest.kt$NestedWebViewTest$8</ID>
+    <ID>MagicNumber:NotificationIdsTest.kt$NotificationIdsTest$1000</ID>
+    <ID>MagicNumber:NotificationIdsTest.kt$NotificationIdsTest$24</ID>
+    <ID>MagicNumber:NotificationIdsTest.kt$NotificationIdsTest$60</ID>
+    <ID>MagicNumber:NotificationIdsTest.kt$NotificationIdsTest$8</ID>
+    <ID>MagicNumber:ObserverRegistryTest.kt$ObserverRegistryTest$100</ID>
+    <ID>MagicNumber:ObserverRegistryTest.kt$ObserverRegistryTest$23</ID>
+    <ID>MagicNumber:ObserverRegistryTest.kt$ObserverRegistryTest$3</ID>
+    <ID>MagicNumber:ObserverRegistryTest.kt$ObserverRegistryTest$4</ID>
+    <ID>MagicNumber:ObserverRegistryTest.kt$ObserverRegistryTest$42</ID>
+    <ID>MagicNumber:OnDeviceAndroidIconDecoderTest.kt$OnDeviceAndroidIconDecoderTest$100</ID>
+    <ID>MagicNumber:OnDeviceAndroidIconDecoderTest.kt$OnDeviceAndroidIconDecoderTest$16</ID>
+    <ID>MagicNumber:OnDeviceAndroidIconDecoderTest.kt$OnDeviceAndroidIconDecoderTest$192</ID>
+    <ID>MagicNumber:OnDeviceAndroidIconDecoderTest.kt$OnDeviceAndroidIconDecoderTest$250</ID>
+    <ID>MagicNumber:OnDeviceAndroidIconDecoderTest.kt$OnDeviceAndroidIconDecoderTest$3</ID>
+    <ID>MagicNumber:OnDeviceAndroidIconDecoderTest.kt$OnDeviceAndroidIconDecoderTest$67</ID>
+    <ID>MagicNumber:OnDeviceBrowserIconsTest.kt$OnDeviceBrowserIconsTest$100</ID>
+    <ID>MagicNumber:OnDeviceBrowserIconsTest.kt$OnDeviceBrowserIconsTest$64</ID>
+    <ID>MagicNumber:OnDeviceSitePermissionsStorageTest.kt$OnDeviceSitePermissionsStorageTest$8</ID>
+    <ID>MagicNumber:OnDeviceSitePermissionsStorageTest.kt$OnDeviceSitePermissionsStorageTest$9</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$0x10</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$0x20</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$0x30</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$0xaa</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$0xbb</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$0xcc</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$200</ID>
+    <ID>MagicNumber:OriginVerifierTest.kt$OriginVerifierTest$3L</ID>
+    <ID>MagicNumber:PaddingTest.kt$PaddingTest$16</ID>
+    <ID>MagicNumber:PaddingTest.kt$PaddingTest$24</ID>
+    <ID>MagicNumber:PaddingTest.kt$PaddingTest$32</ID>
+    <ID>MagicNumber:PaddingTest.kt$PaddingTest$40</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$21</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$23</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$3</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$4</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$42</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$5</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$6</ID>
+    <ID>MagicNumber:ParserTest.kt$ParserTest$7</ID>
+    <ID>MagicNumber:PingMakerTest.kt$PingMakerTest$21</ID>
+    <ID>MagicNumber:PingMakerTest.kt$PingMakerTest$28</ID>
+    <ID>MagicNumber:PingMakerTest.kt$PingMakerTest$3</ID>
+    <ID>MagicNumber:PingStorageEngineTest.kt$PingStorageEngineTest$3</ID>
+    <ID>MagicNumber:PingTypeTest.kt$PingTypeTest$20L</ID>
+    <ID>MagicNumber:PingTypeTest.kt$PingTypeTest$3</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$10</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$123L</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$3</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$30</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$4</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$6</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$10</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$20</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$25</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$3</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$31</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$4</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$5</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$6</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$7</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$8</ID>
+    <ID>MagicNumber:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest.&lt;no name provided&gt;$999</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$10</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$100</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$111</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$123L</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$3</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$4</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$5</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$6</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$7</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$8</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$9</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$10</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$14</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$15</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$3</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$4</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$5</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$6</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$7</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$8</ID>
+    <ID>MagicNumber:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest.&lt;no name provided&gt;$999</ID>
+    <ID>MagicNumber:PocketEndpointTest.kt$PocketEndpointTest$20</ID>
+    <ID>MagicNumber:PocketListenEndpointRawTest.kt$PocketListenEndpointRawTest$404</ID>
+    <ID>MagicNumber:PocketListenEndpointRawTest.kt$PocketListenEndpointRawTest$42</ID>
+    <ID>MagicNumber:PocketListenEndpointRawTest.kt$PocketListenEndpointRawTest$42L</ID>
+    <ID>MagicNumber:PocketListenEndpointTest.kt$PocketListenEndpointTest$1234</ID>
+    <ID>MagicNumber:PocketListenEndpointTest.kt$PocketListenEndpointTest$42</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$100</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$1000L</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$100L</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$3</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$3L</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$50</ID>
+    <ID>MagicNumber:PrecomputedHistogramTest.kt$PrecomputedHistogramTest$60</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$1024</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$1080</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$123</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$128</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$16</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$1920</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$2048</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$240</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$3</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$320</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$4</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$480</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$640</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$768</ID>
+    <ID>MagicNumber:QrFragmentTest.kt$QrFragmentTest$9</ID>
+    <ID>MagicNumber:QuantityMetricTypeTest.kt$QuantityMetricTypeTest$10</ID>
+    <ID>MagicNumber:QuantityMetricTypeTest.kt$QuantityMetricTypeTest$10L</ID>
+    <ID>MagicNumber:ReaderViewControlsBarTest.kt$ReaderViewControlsBarTest$10</ID>
+    <ID>MagicNumber:ReaderViewControlsBarTest.kt$ReaderViewControlsBarTest$5</ID>
+    <ID>MagicNumber:ReaderViewControlsBarTest.kt$ReaderViewControlsBarTest$9</ID>
+    <ID>MagicNumber:ReaderViewControlsInteractorTest.kt$ReaderViewControlsInteractorTest$3</ID>
+    <ID>MagicNumber:ReaderViewControlsInteractorTest.kt$ReaderViewControlsInteractorTest$7</ID>
+    <ID>MagicNumber:ReaderViewControlsInteractorTest.kt$ReaderViewControlsInteractorTest$8</ID>
+    <ID>MagicNumber:ReaderViewControlsInteractorTest.kt$ReaderViewControlsInteractorTest$9</ID>
+    <ID>MagicNumber:ReaderViewControlsPresenterTest.kt$ReaderViewControlsPresenterTest$5</ID>
+    <ID>MagicNumber:ReaderViewFeatureTest.kt$ReaderViewFeatureTest$4</ID>
+    <ID>MagicNumber:RequestTest.kt$RequestTest$10</ID>
+    <ID>MagicNumber:RequestTest.kt$RequestTest$3</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$10</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$100</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$1000</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$120</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$30</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$34</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$3f</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$64</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$70</ID>
+    <ID>MagicNumber:ResizingProcessorTest.kt$ResizingProcessorTest$96</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$200</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$203</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$3</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$302</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$403</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$404</ID>
+    <ID>MagicNumber:ResponseTest.kt$ResponseTest$500</ID>
+    <ID>MagicNumber:ReversibleStringTest.kt$ReversibleStringTest$3</ID>
+    <ID>MagicNumber:ReversibleStringTest.kt$ReversibleStringTest$4</ID>
+    <ID>MagicNumber:ReversibleStringTest.kt$ReversibleStringTest$5</ID>
+    <ID>MagicNumber:SearchEngineManagerTest.kt$SearchEngineManagerTest$3</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$10</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$11</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$20</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$3</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$4</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$404</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$5</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$6</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$7</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$8</ID>
+    <ID>MagicNumber:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest$9</ID>
+    <ID>MagicNumber:SendTabUseCasesTest.kt$SendTabUseCasesTest$4</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$16</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$191</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$192</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$193</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$200</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$32</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$50</ID>
+    <ID>MagicNumber:SessionKtTest.kt$SessionKtTest$512</ID>
+    <ID>MagicNumber:SessionManagerMigrationTest.kt$SessionManagerMigrationTest$10000</ID>
+    <ID>MagicNumber:SessionManagerMigrationTest.kt$SessionManagerMigrationTest$20</ID>
+    <ID>MagicNumber:SessionManagerMigrationTest.kt$SessionManagerMigrationTest$3</ID>
+    <ID>MagicNumber:SessionManagerMigrationTest.kt$SessionManagerMigrationTest$4</ID>
+    <ID>MagicNumber:SessionManagerMigrationTest.kt$SessionManagerMigrationTest$5</ID>
+    <ID>MagicNumber:SessionManagerTest.kt$SessionManagerTest$3</ID>
+    <ID>MagicNumber:SessionManagerTest.kt$SessionManagerTest$4</ID>
+    <ID>MagicNumber:SessionManagerTest.kt$SessionManagerTest$5</ID>
+    <ID>MagicNumber:SessionManagerTest.kt$SessionManagerTest$6</ID>
+    <ID>MagicNumber:SessionStorageTest.kt$SessionStorageTest$3</ID>
+    <ID>MagicNumber:SessionStorageTest.kt$SessionStorageTest$300</ID>
+    <ID>MagicNumber:SessionStorageTest.kt$SessionStorageTest$300L</ID>
+    <ID>MagicNumber:SessionTest.kt$SessionTest$192</ID>
+    <ID>MagicNumber:SessionTest.kt$SessionTest$3</ID>
+    <ID>MagicNumber:SessionTest.kt$SessionTest$75</ID>
+    <ID>MagicNumber:SharedPreferencesTest.kt$SharedPreferencesTest$12f</ID>
+    <ID>MagicNumber:SharedPreferencesTest.kt$SharedPreferencesTest$2.4f</ID>
+    <ID>MagicNumber:SharedPreferencesTest.kt$SharedPreferencesTest$200L</ID>
+    <ID>MagicNumber:SharedPreferencesTest.kt$SharedPreferencesTest$23</ID>
+    <ID>MagicNumber:SharedPreferencesTest.kt$SharedPreferencesTest$5</ID>
+    <ID>MagicNumber:SignatureVerifierTest.kt$SignatureVerifierTest$13</ID>
+    <ID>MagicNumber:SignatureVerifierTest.kt$SignatureVerifierTest$2010</ID>
+    <ID>MagicNumber:SignatureVerifierTest.kt$SignatureVerifierTest$2018</ID>
+    <ID>MagicNumber:SignatureVerifierTest.kt$SignatureVerifierTest$2028</ID>
+    <ID>MagicNumber:SignatureVerifierTest.kt$SignatureVerifierTest$6</ID>
+    <ID>MagicNumber:SimpleBrowserMenuItemTest.kt$SimpleBrowserMenuItemTest$10f</ID>
+    <ID>MagicNumber:SimpleDownloadDialogFragmentTest.kt$SimpleDownloadDialogFragmentTest$5242880</ID>
+    <ID>MagicNumber:SitePermissionsDaoTest.kt$SitePermissionsDaoTest$4</ID>
+    <ID>MagicNumber:SizeTest.kt$SizeTest$100</ID>
+    <ID>MagicNumber:SizeTest.kt$SizeTest$16</ID>
+    <ID>MagicNumber:SizeTest.kt$SizeTest$250</ID>
+    <ID>MagicNumber:SizeTest.kt$SizeTest$256</ID>
+    <ID>MagicNumber:SizeTest.kt$SizeTest$512</ID>
+    <ID>MagicNumber:StorageUtilsTest.kt$StorageUtilsTest$10</ID>
+    <ID>MagicNumber:StorageUtilsTest.kt$StorageUtilsTest$3</ID>
+    <ID>MagicNumber:StorageUtilsTest.kt$StorageUtilsTest$5</ID>
+    <ID>MagicNumber:StorageUtilsTest.kt$StorageUtilsTest$6</ID>
+    <ID>MagicNumber:StoreExtensionsKtTest.kt$StoreExtensionsKtTest$100</ID>
+    <ID>MagicNumber:StoreExtensionsKtTest.kt$StoreExtensionsKtTest$23</ID>
+    <ID>MagicNumber:StoreExtensionsKtTest.kt$StoreExtensionsKtTest$24</ID>
+    <ID>MagicNumber:StoreExtensionsKtTest.kt$StoreExtensionsKtTest$25</ID>
+    <ID>MagicNumber:StoreExtensionsKtTest.kt$StoreExtensionsKtTest$26</ID>
+    <ID>MagicNumber:StoreTest.kt$StoreTest$22</ID>
+    <ID>MagicNumber:StoreTest.kt$StoreTest$23</ID>
+    <ID>MagicNumber:StoreTest.kt$StoreTest$24</ID>
+    <ID>MagicNumber:StrictModeTest.kt$StrictModeTest$27</ID>
+    <ID>MagicNumber:StringListMetricTypeTest.kt$StringListMetricTypeTest$3</ID>
+    <ID>MagicNumber:StringListMetricTypeTest.kt$StringListMetricTypeTest$4</ID>
+    <ID>MagicNumber:StringListsStorageEngineTest.kt$StringListsStorageEngineTest$10</ID>
+    <ID>MagicNumber:StringTest.kt$StringTest$10</ID>
+    <ID>MagicNumber:StringTest.kt$StringTest$2019</ID>
+    <ID>MagicNumber:StringTest.kt$StringTest$28</ID>
+    <ID>MagicNumber:StringTest.kt$StringTest$29</ID>
+    <ID>MagicNumber:StringsStorageEngineTest.kt$StringsStorageEngineTest$20</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$2</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$3</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$4</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$42</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$5</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$6</ID>
+    <ID>MagicNumber:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$7</ID>
+    <ID>MagicNumber:SwipeRefreshFeatureTest.kt$SwipeRefreshFeatureTest$100</ID>
+    <ID>MagicNumber:SyncAuthInfoCacheTest.kt$SyncAuthInfoCacheTest$1000L</ID>
+    <ID>MagicNumber:SyncAuthInfoCacheTest.kt$SyncAuthInfoCacheTest$60</ID>
+    <ID>MagicNumber:SystemEngineSessionStateTest.kt$SystemEngineSessionStateTest$3</ID>
+    <ID>MagicNumber:SystemEngineSessionStateTest.kt$SystemEngineSessionStateTest$5</ID>
+    <ID>MagicNumber:SystemEngineSessionStateTest.kt$SystemEngineSessionStateTest$5.0</ID>
+    <ID>MagicNumber:SystemEngineSessionTest.kt$SystemEngineSessionTest$100</ID>
+    <ID>MagicNumber:SystemEngineSessionTest.kt$SystemEngineSessionTest$3</ID>
+    <ID>MagicNumber:SystemEngineSessionTest.kt$SystemEngineSessionTest$4</ID>
+    <ID>MagicNumber:SystemEngineSessionTest.kt$SystemEngineSessionTest$500</ID>
+    <ID>MagicNumber:SystemEngineViewTest.kt$SystemEngineViewTest$10</ID>
+    <ID>MagicNumber:SystemEngineViewTest.kt$SystemEngineViewTest$100</ID>
+    <ID>MagicNumber:SystemEngineViewTest.kt$SystemEngineViewTest$1337</ID>
+    <ID>MagicNumber:SystemEngineViewTest.kt$SystemEngineViewTest$200</ID>
+    <ID>MagicNumber:SystemEngineViewTest.kt$SystemEngineViewTest$3</ID>
+    <ID>MagicNumber:SystemEngineViewTest.kt$SystemEngineViewTest.&lt;no name provided&gt;$1337L</ID>
+    <ID>MagicNumber:TabCollectionDaoTest.kt$TabCollectionDaoTest$10</ID>
+    <ID>MagicNumber:TabCollectionDaoTest.kt$TabCollectionDaoTest$100</ID>
+    <ID>MagicNumber:TabCollectionDaoTest.kt$TabCollectionDaoTest$4</ID>
+    <ID>MagicNumber:TabCollectionStorageTest.kt$TabCollectionStorageTest$100</ID>
+    <ID>MagicNumber:TabCollectionStorageTest.kt$TabCollectionStorageTest$3</ID>
+    <ID>MagicNumber:TabCollectionStorageTest.kt$TabCollectionStorageTest$4</ID>
+    <ID>MagicNumber:TabCounterTest.kt$TabCounterTest$100</ID>
+    <ID>MagicNumber:TabCounterTest.kt$TabCounterTest$99</ID>
+    <ID>MagicNumber:TabDaoTest.kt$TabDaoTest$10</ID>
+    <ID>MagicNumber:TabListActionTest.kt$TabListActionTest$3</ID>
+    <ID>MagicNumber:TabListActionTest.kt$TabListActionTest$4</ID>
+    <ID>MagicNumber:TabListActionTest.kt$TabListActionTest$5</ID>
+    <ID>MagicNumber:TabListActionTest.kt$TabListActionTest$6</ID>
+    <ID>MagicNumber:TabThumbnailViewTest.kt$TabThumbnailViewTest$5</ID>
+    <ID>MagicNumber:TabViewHolderTest.kt$TabViewHolderTest$40</ID>
+    <ID>MagicNumber:TabsAdapterTest.kt$TabsAdapterTest$3</ID>
+    <ID>MagicNumber:TabsTrayPresenterTest.kt$TabsTrayPresenterTest$3</ID>
+    <ID>MagicNumber:TabsTrayPresenterTest.kt$TabsTrayPresenterTest$5</ID>
+    <ID>MagicNumber:TabsUseCasesTest.kt$TabsUseCasesTest$3</ID>
+    <ID>MagicNumber:TabsUseCasesTest.kt$TabsUseCasesTest$5</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$100</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$1000</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$100f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$10f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$200f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$25</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$25f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$26</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$34f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$39f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$40f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$44f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$5</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$50</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$50f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$51</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$56</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$56f</ID>
+    <ID>MagicNumber:TextViewTest.kt$TextViewTest$94f</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$11</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$12</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$19</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$2018</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$2019</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$223</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$29</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$30</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$6</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$7</ID>
+    <ID>MagicNumber:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$8</ID>
+    <ID>MagicNumber:TimespanMetricTypeTest.kt$TimespanMetricTypeTest$10000000</ID>
+    <ID>MagicNumber:TimespanMetricTypeTest.kt$TimespanMetricTypeTest$1000000000L</ID>
+    <ID>MagicNumber:TimespanMetricTypeTest.kt$TimespanMetricTypeTest$5</ID>
+    <ID>MagicNumber:TimespanMetricTypeTest.kt$TimespanMetricTypeTest$50</ID>
+    <ID>MagicNumber:TimespanMetricTypeTest.kt$TimespanMetricTypeTest$5000000</ID>
+    <ID>MagicNumber:TimespanMetricTypeTest.kt$TimespanMetricTypeTest$6</ID>
+    <ID>MagicNumber:TimespansStorageEngineTest.kt$TimespansStorageEngineTest$3</ID>
+    <ID>MagicNumber:TimespansStorageEngineTest.kt$TimespansStorageEngineTest$37</ID>
+    <ID>MagicNumber:TimingDistributionMetricTypeTest.kt$TimingDistributionMetricTypeTest$1000L</ID>
+    <ID>MagicNumber:TimingDistributionMetricTypeTest.kt$TimingDistributionMetricTypeTest$3</ID>
+    <ID>MagicNumber:TimingDistributionMetricTypeTest.kt$TimingDistributionMetricTypeTest$3L</ID>
+    <ID>MagicNumber:TimingDistributionMetricTypeTest.kt$TimingDistributionMetricTypeTest$6L</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$1000000</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$1000000L</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$10000L</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$1000L</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$100L</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$10L</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$11110</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$4</ID>
+    <ID>MagicNumber:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$81</ID>
+    <ID>MagicNumber:ToolbarPresenterTest.kt$ToolbarPresenterTest$60</ID>
+    <ID>MagicNumber:ToolbarPresenterTest.kt$ToolbarPresenterTest$75</ID>
+    <ID>MagicNumber:ToolbarPresenterTest.kt$ToolbarPresenterTest$90</ID>
+    <ID>MagicNumber:TrackingProtectionActionTest.kt$TrackingProtectionActionTest$3</ID>
+    <ID>MagicNumber:URLRendererTest.kt$URLRendererTest$12</ID>
+    <ID>MagicNumber:URLRendererTest.kt$URLRendererTest$13</ID>
+    <ID>MagicNumber:URLRendererTest.kt$URLRendererTest$23</ID>
+    <ID>MagicNumber:UrlMatcherTest.kt$UrlMatcherTest$4</ID>
+    <ID>MagicNumber:VersionTest.kt$VersionTest$3113</ID>
+    <ID>MagicNumber:VersionTest.kt$VersionTest$60</ID>
+    <ID>MagicNumber:ViewBoundFeatureWrapperTest.kt$ViewBoundFeatureWrapperTest$100</ID>
+    <ID>MagicNumber:ViewKtTest.kt$ViewKtTest$100</ID>
+    <ID>MagicNumber:ViewKtTest.kt$ViewKtTest$24</ID>
+    <ID>MagicNumber:ViewKtTest.kt$ViewKtTest$25</ID>
+    <ID>MagicNumber:ViewKtTest.kt$ViewKtTest$26</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$10</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$100</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$150</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$16</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$20</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$200</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$24</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$250</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$28</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$450</ID>
+    <ID>MagicNumber:ViewTest.kt$ViewTest$5</ID>
+    <ID>MagicNumber:WebAppManifestKtTest.kt$WebAppManifestKtTest$230</ID>
+    <ID>MagicNumber:WebAppManifestKtTest.kt$WebAppManifestKtTest$255</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$103</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$128</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$144</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$168</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$192</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$214</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$240</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$248</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$255</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$3</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$4</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$48</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$5</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$51</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$512</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$6</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$64</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$72</ID>
+    <ID>MagicNumber:WebAppManifestParserTest.kt$WebAppManifestParserTest$96</ID>
+    <ID>MagicNumber:WebAppShortcutManagerTest.kt$WebAppShortcutManagerTest$192</ID>
+    <ID>MagicNumber:WebAppUseCasesTest.kt$WebAppUseCasesTest$192</ID>
+    <ID>MandatoryBracesIfStatements:TestUtil.kt$if (os?.indexOf("win")?.compareTo(0) == 0) "${BuildConfig.GLEAN_MINICONDA_DIR}/python" else "${BuildConfig.GLEAN_MINICONDA_DIR}/bin/python"</ID>
+    <ID>MaxLineLength:AccountSharingTest.kt$AccountSharingTest$val signatureValue = "308203a63082028ea00302010202044c72fd88300d06092a864886f70d0101050500308194310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e2056696577311c301a060355040a13134d6f7a696c6c6120436f72706f726174696f6e311c301a060355040b131352656c6561736520456e67696e656572696e67311c301a0603550403131352656c6561736520456e67696e656572696e67301e170d3130303832333233303032345a170d3338303130383233303032345a308194310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e2056696577311c301a060355040a13134d6f7a696c6c6120436f72706f726174696f6e311c301a060355040b131352656c6561736520456e67696e656572696e67311c301a0603550403131352656c6561736520456e67696e656572696e6730820122300d06092a864886f70d01010105000382010f003082010a0282010100b4160fb324eac03bd9f7ca21a094769d6811d5e9de2a2314b86f279b7de05b086465ec2dda1db2023bc1b33f73e92c52ed185bb95fcb5d2d81667f6e76266e76de836b3e928d94dd9675bb6ec051fc378affae85158e4ffad4ed27c9f3efc8fa7641ff08e43b4c56ded176d981cb83cf87002d0fe55ab00753f8f255b52f04b9d30173fc2c9b980b6ea24d1ae62e0fe0e73e692591e4f4d5701739929d91c6874ccb932bd533ba3f45586a2306bd39e7aa02fa90c0271a50fa3bde8fe4dd820fe8143a18795717349cfc32e9ceecbd01323c7c86f3132b140341bfc6dc26c0559127169510b0181cfa81b5491dd7c9dc0de3f2ab06b8dcdd7331692839f865650203010001300d06092a864886f70d010105050003820101007a06b17b9f5e49cfe86fc7bd9155b9e755d2f770802c3c9d70bde327bb54f5d7e41e8bb1a466dac30e9933f249ba9f06240794d56af9b36afb01e2272f57d14e9ca162733b0dd8ba373fb465428c5cfe14376f08e58d65c82f18f6c26255519f5244c3c34c9f552e1fcb52f71bcc62180f53e8027221af716be5adc55b939478725c12cb688bad617168d0f803513a6c10be147250ed7b5d2d37569135e81ceca38bba7bdcb5f9a802bae6740d85ae0a4c3fb27da78cc5b8c2fae4d8f361894ac70236bdcb3eadf9f36f46ee48662f9be4e22eda49e1b4db1e911ab972d8925298f16e831344da881059a9c0fbce229efeae719740e975d7f0dc691ccca0a9ce"</ID>
+    <ID>MaxLineLength:ActiveExperimentTest.kt$ActiveExperimentTest$`when`(context.getSharedPreferences(eq(prefNameActiveExperiment), eq(Context.MODE_PRIVATE))).thenReturn(sharedPrefs)</ID>
+    <ID>MaxLineLength:AndroidDownloadManagerTest.kt$AndroidDownloadManagerTest$"Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"</ID>
+    <ID>MaxLineLength:AppLinksUseCasesTest.kt$AppLinksUseCasesTest$val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;S.browser_fallback_url=http%3A%2F%2Fzxing.org;end"</ID>
+    <ID>MaxLineLength:BaseDomainAutocompleteProviderTest.kt$BaseDomainAutocompleteProviderTest$assertCompletion(provider, list, domainsCount, "WWW.GOOGLE.", "www.google.", "WWW.GOOGLE.com", "http://google.com")</ID>
+    <ID>MaxLineLength:BaseDomainAutocompleteProviderTest.kt$BaseDomainAutocompleteProviderTest$assertCompletion(provider, list, domainsCount, "facebook.com", "facebook.com", "facebook.com", "http://facebook.com")</ID>
+    <ID>MaxLineLength:BaseDomainAutocompleteProviderTest.kt$BaseDomainAutocompleteProviderTest$assertCompletion(provider, list, domainsCount, "www.face", "www.face", "www.facebook.com", "http://facebook.com")</ID>
+    <ID>MaxLineLength:BaseDomainAutocompleteProviderTest.kt$BaseDomainAutocompleteProviderTest$assertCompletion(provider, list, domainsCount, "www.facebook.com", "www.facebook.com", "www.facebook.com", "http://facebook.com")</ID>
+    <ID>MaxLineLength:BaseDomainAutocompleteProviderTest.kt$private</ID>
+    <ID>MaxLineLength:BitmapKtTest.kt$BitmapKtTest$@Ignore // TODO: convert to integration test. Robolectric's shadows are incomplete and cause this to fail. @Test fun `WHEN withRoundedCorners is called THEN returned bitmap's corners should be transparent and center with color`()</ID>
+    <ID>MaxLineLength:BrowserAwesomeBarTest.kt$BrowserAwesomeBarTest$assertEquals(1, awesomeBar.getUniqueSuggestionId(AwesomeBar.Suggestion(id = "1", score = 0, provider = provider)))</ID>
+    <ID>MaxLineLength:BrowserAwesomeBarTest.kt$BrowserAwesomeBarTest$assertEquals(PROVIDER_MAX_SUGGESTIONS * INITIAL_NUMBER_OF_PROVIDERS, awesomeBar.uniqueSuggestionIds.maxSize())</ID>
+    <ID>MaxLineLength:BrowserIconsTest.kt$BrowserIconsTest$@Test fun `WHEN icon is loaded again and not in memory cache THEN second load is delivered from disk cache`()</ID>
+    <ID>MaxLineLength:BrowserMenuHighlightableItemTest.kt$BrowserMenuHighlightableItemTest$assertEquals(android.R.drawable.ic_menu_report_image, Shadows.shadowOf(startImageView.drawable).createdFromResId)</ID>
+    <ID>MaxLineLength:BrowserToolbarTest.kt$BrowserToolbarTest$Shadows.shadowOf(testContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).setEnabled(true)</ID>
+    <ID>MaxLineLength:BrowserToolbarTest.kt$BrowserToolbarTest$assertEquals(testContext.getString(R.string.mozac_browser_toolbar_progress_loading), captor.allValues[0].text[0])</ID>
+    <ID>MaxLineLength:BrowserToolbarTest.kt$import mozilla.components.browser.toolbar.display.TrackingProtectionIconView.Companion.DEFAULT_ICON_ON_NO_TRACKERS_BLOCKED</ID>
+    <ID>MaxLineLength:CrashHandlerServiceTest.kt$CrashHandlerServiceTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp"</ID>
+    <ID>MaxLineLength:CrashHandlerServiceTest.kt$CrashHandlerServiceTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra"</ID>
+    <ID>MaxLineLength:CrashTest.kt$CrashTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp"</ID>
+    <ID>MaxLineLength:CrashTest.kt$CrashTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra"</ID>
+    <ID>MaxLineLength:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$"store1#telemetry.invalid_td_bucket_count" to "{\"bucket_count\":\"not an int!\",\"range\":[0,60000,12],\"histogram_type\":1,\"values\":{},\"sum\":0}"</ID>
+    <ID>MaxLineLength:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$"store1#telemetry.invalid_td_histogram_type" to "{\"bucket_count\":100,\"range\":[0,60000,12],\"histogram_type\":-1,\"values\":{},\"sum\":0}"</ID>
+    <ID>MaxLineLength:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$"store1#telemetry.invalid_td_range" to "{\"bucket_count\":100,\"range\":[0,60000,12],\"histogram_type\":1,\"values\":{},\"sum\":0}"</ID>
+    <ID>MaxLineLength:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$"store1#telemetry.invalid_td_range2" to "{\"bucket_count\":100,\"range\":[\"not\",\"numeric\"],\"histogram_type\":1,\"values\":{},\"sum\":0}"</ID>
+    <ID>MaxLineLength:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$"store1#telemetry.invalid_td_sum" to "{\"bucket_count\":100,\"range\":[0,60000,12],\"histogram_type\":1,\"values\":{},\"sum\":\"nope\"}"</ID>
+    <ID>MaxLineLength:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest$"store1#telemetry.invalid_td_values" to "{\"bucket_count\":100,\"range\":[0,60000,12],\"histogram_type\":1,\"values\":{\"0\": \"nope\"},\"sum\":0}"</ID>
+    <ID>MaxLineLength:CustomTabConfigHelperTest.kt$CustomTabConfigHelperTest$customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.SHOW_PAGE_TITLE)</ID>
+    <ID>MaxLineLength:DisplayToolbarTest.kt$DisplayToolbarTest$@Test fun `tracking protection and separator views become visible when states ON OR ACTIVE are set to siteTrackingProtection`()</ID>
+    <ID>MaxLineLength:DisplayToolbarTest.kt$DisplayToolbarTest$@Test fun `tracking protection views should only be measured when ON or ACTIVE states are set to siteTrackingProtection`()</ID>
+    <ID>MaxLineLength:DisplayToolbarTest.kt$DisplayToolbarTest$assertEquals</ID>
+    <ID>MaxLineLength:DisplayToolbarTest.kt$DisplayToolbarTest$assertEquals(iconViewRect.width() + urlViewRect.width() + reloadViewRect.width() + readerViewRect.width(), viewRect.width())</ID>
+    <ID>MaxLineLength:DisplayToolbarTest.kt$DisplayToolbarTest$val browserActionViewRect = Rect(browserActionView.left, browserActionView.top, browserActionView.right, browserActionView.bottom)</ID>
+    <ID>MaxLineLength:DownloadDialogFragmentTest.kt$DownloadDialogFragmentTest$"Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"</ID>
+    <ID>MaxLineLength:DownloadUtilsTest.kt$DownloadUtilsTest$DownloadUtils.guessFileName(null, "https://download.msfjarvis.website/caesium/wahoo/beta/Caesium-wahoo-v3.6-b792615ced1b.zip", "application/zip")</ID>
+    <ID>MaxLineLength:EventsStorageEngineTest.kt$EventsStorageEngineTest$assertEquals</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(context.getSharedPreferences(eq(prefBranch), eq(Context.MODE_PRIVATE))).thenReturn(sharedPrefsOverrideBranch)</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(context.getSharedPreferences(eq(prefEnabled), eq(Context.MODE_PRIVATE))).thenReturn(sharedPrefsOverrideEnabled)</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(sharedPreferences.getBoolean(eq("id"), anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(sharedPreferences.getBoolean(eq("name"), anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(sharedPreferences.getBoolean(eq("testexperiment"), anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(sharedPrefsOverrideBranch.getString(anyString(), anyString())).thenAnswer { invocation -&gt; invocation.arguments[1] as String }</ID>
+    <ID>MaxLineLength:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest$`when`(sharedPrefsOverrideEnabled.getBoolean(anyString(), anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:ExperimentsDebugActivityTest.kt$ExperimentsDebugActivityTest$val updater: ExperimentsUpdater = spy(ExperimentsUpdater(ApplicationProvider.getApplicationContext&lt;Context&gt;(), Experiments))</ID>
+    <ID>MaxLineLength:ExperimentsStorageEngineTest.kt$ExperimentsStorageEngineTest$"{\"experiment_1\":{\"branch\":\"branch_a\"},\"experiment_2\":{\"branch\":\"branch_c\",\"extra\":{\"extra_key_1\":\"extra_val_1\"}}}"</ID>
+    <ID>MaxLineLength:ExperimentsTest.kt$ExperimentsTest$`when`(context.getSharedPreferences(eq(ExperimentEvaluator.PREF_NAME_OVERRIDES_BRANCH), anyInt())).thenReturn(sharedPrefsBranch)</ID>
+    <ID>MaxLineLength:ExperimentsTest.kt$ExperimentsTest$`when`(context.getSharedPreferences(eq(ExperimentEvaluator.PREF_NAME_OVERRIDES_ENABLED), anyInt())).thenReturn(sharedPrefsActive)</ID>
+    <ID>MaxLineLength:ExperimentsTest.kt$ExperimentsTest$`when`(sharedPrefs.getBoolean(anyString(), anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:ExperimentsTest.kt$ExperimentsTest$`when`(sharedPrefsActive.getBoolean(anyString(), anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:ExperimentsTest.kt$ExperimentsTest$`when`(sharedPrefsBranch.getString(anyString(), eq(null))).thenAnswer { invocation -&gt; invocation.arguments[1] as String }</ID>
+    <ID>MaxLineLength:ExperimentsUpdaterTest.kt$ExperimentsUpdaterTest$`when`(source.getExperiments(mozilla.components.support.test.any())).thenReturn(ExperimentsSnapshot(emptyList(), null))</ID>
+    <ID>MaxLineLength:FetchDownloadManagerTest.kt$FetchDownloadManagerTest$"Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"</ID>
+    <ID>MaxLineLength:FetchTestCases.kt$FetchTestCases$MutableHeaders() .set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8") .set("Accept-Encoding", "gzip, deflate") .set("Accept-Language", "en-US,en;q=0.5") .set("Connection", "keep-alive") .set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0")</ID>
+    <ID>MaxLineLength:FilePickerTest.kt$FilePickerTest$@Test fun `onActivityResult with RESULT_OK and isMultipleFilesSelection false will consume PromptRequest of the actual session`()</ID>
+    <ID>MaxLineLength:FilePickerTest.kt$FilePickerTest$@Test fun `onActivityResult with RESULT_OK and isMultipleFilesSelection true will consume PromptRequest of the actual session`()</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$FxaAuthData(authType = AuthType.OtherExternal("someNewActionType"), code = "testCode5", state = "testState5")</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$`when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred(AuthFlowUrl("authState", "auth://url")))</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$`when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred(AuthFlowUrl("authState", "auth://url")))</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode1&amp;state=testState1")</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode2&amp;state=testState2&amp;action=signin")</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode3&amp;state=testState3&amp;action=signup")</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode4&amp;state=testState4&amp;action=pairing")</ID>
+    <ID>MaxLineLength:FirefoxAccountsAuthFeatureTest.kt$FirefoxAccountsAuthFeatureTest$feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode5&amp;state=testState5&amp;action=someNewActionType")</ID>
+    <ID>MaxLineLength:FlatFileExperimentStorageTest.kt$FlatFileExperimentStorageTest$it.write("""{"experiments":[{"name":"sample-name","match":{"lang":"es|en","appId":"sample-appId","regions":["US"]},"buckets":{"max":20,"min":0},"description":"sample-description","id":"sample-id","last_modified":1526991669}],"last_modified":1526991669}""")</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(context.getSharedPreferences(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(sharedPrefs)</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(experimentSource.getExperiments(ExperimentsSnapshot(listOf(Experiment("id0", "name0")), null))).thenReturn(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(experimentSource.getExperiments(result)).thenReturn(ExperimentsSnapshot(listOf(Experiment("id", "name")), null))</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(prefsEditor.putBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(prefsEditor)</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(prefsEditor.putString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(prefsEditor)</ID>
+    <ID>MaxLineLength:FretboardTest.kt$FretboardTest$`when`(sharedPrefs.getBoolean(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenAnswer { invocation -&gt; invocation.arguments[1] as Boolean }</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$// We'll test three scenarios: // - hitting a network issue during migration // - hitting an auth issue during migration (bad credentials) // - all good, migrated successfully val accountStorage: AccountStorage = mock() val profile = Profile("testUid", "test@example.com", null, "Test Profile") val constellation: DeviceConstellation = mockDeviceConstellation() val account = StatePersistenceTestableAccount(profile, constellation) val accountObserver: AccountObserver = mock() val manager = TestableFxaAccountManager( testContext, ServerConfig.release("dummyId", "http://auth-url/redirect"), accountStorage, setOf(DeviceCapability.SEND_TAB), null, this.coroutineContext ) { account } manager.register(accountObserver) // We don't have an account at the start. `when`(accountStorage.read()).thenReturn(null) manager.initAsync().await() // Bad package name. var migratableAccount = ShareableAccount( email = "test@example.com", sourcePackage = "org.mozilla.firefox", authInfo = ShareableAuthInfo("session", "kSync", "kXCS") ) // TODO Need to mock inputs into - mock a PackageManager, and have it return PackageInfo with the right signature. // AccountSharing.isTrustedPackage // We failed to migrate for some reason. account.ableToMigrate = false assertFalse(manager.signInWithShareableAccountAsync(migratableAccount).await()) assertEquals("session", account.latestMigrateAuthInfo?.sessionToken) assertEquals("kSync", account.latestMigrateAuthInfo?.kSync) assertEquals("kXCS", account.latestMigrateAuthInfo?.kXCS) assertNull(manager.authenticatedAccount()) // Prepare for a successful migration. `when`(constellation.initDeviceAsync(any(), any(), any())).thenReturn(CompletableDeferred(true)) // Success. account.ableToMigrate = true migratableAccount = migratableAccount.copy( authInfo = ShareableAuthInfo("session2", "kSync2", "kXCS2") ) assertTrue(manager.signInWithShareableAccountAsync(migratableAccount).await()) assertEquals("session2", account.latestMigrateAuthInfo?.sessionToken) assertEquals("kSync2", account.latestMigrateAuthInfo?.kSync) assertEquals("kXCS2", account.latestMigrateAuthInfo?.kXCS) assertNotNull(manager.authenticatedAccount()) assertEquals(profile, manager.accountProfile()) verify(accountObserver, times(1)).onAuthenticated(account, AuthType.Shared)</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$@Test fun `profile fetching flow hit an unrecoverable auth problem for which we can't determine a recovery state`()</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$TestSyncDispatcher : SyncDispatcherObservable</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$`when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred(AuthFlowUrl(EXPECTED_AUTH_STATE, "auth://url")))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$`when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred(AuthFlowUrl(EXPECTED_AUTH_STATE, "auth://url")))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertEquals(AccountState.AuthenticatedNoProfile, FxaAccountManager.nextState(state, Event.Authenticated(FxaAuthData(AuthType.Signin, "code", "state"))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertEquals(AccountState.AuthenticatedNoProfile, FxaAccountManager.nextState(state, Event.Authenticated(FxaAuthData(AuthType.Signup, "code", "state"))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertEquals(AccountState.AuthenticatedNoProfile, FxaAccountManager.nextState(state, Event.FailedToFetchProfile))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertEquals(AccountState.AuthenticatedNoProfile, FxaAccountManager.nextState(state, Event.SignedInShareableAccount))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertEquals(AccountState.AuthenticationProblem, FxaAccountManager.nextState(state, Event.AuthenticationError(AuthException(AuthExceptionType.UNAUTHORIZED))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertEquals(AccountState.NotAuthenticated, FxaAccountManager.nextState(state, Event.SignInShareableAccount(mock())))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertFalse(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signin, "dummyCode", EXPECTED_AUTH_STATE)).await())</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertFalse(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signin, "dummyCode", UNEXPECTED_AUTH_STATE)).await())</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertNull(FxaAccountManager.nextState(state, Event.Authenticated(FxaAuthData(AuthType.OtherExternal("oi"), "code", "state"))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertNull(FxaAccountManager.nextState(state, Event.Authenticated(FxaAuthData(AuthType.Pairing, "code", "state"))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertNull(FxaAccountManager.nextState(state, Event.Authenticated(FxaAuthData(AuthType.Signin, "code", "state"))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertNull(FxaAccountManager.nextState(state, Event.AuthenticationError(AuthException(AuthExceptionType.UNAUTHORIZED))))</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertTrue(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Pairing, "dummyCode", EXPECTED_AUTH_STATE)).await())</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertTrue(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signin, "dummyCode", EXPECTED_AUTH_STATE)).await())</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$assertTrue(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signup, "dummyCode", EXPECTED_AUTH_STATE)).await())</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$val account = StatePersistenceTestableAccount(profile, constellation, tokenServerEndpointUrl = "https://some.server.com/test") { AccessTokenInfo( SCOPE_SYNC, "arda", OAuthScopedKey("kty-test", SCOPE_SYNC, "kid-test", "k-test"), syncAccessTokenExpiresAt ) }</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$val account = StatePersistenceTestableAccount(profile, constellation, tokenServerEndpointUrl = "https://some.server.com/test") { AccessTokenInfo( SCOPE_SYNC, "tolkien", OAuthScopedKey("kty-test", SCOPE_SYNC, "kid-test", "k-test"), syncAccessTokenExpiresAt ) }</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$val accountStorage = mock&lt;AccountStorage&gt;() val mockAccount: OAuthAccount = mock() val constellation: DeviceConstellation = mock() `when`(mockAccount.deviceConstellation()).thenReturn(constellation) `when`(constellation.initDeviceAsync(any(), any(), any())).thenReturn(CompletableDeferred(true)) `when`(mockAccount.getProfileAsync(anyBoolean())).then { // Hit an auth error. authErrorRegistry.notifyObservers { onAuthErrorAsync(AuthException(AuthExceptionType.UNAUTHORIZED)) } CompletableDeferred(value = null) } // Our recovery flow should attempt to hit this API. Model the "don't know what's up" condition by returning null. `when`(mockAccount.checkAuthorizationStatusAsync(eq("profile"))).thenReturn(CompletableDeferred(value = null)) `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred(AuthFlowUrl(EXPECTED_AUTH_STATE, "auth://url"))) `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true)) // There's no account at the start. `when`(accountStorage.read()).thenReturn(null) val manager = TestableFxaAccountManager( testContext, ServerConfig.release("dummyId", "bad://url"), accountStorage, coroutineContext = this.coroutineContext ) { mockAccount } val accountObserver: AccountObserver = mock() manager.register(accountObserver) manager.initAsync().await() // We start off as logged-out, but the event won't be called (initial default state is assumed). verify(accountObserver, never()).onLoggedOut() verify(accountObserver, never()).onAuthenticated(any(), any()) verify(accountObserver, never()).onAuthenticationProblems() verify(mockAccount, never()).checkAuthorizationStatusAsync(any()) assertFalse(manager.accountNeedsReauth()) reset(accountObserver) assertEquals("auth://url", manager.beginAuthenticationAsync().await()) assertNull(manager.authenticatedAccount()) assertNull(manager.accountProfile()) assertTrue(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signin, "dummyCode", EXPECTED_AUTH_STATE)).await()) assertTrue(manager.accountNeedsReauth()) verify(accountObserver, times(1)).onAuthenticationProblems() verify(mockAccount, times(1)).checkAuthorizationStatusAsync(eq("profile")) Unit</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$val manager = prepareHappyAuthenticationFlow(mockAccount, profile, accountStorage, accountObserver, this.coroutineContext)</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest$val manager = prepareUnhappyAuthenticationFlow(mockAccount, profile, accountStorage, accountObserver, this.coroutineContext)</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$FxaAccountManagerTest.StatePersistenceTestableAccount$override</ID>
+    <ID>MaxLineLength:FxaAccountManagerTest.kt$TestableFxaAccountManager$( context: Context, config: ServerConfig, private val storage: AccountStorage, capabilities: Set&lt;DeviceCapability&gt; = emptySet(), syncConfig: SyncConfig? = null, coroutineContext: CoroutineContext, private val block: () -&gt; OAuthAccount = { mock() } )</ID>
+    <ID>MaxLineLength:FxaDeviceConstellationTest.kt$FxaDeviceConstellationTest$assertEquals(ConstellationState(currentDevice.into(), listOf(testDevice1.into(), testDevice2.into())), constellation.state())</ID>
+    <ID>MaxLineLength:FxaDeviceConstellationTest.kt$FxaDeviceConstellationTest$assertEquals(ConstellationState(currentDevice.into(), listOf(testDevice1.into(), testDevice2.into())), observer.state)</ID>
+    <ID>MaxLineLength:FxaDeviceConstellationTest.kt$FxaDeviceConstellationTest$verify(account).initializeDevice("VR device", NativeDevice.Type.VR, setOf(mozilla.appservices.fxaclient.Device.Capability.SEND_TAB))</ID>
+    <ID>MaxLineLength:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest$private</ID>
+    <ID>MaxLineLength:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest$spy(FxaWebChannelFeature(testContext, null, mock(), sessionManager, accountManager, setOf(FxaCapability.CHOOSE_WHAT_TO_SYNC)))</ID>
+    <ID>MaxLineLength:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest$verifyOauthLogin("newAction", AuthType.OtherExternal("newAction"), "anotherCode3", "anotherState4", messageHandler.value, accountManager)</ID>
+    <ID>MaxLineLength:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest$verifyOauthLogin("pairing", AuthType.Pairing, "anotherCode2", "anotherState3", messageHandler.value, accountManager)</ID>
+    <ID>MaxLineLength:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest$verifyOauthLogin("signup", AuthType.Signup, "anotherCode1", "anotherState2", messageHandler.value, accountManager)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$@Test fun `WHEN disabling tracking protection THEN CookieBehavior and AntiTracking category must be set to ACCEPT_ALL and NONE`()</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$historyDelegate.value.onVisited(geckoSession, "about:neterror", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL or GeckoSession.HistoryDelegate.VISIT_UNRECOVERABLE_ERROR)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", "https://www.mozilla.com", GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_REDIRECT_TEMPORARY)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$historyDelegate.value.onVisited(geckoSession, "https://www.mozilla.com/not-allowed", null, GeckoSession.HistoryDelegate.VISIT_TOP_LEVEL)</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/permredirect"), eq(VisitType.REDIRECT_PERMANENT))</ID>
+    <ID>MaxLineLength:GeckoEngineSessionTest.kt$GeckoEngineSessionTest$verify(historyTrackingDelegate).onVisited(eq("https://www.mozilla.com/tempredirect"), eq(VisitType.REDIRECT_TEMPORARY))</ID>
+    <ID>MaxLineLength:GeckoMediaDelegateTest.kt$GeckoMediaDelegateTest$assertEquals(RecordingDevice(RecordingDevice.Type.MICROPHONE, RecordingDevice.Status.INACTIVE), observedDevices[1])</ID>
+    <ID>MaxLineLength:GeckoPromptDelegateTest.kt$GeckoPromptDelegateTest$promptDelegate.onFilePrompt(mock(), "title", GeckoSession.PromptDelegate.FILE_TYPE_SINGLE, emptyArray(), callback)</ID>
+    <ID>MaxLineLength:GleanCrashReporterServiceTest.kt$GleanCrashReporterServiceTest$CrashMetrics.crashCount[GleanCrashReporterService.NATIVE_CODE_CRASH_KEY].testGetValue() - initialNativeCrashValue</ID>
+    <ID>MaxLineLength:GleanCrashReporterServiceTest.kt$GleanCrashReporterServiceTest$CrashMetrics.crashCount[GleanCrashReporterService.UNCAUGHT_EXCEPTION_KEY].testGetValue() - initialExceptionValue</ID>
+    <ID>MaxLineLength:HeadersTest.kt$HeadersTest$assertEquals("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0", headers[5].value)</ID>
+    <ID>MaxLineLength:HistoryDelegateTest.kt$HistoryDelegateTest$assertTrue(delegate.shouldStoreUri("https://john.doe@www.example.com:123/forum/questions/?tag=networking&amp;order=newest#top"))</ID>
+    <ID>MaxLineLength:HistoryDelegateTest.kt$HistoryDelegateTest.TestHistoryStorage$override suspend</ID>
+    <ID>MaxLineLength:HistoryStorageSuggestionProviderTest.kt$HistoryStorageSuggestionProviderTest$`when`(storage.getSuggestions(eq("www"), eq(HISTORY_SUGGESTION_LIMIT))).thenReturn(pocketSuggestions + mozSuggestions + exampleSuggestions)</ID>
+    <ID>MaxLineLength:IconMessageHandlerTest.kt$IconMessageHandlerTest$ </ID>
+    <ID>MaxLineLength:IconMessageHandlerTest.kt$IconMessageHandlerTest$assertEquals("https://cdn.vox-cdn.com/uploads/chorus_asset/file/7396113/221a67c8-a10f-11e6-8fae-983107008690.0.png", url)</ID>
+    <ID>MaxLineLength:IconResourceComparatorTest.kt$IconResourceComparatorTest$url = "https://cdn.vox-cdn.com/uploads/chorus_asset/file/7396113/221a67c8-a10f-11e6-8fae-983107008690.0.png"</ID>
+    <ID>MaxLineLength:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$assertEquals(listOf(false, true), history.getVisited(listOf("https://www.unknown.com", "https://www.mozilla.org")))</ID>
+    <ID>MaxLineLength:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$assertEquals(listOf(true, false), history.getVisited(listOf("https://www.mozilla.org", "https://www.unknown.com")))</ID>
+    <ID>MaxLineLength:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$assertEquals(listOf(true, true), history.getVisited(listOf("https://www.mozilla.org", "https://www.mozilla.org")))</ID>
+    <ID>MaxLineLength:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest$assertEquals(listOf(true, true, false, true), history.getVisited(listOf("https://www.firefox.com", "https://www.wikipedia.org", "https://www.unknown.com", "https://www.mozilla.org")))</ID>
+    <ID>MaxLineLength:JSONExperimentParserTest.kt$JSONExperimentParserTest$assertEquals</ID>
+    <ID>MaxLineLength:JSONExperimentParserTest.kt$JSONExperimentParserTest$val emptyObjects = """{"id":"sample-id","name":"sample-name","buckets":{"min":null,"max":null},"match":{"lang":null,"appId":null,"region":null}}"""</ID>
+    <ID>MaxLineLength:JSONExperimentParserTest.kt$JSONExperimentParserTest$val json = """{"buckets":null,"name":"sample-name","match":null,"description":null,"id":"sample-id","last_modified":null}"""</ID>
+    <ID>MaxLineLength:JSONExperimentParserTest.kt$JSONExperimentParserTest$val json = """{"buckets":null,"name":null,"match":null,"description":null,"id":"sample-id","last_modified":null,"values":{"a":"a","b":3,"c":3.5,"d":true,"e":[1,2,3,4]}}"""</ID>
+    <ID>MaxLineLength:JSONExperimentParserTest.kt$JSONExperimentParserTest$val json = """{"buckets":{"min":0,"max":20},"name":"sample-name","match":{"regions":["US"],"appId":"sample-appId","lang":"es|en"},"description":"sample-description","id":"sample-id","last_modified":1526991669}"""</ID>
+    <ID>MaxLineLength:JSONObjectTest.kt$JSONObjectTest$assertEquals("""{"first-key":{"a-key":"a-value","one-key":"one-value","second-key":"second"},"second-key":"second-value","third-key":[1,2,3]}""", jsonObject.sortKeys().toString())</ID>
+    <ID>MaxLineLength:KintoClientTest.kt$KintoClientTest$verify(kintoClient).fetch(eq("http://example.test/buckets/fretboard/collections/experiments/records?_since=1527179995"))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$Response.Body("""{"data":[{"deleted":true,"id":"id","last_modified":1523549899999}]}""".byteInputStream())</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$Response.Body("""{"data":[{"name":"first-name","match":{"lang":"eng","appId":"first-appId",regions:[]},"schema":1523549592861,"buckets":{"max":"100","min":"0"},"description":"first-description", "id":"first-id","last_modified":1523549895713}]}""".byteInputStream())</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val experimentsResult = experimentSource.getExperiments(ExperimentsSnapshot(kintoExperiments.experiments, 1523549899999))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val experimentsResult = experimentSource.getExperiments(ExperimentsSnapshot(kintoExperiments.experiments, currentTime))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val kintoExperiments = experimentSource.getExperiments(ExperimentsSnapshot(listOf(storageExperiment), 1523549800000))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val kintoExperiments = experimentSource.getExperiments(ExperimentsSnapshot(listOf(storageExperiment), 1523549890000))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val kintoExperiments = experimentSource.getExperiments(ExperimentsSnapshot(listOf(storageExperiment), 1523549895713))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val kintoExperiments = experimentSource.getExperiments(ExperimentsSnapshot(listOf(storageExperiment, secondExperiment), 1523549890000))</ID>
+    <ID>MaxLineLength:KintoExperimentSourceTest.kt$KintoExperimentSourceTest$val kintoExperiments = experimentSource.getExperiments(ExperimentsSnapshot(listOf(storageExperiment, secondExperiment), pastTime))</ID>
+    <ID>MaxLineLength:LocaleManagerTest.kt$LocaleManagerTest$@Test fun `when calling updateResources with none current language must not change the system locale neither change configurations`()</ID>
+    <ID>MaxLineLength:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$"store1#telemetry.invalid_md_sum" to "{\"log_base\":2.0,\"buckets_per_magnitude\":16.0,\"values\":{},\"sum\":\"nope\"}"</ID>
+    <ID>MaxLineLength:MemoryDistributionsStorageEngineTest.kt$MemoryDistributionsStorageEngineTest$"store1#telemetry.invalid_md_values" to "{\"log_base\":2.0,\"buckets_per_magnitude\":16.0,\"values\":{\"0\": \"nope\"},\"sum\":0}"</ID>
+    <ID>MaxLineLength:Mock.kt$ fun mockMotionEvent( action: Int, downTime: Long = System.currentTimeMillis(), eventTime: Long = System.currentTimeMillis(), x: Float = 0f, y: Float = 0f, metaState: Int = 0 ): MotionEvent</ID>
+    <ID>MaxLineLength:MonthAndYearPickerTest.kt$MonthAndYearPickerTest$@Test fun `WHEN max or min date are in a illogical range THEN picker must allow to select the default values for max and min`()</ID>
+    <ID>MaxLineLength:MonthAndYearPickerTest.kt$MonthAndYearPickerTest$@Test fun `WHEN selectedDate is a year less than maxDate THEN month picker MUST allow selecting until the last month of the year`()</ID>
+    <ID>MaxLineLength:NativeCodeCrashTest.kt$NativeCodeCrashTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp"</ID>
+    <ID>MaxLineLength:NativeCodeCrashTest.kt$NativeCodeCrashTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra"</ID>
+    <ID>MaxLineLength:OnDeviceSitePermissionsStorageTest.kt$OnDeviceSitePermissionsStorageTest$"(origin, location, notification, microphone,camera_front,camera_back,bluetooth,local_storage,saved_at) "</ID>
+    <ID>MaxLineLength:OriginVerifierTest.kt$OriginVerifierTest$OriginVerifier.byteArrayToHexString(byteArrayOf(0xaa.toByte(), 0xbb.toByte(), 0xcc.toByte(), 0x10, 0x20, 0x30, 0x01, 0x02))</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("Code", "Code Geass", "Codeine", "Codename: Kids Next Door", "Code page", "Codex Sinaiticus", "Code talker", "Code Black (TV series)", "Codependency", "Codex Vaticanus")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("Firefox", "Firefox", "Mountain Equipment Firefox Pants (Herr)", "Mountain Equipment Firefox (Herr)", "Firefox (DE)")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox (video game)", "firefox addons", "firefox", "firefox quantum", "firefox focus")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox for fire tv", "firefox movie", "firefox app", "firefox books", "firefox glider", "firefox stick", "firefox for firestick", "firefox", "firefox books series", "firefox browser")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox rocket", "firefox手机浏览器", "firefox是什么意思", "firefox focus", "firefox风哥", "firefox官网", "firefox吧", "firefox os", "firefox国际版", "firefox android")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "Mozilla Firefox", "firefox add-on to detect vulnerable websites", "firefox ak", "firefox as gaeilge", "firefox developer edition", "firefox down", "firefox for dummies", "firefox for mac", "firefox for mobile")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "firefox ak keep it up", "firefox ak city to city", "firefox ak all those people", "firefox ak who can act", "firefox ak color the trees", "firefox ak habibi", "firefox ak zodiac", "firefox ak the draft", "mozilla firefox")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "firefox browser", "firefox.com", "firefox update", "firefox for mac", "firefox quantum", "firefox extensions", "firefox esr", "firefox clear cache", "firefox themes")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "firefox download", "firefox focus", "mozilla firefox", "firefox adobe flash", "firefox 삭제", "firefox 한글판", "firefox 즐겨찾기 가져오기", "firefox quantum", "firefox 57", "mozila firefox", "mozilla firefox download", "mozilla firefox 삭제", "Hacking Firefox", "Programming Firefox")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "firefox download", "firefox for windows 10", "firefox browser", "firefox quantum", "firefox esr", "firefox 64-bit", "firefox mozilla", "firefox nightly", "firefox update", "firefox install", "firefox focus", "firefox beta", "firefox developer edition", "firefox portable", "firefox add-ons")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "firefox for mac", "firefox quantum", "firefox update", "firefox esr", "firefox focus", "firefox addons", "firefox extensions", "firefox nightly", "firefox clear cache")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val expectedResults = listOf("firefox", "firefox tiếng việt", "firefox download", "firefox quantum", "firefox 51", "firefox 42", "firefox english", "firefox portable", "firefox 49", "firefox viet nam")</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"code\",[\"Code\",\"Code Geass\",\"Codeine\",\"Codename: Kids Next Door\",\"Code page\",\"Codex Sinaiticus\",\"Code talker\",\"Code Black (TV series)\",\"Codependency\",\"Codex Vaticanus\"],[\"In communications and information processing, code is a system of rules to convert information\\u2014such as a letter, word, sound, image, or gesture\\u2014into another form or representation, sometimes shortened or secret, for communication through a communication channel or storage in a storage medium.\",\"Code Geass: Lelouch of the Rebellion (\\u30b3\\u30fc\\u30c9\\u30ae\\u30a2\\u30b9 \\u53cd\\u9006\\u306e\\u30eb\\u30eb\\u30fc\\u30b7\\u30e5, K\\u014ddo Giasu: Hangyaku no Rur\\u016bshu), often referred to as simply Code Geass, is a Japanese anime series created by Sunrise, directed by Gor\\u014d Taniguchi, and written by Ichir\\u014d \\u014ckouchi, with original character designs by manga authors Clamp.\",\"Codeine is an opiate used to treat pain, as a cough medicine, and for diarrhea. It is typically used to treat mild to moderate degrees of pain.\",\"Codename: Kids Next Door, commonly abbreviated to Kids Next Door or KND, is an American animated television series created by Tom Warburton for Cartoon Network, and the 13th of the network's Cartoon Cartoons.\",\"In computing, a code page is a table of values that describes the character set used for encoding a particular set of characters, usually combined with a number of control characters.\",\"Codex Sinaiticus (Greek: \\u03a3\\u03b9\\u03bd\\u03b1\\u03ca\\u03c4\\u03b9\\u03ba\\u03cc\\u03c2 \\u039a\\u03ce\\u03b4\\u03b9\\u03ba\\u03b1\\u03c2, Hebrew: \\u05e7\\u05d5\\u05d3\\u05e7\\u05e1 \\u05e1\\u05d9\\u05e0\\u05d0\\u05d9\\u05d8\\u05d9\\u05e7\\u05d5\\u05e1\\u200e; Shelfmarks and references: London, Brit.\",\"Code talkers are people in the 20th century who used obscure languages as a means of secret communication during wartime.\",\"Code Black is an American medical drama television series created by Michael Seitzman which premiered on CBS on September 30, 2015. It takes place in an overcrowded and understaffed emergency room in Los Angeles, California, and is based on a documentary by Ryan McGarry.\",\"Codependency is a controversial concept for a dysfunctional helping relationship where one person supports or enables another person's addiction, poor mental health, immaturity, irresponsibility, or under-achievement.\",\"The Codex Vaticanus (The Vatican, Bibl. Vat., Vat. gr. 1209; no. B or 03 Gregory-Aland, \\u03b4 1 von Soden) is regarded as the oldest extant manuscript of the Greek Bible (Old and New Testament), one of the four great uncial codices.\"],[\"https://en.wikipedia.org/wiki/Code\",\"https://en.wikipedia.org/wiki/Code_Geass\",\"https://en.wikipedia.org/wiki/Codeine\",\"https://en.wikipedia.org/wiki/Codename:_Kids_Next_Door\",\"https://en.wikipedia.org/wiki/Code_page\",\"https://en.wikipedia.org/wiki/Codex_Sinaiticus\",\"https://en.wikipedia.org/wiki/Code_talker\",\"https://en.wikipedia.org/wiki/Code_Black_(TV_series)\",\"https://en.wikipedia.org/wiki/Codependency\",\"https://en.wikipedia.org/wiki/Codex_Vaticanus\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\", [\"firefox\", \"firefox ak keep it up\", \"firefox ak city to city\", \"firefox ak all those people\", \"firefox ak who can act\", \"firefox ak color the trees\", \"firefox ak habibi\", \"firefox ak zodiac\", \"firefox ak the draft\", \"mozilla firefox\"], [], []]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"Firefox\",\"Firefox\",\"Mountain Equipment Firefox Pants (Herr)\",\"Mountain Equipment Firefox (Herr)\",\"Firefox (DE)\"],[\"L\\u00e4gsta pris: 149:-\",\"L\\u00e4gsta pris: 205:-\",\"L\\u00e4gsta pris: 1 559:-\",\"L\\u00e4gsta pris: 2 773:-\",\"L\\u00e4gsta pris: 198:-\"],[\"https:\\/\\/www.prisjakt.nu\\/produkt.php?p=886794\",\"https:\\/\\/www.prisjakt.nu\\/produkt.php?p=53272\",\"https:\\/\\/www.prisjakt.nu\\/produkt.php?p=3548472\",\"https:\\/\\/www.prisjakt.nu\\/produkt.php?p=1822581\",\"https:\\/\\/www.prisjakt.nu\\/produkt.php?p=3408551\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox for fire tv\",\"firefox movie\",\"firefox app\",\"firefox books\",\"firefox glider\",\"firefox stick\",\"firefox for firestick\",\"firefox\",\"firefox books series\",\"firefox browser\"],[{\"nodes\":[{\"name\":\"Apps &amp; Games\",\"alias\":\"mobile-apps\"}]},{},{},{},{},{},{},{},{},{}],[],\"344I6KZL0KU9N\"]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox rocket\",\"firefox手机浏览器\",\"firefox是什么意思\",\"firefox focus\",\"firefox风哥\",\"firefox官网\",\"firefox吧\",\"firefox os\",\"firefox国际版\",\"firefox android\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox\",\"Mozilla Firefox\",\"firefox add-on to detect vulnerable websites\",\"firefox ak\",\"firefox as gaeilge\",\"firefox developer edition\",\"firefox down\",\"firefox for dummies\",\"firefox for mac\",\"firefox for mobile\"],[],[\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=Mozilla+Firefox\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+add-on+to+detect+vulnerable+websites\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+ak\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+as+gaeilge\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+developer+edition\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+down\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+for+dummies\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+for+mac\",\"http://search.naver.com/search.naver?where=nexearch&amp;sm=osp_sug&amp;ie=utf8&amp;query=firefox+for+mobile\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox\",\"firefox browser\",\"firefox.com\",\"firefox update\",\"firefox for mac\",\"firefox quantum\",\"firefox extensions\",\"firefox esr\",\"firefox clear cache\",\"firefox themes\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox\",\"firefox download\",\"firefox browser\",\"firefox update\",\"firefox.com\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox\",\"firefox download\",\"firefox for windows 10\",\"firefox browser\",\"firefox quantum\",\"firefox esr\",\"firefox 64-bit\",\"firefox mozilla\",\"firefox nightly\",\"firefox update\",\"firefox install\",\"firefox focus\",\"firefox beta\",\"firefox developer edition\",\"firefox portable\",\"firefox add-ons\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "[\"firefox\",[\"firefox\",\"firefox tiếng việt\",\"firefox download\",\"firefox quantum\",\"firefox 51\",\"firefox 42\",\"firefox english\",\"firefox portable\",\"firefox 49\",\"firefox viet nam\"],[\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"],[\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"],{\"google:suggesttype\":[\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\",\"QUERY\"]}]"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "{\"q\":\"firefox\",\"rq\":\"firefox\",\"items\":[\"firefox\",\"firefox download\",\"firefox focus\",\"mozilla firefox\",\"firefox adobe flash\",\"firefox 삭제\",\"firefox 한글판\",\"firefox 즐겨찾기 가져오기\",\"firefox quantum\",\"firefox 57\",\"mozila firefox\",\"mozilla firefox download\",\"mozilla firefox 삭제\",\"Hacking Firefox\",\"Programming Firefox\"],\"r_items\":[]}"</ID>
+    <ID>MaxLineLength:ParserTest.kt$ParserTest$val json = "{\"status\":\"success\",\"data\":{\"items\":[{\"value\":\"firefox (video game)\",\"suggestType\":3},{\"value\":\"firefox addons\",\"suggestType\":12},{\"value\":\"firefox\",\"suggestType\":2},{\"value\":\"firefox quantum\",\"suggestType\":12},{\"value\":\"firefox focus\",\"suggestType\":12}],\"special\":[],\"availableQwick\":[]}}"</ID>
+    <ID>MaxLineLength:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest$private fun BookmarkInfo.asBookmarkUpdateInfo(): BookmarkUpdateInfo</ID>
+    <ID>MaxLineLength:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$assertEquals(listOf(false, true), history.getVisited(listOf("https://www.unknown.com", "https://www.mozilla.org")))</ID>
+    <ID>MaxLineLength:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$assertEquals(listOf(true, false), history.getVisited(listOf("https://www.mozilla.org", "https://www.unknown.com")))</ID>
+    <ID>MaxLineLength:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$assertEquals(listOf(true, true), history.getVisited(listOf("https://www.mozilla.org", "https://www.mozilla.org")))</ID>
+    <ID>MaxLineLength:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$assertEquals(listOf(true, true, false, true), history.getVisited(listOf("https://www.firefox.com", "https://www.wikipedia.org", "https://www.unknown.com", "https://www.mozilla.org")))</ID>
+    <ID>MaxLineLength:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest$val page1Limited = history.getVisitsPaginated(0, 10, listOf(VisitType.REDIRECT_PERMANENT, VisitType.REDIRECT_TEMPORARY))</ID>
+    <ID>MaxLineLength:PocketEndpointRawTest.kt$private const</ID>
+    <ID>MaxLineLength:PocketEndpointTest.kt$PocketEndpointTest$@Test fun `WHEN getting video recommendations and the endpoint returns a String THEN the String is put into the jsonParser`()</ID>
+    <ID>MaxLineLength:PocketEndpointTest.kt$PocketEndpointTest$@Test fun `WHEN getting video recommendations, the server returns a String, and the JSON parser returns null THEN a failure is returned`()</ID>
+    <ID>MaxLineLength:PocketEndpointTest.kt$PocketEndpointTest$@Test fun `WHEN getting video recommendations, the server returns a String, and the jsonParser returns an empty list THEN a failure is returned`()</ID>
+    <ID>MaxLineLength:PocketEndpointTest.kt$PocketEndpointTest$@Test fun `WHEN getting video recommendations, the server returns a String, and the jsonParser returns valid data THEN a success with the data is returned`()</ID>
+    <ID>MaxLineLength:PocketEndpointTest.kt$PocketEndpointTest$`when`(jsonParser.jsonToGlobalVideoRecommendations(any())).thenThrow(AssertionError("We assume this won't get called so we don't mock it"))</ID>
+    <ID>MaxLineLength:PocketJSONParserTest.kt$PocketJSONParserTest$@Test fun `WHEN parsing global video recommendations with some invalid authors THEN the authors are returned without invalid entries`()</ID>
+    <ID>MaxLineLength:PocketListenEndpointTest.kt$PocketListenEndpointTest$@Test fun `WHEN getting listen article metadata and the endpoint returns a String THEN the String is put into the jsonParser`()</ID>
+    <ID>MaxLineLength:PocketListenEndpointTest.kt$PocketListenEndpointTest$@Test fun `WHEN getting listen article metadata, the server returns a String, and the JSON parser returns null THEN a failure is returned`()</ID>
+    <ID>MaxLineLength:PocketListenEndpointTest.kt$PocketListenEndpointTest$@Test fun `WHEN getting listen article metadata, the server returns a String, and the jsonParser returns valid data THEN a success with the data is returned`()</ID>
+    <ID>MaxLineLength:PocketListenEndpointTest.kt$PocketListenEndpointTest$`when`(jsonParser.jsonToListenArticleMetadata(any())).thenThrow(AssertionError("We assume this won't get called so we don't mock it"))</ID>
+    <ID>MaxLineLength:PocketListenEndpointTest.kt$PocketListenEndpointTest$val subject = PocketListenEndpoint.newInstance(client, accessToken, "android-components:PocketListenEndpointTest")</ID>
+    <ID>MaxLineLength:PocketListenEndpointTest.kt$PocketListenEndpointTest${ // To use this test locally, add the access token file (see LISTEN_ACCESS_TOKEN comments) and comment out ignore annotation. val client = HttpURLConnectionClient() val accessToken = PocketTestResource.LISTEN_ACCESS_TOKEN.get() val subject = PocketListenEndpoint.newInstance(client, accessToken, "android-components:PocketListenEndpointTest") // The input article may seem invalid but it's test data from the server docs: // https://documenter.getpostman.com/view/777613/S17jXChA#426b37e2-0a4f-bd65-35c6-e14f1b19d0f0 val response = subject.getListenArticleMetadata(1234, "https://news.com/my-article.html") val result = (response as? PocketResponse.Success)?.data assertNotNull(result) println(result) }</ID>
+    <ID>MaxLineLength:PocketTestResource.kt$PocketTestResource.Companion$excerpt = "At New York City's International Culinary Center, host Rebecca DeAngelis makes a modern day croquembouche with architect-turned pastry chef Jansen Chan"</ID>
+    <ID>MaxLineLength:PocketTestResource.kt$PocketTestResource.Companion$excerpt = "Power is tied to a hierarchical escalator that we rise up through decisions and actions. But once we have power, how does it affect our brain and behavior? How Our Brains Respond to People Who Aren't Like Us - https://youtu.be/KIwe_O0am4URead More:The age of adolescencehttps://www.thelancet.com/jour"</ID>
+    <ID>MaxLineLength:PocketTestResource.kt$PocketTestResource.Companion$imageSrc = "https://img-getpocket.cdn.mozilla.net/direct?url=http%3A%2F%2Fimg.youtube.com%2Fvi%2F953Qt4FnAcU%2Fmaxresdefault.jpg&amp;resize=w450"</ID>
+    <ID>MaxLineLength:PocketTestResource.kt$PocketTestResource.Companion$imageSrc = "https://img-getpocket.cdn.mozilla.net/direct?url=http%3A%2F%2Fimg.youtube.com%2Fvi%2FGHZ7-kq3GDQ%2Fmaxresdefault.jpg&amp;resize=w450"</ID>
+    <ID>MaxLineLength:PromptFeatureTest.kt$PromptFeatureTest$@Test fun `onActivityResult with RESULT_OK and isMultipleFilesSelection false will consume PromptRequest of the actual session`()</ID>
+    <ID>MaxLineLength:PromptFeatureTest.kt$PromptFeatureTest$@Test fun `onActivityResult with RESULT_OK and isMultipleFilesSelection true will consume PromptRequest of the actual session`()</ID>
+    <ID>MaxLineLength:ProvidersTest.kt$ProvidersTest$assertCompletion(provider, "f", DomainList.CUSTOM, customDomains.size, "fanfiction.com", "http://www.fanfiction.com")</ID>
+    <ID>MaxLineLength:ProvidersTest.kt$ProvidersTest$assertCompletion(provider, "fa", DomainList.CUSTOM, customDomains.size, "fanfiction.com", "http://www.fanfiction.com")</ID>
+    <ID>MaxLineLength:ProvidersTest.kt$ProvidersTest$assertCompletion(provider, "www.facebook.com", DomainList.DEFAULT, size, "www.facebook.com", "http://facebook.com")</ID>
+    <ID>MaxLineLength:PublicSuffixListTest.kt$PublicSuffixListTest$// empty input assertNull(publicSuffixList.getPublicSuffixPlusOne("").await()) // Mixed case. assertNull(publicSuffixList.getPublicSuffixPlusOne("COM").await()) assertEquals( "example.COM", publicSuffixList.getPublicSuffixPlusOne("example.COM").await()) assertEquals( "eXample.COM", publicSuffixList.getPublicSuffixPlusOne("WwW.eXample.COM").await()) // Leading dot. // ArrayIndexOutOfBoundsException: assertEquals("", publicSuffixList.getPublicSuffixPlusOne(".example.com").await()) // TLD with only 1 rule. assertNull(publicSuffixList.getPublicSuffixPlusOne("biz").await()) assertEquals( "domain.biz", publicSuffixList.getPublicSuffixPlusOne("domain.biz").await()) assertEquals( "domain.biz", publicSuffixList.getPublicSuffixPlusOne("b.domain.biz").await()) assertEquals( "domain.biz", publicSuffixList.getPublicSuffixPlusOne("a.b.domain.biz").await()) // TLD with some 2-level rules. assertNull(publicSuffixList.getPublicSuffixPlusOne("com").await()) assertEquals( "example.com", publicSuffixList.getPublicSuffixPlusOne("example.com").await()) assertEquals( "example.com", publicSuffixList.getPublicSuffixPlusOne("b.example.com").await()) assertEquals( "example.com", publicSuffixList.getPublicSuffixPlusOne("a.b.example.com").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("uk.com").await()) assertEquals( "example.uk.com", publicSuffixList.getPublicSuffixPlusOne("example.uk.com").await()) assertEquals( "example.uk.com", publicSuffixList.getPublicSuffixPlusOne("b.example.uk.com").await()) assertEquals( "example.uk.com", publicSuffixList.getPublicSuffixPlusOne("a.b.example.uk.com").await()) assertEquals( "test.ac", publicSuffixList.getPublicSuffixPlusOne("test.ac").await()) // TLD with only 1 (wildcard) rule. assertNull(publicSuffixList.getPublicSuffixPlusOne("mm").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("c.mm").await()) assertEquals( "b.c.mm", publicSuffixList.getPublicSuffixPlusOne("b.c.mm").await()) assertEquals( "b.c.mm", publicSuffixList.getPublicSuffixPlusOne("a.b.c.mm").await()) // More complex TLD. assertNull(publicSuffixList.getPublicSuffixPlusOne("jp").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("ac.jp").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("kyoto.jp").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("ide.kyoto.jp").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("c.kobe.jp").await()) assertEquals( "test.jp", publicSuffixList.getPublicSuffixPlusOne("test.jp").await()) assertEquals( "test.jp", publicSuffixList.getPublicSuffixPlusOne("www.test.jp").await()) assertEquals( "test.ac.jp", publicSuffixList.getPublicSuffixPlusOne("test.ac.jp").await()) assertEquals( "test.ac.jp", publicSuffixList.getPublicSuffixPlusOne("www.test.ac.jp").await()) assertEquals( "test.kyoto.jp", publicSuffixList.getPublicSuffixPlusOne("test.kyoto.jp").await()) assertEquals( "b.ide.kyoto.jp", publicSuffixList.getPublicSuffixPlusOne("b.ide.kyoto.jp").await()) assertEquals( "b.ide.kyoto.jp", publicSuffixList.getPublicSuffixPlusOne("a.b.ide.kyoto.jp").await()) assertEquals( "b.c.kobe.jp", publicSuffixList.getPublicSuffixPlusOne("b.c.kobe.jp").await()) assertEquals( "b.c.kobe.jp", publicSuffixList.getPublicSuffixPlusOne("a.b.c.kobe.jp").await()) assertEquals( "city.kobe.jp", publicSuffixList.getPublicSuffixPlusOne("city.kobe.jp").await()) assertEquals( "city.kobe.jp", publicSuffixList.getPublicSuffixPlusOne("www.city.kobe.jp").await()) // TLD with a wildcard rule and exceptions. assertNull(publicSuffixList.getPublicSuffixPlusOne("ck").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("test.ck").await()) assertEquals( "b.test.ck", publicSuffixList.getPublicSuffixPlusOne("b.test.ck").await()) assertEquals( "b.test.ck", publicSuffixList.getPublicSuffixPlusOne("a.b.test.ck").await()) assertEquals( "www.ck", publicSuffixList.getPublicSuffixPlusOne("www.ck").await()) assertEquals( "www.ck", publicSuffixList.getPublicSuffixPlusOne("www.www.ck").await()) // US K12. assertNull(publicSuffixList.getPublicSuffixPlusOne("us").await()) assertEquals( "test.us", publicSuffixList.getPublicSuffixPlusOne("test.us").await()) assertEquals( "test.us", publicSuffixList.getPublicSuffixPlusOne("www.test.us").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("ak.us").await()) assertEquals( "test.ak.us", publicSuffixList.getPublicSuffixPlusOne("www.test.ak.us").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("k12.ak.us").await()) assertEquals( "test.k12.ak.us", publicSuffixList.getPublicSuffixPlusOne("test.k12.ak.us").await()) assertEquals( "test.k12.ak.us", publicSuffixList.getPublicSuffixPlusOne("www.test.k12.ak.us").await()) // IDN labels. assertEquals( "食狮.com.cn", publicSuffixList.getPublicSuffixPlusOne("食狮.com.cn").await()) // https://github.com/mozilla-mobile/android-components/issues/1777 assertEquals( "食狮.公司.cn", publicSuffixList.getPublicSuffixPlusOne("食狮.公司.cn").await()) assertEquals( "食狮.公司.cn", publicSuffixList.getPublicSuffixPlusOne("www.食狮.公司.cn").await()) assertEquals( "shishi.公司.cn", publicSuffixList.getPublicSuffixPlusOne("shishi.公司.cn").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("公司.cn").await()) assertEquals( "食狮.中国", publicSuffixList.getPublicSuffixPlusOne("食狮.中国").await()) assertEquals( "食狮.中国", publicSuffixList.getPublicSuffixPlusOne("www.食狮.中国").await()) assertEquals( "shishi.中国", publicSuffixList.getPublicSuffixPlusOne("shishi.中国").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("中国").await()) // Same as above, but punycoded. assertEquals( "xn--85x722f.com.cn", publicSuffixList.getPublicSuffixPlusOne("xn--85x722f.com.cn").await()) // https://github.com/mozilla-mobile/android-components/issues/1777 assertEquals( "xn--85x722f.xn--55qx5d.cn", publicSuffixList.getPublicSuffixPlusOne("xn--85x722f.xn--55qx5d.cn").await()) assertEquals( "xn--85x722f.xn--55qx5d.cn", publicSuffixList.getPublicSuffixPlusOne("www.xn--85x722f.xn--55qx5d.cn").await()) assertEquals( "shishi.xn--55qx5d.cn", publicSuffixList.getPublicSuffixPlusOne("shishi.xn--55qx5d.cn").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("xn--55qx5d.cn").await()) assertEquals( "xn--85x722f.xn--fiqs8s", publicSuffixList.getPublicSuffixPlusOne("xn--85x722f.xn--fiqs8s").await()) assertEquals( "xn--85x722f.xn--fiqs8s", publicSuffixList.getPublicSuffixPlusOne("www.xn--85x722f.xn--fiqs8s").await()) assertEquals( "shishi.xn--fiqs8s", publicSuffixList.getPublicSuffixPlusOne("shishi.xn--fiqs8s").await()) assertNull(publicSuffixList.getPublicSuffixPlusOne("xn--fiqs8s").await())</ID>
+    <ID>MaxLineLength:QrFragmentTest.kt$QrFragmentTest$whenever(camera.createCaptureRequest(anyInt())).thenThrow(IllegalStateException("CameraDevice was already closed"))</ID>
+    <ID>MaxLineLength:ReaderViewFeatureTest.kt$ReaderViewFeatureTest$assertEquals(ReaderViewFeature.ACTION_CHECK_READERABLE, message.allValues[0][ReaderViewFeature.ACTION_MESSAGE_KEY])</ID>
+    <ID>MaxLineLength:ReaderViewFeatureTest.kt$ReaderViewFeatureTest$verify(ext).registerContentMessageHandler(eq(engineSession), eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID), messageHandler.capture())</ID>
+    <ID>MaxLineLength:RequestTest.kt$RequestTest$@Test fun `WHEN creating a request body from non-alphabetized params for urlencoded THEN it's in the correct format and ordering`()</ID>
+    <ID>MaxLineLength:RequestTest.kt$RequestTest$@Test fun `WHEN creating a request body from params with empty keys or values THEN they are represented as the empty string in the result`()</ID>
+    <ID>MaxLineLength:SearchEngineTest.kt$SearchEngineTest$"https://mozilla.org/?locale=en_US&amp;dist=&amp;official=unofficial&amp;q=hello%20world&amp;input=UTF-8&amp;output=UTF-8&amp;lang=en_US&amp;random=&amp;foo="</ID>
+    <ID>MaxLineLength:SearchSuggestionClientTest.kt$SearchSuggestionClientTest$val expectedResults = listOf("firefox (video game)", "firefox addons", "firefox", "firefox quantum", "firefox focus")</ID>
+    <ID>MaxLineLength:SearchSuggestionClientTest.kt$SearchSuggestionClientTest$val expectedResults = listOf("firefox", "firefox for mac", "firefox quantum", "firefox update", "firefox esr", "firefox focus", "firefox addons", "firefox extensions", "firefox nightly", "firefox clear cache")</ID>
+    <ID>MaxLineLength:SearchSuggestionClientTest.kt$SearchSuggestionClientTest.Companion$val GOOGLE_MOCK_RESPONSE: SearchSuggestionFetcher = { "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]" }</ID>
+    <ID>MaxLineLength:SearchSuggestionClientTest.kt$SearchSuggestionClientTest.Companion$val QWANT_MOCK_RESPONSE: SearchSuggestionFetcher = { "{\"status\":\"success\",\"data\":{\"items\":[{\"value\":\"firefox (video game)\",\"suggestType\":3},{\"value\":\"firefox addons\",\"suggestType\":12},{\"value\":\"firefox\",\"suggestType\":2},{\"value\":\"firefox quantum\",\"suggestType\":12},{\"value\":\"firefox focus\",\"suggestType\":12}],\"special\":[],\"availableQwick\":[]}}" }</ID>
+    <ID>MaxLineLength:SearchSuggestionProviderTest.kt$private const val GOOGLE_MOCK_RESPONSE = "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"</ID>
+    <ID>MaxLineLength:SearchSuggestionProviderTest.kt$private const val GOOGLE_MOCK_RESPONSE_WITH_DUPLICATES = "[\"firefox\",[\"firefox\",\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"</ID>
+    <ID>MaxLineLength:SendCrashReportServiceTest.kt$SendCrashReportServiceTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp"</ID>
+    <ID>MaxLineLength:SendCrashReportServiceTest.kt$SendCrashReportServiceTest$"/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra"</ID>
+    <ID>MaxLineLength:SessionTest.kt$SessionTest$verify(store).dispatch(ContentAction.UpdateSecurityInfoAction(session.id, session.securityInfo.toSecurityInfoState()))</ID>
+    <ID>MaxLineLength:SignatureVerifierTest.kt$SignatureVerifierTest$ </ID>
+    <ID>MaxLineLength:SignatureVerifierTest.kt$SignatureVerifierTest$private</ID>
+    <ID>MaxLineLength:SignatureVerifierTest.kt$SignatureVerifierTest$val experimentsJson = "{\"data\":[{\"name\":\"leanplum-start\",\"match\":{\"lang\":\"eng|zho|deu|fra|ita|ind|por|spa|pol|rus\",\"appId\":\"^org.mozilla.firefox_beta\$|^org.mozilla.firefox\$\",\"regions\":[]},\"schema\":1523549592861,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Enable Leanplum SDK - Bug 1351571 \\nExpand English Users to more region - Bug 1411066\\nEnable 50% eng|zho|deu globally for Leanplum. see https://bugzilla.mozilla.org/show_bug.cgi?id=1411066#c8\",\"id\":\"12f8f0dc-6401-402e-9e7d-3aec52576b87\",\"last_modified\":1523549895713},{\"name\":\"custom-tabs\",\"match\":{\"regions\":[]},\"schema\":1510207707840,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Allows apps to open tabs in a customized UI.\",\"id\":\"5e23b482-8800-47be-b6dc-1a3bb6e455d4\",\"last_modified\":1510211043874},{\"name\":\"activity-stream-opt-out\",\"match\":{\"appId\":\"^org.mozilla.fennec.*\$\",\"regions\":[]},\"schema\":1498764179980,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Enable Activity stream by default for users in the \\\"opt out\\\" group.\",\"id\":\"7d504093-67c4-4afb-adf5-5ad23c7c1995\",\"last_modified\":1500969355986},{\"name\":\"full-bookmark-management\",\"match\":{\"appId\":\"^org.mozilla.fennec.*\$\"},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Bug 1232439 - Show full-page edit bookmark dialog\",\"id\":\"9ae1019b-9107-47c5-83f3-afa73360b020\",\"last_modified\":1498690258010},{\"name\":\"top-addons-menu\",\"match\":{},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Show addon menu item in top-level.\",\"id\":\"46894232-177a-4cd1-b620-47c0b8e5e2aa\",\"last_modified\":1498599522440},{\"name\":\"offline-cache\",\"match\":{\"appId\":\"^org.mozilla.fennec|org.mozilla.firefox_beta\"},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"id\":\"5e4277e0-1029-ea14-1b74-5d25d301c5dc\",\"last_modified\":1497643056372},{\"name\":\"process-background-telemetry\",\"match\":{},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Gate flag for controlling if background telemetry processing (sync ping) is enabled or not.\",\"id\":\"e6f9d217-3f43-478f-bff3-7829d7b9eeeb\",\"last_modified\":1496971360625},{\"name\":\"activity-stream-setting\",\"match\":{\"appId\":\"^org.mozilla.fennec.*\$\"},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Show a setting in \\\"experimental features\\\" for enabling/disabling activity stream.\",\"id\":\"7a022463-67fd-4ba3-8b06-a79d0c5e1fdc\",\"last_modified\":1496331790186},{\"name\":\"activity-stream\",\"match\":{\"appId\":\"^org.mozilla.fennec.*\$\"},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"description\":\"Enable/Disable Activity Stream\",\"id\":\"d4fd9cfb-4c8b-4963-b21e-1c2f4bcd61d6\",\"last_modified\":1496331773809},{\"name\":\"download-content-catalog-sync\",\"match\":{\"appId\":\"\"},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"id\":\"4d2fa5c3-18b2-8734-49be-fe58993d2cf6\",\"last_modified\":1485853244635},{\"name\":\"promote-add-to-homescreen\",\"match\":{\"appId\":\"^org.mozilla.fennec.*\$|^org.mozilla.firefox_beta\$\"},\"schema\":1480618438089,\"values\":{\"minimumTotalVisits\":5,\"lastVisitMaximumAgeMs\":600000,\"lastVisitMinimumAgeMs\":30000},\"buckets\":{\"max\":\"100\",\"min\":\"50\"},\"id\":\"1d05fa3e-095f-b29a-d9b6-ab3a578efd0b\",\"last_modified\":1482264639326},{\"name\":\"triple-readerview-bookmark-prompt\",\"match\":{\"appId\":\"^org.mozilla.fennec.*\$|^org.mozilla.firefox_beta\$\"},\"schema\":1480618438089,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"id\":\"02d7caa1-cd9e-6949-084c-18bc9d468b6b\",\"last_modified\":1482262302021},{\"name\":\"compact-tabs\",\"match\":{},\"schema\":1480618438089,\"buckets\":{\"max\":\"50\",\"min\":\"0\"},\"description\":\"Arrange tabs in two columns in portrait mode (tabs tray)\",\"id\":\"14fdc9f3-cf11-4bee-84f6-98495d08c61f\",\"last_modified\":1482242613284},{\"name\":\"hls-video-playback\",\"match\":{},\"schema\":1467794476773,\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"id\":\"d9f9f124-a4d6-47db-a9f4-cf0d00915088\",\"last_modified\":1477907551487},{\"name\":\"bookmark-history-menu\",\"match\":{},\"buckets\":{\"max\":\"100\",\"min\":\"0\"},\"id\":\"9a53ebfa-772d-d2d8-8307-f98943310360\",\"last_modified\":1467794477013},{\"name\":\"content-notifications-12hrs\",\"match\":{},\"buckets\":{\"max\":\"0\",\"min\":\"0\"},\"id\":\"3e4cef10-3a87-3cdd-4562-0062c2a9125b\",\"last_modified\":1467794476938},{\"name\":\"whatsnew-notification\",\"match\":{},\"buckets\":{\"max\":\"0\",\"min\":\"0\"},\"id\":\"d9fd5223-965c-2f0d-a798-b8cbc96f6e09\",\"last_modified\":1467794476893},{\"name\":\"content-notifications-8am\",\"match\":{},\"buckets\":{\"max\":\"0\",\"min\":\"0\"},\"id\":\"1829570e-f582-298b-63b3-3c9d8380be6b\",\"last_modified\":1467794476875},{\"name\":\"content-notifications-5pm\",\"match\":{},\"buckets\":{\"max\":\"0\",\"min\":\"0\"},\"id\":\"c011528e-e03a-7272-6d8b-ef1d4bea4689\",\"last_modified\":1467794476838}],\"last_modified\":\"1523549895713\"}"</ID>
+    <ID>MaxLineLength:SignatureVerifierTest.kt$SignatureVerifierTest$val metadataBody = "{\"data\":{\"signature\":{\"x5u\":\"$url\",\"signature\":\"kRhyWZdLyjligYHSFhzhbyzUXBoUwoTPvyt9V0e-E7LKGgUYF2MVfqpA2zfIEDdqrImcMABVGHLUx9Nk614zciRBQ-gyaKA5SL2pPdZvoQXk_LLsPhEBgG4VDnxG4SBL\"}}}"</ID>
+    <ID>MaxLineLength:SignatureVerifierTest.kt$SignatureVerifierTest$val metadataBody = "{\"data\":{\"signature\":{\"x5u\":\"$url\",\"signature\":\"kRyhWZdLyjligYHSFhzhbyzUXBoUwoTPvyt9V0e-E7LKGgUYF2MVfqpA2zfIEDdqrImcMABVGHLUx9Nk614zciRBQ-gyaKA5SL2pPdZvoQXk_LLsPhEBgG4VDnxG4SBL\"}}}"</ID>
+    <ID>MaxLineLength:SignatureVerifierTest.kt$mozilla.components.service.experiments.SignatureVerifierTest.kt</ID>
+    <ID>MaxLineLength:SimpleDownloadDialogFragmentTest.kt$SimpleDownloadDialogFragmentTest$"Mozilla/5.0 (Linux; Android 7.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/8.0 Chrome/69.0.3497.100 Mobile Safari/537.36"</ID>
+    <ID>MaxLineLength:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest$@Test fun `calling onPermissionsResult on a feature session with a sessionId will call grant on the permissionsRequest and consume it`()</ID>
+    <ID>MaxLineLength:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest$@Test fun `calling onPermissionsResult with NOT all permissions granted will call reject on the permissionsRequest and consume it`()</ID>
+    <ID>MaxLineLength:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest$@Test fun `calling onPermissionsResult with all permissions granted will call grant on the permissionsRequest and consume it`()</ID>
+    <ID>MaxLineLength:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest$@Test fun `requesting a content permissions with already permissions and doNotAskAgain equals false on the store, will show a prompt`()</ID>
+    <ID>MaxLineLength:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest$@Test fun `requesting a content permissions with an already stored allowed permissions will auto granted it and not show a prompt`()</ID>
+    <ID>MaxLineLength:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest$@Test fun `requesting a content permissions with an already stored blocked permission will auto block it and not show a prompt`()</ID>
+    <ID>MaxLineLength:SuggestionsAdapterTest.kt$SuggestionsAdapterTest$doReturn(holder).`when`(layout).createViewHolder(any(), any(), eq(R.layout.mozac_browser_awesomebar_item_generic))</ID>
+    <ID>MaxLineLength:SwipeRefreshFeatureTest.kt$SwipeRefreshFeatureTest$layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)</ID>
+    <ID>MaxLineLength:SystemEngineTest.kt$SystemEngineTest$assertEquals("foo", SystemEngine(testContext, DefaultSettings(userAgentString = "foo")).settings.userAgentString)</ID>
+    <ID>MaxLineLength:SystemEngineViewTest.kt$SystemEngineViewTest$engineSession.webView.webViewClient.doUpdateVisitedHistory(webView, "https://www.mozilla.com/not-allowed", false)</ID>
+    <ID>MaxLineLength:TestUtil.kt$Mockito.`when`(packageManager.getPackageInfo(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(packageInfo)</ID>
+    <ID>MaxLineLength:TimePickerDialogFragmentTest.kt$TimePickerDialogFragmentTest$@Test(expected = IllegalArgumentException::class) fun `creating a TimePickerDialogFragment with empty title and an invalid type selection will throw an exception `()</ID>
+    <ID>MaxLineLength:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$"store1#telemetry.invalid_td_sum" to "{\"log_base\":2.0,\"buckets_per_magnitude\":8.0,\"values\":{},\"sum\":\"nope\"}"</ID>
+    <ID>MaxLineLength:TimingDistributionsStorageEngineTest.kt$TimingDistributionsStorageEngineTest$"store1#telemetry.invalid_td_values" to "{\"log_base\":2.0,\"buckets_per_magnitude\":8.0,\"values\":{\"0\": \"nope\"},\"sum\":0}"</ID>
+    <ID>MaxLineLength:ToolbarAutocompleteFeatureTest.kt$ToolbarAutocompleteFeatureTest$@Suppress("SameParameterValue") private</ID>
+    <ID>MaxLineLength:ToolbarAutocompleteFeatureTest.kt$ToolbarAutocompleteFeatureTest$private</ID>
+    <ID>NewLineAtEndOfFile:AbstractFirebasePushServiceTest.kt$mozilla.components.lib.push.firebase.AbstractFirebasePushServiceTest.kt</ID>
+    <ID>NewLineAtEndOfFile:AccountObserverTest.kt$mozilla.components.feature.sendtab.AccountObserverTest.kt</ID>
+    <ID>NewLineAtEndOfFile:AccountSharingTest.kt$mozilla.components.service.fxa.sharing.AccountSharingTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ActionButtonTest.kt$mozilla.components.concept.toolbar.ActionButtonTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ActionSpaceTest.kt$mozilla.components.concept.toolbar.ActionSpaceTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ActionToggleButtonTest.kt$mozilla.components.concept.toolbar.ActionToggleButtonTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ActivityTest.kt$mozilla.components.support.ktx.android.view.ActivityTest.kt</ID>
+    <ID>NewLineAtEndOfFile:AtomicFileKtTest.kt$mozilla.components.browser.session.ext.AtomicFileKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:AudioFocusTest.kt$mozilla.components.feature.media.focus.AudioFocusTest.kt</ID>
+    <ID>NewLineAtEndOfFile:AuthenticationDialogFragmentTest.kt$mozilla.components.feature.prompts.AuthenticationDialogFragmentTest.kt</ID>
+    <ID>NewLineAtEndOfFile:AutoFitTextureViewTest.kt$mozilla.components.support.base.android.view.AutoFitTextureViewTest.kt</ID>
+    <ID>NewLineAtEndOfFile:Base64Test.kt$mozilla.components.support.ktx.android.util.Base64Test.kt</ID>
+    <ID>NewLineAtEndOfFile:BrowserAwesomeBarTest.kt$mozilla.components.browser.awesomebar.BrowserAwesomeBarTest.kt</ID>
+    <ID>NewLineAtEndOfFile:BrowserToolbarBottomBehaviorTest.kt$mozilla.components.browser.toolbar.behavior.BrowserToolbarBottomBehaviorTest.kt</ID>
+    <ID>NewLineAtEndOfFile:BrowsersTest.kt$mozilla.components.support.utils.BrowsersTest.kt</ID>
+    <ID>NewLineAtEndOfFile:BuildTest.kt$mozilla.components.BuildTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ByteArrayTest.kt$mozilla.components.support.ktx.kotlin.ByteArrayTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ChoiceDialogFragmentTest.kt$mozilla.components.feature.prompts.ChoiceDialogFragmentTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ChoiceTest.kt$mozilla.components.concept.engine.prompt.ChoiceTest.kt</ID>
+    <ID>NewLineAtEndOfFile:CollectionKtTest.kt$mozilla.components.support.ktx.kotlin.CollectionKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ConnectionKtTest.kt$mozilla.components.feature.push.ConnectionKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ContentActionTest.kt$mozilla.components.browser.state.action.ContentActionTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ContextMenuCandidateTest.kt$mozilla.components.feature.contextmenu.ContextMenuCandidateTest.kt</ID>
+    <ID>NewLineAtEndOfFile:CoordinateScrollingFeatureTest.kt$mozilla.components.feature.session.CoordinateScrollingFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:CustomDomainsTest.kt$mozilla.components.browser.domains.CustomDomainsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DeviceObserverTest.kt$mozilla.components.feature.sendtab.DeviceObserverTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DeviceUuidFactoryTest.kt$mozilla.components.service.experiments.DeviceUuidFactoryTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DeviceUuidFactoryTest.kt$mozilla.components.service.fretboard.DeviceUuidFactoryTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DiskIconLoaderTest.kt$mozilla.components.browser.icons.loader.DiskIconLoaderTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DiskIconPreparerTest.kt$mozilla.components.browser.icons.preparer.DiskIconPreparerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DomainsTest.kt$mozilla.components.browser.domains.DomainsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DownloadDialogFragmentTest.kt$mozilla.components.feature.downloads.DownloadDialogFragmentTest.kt</ID>
+    <ID>NewLineAtEndOfFile:DownloadsFeatureTest.kt$mozilla.components.feature.downloads.DownloadsFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:EncryptedPushMessageTest.kt$mozilla.components.concept.push.EncryptedPushMessageTest.kt</ID>
+    <ID>NewLineAtEndOfFile:EngineSessionHolderTest.kt$mozilla.components.browser.session.engine.EngineSessionHolderTest.kt</ID>
+    <ID>NewLineAtEndOfFile:EngineTest.kt$mozilla.components.concept.engine.EngineTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ErrorPagesTest.kt$mozilla.components.browser.errorpages.ErrorPagesTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExceptionHandlerTest.kt$mozilla.components.lib.crash.handler.ExceptionHandlerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExperimentEvaluatorTest.kt$mozilla.components.service.fretboard.ExperimentEvaluatorTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExperimentPayloadTest.kt$mozilla.components.service.experiments.ExperimentPayloadTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExperimentPayloadTest.kt$mozilla.components.service.fretboard.ExperimentPayloadTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExperimentTest.kt$mozilla.components.service.fretboard.ExperimentTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExperimentsSerializerTest.kt$mozilla.components.service.experiments.ExperimentsSerializerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ExperimentsSerializerTest.kt$mozilla.components.service.fretboard.storage.flatfile.ExperimentsSerializerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FactProcessorTest.kt$mozilla.components.support.base.facts.FactProcessorTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FactsTest.kt$mozilla.components.support.base.facts.FactsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FileKtTest.kt$mozilla.components.support.ktx.java.io.FileKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FindInPagePresenterTest.kt$mozilla.components.feature.findinpage.internal.FindInPagePresenterTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FirefoxAccountsAuthFeatureTest.kt$mozilla.components.feature.accounts.FirefoxAccountsAuthFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FlatFileExperimentStorageTest.kt$mozilla.components.service.experiments.FlatFileExperimentStorageTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FlatFileExperimentStorageTest.kt$mozilla.components.service.fretboard.storage.flatfile.FlatFileExperimentStorageTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FretboardTest.kt$mozilla.components.service.fretboard.FretboardTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FxaAccountManagerTest.kt$mozilla.components.service.fxa.FxaAccountManagerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:FxaDeviceConstellationTest.kt$mozilla.components.service.fxa.FxaDeviceConstellationTest.kt</ID>
+    <ID>NewLineAtEndOfFile:GeckoEngineTest.kt$mozilla.components.browser.engine.gecko.GeckoEngineTest.kt</ID>
+    <ID>NewLineAtEndOfFile:GeckoPromptDelegateTest.kt$mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegateTest.kt</ID>
+    <ID>NewLineAtEndOfFile:GeckoWebExtensionTest.kt$mozilla.components.browser.engine.gecko.webextension.GeckoWebExtensionTest.kt</ID>
+    <ID>NewLineAtEndOfFile:GeckoWindowRequestTest.kt$mozilla.components.browser.engine.gecko.window.GeckoWindowRequestTest.kt</ID>
+    <ID>NewLineAtEndOfFile:HitResultTest.kt$mozilla.components.concept.engine.HitResultTest.kt</ID>
+    <ID>NewLineAtEndOfFile:JexlExtensionsTest.kt$mozilla.components.lib.jexl.ext.JexlExtensionsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:JexlValueTest.kt$mozilla.components.lib.jexl.value.JexlValueTest.kt</ID>
+    <ID>NewLineAtEndOfFile:KintoClientTest.kt$mozilla.components.service.experiments.KintoClientTest.kt</ID>
+    <ID>NewLineAtEndOfFile:KintoClientTest.kt$mozilla.components.service.fretboard.source.kinto.KintoClientTest.kt</ID>
+    <ID>NewLineAtEndOfFile:KintoExperimentSourceTest.kt$mozilla.components.service.experiments.KintoExperimentSourceTest.kt</ID>
+    <ID>NewLineAtEndOfFile:KintoExperimentSourceTest.kt$mozilla.components.service.fretboard.source.kinto.KintoExperimentSourceTest.kt</ID>
+    <ID>NewLineAtEndOfFile:LexerTest.kt$mozilla.components.lib.jexl.lexer.LexerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:LifecycleTest.kt$mozilla.components.support.ktx.android.arch.lifecycle.LifecycleTest.kt</ID>
+    <ID>NewLineAtEndOfFile:LintLogChecksTest.kt$mozilla.components.tooling.lint.LintLogChecksTest.kt</ID>
+    <ID>NewLineAtEndOfFile:LocaleManagerTest.kt$mozilla.components.support.locale.LocaleManagerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:MainActivityTest.kt$org.mozilla.samples.glean.MainActivityTest.kt</ID>
+    <ID>NewLineAtEndOfFile:MediaNotificationTest.kt$mozilla.components.feature.media.notification.MediaNotificationTest.kt</ID>
+    <ID>NewLineAtEndOfFile:MemoryIconLoaderTest.kt$mozilla.components.browser.icons.loader.MemoryIconLoaderTest.kt</ID>
+    <ID>NewLineAtEndOfFile:MessageBusTest.kt$mozilla.components.feature.push.MessageBusTest.kt</ID>
+    <ID>NewLineAtEndOfFile:Mock.kt$mozilla.components.support.test.Mock.kt</ID>
+    <ID>NewLineAtEndOfFile:MockMedia.kt$mozilla.components.feature.media.MockMedia.kt</ID>
+    <ID>NewLineAtEndOfFile:MonthAndYearPickerTest.kt$mozilla.components.feature.prompts.widget.MonthAndYearPickerTest.kt</ID>
+    <ID>NewLineAtEndOfFile:NestedGeckoViewTest.kt$mozilla.components.browser.engine.gecko.NestedGeckoViewTest.kt</ID>
+    <ID>NewLineAtEndOfFile:NestedWebViewTest.kt$mozilla.components.browser.engine.system.NestedWebViewTest.kt</ID>
+    <ID>NewLineAtEndOfFile:PaddingTest.kt$mozilla.components.support.base.android.PaddingTest.kt</ID>
+    <ID>NewLineAtEndOfFile:PermissionRequestTest.kt$mozilla.components.concept.engine.permission.PermissionRequestTest.kt</ID>
+    <ID>NewLineAtEndOfFile:Permissions.kt$mozilla.components.support.test.robolectric.Permissions.kt</ID>
+    <ID>NewLineAtEndOfFile:PlacesBookmarksStorageTest.kt$mozilla.components.browser.storage.sync.PlacesBookmarksStorageTest.kt</ID>
+    <ID>NewLineAtEndOfFile:PushErrorTest.kt$mozilla.components.concept.push.PushErrorTest.kt</ID>
+    <ID>NewLineAtEndOfFile:PushObserverTest.kt$mozilla.components.feature.sendtab.PushObserverTest.kt</ID>
+    <ID>NewLineAtEndOfFile:PushProcessorTest.kt$mozilla.components.concept.push.PushProcessorTest.kt</ID>
+    <ID>NewLineAtEndOfFile:PushTypeTest.kt$mozilla.components.feature.push.PushTypeTest.kt</ID>
+    <ID>NewLineAtEndOfFile:QrFragmentTest.kt$mozilla.components.feature.qr.QrFragmentTest.kt</ID>
+    <ID>NewLineAtEndOfFile:RequestInterceptorTest.kt$mozilla.components.concept.engine.request.RequestInterceptorTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ReversibleStringTest.kt$mozilla.components.browser.engine.system.matcher.ReversibleStringTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SendTabFeatureKtTest.kt$mozilla.components.feature.sendtab.SendTabFeatureKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SendTabUseCasesTest.kt$mozilla.components.feature.sendtab.SendTabUseCasesTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SessionExtensionsTest.kt$mozilla.components.browser.session.ext.SessionExtensionsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SessionFeatureTest.kt$mozilla.components.feature.session.SessionFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SessionStorageTest.kt$mozilla.components.browser.session.storage.SessionStorageTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SettingsTest.kt$mozilla.components.concept.engine.SettingsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SimpleBrowserMenuItemTest.kt$mozilla.components.browser.menu.item.SimpleBrowserMenuItemTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SimpleDownloadDialogFragmentTest.kt$mozilla.components.feature.downloads.SimpleDownloadDialogFragmentTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SitePermissionEntityTest.kt$mozilla.components.feature.sitepermissions.db.SitePermissionEntityTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SitePermissionsStorageTest.kt$mozilla.components.feature.sitepermissions.SitePermissionsStorageTest.kt</ID>
+    <ID>NewLineAtEndOfFile:StatusConverterTest.kt$mozilla.components.feature.sitepermissions.db.StatusConverterTest.kt</ID>
+    <ID>NewLineAtEndOfFile:StorageUtilsTest.kt$mozilla.components.support.utils.StorageUtilsTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SyncAuthInfoCacheTest.kt$mozilla.components.service.fxa.SyncAuthInfoCacheTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SystemEngineSessionTest.kt$mozilla.components.browser.engine.system.SystemEngineSessionTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SystemEngineTest.kt$mozilla.components.browser.engine.system.SystemEngineTest.kt</ID>
+    <ID>NewLineAtEndOfFile:SystemWindowRequestTest.kt$mozilla.components.browser.engine.system.window.SystemWindowRequestTest.kt</ID>
+    <ID>NewLineAtEndOfFile:TabThumbnailViewTest.kt$mozilla.components.browser.tabstray.thumbnail.TabThumbnailViewTest.kt</ID>
+    <ID>NewLineAtEndOfFile:TabsFeatureTest.kt$mozilla.components.feature.tabs.tabstray.TabsFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:TestUtil.kt$mozilla.components.service.experiments.TestUtil.kt</ID>
+    <ID>NewLineAtEndOfFile:TextViewTest.kt$mozilla.components.support.ktx.android.widget.TextViewTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ToolbarFeatureTest.kt$mozilla.components.feature.toolbar.ToolbarFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:TrieTest.kt$mozilla.components.browser.engine.system.matcher.TrieTest.kt</ID>
+    <ID>NewLineAtEndOfFile:UtilsKtTest.kt$mozilla.components.service.fxa.UtilsKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:VersionStringTest.kt$mozilla.components.service.experiments.util.VersionStringTest.kt</ID>
+    <ID>NewLineAtEndOfFile:ViewKtTest.kt$mozilla.components.lib.state.ext.ViewKtTest.kt</ID>
+    <ID>NewLineAtEndOfFile:WebExtensionTest.kt$mozilla.components.concept.engine.webextension.WebExtensionTest.kt</ID>
+    <ID>NewLineAtEndOfFile:WhiteListTest.kt$mozilla.components.browser.engine.system.matcher.WhiteListTest.kt</ID>
+    <ID>NewLineAtEndOfFile:WindowFeatureTest.kt$mozilla.components.feature.session.WindowFeatureTest.kt</ID>
+    <ID>NewLineAtEndOfFile:context.kt$mozilla.ext.context.kt</ID>
+    <ID>NewLineAtEndOfFile:coroutines.kt$mozilla.utils.coroutines.kt</ID>
+    <ID>SpacingBetweenPackageAndImports:GeckoEngineSessionTest.kt$ </ID>
+    <ID>SpacingBetweenPackageAndImports:GeckoPromptDelegateTest.kt$ </ID>
+    <ID>ThrowsCount:UtilsKtTest.kt$UtilsKtTest$@Test fun `handleFxaExceptions form 1 does not swallow non-panics`()</ID>
+    <ID>ThrowsCount:UtilsKtTest.kt$UtilsKtTest$@Test fun `handleFxaExceptions form 2 works`()</ID>
+    <ID>ThrowsCount:UtilsKtTest.kt$UtilsKtTest$@Test fun `handleFxaExceptions form 3 works`()</ID>
+    <ID>TooGenericExceptionCaught:BrowserStoreExceptionTest.kt$BrowserStoreExceptionTest$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:EventMetricTypeTest.kt$EventMetricTypeTest$e: NullPointerException</ID>
+    <ID>TooGenericExceptionCaught:Expect.kt$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FetchTestCases.kt$FetchTestCases$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GeckoEngineSessionTest.kt$GeckoEngineSessionTest.&lt;no name provided&gt;$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:GleanCrashReporterServiceTest.kt$GleanCrashReporterServiceTest$e: NullPointerException</ID>
+    <ID>TooGenericExceptionCaught:JexlValueTest.kt$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:LanguageTest.kt$LanguageTest$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:MotionEventKtTest.kt$MotionEventKtTest$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:StrictModeTest.kt$StrictModeTest$e: RuntimeException</ID>
+    <ID>TooGenericExceptionThrown:StrictModeTest.kt$StrictModeTest$throw RuntimeException("Boing!")</ID>
+    <ID>TooManyFunctions:ActionToggleButtonTest.kt$ActionToggleButtonTest</ID>
+    <ID>TooManyFunctions:AndroidLogSinkTest.kt$AndroidLogSinkTest</ID>
+    <ID>TooManyFunctions:AppLinksFeatureTest.kt$AppLinksFeatureTest</ID>
+    <ID>TooManyFunctions:AssetsSearchEngineProviderTest.kt$AssetsSearchEngineProviderTest</ID>
+    <ID>TooManyFunctions:AutoPushFeatureTest.kt$AutoPushFeatureTest</ID>
+    <ID>TooManyFunctions:BookmarksStorageSuggestionProviderTest.kt$BookmarksStorageSuggestionProviderTest$testableBookmarksStorage : BookmarksStorage</ID>
+    <ID>TooManyFunctions:BrowserAwesomeBarTest.kt$BrowserAwesomeBarTest</ID>
+    <ID>TooManyFunctions:BrowserMenuItemToolbarTest.kt$BrowserMenuItemToolbarTest</ID>
+    <ID>TooManyFunctions:BrowserMenuTest.kt$BrowserMenuTest</ID>
+    <ID>TooManyFunctions:BrowserToolbarTest.kt$BrowserToolbarTest</ID>
+    <ID>TooManyFunctions:BrowsersTest.kt$BrowsersTest</ID>
+    <ID>TooManyFunctions:ChoiceDialogFragmentTest.kt$ChoiceDialogFragmentTest</ID>
+    <ID>TooManyFunctions:ClipboardSuggestionProviderTest.kt$ClipboardSuggestionProviderTest</ID>
+    <ID>TooManyFunctions:ConceptFetchHttpUploaderTest.kt$ConceptFetchHttpUploaderTest</ID>
+    <ID>TooManyFunctions:ConsumableTest.kt$ConsumableTest</ID>
+    <ID>TooManyFunctions:ContentActionTest.kt$ContentActionTest</ID>
+    <ID>TooManyFunctions:ContextMenuCandidateTest.kt$ContextMenuCandidateTest</ID>
+    <ID>TooManyFunctions:ContextMenuFeatureTest.kt$ContextMenuFeatureTest</ID>
+    <ID>TooManyFunctions:ContextMenuFragmentTest.kt$ContextMenuFragmentTest</ID>
+    <ID>TooManyFunctions:CrashReporterTest.kt$CrashReporterTest</ID>
+    <ID>TooManyFunctions:CustomDistributionsStorageEngineTest.kt$CustomDistributionsStorageEngineTest</ID>
+    <ID>TooManyFunctions:CustomTabConfigHelperTest.kt$CustomTabConfigHelperTest</ID>
+    <ID>TooManyFunctions:CustomTabsToolbarFeatureTest.kt$CustomTabsToolbarFeatureTest</ID>
+    <ID>TooManyFunctions:DisplayToolbarTest.kt$DisplayToolbarTest</ID>
+    <ID>TooManyFunctions:DownloadsFeatureTest.kt$DownloadsFeatureTest</ID>
+    <ID>TooManyFunctions:EditToolbarTest.kt$EditToolbarTest</ID>
+    <ID>TooManyFunctions:EngineObserverTest.kt$EngineObserverTest</ID>
+    <ID>TooManyFunctions:EngineSessionTest.kt$DummyEngineSession : EngineSession</ID>
+    <ID>TooManyFunctions:EngineSessionTest.kt$EngineSessionTest</ID>
+    <ID>TooManyFunctions:EvaluatorTest.kt$EvaluatorTest</ID>
+    <ID>TooManyFunctions:EventsStorageEngineTest.kt$EventsStorageEngineTest</ID>
+    <ID>TooManyFunctions:ExperimentEvaluatorTest.kt$ExperimentEvaluatorTest</ID>
+    <ID>TooManyFunctions:ExperimentPayloadTest.kt$ExperimentPayloadTest</ID>
+    <ID>TooManyFunctions:ExperimentsTest.kt$ExperimentsTest</ID>
+    <ID>TooManyFunctions:FetchTestCases.kt$FetchTestCases</ID>
+    <ID>TooManyFunctions:FilePickerTest.kt$FilePickerTest</ID>
+    <ID>TooManyFunctions:FindInPageInteractorTest.kt$FindInPageInteractorTest</ID>
+    <ID>TooManyFunctions:FretboardTest.kt$FretboardTest</ID>
+    <ID>TooManyFunctions:FxaAccountManagerTest.kt$FxaAccountManagerTest</ID>
+    <ID>TooManyFunctions:FxaAccountManagerTest.kt$FxaAccountManagerTest$StatePersistenceTestableAccount : OAuthAccount</ID>
+    <ID>TooManyFunctions:FxaDeviceConstellationTest.kt$FxaDeviceConstellationTest</ID>
+    <ID>TooManyFunctions:FxaWebChannelFeatureTest.kt$FxaWebChannelFeatureTest</ID>
+    <ID>TooManyFunctions:GeckoEngineSessionTest.kt$GeckoEngineSessionTest</ID>
+    <ID>TooManyFunctions:GeckoEngineTest.kt$GeckoEngineTest</ID>
+    <ID>TooManyFunctions:GeckoPromptDelegateTest.kt$GeckoPromptDelegateTest</ID>
+    <ID>TooManyFunctions:GeckoViewFetchUnitTestCases.kt$GeckoViewFetchUnitTestCases : FetchTestCases</ID>
+    <ID>TooManyFunctions:GleanTest.kt$GleanTest</ID>
+    <ID>TooManyFunctions:HeadersTest.kt$HeadersTest</ID>
+    <ID>TooManyFunctions:InMemoryHistoryStorageTest.kt$InMemoryHistoryStorageTest</ID>
+    <ID>TooManyFunctions:InlineAutocompleteEditTextTest.kt$InlineAutocompleteEditTextTest</ID>
+    <ID>TooManyFunctions:JSONArrayTest.kt$JSONArrayTest</ID>
+    <ID>TooManyFunctions:JSONObjectTest.kt$JSONObjectTest</ID>
+    <ID>TooManyFunctions:LabeledMetricTypeTest.kt$LabeledMetricTypeTest</ID>
+    <ID>TooManyFunctions:LexerTest.kt$LexerTest</ID>
+    <ID>TooManyFunctions:MetricsPingSchedulerTest.kt$MetricsPingSchedulerTest</ID>
+    <ID>TooManyFunctions:MimeTypeTest.kt$MimeTypeTest</ID>
+    <ID>TooManyFunctions:MozillaLocationServiceTest.kt$MozillaLocationServiceTest</ID>
+    <ID>TooManyFunctions:ObserverRegistryTest.kt$ObserverRegistryTest</ID>
+    <ID>TooManyFunctions:ParserTest.kt$ParserTest</ID>
+    <ID>TooManyFunctions:PictureInPictureFeatureTest.kt$PictureInPictureFeatureTest</ID>
+    <ID>TooManyFunctions:PlacesBookmarksStorageTest.kt$PlacesBookmarksStorageTest</ID>
+    <ID>TooManyFunctions:PlacesHistoryStorageTest.kt$PlacesHistoryStorageTest</ID>
+    <ID>TooManyFunctions:PocketEndpointRawTest.kt$PocketEndpointRawTest</ID>
+    <ID>TooManyFunctions:PocketListenEndpointRawTest.kt$PocketListenEndpointRawTest</ID>
+    <ID>TooManyFunctions:PromptFeatureTest.kt$PromptFeatureTest</ID>
+    <ID>TooManyFunctions:QrFragmentTest.kt$QrFragmentTest</ID>
+    <ID>TooManyFunctions:ReaderViewFeatureTest.kt$ReaderViewFeatureTest</ID>
+    <ID>TooManyFunctions:RequestTest.kt$RequestTest</ID>
+    <ID>TooManyFunctions:ResponseTest.kt$ResponseTest</ID>
+    <ID>TooManyFunctions:RustPushConnectionTest.kt$RustPushConnectionTest</ID>
+    <ID>TooManyFunctions:SafeIntentTest.kt$SafeIntentTest</ID>
+    <ID>TooManyFunctions:SearchEngineManagerTest.kt$SearchEngineManagerTest</ID>
+    <ID>TooManyFunctions:SearchSuggestionProviderTest.kt$SearchSuggestionProviderTest</ID>
+    <ID>TooManyFunctions:SendTabUseCasesTest.kt$SendTabUseCasesTest</ID>
+    <ID>TooManyFunctions:SessionManagerMigrationTest.kt$SessionManagerMigrationTest</ID>
+    <ID>TooManyFunctions:SessionManagerTest.kt$SessionManagerTest</ID>
+    <ID>TooManyFunctions:SessionStorageTest.kt$SessionStorageTest</ID>
+    <ID>TooManyFunctions:SessionTest.kt$SessionTest</ID>
+    <ID>TooManyFunctions:SessionUseCasesTest.kt$SessionUseCasesTest</ID>
+    <ID>TooManyFunctions:SharedPreferencesTest.kt$SharedPreferencesTest</ID>
+    <ID>TooManyFunctions:SitePermissionsDialogFragmentTest.kt$SitePermissionsDialogFragmentTest</ID>
+    <ID>TooManyFunctions:SitePermissionsFeatureTest.kt$SitePermissionsFeatureTest</ID>
+    <ID>TooManyFunctions:SitePermissionsStorageTest.kt$SitePermissionsStorageTest</ID>
+    <ID>TooManyFunctions:StoreExtensionsKtTest.kt$StoreExtensionsKtTest</ID>
+    <ID>TooManyFunctions:SuggestionsAdapterTest.kt$SuggestionsAdapterTest</ID>
+    <ID>TooManyFunctions:SystemEngineSessionTest.kt$SystemEngineSessionTest</ID>
+    <ID>TooManyFunctions:SystemEngineViewTest.kt$SystemEngineViewTest</ID>
+    <ID>TooManyFunctions:TabCollectionStorageTest.kt$TabCollectionStorageTest</ID>
+    <ID>TooManyFunctions:TabListActionTest.kt$TabListActionTest</ID>
+    <ID>TooManyFunctions:TabsTrayPresenterTest.kt$MockedTabsTray : TabsTray</ID>
+    <ID>TooManyFunctions:TimespanMetricTypeTest.kt$TimespanMetricTypeTest</ID>
+    <ID>TooManyFunctions:ToolbarAutocompleteFeatureTest.kt$ToolbarAutocompleteFeatureTest$TestToolbar : Toolbar</ID>
+    <ID>TooManyFunctions:ToolbarInteractorTest.kt$ToolbarInteractorTest$TestToolbar : Toolbar</ID>
+    <ID>TooManyFunctions:ToolbarPresenterTest.kt$ToolbarPresenterTest</ID>
+    <ID>TooManyFunctions:UtilsKtTest.kt$UtilsKtTest</ID>
+    <ID>TooManyFunctions:ViewBoundFeatureWrapperTest.kt$ViewBoundFeatureWrapperTest</ID>
+    <ID>TooManyFunctions:WebAppManifestParserTest.kt$WebAppManifestParserTest</ID>
+    <ID>TooManyFunctions:WebAppShortcutManagerTest.kt$WebAppShortcutManagerTest</ID>
+    <ID>TopLevelPropertyNaming:ExperimentsSerializerTest.kt$const val experimentsJson = """ { "experiments": [ { "buckets":{ "min":0, "max":100 }, "name":"first", "match":{ "regions": [ "esp" ], "appId":"^org.mozilla.firefox_beta${'$'}", "lang":"eng|es|deu|fra" }, "description":"Description", "id":"experiment-id", "last_modified":1523549895713 }, { "buckets":{ "min":5, "max":10 }, "name":"second", "match":{ "regions": [ "deu" ], "appId":"^org.mozilla.firefox${'$'}", "lang":"es|deu" }, "description":"SecondDescription", "id":"experiment-2-id", "last_modified":1523549895749 } ], "last_modified": 1523549895749 } """</ID>
+    <ID>TopLevelPropertyNaming:KeystoreTest.kt$private val DEFAULTPASS = "testit!".toCharArray()</ID>
+    <ID>TopLevelPropertyNaming:PocketEndpointRawTest.kt$private val TEST_URL = "https://mozilla.org".toUri()</ID>
+    <ID>TopLevelPropertyNaming:PocketJSONParserTest.kt$private val TEST_AUTHOR = PocketGlobalVideoRecommendation.Author( id = "101", name = "The New York Times", url = "https://www.nytimes.com/" )</ID>
+    <ID>TopLevelPropertyNaming:PocketListenEndpointRawTest.kt$private val TEST_URL = "https://mozilla.org".toUri()</ID>
+    <ID>TopLevelPropertyNaming:ViewMatchersKtTest.kt$private val BOOLEAN_VIEW_MATCHER_TO_UNDERLYING_MATCHER: List&lt;Pair&lt;(Boolean) -&gt; Matcher&lt;View&gt;, Matcher&lt;View&gt;&gt;&gt; = listOf( ::hasFocus to ViewMatchers.hasFocus(), ::isChecked to ViewMatchers.isChecked(), ::isDisplayed to ViewMatchers.isDisplayed(), ::isEnabled to ViewMatchers.isEnabled(), ::isSelected to ViewMatchers.isSelected() )</ID>
+    <ID>VariableNaming:DisplayToolbarTest.kt$DisplayToolbarTest$val LEFT_WITHOUT_TP_VIEWS = navigationActionsWidth</ID>
+    <ID>VariableNaming:DisplayToolbarTest.kt$DisplayToolbarTest$val LEFT_WITH_TP_VIEWS = navigationActionsWidth + separatorWidth + trackingProtectionWidth</ID>
+    <ID>VariableNaming:DisplayToolbarTest.kt$DisplayToolbarTest$val RIGHT_WITHOUT_TP_VIEWS = navigationActionsWidth + securityIconWidth</ID>
+    <ID>VariableNaming:DisplayToolbarTest.kt$DisplayToolbarTest$val RIGHT_WITH_TP_VIEWS = navigationActionsWidth + separatorWidth + securityIconWidth + trackingProtectionWidth</ID>
+    <ID>VariableNaming:ExperimentsTest.kt$ExperimentsTest$private val EXAMPLE_CLIENT_ID = "c641eacf-c30c-4171-b403-f077724e848a"</ID>
+    <ID>VariableNaming:SystemEngineViewTest.kt$SystemEngineViewTest$val BLOCK_LIST = """{ "license": "test-license", "categories": { "Advertising": [ { "AdTest1": { "http://www.adtest1.com/": [ "adtest1.com" ] } } ], "Analytics": [ { "AnalyticsTest": { "http://analyticsTest1.com/": [ "analyticsTest1.com" ] } } ], "Content": [ { "ContentTest1": { "http://contenttest1.com/": [ "contenttest1.com" ] } } ], "Social": [ { "SocialTest1": { "http://www.socialtest1.com/": [ "socialtest1.com" ] } } ] } } """</ID>
+    <ID>VariableNaming:UrlMatcherTest.kt$UrlMatcherTest$val BLOCK_LIST = """{ "license": "test-license", "categories": { "Disconnect": [ { "Facebook": { "http://www.facebook.com/": [ "facebook.com" ] } }, { "Disconnect1": { "http://www.disconnect1.com/": [ "disconnect1.com" ] } } ], "Advertising": [ { "AdTest1": { "http://www.adtest1.com/": [ "adtest1.com", "adtest1.de" ] } }, { "AdTest2": { "http://www.adtest2.com/": [ "adtest2.com" ] } } ], "Analytics": [ { "AnalyticsTest": { "http://analyticsTest1.com/": [ "analyticsTest1.com", "analyticsTest1.de" ] } } ], "Content": [ { "ContentTest1": { "http://contenttest1.com/": [ "contenttest1.com" ] } } ], "Social": [ { "SocialTest1": { "http://www.socialtest1.com/": [ "socialtest1.com", "socialtest1.de" ] } } ], "Legacy Disconnect": [ { "Ignored1": { "http://www.ignored1.com/": [ "ignored.de" ] } } ], "Legacy Content": [ { "Ignored2": { "http://www.ignored2.com/": [ "ignored.de" ] } } ] } } """</ID>
+    <ID>VariableNaming:UrlMatcherTest.kt$UrlMatcherTest$val OVERRIDES = """{ "categories": { "Advertising": [ { "AdTest2": { "http://www.adtest2.com/": [ "adtest2.de", "adtest2.at" ] } } ] } } """</ID>
+    <ID>VariableNaming:UrlMatcherTest.kt$UrlMatcherTest$val WHITE_LIST = """{ "SocialTest1": { "properties": [ "www.socialtest1.com" ], "resources": [ "socialtest1.de" ] } }"""</ID>
+    <ID>VariableNaming:WhiteListTest.kt$WhiteListTest$val WHITE_LIST_JSON = """{ "Host1": { "properties": [ "host1.com", "host1.de" ], "resources": [ "host1ads.com", "host1ads.de" ] }, "Host2": { "properties": [ "host2.com", "host2.de" ], "resources": [ "host2ads.com", "host2ads.de" ] } }"""</ID>
   </Whitelist>
 </SmellBaseline>

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -380,3 +380,7 @@ style:
   WildcardImport:
     active: true
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+
+mozilla-rules:
+  AbsentOrWrongFileLicense:
+    active: true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,9 @@ permalink: /changelog/
 * **lib-push-amazon**
   * Fixed usage of cache version of registration ID in situations when app data is deleted.
 
+* **tools-detekt**
+  * New (internal-only) component with custom detekt rules.
+
 # 13.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v12.0.0...v13.0.0)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

  - Created new component for custom detekt plugins (rules, reporters etc).
  - Created custom `AbsentOrWrongFileLicense` rule. Parsing file header because detekt don't recognize `\* ... *\` atop as a comment.
  - Created custom `mozilla-rules` ruleset for detekt.
  - Activated the rule.
  - Generated new baseline file (btw, there are some false-positives because we are checking exact license string and in few files leading spaces are missed). Follow-up issue: #4460.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
