### PR TITLE
For #3707 - Add feature-private component

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -96,6 +96,10 @@ projects:
     path: components/feature/downloads
     description: 'Feature implementation for apps that want to use Android downloads manager.'
     publish: true
+  feature-privatemode:
+    path: components/feature/privatemode
+    description: 'Features used to enhance private browsing mode.'
+    publish: true
   feature-prompts:
     path: components/feature/prompts
     description: 'Feature that will subscribe to the selected session and will handle all the common prompt dialogs from web content.'

--- a/components/feature/privatemode/README.md
+++ b/components/feature/privatemode/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Feature > Private Mode
+
+Features used to enhance private browsing mode.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-privatemode:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/privatemode/build.gradle
+++ b/components/feature/privatemode/build.gradle
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':support-ktx')
+
+    implementation Dependencies.androidx_core_ktx
+    implementation Dependencies.kotlin_stdlib
+
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.testing_mockito
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/feature/privatemode/proguard-rules.pro
+++ b/components/feature/privatemode/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/privatemode/src/main/AndroidManifest.xml
+++ b/components/feature/privatemode/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.privatemode" />

--- a/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/Placeholder.kt
+++ b/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/Placeholder.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.privatemode
+
+internal class Placeholder

--- a/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/PlaceholderTest.kt
+++ b/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/PlaceholderTest.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.privatemode
+
+class PlaceholderTest

--- a/components/feature/privatemode/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/privatemode/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)


### PR DESCRIPTION
Adds new component for private mode features such as preventing screenshots and showing a notification when private tabs are open.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
