### PR TITLE
 Closes #4289: Migrate feature-prompts to use browser-state 

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -178,7 +178,10 @@ internal class EngineObserver(
     }
 
     override fun onPromptRequest(promptRequest: PromptRequest) {
-        session.promptRequest = Consumable.from(promptRequest)
+        store?.dispatch(ContentAction.UpdatePromptRequestAction(
+            session.id,
+            promptRequest
+        ))
     }
 
     override fun onOpenWindowRequest(windowRequest: WindowRequest) {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -13,7 +13,6 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
-import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -24,7 +23,6 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.`when`
 
 /**
  * This test suite validates that calls on [SessionManager] update [BrowserStore] to create a matching state.
@@ -797,32 +795,6 @@ class SessionManagerMigrationTest {
 
         store.state.findTab("session2")!!.also { tab ->
             assertEquals(engineSession, tab.engineState.engineSession)
-        }
-    }
-
-    @Test
-    fun `Adding a prompt request`() {
-        val store = BrowserStore()
-        val manager = SessionManager(engine = mock(), store = store)
-
-        val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
-        manager.add(session)
-
-        assertNull(session.promptRequest.peek())
-        assertNull(store.state.findTab("session")!!.content.promptRequest)
-
-        val promptRequest: PromptRequest = mock()
-        session.promptRequest = Consumable.from(promptRequest)
-
-        assertEquals(promptRequest, session.promptRequest.peek())
-        store.state.findTab("session")!!.also { tab ->
-            assertNotNull(tab.content.promptRequest)
-            assertSame(promptRequest, tab.content.promptRequest)
-        }
-
-        session.promptRequest.consume { true }
-        store.state.findTab("session")!!.also { tab ->
-            assertNull(tab.content.promptRequest)
         }
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -8,6 +8,8 @@ import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.engine.request.LoadRequestOption
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
@@ -20,7 +22,6 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.mock
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -76,13 +77,13 @@ class EngineObserverTest {
 
         engineSession.loadUrl("http://mozilla.org")
         engineSession.toggleDesktopMode(true)
-        Assert.assertEquals("http://mozilla.org", session.url)
-        Assert.assertEquals("", session.searchTerms)
-        Assert.assertEquals(100, session.progress)
-        Assert.assertEquals(true, session.loading)
-        Assert.assertEquals(true, session.canGoForward)
-        Assert.assertEquals(true, session.canGoBack)
-        Assert.assertEquals(true, session.desktopMode)
+        assertEquals("http://mozilla.org", session.url)
+        assertEquals("", session.searchTerms)
+        assertEquals(100, session.progress)
+        assertEquals(true, session.loading)
+        assertEquals(true, session.canGoForward)
+        assertEquals(true, session.canGoBack)
+        assertEquals(true, session.desktopMode)
     }
 
     @Test
@@ -118,10 +119,10 @@ class EngineObserverTest {
         engineSession.register(EngineObserver(session))
 
         engineSession.loadUrl("http://mozilla.org")
-        Assert.assertEquals(Session.SecurityInfo(false), session.securityInfo)
+        assertEquals(Session.SecurityInfo(false), session.securityInfo)
 
         engineSession.loadUrl("https://mozilla.org")
-        Assert.assertEquals(Session.SecurityInfo(true, "host", "issuer"), session.securityInfo)
+        assertEquals(Session.SecurityInfo(true, "host", "issuer"), session.securityInfo)
     }
 
     @Test
@@ -364,15 +365,17 @@ class EngineObserverTest {
     }
 
     @Test
-    fun engineSessionObserverWithOnPromptRequest() {
-
+    fun engineObserverHandlesPromptRequest() {
         val promptRequest = mock(PromptRequest::class.java)
-        val session = Session("")
-        val observer = EngineObserver(session)
+        val session = Session(id = "test-session", initialUrl = "")
+        val store = mock(BrowserStore::class.java)
+        val observer = EngineObserver(session, store)
 
-        assertTrue(session.promptRequest.isConsumed())
         observer.onPromptRequest(promptRequest)
-        assertFalse(session.promptRequest.isConsumed())
+        verify(store).dispatch(ContentAction.UpdatePromptRequestAction(
+            session.id,
+            promptRequest
+        ))
     }
 
     @Test

--- a/components/feature/prompts/build.gradle
+++ b/components/feature/prompts/build.gradle
@@ -21,8 +21,14 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
-    implementation project(':browser-session')
+    implementation project(':browser-state')
     implementation project(':concept-engine')
     implementation project(':lib-state')
     implementation project(':support-ktx')
@@ -34,6 +40,7 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_coroutines
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
@@ -53,7 +53,7 @@ fun <T, R> Flow<T>.ifChanged(transform: (T) -> R): Flow<T> {
  *
  * Example:
  * ```
- * Block: x -> x[0]  // Map to first character of input
+ * Block: x -> [x[0], x[1]]  // Map to first two characters of input
  * Original Flow: "banana", "bandanna", "bus", "apple", "big", "coconut", "circle", "home"
  * Mapped: [b, a], [b, a], [b, u], [a, p], [b, i], [c, o], [c, i], [h, o]
  * Returned Flow: "banana", "bus, "apple", "big", "coconut", "circle", "home"
@@ -65,11 +65,12 @@ fun <T, R> Flow<T>.ifAnyChanged(transform: (T) -> Array<R>): Flow<T> {
 
     return filter { value ->
         val mapped = transform(value)
-        val hasChanged = lastMappedValues
-            ?.mapIndexed { i, r -> mapped[i] === r }
-            ?.reduce { a, b -> a && b } == false
+        val hasChanges = lastMappedValues
+            ?.asSequence()
+            ?.filterIndexed { i, r -> mapped[i] !== r }
+            ?.any()
 
-        if (!observedValueOnce || hasChanged) {
+        if (!observedValueOnce || hasChanges == true) {
             lastMappedValues = mapped
             observedValueOnce = true
             true

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
@@ -35,4 +35,18 @@ class FlowKtTest {
             items
         )
     }
+
+    @Test
+    fun `ifAnyChanged operator with block`() {
+        val originalFlow = flowOf("banana", "bandanna", "bus", "apple", "big", "coconut", "circle", "home")
+
+        val items = runBlocking {
+            originalFlow.ifAnyChanged { item -> arrayOf(item[0], item[1]) }.toList()
+        }
+
+        assertEquals(
+                listOf("banana", "bus", "apple", "big", "coconut", "circle", "home"),
+                items
+        )
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-customtabs**
   * 'CustomTabIntentProcessor' can create private sessions now.
 
+* **browser-session**, **browser-state**, **feature-prompts**
+  *  ⚠️ **This is a breaking change**: The `feature-prompts` component has been migrated to `browser-state` from `browser-session`. Therefore creating a `PromptFeature` requires a `BrowserStore` instance (instead of a `SessionManager` instance). The `promptRequest` property has been removed `Session`. Prompt requests can now only be observed on a `BrowserStore` from the `browser-state` component.
+
 # 15.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v14.0.0...v15.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -137,7 +137,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler {
         promptFeature.set(
             feature = PromptFeature(
                 fragment = this,
-                sessionManager = components.sessionManager,
+                store = components.store,
                 sessionId = sessionId,
                 fragmentManager = requireFragmentManager(),
                 onNeedToRequestPermissions = { permissions ->


### PR DESCRIPTION
This migrates our feature-prompts module to browser-state. 

@pocmo I ended up introducing `Flow.ifAnyChanged` here because returning a `Pair` or other data class instance from `ifChanged` wouldn't have worked. We're comparing for reference equality in `ifChanged` so returning a new `Pair` would always indicate change and forward the value. 

The `ifChanged` block would have to get quite complicated. We'd have to return a different instance only if changed but then we're doing all the work in the feature module and the API doesn't help us. With `ifAnyChanged` this looks quite nice and we can refine the API more later.

Most other changes are in the unit tests. I also did a round of manual testing, thanks to @Amejia481 for sending me lots of links to test :). 

I'll put up PRs for R-B and Fenix, once this one is approved.