### PR TITLE
Closes #4486: startup crash after closing all tabs

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -101,8 +101,10 @@ class ReaderViewFeature(
         registerReaderViewContentMessageHandler()
 
         extensionController.install(engine)
-        if (extensionController.portConnected(sessionManager.getOrCreateEngineSession())) {
-            updateReaderViewState()
+        activeSession?.let {
+            if (extensionController.portConnected(sessionManager.getEngineSession(it))) {
+                updateReaderViewState(it)
+            }
         }
 
         controlsInteractor.start()

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -192,13 +192,20 @@ class ReaderViewFeatureTest {
         val sessionManager = mock<SessionManager>()
         val view = mock<ReaderViewControlsView>()
         val controller = mock<WebExtensionController>()
-        whenever(controller.portConnected(any(), any())).thenReturn(true)
+        val selectedSession = mock<Session>()
 
         val readerViewFeature = spy(ReaderViewFeature(testContext, engine, sessionManager, view))
         readerViewFeature.extensionController = controller
         readerViewFeature.start()
+        verify(readerViewFeature, never()).updateReaderViewState(any())
 
-        verify(readerViewFeature).updateReaderViewState(any())
+        whenever(controller.portConnected(any(), any())).thenReturn(true)
+        readerViewFeature.start()
+        verify(readerViewFeature, never()).updateReaderViewState(any())
+
+        readerViewFeature.onSessionSelected(selectedSession)
+        readerViewFeature.start()
+        verify(readerViewFeature).updateReaderViewState(selectedSession)
     }
 
     @Test


### PR DESCRIPTION
This was introduced with the recent refactoring. We don't need to check for a connected port or update reader mode if there's no selected session.