### PR TITLE
Fixes #4414 - Disable disk cache for PWA icons

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -22,18 +22,14 @@ import mozilla.components.browser.icons.decoder.ICOIconDecoder
 import mozilla.components.browser.icons.extension.toIconRequest
 import mozilla.components.browser.icons.generator.DefaultIconGenerator
 import mozilla.components.browser.icons.loader.DataUriIconLoader
-import mozilla.components.browser.icons.loader.DiskIconLoader
 import mozilla.components.browser.icons.loader.HttpIconLoader
 import mozilla.components.browser.icons.loader.MemoryIconLoader
-import mozilla.components.browser.icons.preparer.DiskIconPreparer
 import mozilla.components.browser.icons.preparer.MemoryIconPreparer
 import mozilla.components.browser.icons.preparer.TippyTopIconPreparer
 import mozilla.components.browser.icons.processor.AdaptiveIconProcessor
 import mozilla.components.browser.icons.processor.ColorProcessor
-import mozilla.components.browser.icons.processor.DiskIconProcessor
 import mozilla.components.browser.icons.processor.MemoryIconProcessor
 import mozilla.components.browser.icons.processor.ResizingProcessor
-import mozilla.components.browser.icons.utils.IconDiskCache
 import mozilla.components.browser.icons.utils.IconMemoryCache
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -42,7 +38,6 @@ import mozilla.components.feature.pwa.WebAppLauncherActivity.Companion.ACTION_PW
 import mozilla.components.feature.pwa.ext.installableManifest
 
 private val pwaIconMemoryCache = IconMemoryCache()
-private val pwaIconDiskCache = IconDiskCache()
 
 class WebAppShortcutManager(
     context: Context,
@@ -197,12 +192,10 @@ private fun webAppIcons(
     generator = DefaultIconGenerator(cornerRadiusDimen = null),
     preparers = listOf(
         TippyTopIconPreparer(context.assets),
-        MemoryIconPreparer(pwaIconMemoryCache),
-        DiskIconPreparer(pwaIconDiskCache)
+        MemoryIconPreparer(pwaIconMemoryCache)
     ),
     loaders = listOf(
         MemoryIconLoader(pwaIconMemoryCache),
-        DiskIconLoader(pwaIconDiskCache),
         HttpIconLoader(httpClient),
         DataUriIconLoader()
     ),
@@ -213,7 +206,6 @@ private fun webAppIcons(
     processors = listOf(
         MemoryIconProcessor(pwaIconMemoryCache),
         ResizingProcessor(),
-        DiskIconProcessor(pwaIconDiskCache),
         ColorProcessor(),
         AdaptiveIconProcessor()
     )


### PR DESCRIPTION
For some reason the disk cache causes problems with loading PWA icons from some sites like proxx.app and twitter.com. For now, let's remove it and we can add it back in later through #3799.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
