### PR TITLE
Hide custom tab close button in PWAs

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
@@ -20,6 +20,7 @@ import java.util.UUID
  * @property closeButtonIcon Custom icon of the back button on the toolbar.
  * @property enableUrlbarHiding Enables the toolbar to hide as the user scrolls down on the page.
  * @property actionButtonConfig Custom action button on the toolbar.
+ * @property showCloseButton Specifies whether the close button will be shown on the toolbar.
  * @property showShareMenuItem Specifies whether a default share button will be shown in the menu.
  * @property menuItems Custom overflow menu items.
  * @property exitAnimations Bundle containing custom exit animations for the tab.
@@ -33,6 +34,7 @@ data class CustomTabConfig(
     val closeButtonIcon: Bitmap? = null,
     val enableUrlbarHiding: Boolean = false,
     val actionButtonConfig: CustomTabActionButtonConfig? = null,
+    val showCloseButton: Boolean = true,
     val showShareMenuItem: Boolean = false,
     val menuItems: List<CustomTabMenuItem> = emptyList(),
     val exitAnimations: Bundle? = null,

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -73,7 +73,9 @@ class CustomTabsToolbarFeature(
             updateToolbarColor(config.toolbarColor, config.navigationBarColor)
 
             // Add navigation close action
-            addCloseButton(session, config.closeButtonIcon)
+            if (config.showCloseButton) {
+                addCloseButton(session, config.closeButtonIcon)
+            }
 
             // Add action button
             addActionButton(session, config.actionButtonConfig)

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -181,13 +181,26 @@ class CustomTabsToolbarFeatureTest {
     fun `initialize calls addCloseButton`() {
         val session: Session = mock()
         val toolbar = BrowserToolbar(testContext)
-        `when`(session.customTabConfig).thenReturn(mock())
+        `when`(session.customTabConfig).thenReturn(CustomTabConfig())
 
         val feature = spy(CustomTabsToolbarFeature(mock(), toolbar, "") {})
 
         feature.initialize(session)
 
         verify(feature).addCloseButton(session, null)
+    }
+
+    @Test
+    fun `initialize doesn't call addCloseButton if the button should be hidden`() {
+        val session: Session = mock()
+        val toolbar = BrowserToolbar(testContext)
+        `when`(session.customTabConfig).thenReturn(CustomTabConfig(showCloseButton = false))
+
+        val feature = spy(CustomTabsToolbarFeature(mock(), toolbar, "") {})
+
+        feature.initialize(session)
+
+        verify(feature, never()).addCloseButton(session, null)
     }
 
     @Test
@@ -198,7 +211,7 @@ class CustomTabsToolbarFeatureTest {
         var closeClicked = false
         val feature = spy(CustomTabsToolbarFeature(sessionManager, toolbar, "") { closeClicked = true })
 
-        `when`(session.customTabConfig).thenReturn(mock())
+        `when`(session.customTabConfig).thenReturn(CustomTabConfig())
 
         feature.initialize(session)
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -40,6 +40,7 @@ fun WebAppManifest.toCustomTabConfig(): CustomTabConfig {
         closeButtonIcon = null,
         enableUrlbarHiding = true,
         actionButtonConfig = null,
+        showCloseButton = false,
         showShareMenuItem = true,
         menuItems = emptyList()
     )


### PR DESCRIPTION
The close button destroys the entire PWA, which isn't what we want. Let's hide the button for now.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
