### PR TITLE
Fix find in page not working with fresh install

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -131,9 +131,6 @@ class SessionManager(
     ) {
         // Add store to Session so that it can dispatch actions whenever it changes.
         session.store = store
-
-        delegate.add(session, selected, engineSession, parent)
-
         if (session.isCustomTabSession()) {
             store?.syncDispatch(
                 CustomTabListAction.AddCustomTabAction(
@@ -148,6 +145,8 @@ class SessionManager(
                 )
             )
         }
+
+        delegate.add(session, selected, engineSession, parent)
     }
 
     /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -24,7 +24,6 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.`when`
 
 /**
  * This test suite validates that calls on [SessionManager] update [BrowserStore] to create a matching state.
@@ -762,6 +761,30 @@ class SessionManagerMigrationTest {
         assertEquals(engineSession2, sessionManager.getOrCreateEngineSession(session))
         store.state.findTab("session")!!.also { tab ->
             assertEquals(engineSession2, tab.engineState.engineSession)
+        }
+    }
+
+    @Test
+    fun `Session is added to store before engine session can be created and linked`() {
+        val store = BrowserStore()
+        val engine: Engine = mock()
+
+        val engineSession1: EngineSession = mock()
+        doReturn(engineSession1).`when`(engine).createSession(false)
+
+        val sessionManager = SessionManager(engine, store)
+        sessionManager.register(object : SessionManager.Observer {
+            override fun onSessionAdded(session: Session) {
+                sessionManager.getOrCreateEngineSession(session)
+            }
+        })
+
+        val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
+        sessionManager.add(session)
+
+        assertEquals(engineSession1, sessionManager.getOrCreateEngineSession(session))
+        store.state.findTab("session")!!.also { tab ->
+            assertEquals(engineSession1, tab.engineState.engineSession)
         }
     }
 


### PR DESCRIPTION
### Description
Fixed issue: https://github.com/mozilla-mobile/reference-browser/issues/915

The `engineSession` is null on `FindInPageInteractor` because the `bind()` method set it as null via `session.engineState.engineSession`. 
<img width="752" alt="Screenshot 2019-10-02 at 08 25 39" src="https://user-images.githubusercontent.com/18151158/66025739-799e8e00-e4f7-11e9-944d-73ab86d45485.png">

Finally and after deep research I discover the problem is related with the tabs, when `EngineStateReducer.reduce()` is called for the first time no one has add the new tab created and without it it's imposible to propagate the `GeckoEngineSession` to the `BrowserState`

```
2019-10-02 17:50:58.885 8585-9964/org.mozilla.samples.browser: UnlinkEngineSessionAction
2019-10-02 17:50:58.891 8585-9964/org.mozilla.samples.browser: LinkEngineSessionAction
2019-10-02 17:50:58.919 8585-9964/org.mozilla.samples.browser: AddTabAction  // after link
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
