### PR TITLE
1580812: Add "glinter" for linting glean metrics

### DIFF
--- a/components/service/glean/metrics.yaml
+++ b/components/service/glean/metrics.yaml
@@ -221,6 +221,8 @@ glean.error:
     notification_emails:
       - telemetry-client-dev@mozilla.com
     expires: never
+    no_lint:
+      - COMMON_PREFIX
 
   invalid_label:
     type: labeled_counter
@@ -236,3 +238,5 @@ glean.error:
     notification_emails:
       - telemetry-client-dev@mozilla.com
     expires: never
+    no_lint:
+      - COMMON_PREFIX

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.ArtifactAttributes
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
-String GLEAN_PARSER_VERSION = "1.6.1"
+String GLEAN_PARSER_VERSION = "1.7.0"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.
 String MINICONDA_VERSION = "4.5.11"

--- a/samples/glean/metrics.yaml
+++ b/samples/glean/metrics.yaml
@@ -8,6 +8,9 @@
 
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
+no_lint:
+  - COMMON_PREFIX
+
 browser.engagement:
   click:
     type: event

--- a/samples/glean/metrics.yaml
+++ b/samples/glean/metrics.yaml
@@ -8,9 +8,6 @@
 
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
-no_lint:
-  - COMMON_PREFIX
-
 browser.engagement:
   click:
     type: event
@@ -55,7 +52,7 @@ basic:
     expires: 2100-01-01
 
 test:
-  test_string_list:
+  string_list:
     type: string_list
     description: >
       Testing StringList ping
@@ -70,7 +67,7 @@ test:
       - CHANGE-ME@example.com
     expires: 2100-01-01
 
-  test_counter:
+  counter:
     type: counter
     description: >
       Testing counter
@@ -85,7 +82,7 @@ test:
       - CHANGE-ME@example.com
     expires: 2100-01-01
 
-  test_timespan:
+  timespan:
     type: timespan
     description: >
       Testing a timespan

--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/MainActivityTest.kt
@@ -37,8 +37,8 @@ class MainActivityTest {
         onView(withId(R.id.buttonGenerateData)).perform(click())
 
         // Use the Glean testing API to check if the expected data was recorded.
-        assertTrue(GleanTestMetrics.testCounter.testHasValue())
-        assertEquals(1, GleanTestMetrics.testCounter.testGetValue())
+        assertTrue(GleanTestMetrics.counter.testHasValue())
+        assertEquals(1, GleanTestMetrics.counter.testGetValue())
     }
 
     @Test

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/GleanApplication.kt
@@ -33,7 +33,7 @@ class GleanApplication : Application() {
         // not be activated before this, so it's important to do this early.
         Experiments.initialize(applicationContext)
 
-        Test.testTimespan.start()
+        Test.timespan.start()
 
         Custom.counter.add()
 

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -26,12 +26,12 @@ open class MainActivity : AppCompatActivity() {
 
             // Adds the EditText's text content as a new string in the string list metric from the
             // metrics.yaml file.
-            Test.testStringList.add(etStringListInput.text.toString())
+            Test.stringList.add(etStringListInput.text.toString())
             // Clear current text to help indicate something happened
             etStringListInput.setText("")
 
             // Increments the test_counter metric from the metrics.yaml file.
-            Test.testCounter.add()
+            Test.counter.add()
 
             // This is referencing the event ping named 'click' from the metrics.yaml file. In
             // order to illustrate adding extra information to the event, it is also adding to the
@@ -45,7 +45,7 @@ open class MainActivity : AppCompatActivity() {
             )
         }
 
-        Test.testTimespan.stop()
+        Test.timespan.stop()
 
         // Update some metrics from a third-party library
         SamplesGleanLibrary.recordMetric()


### PR DESCRIPTION
This change:

1) Updates to glean_parser 1.7.0 which includes a "glinter". The linting
violations are written to the build log, but are not treated as errors (yet).

2) Adds linting overrides for the small number of linting violations that
currently exist in the android-components code base.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
