### PR TITLE
Fixes #4296 - Open a new window in custom tabs

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabWindowFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabWindowFeature.kt
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+
+/**
+ * Feature implementation for handling window requests by opening custom tabs.
+ */
+class CustomTabWindowFeature(
+    private val context: Context,
+    private val sessionManager: SessionManager,
+    private val sessionId: String
+) : LifecycleAwareFeature {
+
+    @VisibleForTesting
+    internal val windowObserver = object : Session.Observer {
+        override fun onOpenWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
+            val intent = configToIntent(session.customTabConfig)
+            intent.launchUrl(context, windowRequest.url.toUri())
+            return true
+        }
+    }
+
+    /**
+     * Transform a [CustomTabConfig] into a [CustomTabsIntent] that creates a
+     * new custom tab with the same styling and layout
+     */
+    @Suppress("ComplexMethod")
+    @VisibleForTesting
+    internal fun configToIntent(config: CustomTabConfig?): CustomTabsIntent {
+        val intent = CustomTabsIntent.Builder().apply {
+            setInstantAppsEnabled(false)
+            config?.toolbarColor?.let { setToolbarColor(it) }
+            config?.navigationBarColor?.let { setNavigationBarColor(it) }
+            if (config?.enableUrlbarHiding == true) enableUrlBarHiding()
+            config?.closeButtonIcon?.let { setCloseButtonIcon(it) }
+            if (config?.showShareMenuItem == true) addDefaultShareMenuItem()
+            config?.titleVisible?.let { setShowTitle(it) }
+            config?.actionButtonConfig?.apply { setActionButton(icon, description, pendingIntent, tint) }
+            config?.menuItems?.forEach { addMenuItem(it.name, it.pendingIntent) }
+        }.build()
+
+        intent.intent.`package` = context.packageName
+
+        return intent
+    }
+
+    /**
+     * Starts the feature and a observer to listen for window requests.
+     */
+    override fun start() {
+        sessionManager.findSessionById(sessionId)?.register(windowObserver)
+    }
+
+    /**
+     * Stops the feature and the window request observer.
+     */
+    override fun stop() {
+        sessionManager.findSessionById(sessionId)?.unregister(windowObserver)
+    }
+}

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabWindowFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabWindowFeatureTest.kt
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs
+
+import android.content.Context
+import android.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.window.WindowRequest
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class CustomTabWindowFeatureTest {
+
+    private val sessionId = "session-uuid"
+    private lateinit var context: Context
+    private lateinit var engine: Engine
+    private lateinit var sessionManager: SessionManager
+    private lateinit var session: Session
+
+    @Before
+    fun setup() {
+        context = mock()
+        engine = mock()
+        sessionManager = mock()
+        session = mock()
+
+        whenever(context.packageName).thenReturn("org.mozilla.firefox")
+    }
+
+    @Test
+    fun `start registers window observer`() {
+        whenever(sessionManager.findSessionById(sessionId)).thenReturn(session)
+
+        val feature = CustomTabWindowFeature(context, sessionManager, sessionId)
+        feature.start()
+        verify(session).register(feature.windowObserver)
+    }
+
+    @Test
+    fun `observer handles open window request`() {
+        whenever(sessionManager.findSessionById(sessionId)).thenReturn(session)
+
+        val session = Session("https://www.mozilla.org")
+        val request = mock<WindowRequest>()
+        whenever(request.url).thenReturn("about:blank")
+
+        val feature = CustomTabWindowFeature(context, sessionManager, sessionId)
+        feature.windowObserver.onOpenWindowRequested(session, request)
+
+        verify(context).startActivity(any(), any())
+    }
+
+    @Test
+    fun `creates intent based on custom tab config`() {
+        val feature = CustomTabWindowFeature(context, sessionManager, sessionId)
+        val intent = feature.configToIntent(CustomTabConfig(
+            toolbarColor = Color.RED,
+            navigationBarColor = Color.BLUE,
+            enableUrlbarHiding = true,
+            showShareMenuItem = true,
+            titleVisible = true
+        ))
+
+        val newConfig = createCustomTabConfigFromIntent(intent.intent, null)
+        assertEquals("org.mozilla.firefox", intent.intent.`package`)
+        assertEquals(Color.RED, newConfig.toolbarColor)
+        assertEquals(Color.BLUE, newConfig.navigationBarColor)
+        assertTrue(newConfig.enableUrlbarHiding)
+        assertTrue(newConfig.showShareMenuItem)
+        assertTrue(newConfig.titleVisible)
+    }
+
+    @Test
+    fun `stop unregisters window observer`() {
+        whenever(sessionManager.findSessionById(sessionId)).thenReturn(session)
+
+        val feature = CustomTabWindowFeature(context, sessionManager, sessionId)
+        feature.stop()
+        verify(session).unregister(feature.windowObserver)
+    }
+
+    @Test
+    fun `start and stop are no-op when session is null`() {
+        whenever(sessionManager.findSessionById(sessionId)).thenReturn(null)
+
+        val feature = CustomTabWindowFeature(context, sessionManager, sessionId)
+        feature.start()
+        feature.stop()
+        verify(session, never()).register(feature.windowObserver)
+        verify(session, never()).unregister(feature.windowObserver)
+    }
+}

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/WindowFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/WindowFeature.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.session
 
+import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -15,6 +16,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  */
 class WindowFeature(private val sessionManager: SessionManager) : LifecycleAwareFeature {
 
+    @VisibleForTesting
     internal val windowObserver = object : SelectionAwareSessionObserver(sessionManager) {
         override fun onOpenWindowRequested(session: Session, windowRequest: WindowRequest): Boolean {
             val newSession = Session(windowRequest.url, session.private)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,9 @@ permalink: /changelog/
   * Adds `Resources.Theme.resolveAttribute(Int)` to quickly get a resource ID from a theme.
   * Adds `Context.getColorFromAttr` to get a color int from an attribute.
 
+* **feature-customtabs**
+  * Added `CustomTabWindowFeature` to handle windows inside custom tabs, PWAs, and TWAs.
+
 # 14.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v14.0.0...v14.0.1)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -23,7 +23,6 @@ import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.CoordinateScrollingFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
-import mozilla.components.feature.session.WindowFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.support.base.feature.BackHandler
@@ -147,8 +146,6 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler {
             owner = this,
             view = layout)
 
-        val windowFeature = WindowFeature(components.sessionManager)
-
         sitePermissionsFeature.set(
             feature = SitePermissionsFeature(
                 context = requireContext(),
@@ -171,7 +168,6 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler {
         lifecycle.addObservers(
             scrollFeature,
             contextMenuFeature,
-            windowFeature,
             menuUpdaterFeature
         )
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.session.ThumbnailsFeature
+import mozilla.components.feature.session.WindowFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.support.base.feature.BackHandler
@@ -67,6 +68,9 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
             owner = this,
             view = layout
         )
+
+        val windowFeature = WindowFeature(components.sessionManager)
+        lifecycle.addObserver(windowFeature)
 
         return layout
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.feature.customtabs.CustomTabWindowFeature
 import mozilla.components.feature.customtabs.CustomTabsToolbarFeature
 import mozilla.components.feature.pwa.ext.getTrustedScope
 import mozilla.components.feature.pwa.ext.getWebAppManifest
@@ -60,6 +61,13 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
             ),
             owner = this,
             view = layout.toolbar)
+
+        val windowFeature = CustomTabWindowFeature(
+            requireContext(),
+            components.sessionManager,
+            sessionId!!
+        )
+        lifecycle.addObserver(windowFeature)
 
         if (manifest != null) {
             activity?.lifecycle?.addObserver(


### PR DESCRIPTION
Adds WindowFeature alternative to open new windows in a new custom tab.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
