### PR TITLE
Add the WebCompat feature to the sample browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ _Combined components to implement feature-specific use cases._
 
 * 🔴 [**Web Notifications**](components/feature/webnotifications/README.md) - A component for displaying web notifications.
 
+* 🔵 [**WebCompat**](components/feature/webcompat/README.md) - A feature to enable website-hotfixing via the Web Compatibility System-Addon.
+
 ## UI
 
 _Generic low-level UI components for building apps._

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     implementation project(':feature-pwa')
     implementation project(':feature-findinpage')
     implementation project(':feature-sitepermissions')
+    implementation project(':feature-webcompat')
 
     implementation project(':ui-autocomplete')
 

--- a/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
@@ -7,12 +7,15 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.Engine
+import mozilla.components.feature.webcompat.WebCompatFeature
 
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings)
+        GeckoEngine(applicationContext, engineSettings).also {
+            WebCompatFeature.install(it)
+        }
     }
 }

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.Engine
+import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.support.base.log.Log
 
 /**
@@ -13,10 +14,12 @@ import mozilla.components.support.base.log.Log
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings).apply {
-            installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
+        GeckoEngine(applicationContext, engineSettings).also {
+            it.installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }
+
+            WebCompatFeature.install(it)
         }
     }
 }

--- a/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
@@ -6,12 +6,15 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.concept.engine.Engine
+import mozilla.components.feature.webcompat.WebCompatFeature
 
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings)
+        GeckoEngine(applicationContext, engineSettings).also {
+            WebCompatFeature.install(it)
+        }
     }
 }


### PR DESCRIPTION
We're shipping it in Fenix, and we need a simple way to test new interventions across products, so it makes sense to include the feature in the sample browsers.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

As suggested by @pocmo. :) Also, this PR has a sneaky second commit that adds the feature to the README, because I missed that the first time!

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
