### PR TITLE
1581556: Enforce that Glean.initialize is only called on the MainThread

### DIFF
--- a/components/service/glean/build.gradle
+++ b/components/service/glean/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation project(':support-base')
     implementation project(':concept-fetch')
     implementation project(':lib-fetch-httpurlconnection')
+    implementation project(':support-utils')
 
     // We need a compileOnly dependency on the following block of testing
     // libraries in order to expose the GleanTestRule to applications/libraries

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -8,6 +8,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.Job
@@ -92,6 +93,7 @@ open class GleanInternalAPI internal constructor () {
      * @param configuration A Glean [Configuration] object with global settings.
      */
     @JvmOverloads
+    @MainThread
     fun initialize(
         applicationContext: Context,
         configuration: Configuration = Configuration()
@@ -146,6 +148,9 @@ open class GleanInternalAPI internal constructor () {
         Dispatchers.API.flushQueuedInitialTasks()
 
         // At this point, all metrics and events can be recorded.
+        // This should only be called from the main thread. This is enforced by
+        // the @MainThread decorator on this method.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1581556
         ProcessLifecycleOwner.get().lifecycle.addObserver(gleanLifecycleObserver)
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -39,6 +39,7 @@ import mozilla.components.service.glean.utils.getLocaleTag
 import mozilla.components.service.glean.utils.parseISOTimeString
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.isMainProcess
+import mozilla.components.support.utils.ThreadUtils
 
 @Suppress("TooManyFunctions", "LargeClass")
 open class GleanInternalAPI internal constructor () {
@@ -100,6 +101,12 @@ open class GleanInternalAPI internal constructor () {
         applicationContext: Context,
         configuration: Configuration = Configuration()
     ) {
+        // Glean initialization must be called on the main thread, or lifecycle
+        // registration may fail. This is also enforced at build time by the
+        // @MainThread decorator, but this run time check is also performed to
+        // be extra certain.
+        ThreadUtils.assertOnUiThread()
+
         // In certain situations Glean.initialize may be called from a process other than the main
         // process.  In this case we want initialize to be a no-op and just return.
         if (!applicationContext.isMainProcess()) {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -88,6 +88,8 @@ open class GleanInternalAPI internal constructor () {
      * A LifecycleObserver will be added to send pings when the application goes
      * into the background.
      *
+     * This method must be called from the main thread.
+     *
      * @param applicationContext [Context] to access application features, such
      * as shared preferences
      * @param configuration A Glean [Configuration] object with global settings.

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
@@ -24,6 +24,7 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.service.glean.utils.getISOTimeString
 import mozilla.components.service.glean.utils.parseISOTimeString
 import mozilla.components.service.glean.private.TimeUnit
+import mozilla.components.support.utils.ThreadUtils
 import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.TimeUnit as AndroidTimeUnit
@@ -61,10 +62,14 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
     }
 
     init {
-        // This should only be called from the main thread. This is enforced by
-        // the @MainThread decorator on Glean.initialize. That decorator can not
-        // be applied to a constructor, so it is not applied here.
+        // This should only be called from the main thread.
+        // We can't enforce this at build time here, since the @MainThread
+        // decorator can not be applied to a contructor.  However, in practice
+        // this is only called from Glean.initialize which does have that
+        // decorator.  For good measure, we also perform this run time check
+        // here.
         // See https://bugzilla.mozilla.org/show_bug.cgi?id=1581556
+        ThreadUtils.assertOnUiThread()
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
@@ -61,6 +61,10 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
     }
 
     init {
+        // This should only be called from the main thread. This is enforced by
+        // the @MainThread decorator on Glean.initialize. That decorator can not
+        // be applied to a constructor, so it is not applied here.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1581556
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers as KotlinDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -679,5 +680,14 @@ class GleanTest {
 
         `when`(gleanMock.onChangeUploadEnabled(anyBoolean())).thenThrow(AssertionError::class.java)
         gleanMock.setUploadEnabled(true)
+    }
+
+    @Test(expected = IllegalThreadStateException::class)
+    fun `Glean initialize must be called on the main thread`() {
+        runBlocking(KotlinDispatchers.IO) {
+            val context: Context = ApplicationProvider.getApplicationContext()
+
+            Glean.initialize(context)
+        }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,7 +44,7 @@ permalink: /changelog/
   * New (internal-only) component with custom detekt rules.
   
 * **service-glean**
-  * ⚠️ **This is a breaking change**: Glean.initialize() must be called on the main thread.
+  * ⚠ **This is a breaking change**: Glean.initialize() must be called on the main thread.
 
 # 13.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ permalink: /changelog/
 
 * **tools-detekt**
   * New (internal-only) component with custom detekt rules.
+  
+* **service-glean**
+  * ⚠️ **This is a breaking change**: Glean.initialize() must be called on the main thread.
 
 # 13.0.0
 


### PR DESCRIPTION
Android `LifecycleObserver` s must be registered on the main thread [otherwise there is a race condition that may cause them to not be registered and/or unregister other observers](https://issuetracker.google.com/issues/138953075#comment2).  Also see [the implementation](https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/lifecycle/lifecycle-runtime/src/main/java/androidx/lifecycle/LifecycleRegistry.java#187) that has a non-atomic push/operate/pop sequence of events.

This bug is the source of all of the significant Fenix Sentry issues involving Glean:

- https://sentry.prod.mozaws.net/operations/fenix/issues/5856320/?query=is:unresolved%20glean
- https://sentry.prod.mozaws.net/operations/fenix/issues/5863576/?query=is:unresolved%20glean
- https://sentry.prod.mozaws.net/operations/fenix/issues/5837548/?query=is:unresolved%20glean
- https://sentry.prod.mozaws.net/operations/fenix/issues/5831193/?query=is:unresolved%20glean

Beyond theoretical, this is quite likely the source of [Fenix reporting 50% more clients on metrics ping than baseline ping](https://bugzilla.mozilla.org/show_bug.cgi?id=1581556).  Glean has two lifecycle observers.  Failing to register one of them would disable the baseline ping.  Failing to register the other would send metrics pings more than once between runs of the application.  The combination of these two is *probably* enough to explain the problem, though it's hard to compare the scale of Sentry events to the scale of the problems in the data.

@pocmo: Can you please confirm this is the appropriate way to dispatch something **back** to the main thread from a coroutine thread?  Also, there are other instances of `addObserver` that may also need this treatment, but that largely depends on how that code is being used from the application, I suppose.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
