### PR TITLE
Issue #4282: Remove browser-session dependency from feature-downloads

### DIFF
--- a/components/feature/downloads/build.gradle
+++ b/components/feature/downloads/build.gradle
@@ -30,9 +30,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
 
-    implementation project(':browser-session')
+    implementation project(':browser-state')
     implementation project(':concept-fetch')
     implementation project(':support-ktx')
+    implementation project(':support-base')
     implementation project(':support-utils')
 
     implementation Dependencies.androidx_core_ktx

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsUseCases.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsUseCases.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.downloads
 
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.store.BrowserStore
 
@@ -20,7 +19,7 @@ class DownloadsUseCases(
         private val store: BrowserStore
     ) {
         /**
-         * Consumes the [Download] with the given [downloadId] from the [Session] with the given
+         * Consumes the download with the given [downloadId] from the session with the given
          * [tabId].
          */
         operator fun invoke(tabId: String, downloadId: String) {


### PR DESCRIPTION
Just some cleanup we missed? in #4282