### PR TITLE
Closes #4483: Move "ignore media with short duration" inside MediaStateMachine.

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/MediaFeature.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/MediaFeature.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.media
 
 import android.content.Context
-import mozilla.components.feature.media.ext.hasMediaWithSufficientLongDuration
 import mozilla.components.feature.media.facts.emitStatePauseFact
 import mozilla.components.feature.media.facts.emitStatePlayFact
 import mozilla.components.feature.media.facts.emitStateStopFact
@@ -48,11 +47,9 @@ class MediaFeature(
     private fun notifyService(state: MediaState) {
         when (state) {
             is MediaState.Playing -> {
-                if (state.hasMediaWithSufficientLongDuration()) {
-                    MediaService.updateState(context)
-                    serviceStarted = true
-                    emitStatePlayFact()
-                }
+                MediaService.updateState(context)
+                serviceStarted = true
+                emitStatePlayFact()
             }
 
             is MediaState.Paused -> {

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/ext/Media.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/ext/Media.kt
@@ -7,6 +7,11 @@ package mozilla.components.feature.media.ext
 import mozilla.components.concept.engine.media.Media
 
 /**
+ * The minimum duration (in seconds) for media so that we bother with showing a media notification.
+ */
+private const val MINIMUM_DURATION_SECONDS = 5
+
+/**
  * Pauses all [Media] in this list.
  */
 internal fun List<Media>.pause() {
@@ -18,4 +23,21 @@ internal fun List<Media>.pause() {
  */
 internal fun List<Media>.play() {
     forEach { it.controller.play() }
+}
+
+/**
+ * Does this list contain [Media] that is sufficient long to justify showing media controls for it?
+ */
+internal fun List<Media>.hasMediaWithSufficientLongDuration(): Boolean {
+    forEach { media ->
+        if (media.metadata.duration < 0) {
+            return true
+        }
+
+        if (media.metadata.duration > MINIMUM_DURATION_SECONDS) {
+            return true
+        }
+    }
+
+    return false
 }

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/ext/MediaState.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/ext/MediaState.kt
@@ -10,11 +10,6 @@ import mozilla.components.concept.engine.media.Media
 import mozilla.components.feature.media.state.MediaState
 
 /**
- * The minimum duration (in seconds) for media so that we bother with showing a media notification.
- */
-private const val MINIMUM_DURATION_SECONDS = 5
-
-/**
  * Gets the list of [Media] associated with this [MediaState].
  */
 internal fun MediaState.getMedia(): List<Media> {
@@ -83,18 +78,4 @@ fun MediaState.playIfPaused() {
     if (this is MediaState.Paused) {
         media.play()
     }
-}
-
-internal fun MediaState.hasMediaWithSufficientLongDuration(): Boolean {
-    getMedia().forEach { media ->
-        if (media.metadata.duration < 0) {
-            return true
-        }
-
-        if (media.metadata.duration > MINIMUM_DURATION_SECONDS) {
-            return true
-        }
-    }
-
-    return false
 }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/MockMedia.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/MockMedia.kt
@@ -6,16 +6,19 @@ package mozilla.components.feature.media
 
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.support.test.mock
+import org.mockito.Mockito.doReturn
 
 internal class MockMedia(
-    initialState: PlaybackState
+    initialState: PlaybackState,
+    duration: Double = 10.0
 ) : Media() {
-    init {
-        playbackState = initialState
-    }
-
     override val controller: Controller =
         mock()
     override val metadata: Metadata =
         mock()
+
+    init {
+        playbackState = initialState
+        doReturn(duration).`when`(metadata).duration
+    }
 }

--- a/components/feature/media/src/test/java/mozilla/components/feature/media/state/MediaStateMachineTest.kt
+++ b/components/feature/media/src/test/java/mozilla/components/feature/media/state/MediaStateMachineTest.kt
@@ -229,4 +229,34 @@ class MediaStateMachineTest {
             assertEquals(media1, it.getMedia()[0])
         }
     }
+
+    @Test
+    fun `Does not switch to playing state if media has short duration`() {
+        val media1 = MockMedia(Media.PlaybackState.PLAYING, duration = 2.0)
+        val media2 = MockMedia(Media.PlaybackState.PLAYING, duration = 4.0)
+        val media3 = MockMedia(Media.PlaybackState.PLAYING, duration = 30.0)
+
+        val sessionManager = SessionManager(mock())
+
+        val session = Session("https://www.mozilla.org").also {
+            sessionManager.add(it)
+
+            it.media = listOf(media1)
+        }
+
+        MediaStateMachine.start(sessionManager)
+
+        MediaStateMachine.waitForStateChange()
+        assertEquals(MediaState.None, MediaStateMachine.state)
+
+        session.media = listOf(media1, media2)
+
+        MediaStateMachine.waitForStateChange()
+        assertEquals(MediaState.None, MediaStateMachine.state)
+
+        session.media = listOf(media1, media2, media3)
+
+        MediaStateMachine.waitForStateChange()
+        assertTrue(MediaStateMachine.state is MediaState.Playing)
+    }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
