### PR TITLE
Closes #4379 - Upgrade WorkManager to v2.2.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -48,7 +48,7 @@ object Versions {
         const val palette = "1.0.0"
         const val lifecycle = "2.1.0"
         const val media = "1.1.0"
-        const val work = "2.0.1"
+        const val work = "2.2.0"
         const val arch_core_testing = "2.1.0"
         const val uiautomator = "2.2.0"
         const val localbroadcastmanager = "1.0.0"

--- a/components/feature/push/build.gradle
+++ b/components/feature/push/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
     implementation Dependencies.androidx_work_runtime
+    implementation Dependencies.androidx_lifecycle_extensions
 
     testImplementation project(':support-test')
 

--- a/components/feature/sendtab/build.gradle
+++ b/components/feature/sendtab/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(':feature-push')
 
     implementation Dependencies.androidx_work_runtime
+    implementation Dependencies.androidx_lifecycle_extensions
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentsUpdater.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentsUpdater.kt
@@ -60,7 +60,7 @@ internal class ExperimentsUpdater(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun scheduleUpdates() {
-        WorkManager.getInstance().enqueueUniquePeriodicWork(
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             TAG,
             // We rely on REPLACE behavior to run immediately and then schedule the next update per
             // the specified interval.  KEEP behavior does not run immediately and it is desired to

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentsUpdaterTest.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/ExperimentsUpdaterTest.kt
@@ -79,11 +79,11 @@ class ExperimentsUpdaterTest {
     @Test
     fun `ExperimentsUpdater initialize schedules ExperimentsUpdateWorker in WorkManager`() {
         assertFalse("ExperimentsUpdateWorker should not be scheduled yet",
-            isWorkScheduled(ExperimentsUpdater.TAG))
+            isWorkScheduled(context, ExperimentsUpdater.TAG))
         experimentsUpdater.initialize(configuration)
         assertTrue("initialize must schedule ExperimentsUpdateWorker",
-            isWorkScheduled(ExperimentsUpdater.TAG))
-        val workInfo = getWorkInfoByTag(ExperimentsUpdater.TAG)
+            isWorkScheduled(context, ExperimentsUpdater.TAG))
+        val workInfo = getWorkInfoByTag(context, ExperimentsUpdater.TAG)
         assertNotNull("workInfo must not be null", workInfo)
         assertEquals("workInfo id must match request id", workRequest.id, workInfo?.id)
     }

--- a/components/service/experiments/src/test/java/mozilla/components/service/experiments/TestUtil.kt
+++ b/components/service/experiments/src/test/java/mozilla/components/service/experiments/TestUtil.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.experiments
 
+import android.content.Context
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import java.util.concurrent.ExecutionException
@@ -14,8 +15,8 @@ import java.util.concurrent.ExecutionException
  * @param tag a string representing the worker tag
  * @return True if the task found in [WorkManager], false otherwise
  */
-internal fun isWorkScheduled(tag: String): Boolean {
-    val instance = WorkManager.getInstance()
+internal fun isWorkScheduled(context: Context, tag: String): Boolean {
+    val instance = WorkManager.getInstance(context)
     val statuses = instance.getWorkInfosByTag(tag)
     try {
         val workInfoList = statuses.get()
@@ -41,8 +42,8 @@ internal fun isWorkScheduled(tag: String): Boolean {
  * @param tag a string representing the worker tag
  * @return [WorkInfo] for the tag that was passed in or null
  */
-internal fun getWorkInfoByTag(tag: String): WorkInfo? {
-    val instance = WorkManager.getInstance()
+internal fun getWorkInfoByTag(context: Context, tag: String): WorkInfo? {
+    val instance = WorkManager.getInstance(context)
     val statuses = instance.getWorkInfosByTag(tag)
     try {
         val workInfoList = statuses.get()

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -890,7 +890,7 @@ open class FxaAccountManager(
 
     @VisibleForTesting
     open fun createSyncManager(config: SyncConfig): SyncManager {
-        return WorkManagerSyncManager(config)
+        return WorkManagerSyncManager(context, config)
     }
 
     @VisibleForTesting

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -60,8 +60,8 @@ private const val SYNC_WORKER_BACKOFF_DELAY_MINUTES = 3L
  * Must be initialized on the main thread.
  */
 internal class WorkManagerSyncManager(
-    syncConfig: SyncConfig,
-    private val context: Context
+    private val context: Context,
+    syncConfig: SyncConfig
 ) : SyncManager(syncConfig) {
     override val logger = Logger("BgSyncManager")
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -59,8 +59,10 @@ private const val SYNC_WORKER_BACKOFF_DELAY_MINUTES = 3L
  *
  * Must be initialized on the main thread.
  */
-internal class WorkManagerSyncManager(syncConfig: SyncConfig,
-                                      private val context: Context) : SyncManager(syncConfig) {
+internal class WorkManagerSyncManager(
+    syncConfig: SyncConfig,
+    private val context: Context
+) : SyncManager(syncConfig) {
     override val logger = Logger("BgSyncManager")
 
     init {
@@ -90,7 +92,7 @@ internal class WorkManagerSyncManager(syncConfig: SyncConfig,
  */
 internal object WorkersLiveDataObserver {
     private lateinit var workManager: WorkManager
-    private val workersLiveData  by lazy {
+    private val workersLiveData by lazy {
         workManager.getWorkInfosByTagLiveData(SyncWorkerTag.Common.name)
     }
 

--- a/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/workmanager/WorkManagerSyncScheduler.kt
+++ b/components/service/fretboard/src/main/java/mozilla/components/service/fretboard/scheduler/workmanager/WorkManagerSyncScheduler.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.fretboard.scheduler.workmanager
 
+import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -15,7 +16,7 @@ import java.util.concurrent.TimeUnit
  * Class used to schedule sync of experiment
  * configuration from the server using WorkManager
  */
-class WorkManagerSyncScheduler {
+class WorkManagerSyncScheduler(private val context: Context) {
     /**
      * Schedule sync with the default constraints
      * (once a day and charging)
@@ -33,7 +34,7 @@ class WorkManagerSyncScheduler {
             .addTag(TAG)
             .setConstraints(constraints)
             .build()
-        WorkManager.getInstance().enqueueUniquePeriodicWork(TAG, ExistingPeriodicWorkPolicy.KEEP, syncWork)
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(TAG, ExistingPeriodicWorkPolicy.KEEP, syncWork)
     }
 
     companion object {

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -40,12 +40,13 @@ import mozilla.components.service.glean.utils.parseISOTimeString
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.utils.ThreadUtils
+import kotlin.properties.Delegates
 
 @Suppress("TooManyFunctions", "LargeClass")
 open class GleanInternalAPI internal constructor () {
     private val logger = Logger("glean/Glean")
 
-    private var applicationContext: Context? = null
+    private var applicationContext: Context by Delegates.notNull()
 
     // Include our singletons of StorageEngineManager and PingMaker
     private lateinit var storageEngineManager: StorageEngineManager
@@ -231,7 +232,7 @@ open class GleanInternalAPI internal constructor () {
      * will perform the migration one more time.
      */
     private fun resetMigration() {
-        val migrationPrefs = applicationContext?.getSharedPreferences(
+        val migrationPrefs = applicationContext.getSharedPreferences(
             MIGRATION_PREFS_FILE,
             Context.MODE_PRIVATE
         )
@@ -251,7 +252,7 @@ open class GleanInternalAPI internal constructor () {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun onChangeUploadEnabled(enabled: Boolean) {
         if (enabled) {
-            initializeCoreMetrics(applicationContext!!)
+            initializeCoreMetrics(applicationContext)
         } else {
             cancelPingWorkers()
             clearMetrics()
@@ -263,8 +264,8 @@ open class GleanInternalAPI internal constructor () {
      * accidentally upload or collect data after the upload has been disabled.
      */
     private fun cancelPingWorkers() {
-        MetricsPingScheduler.cancel()
-        PingUploadWorker.cancel()
+        MetricsPingScheduler.cancel(applicationContext)
+        PingUploadWorker.cancel(applicationContext)
     }
 
     /**
@@ -539,7 +540,7 @@ open class GleanInternalAPI internal constructor () {
                 // Await the serialization tasks. Once the serialization tasks have all completed,
                 // we can then safely enqueue the PingUploadWorker.
                 pingSerializationTasks.joinAll()
-                PingUploadWorker.enqueueWorker()
+                PingUploadWorker.enqueueWorker(applicationContext)
             }
         }
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -46,7 +46,7 @@ import kotlin.properties.Delegates
 open class GleanInternalAPI internal constructor () {
     private val logger = Logger("glean/Glean")
 
-    private var applicationContext: Context by Delegates.notNull()
+    private lateinit var applicationContext: Context
 
     // Include our singletons of StorageEngineManager and PingMaker
     private lateinit var storageEngineManager: StorageEngineManager

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -40,13 +40,12 @@ import mozilla.components.service.glean.utils.parseISOTimeString
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.utils.ThreadUtils
-import kotlin.properties.Delegates
 
 @Suppress("TooManyFunctions", "LargeClass")
 open class GleanInternalAPI internal constructor () {
     private val logger = Logger("glean/Glean")
 
-    private lateinit var applicationContext: Context
+    private var applicationContext: Context? = null
 
     // Include our singletons of StorageEngineManager and PingMaker
     private lateinit var storageEngineManager: StorageEngineManager
@@ -232,7 +231,7 @@ open class GleanInternalAPI internal constructor () {
      * will perform the migration one more time.
      */
     private fun resetMigration() {
-        val migrationPrefs = applicationContext.getSharedPreferences(
+        val migrationPrefs = applicationContext?.getSharedPreferences(
             MIGRATION_PREFS_FILE,
             Context.MODE_PRIVATE
         )
@@ -252,7 +251,7 @@ open class GleanInternalAPI internal constructor () {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun onChangeUploadEnabled(enabled: Boolean) {
         if (enabled) {
-            initializeCoreMetrics(applicationContext)
+            initializeCoreMetrics(applicationContext!!)
         } else {
             cancelPingWorkers()
             clearMetrics()
@@ -264,8 +263,8 @@ open class GleanInternalAPI internal constructor () {
      * accidentally upload or collect data after the upload has been disabled.
      */
     private fun cancelPingWorkers() {
-        MetricsPingScheduler.cancel(applicationContext)
-        PingUploadWorker.cancel(applicationContext)
+        MetricsPingScheduler.cancel(applicationContext!!)
+        PingUploadWorker.cancel(applicationContext!!)
     }
 
     /**
@@ -540,7 +539,7 @@ open class GleanInternalAPI internal constructor () {
                 // Await the serialization tasks. Once the serialization tasks have all completed,
                 // we can then safely enqueue the PingUploadWorker.
                 pingSerializationTasks.joinAll()
-                PingUploadWorker.enqueueWorker(applicationContext)
+                PingUploadWorker.enqueueWorker(applicationContext!!)
             }
         }
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/MetricsPingScheduler.kt
@@ -56,8 +56,8 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
         /**
          * Function to cancel any pending metrics ping workers
          */
-        internal fun cancel() {
-            WorkManager.getInstance().cancelUniqueWork(MetricsPingWorker.TAG)
+        internal fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(MetricsPingWorker.TAG)
         }
     }
 
@@ -104,7 +104,7 @@ internal class MetricsPingScheduler(val applicationContext: Context) : Lifecycle
         // - Glean restarts;
         // - the ping is overdue and is immediately collected at startup;
         // - a new work is scheduled for the next calendar day.
-        WorkManager.getInstance().enqueueUniqueWork(
+        WorkManager.getInstance(applicationContext).enqueueUniqueWork(
             MetricsPingWorker.TAG,
             ExistingWorkPolicy.REPLACE,
             workRequest)

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/PingUploadWorker.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/scheduler/PingUploadWorker.kt
@@ -49,8 +49,8 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
         /**
          * Function to aid in properly enqueuing the worker in [WorkManager]
          */
-        internal fun enqueueWorker() {
-            WorkManager.getInstance().enqueueUniqueWork(
+        internal fun enqueueWorker(context: Context) {
+            WorkManager.getInstance(context).enqueueUniqueWork(
                 PING_WORKER_TAG,
                 ExistingWorkPolicy.KEEP,
                 buildWorkRequest())
@@ -70,8 +70,8 @@ class PingUploadWorker(context: Context, params: WorkerParameters) : Worker(cont
         /**
          * Function to cancel any pending ping upload workers
          */
-        internal fun cancel() {
-            WorkManager.getInstance().cancelUniqueWork(PING_WORKER_TAG)
+        internal fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(PING_WORKER_TAG)
         }
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanTest.kt
@@ -64,8 +64,11 @@ import mozilla.components.service.glean.private.TimeUnit as GleanTimeUnit
 @RunWith(RobolectricTestRunner::class)
 class GleanTest {
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestRule(context)
 
     @Test
     fun `disabling upload should disable metrics recording`() {
@@ -150,7 +153,7 @@ class GleanTest {
             lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
 
             // Trigger worker task to upload the pings in the background
-            triggerWorkManager()
+            triggerWorkManager(context)
 
             val requests = mutableMapOf<String, String>()
             for (i in 0..1) {
@@ -271,7 +274,7 @@ class GleanTest {
         runBlocking {
             gleanSpy.handleBackgroundEvent()
         }
-        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+        assertFalse(getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     @Test
@@ -281,7 +284,7 @@ class GleanTest {
         runBlocking {
             Glean.handleBackgroundEvent()
         }
-        assertFalse(getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+        assertFalse(getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 
     @Test
@@ -521,8 +524,8 @@ class GleanTest {
         // Trigger worker task to upload the pings in the background. We need
         // to wait for the work to be enqueued first, since this test runs
         // asynchronously.
-        waitForEnqueuedWorker(PingUploadWorker.PING_WORKER_TAG)
-        triggerWorkManager()
+        waitForEnqueuedWorker(context, PingUploadWorker.PING_WORKER_TAG)
+        triggerWorkManager(context)
 
         // Validate the received data.
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
@@ -588,18 +591,18 @@ class GleanTest {
 
         // Verify that the workers are enqueued
         assertTrue("PingUploadWorker is enqueued",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
         assertTrue("MetricsPingWorker is enqueued",
-            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
 
         // Toggle upload enabled to false
         Glean.setUploadEnabled(false)
 
         // Verify workers have been cancelled
         assertFalse("PingUploadWorker is not enqueued",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
         assertFalse("MetricsPingWorker is not enqueued",
-            getWorkerStatus(MetricsPingWorker.TAG).isEnqueued)
+            getWorkerStatus(context, MetricsPingWorker.TAG).isEnqueued)
     }
 
     @Test

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/TestUtil.kt
@@ -152,12 +152,13 @@ internal class WorkerStatus(val isEnqueued: Boolean, val workerId: UUID? = null)
 /**
  * Helper function to check to see if a worker has been scheduled with the [WorkManager]
  *
+ * @param context the context that will be used to get the [WorkManager]
  * @param tag a string representing the worker tag
  * @return Pair<Boolean, UUID> first contains True if the task found in [WorkManager], False otherwise
  *         AND second contains the UUID of the running task so its constraints can be met.
  */
-internal fun getWorkerStatus(tag: String): WorkerStatus {
-    val instance = WorkManager.getInstance()
+internal fun getWorkerStatus(context: Context, tag: String): WorkerStatus {
+    val instance = WorkManager.getInstance(context)
     val statuses = instance.getWorkInfosByTag(tag)
     try {
         val workInfoList = statuses.get()
@@ -179,14 +180,15 @@ internal fun getWorkerStatus(tag: String): WorkerStatus {
 /**
  * Wait for a specifically tagged [WorkManager]'s Worker to be enqueued.
  *
+ * @param context the context that will be used to get the [WorkManager]
  * @param workTag the tag of the expected Worker
  * @param timeoutMillis how log before stopping the wait. This defaults to 5000ms (5 seconds).
  */
-internal fun waitForEnqueuedWorker(workTag: String, timeoutMillis: Long = 5000) = runBlocking {
+internal fun waitForEnqueuedWorker(context: Context, workTag: String, timeoutMillis: Long = 5000) = runBlocking {
     runBlocking {
         withTimeout(timeoutMillis) {
             do {
-                if (getWorkerStatus(workTag).isEnqueued) {
+                if (getWorkerStatus(context, workTag).isEnqueued) {
                     return@withTimeout
                 }
             } while (true)
@@ -198,16 +200,18 @@ internal fun waitForEnqueuedWorker(workTag: String, timeoutMillis: Long = 5000) 
  * Helper function to simulate WorkManager being triggered since there appears to be a bug in
  * the current WorkManager test utilites that prevent it from being triggered by a test.  Once this
  * is fixed, the contents of this can be amended to trigger WorkManager directly.
+ *
+ * @param context the context that will be used to get the [WorkManager]
  */
-internal fun triggerWorkManager() {
+internal fun triggerWorkManager(context: Context) {
     // Check that the work is scheduled
-    val status = getWorkerStatus(PingUploadWorker.PING_WORKER_TAG)
+    val status = getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG)
     Assert.assertTrue("A scheduled PingUploadWorker must exist",
         status.isEnqueued)
 
     // Trigger WorkManager using TestDriver
-    val workManagerTestInitHelper = WorkManagerTestInitHelper.getTestDriver()
-    workManagerTestInitHelper.setAllConstraintsMet(status.workerId!!)
+    val workManagerTestInitHelper = WorkManagerTestInitHelper.getTestDriver(context)
+    workManagerTestInitHelper?.setAllConstraintsMet(status.workerId!!)
 }
 
 /**

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/debug/GleanDebugActivityTest.kt
@@ -37,8 +37,11 @@ class GleanDebugActivityTest {
 
     private val testPackageName = "mozilla.components.service.glean"
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestRule(context)
 
     @Before
     fun setup() {
@@ -144,7 +147,7 @@ class GleanDebugActivityTest {
             serverEndpoint = "http://" + server.hostName + ":" + server.port
         )
 
-        triggerWorkManager()
+        triggerWorkManager(context)
         val request = server.takeRequest(10L, TimeUnit.SECONDS)
 
         assertTrue(
@@ -188,7 +191,7 @@ class GleanDebugActivityTest {
         assertEquals("Server endpoint must be reset if tag didn't pass regex",
             "http://" + server.hostName + ":" + server.port, Glean.configuration.serverEndpoint)
 
-        triggerWorkManager()
+        triggerWorkManager(context)
         val request = server.takeRequest(10L, TimeUnit.SECONDS)
 
         assertTrue(
@@ -241,6 +244,6 @@ class GleanDebugActivityTest {
 
         // This will trigger the call to `fetch()` in the TestPingTagClient which is where the
         // test assertions will occur
-        triggerWorkManager()
+        triggerWorkManager(context)
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/private/PingTypeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.service.glean.private
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.checkPingSchema
@@ -29,8 +30,11 @@ import java.util.concurrent.TimeUnit
 @RunWith(RobolectricTestRunner::class)
 class PingTypeTest {
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestRule(context)
 
     @Test
     fun `test sending of custom pings`() {
@@ -59,7 +63,7 @@ class PingTypeTest {
 
         customPing.send()
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         val docType = request.path.split("/")[3]
@@ -97,7 +101,7 @@ class PingTypeTest {
 
         customPing.send()
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         val docType = request.path.split("/")[3]
@@ -131,7 +135,7 @@ class PingTypeTest {
         Glean.sendPingsByName(listOf("unknown"))
 
         assertFalse("We shouldn't have any pings scheduled",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued
         )
     }
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/scheduler/PingUploadWorkerTest.kt
@@ -23,6 +23,9 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PingUploadWorkerTest {
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @Mock
     var workerParams: WorkerParameters? = null
 
@@ -31,7 +34,6 @@ class PingUploadWorkerTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
-        val context: Context = ApplicationProvider.getApplicationContext()
         MockitoAnnotations.initMocks(this)
         resetGlean(context, config = Configuration().copy(logPings = true))
         pingUploadWorker = PingUploadWorker(context, workerParams!!)
@@ -58,17 +60,17 @@ class PingUploadWorkerTest {
 
     @Test
     fun `cancel() correctly cancels worker`() {
-        PingUploadWorker.enqueueWorker()
+        PingUploadWorker.enqueueWorker(context)
 
         // Verify that the worker is enqueued
         Assert.assertTrue("PingUploadWorker is enqueued",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
 
         // Cancel the worker
-        PingUploadWorker.cancel()
+        PingUploadWorker.cancel(context)
 
         // Verify worker has been cancelled
         Assert.assertFalse("PingUploadWorker is not enqueued",
-            getWorkerStatus(PingUploadWorker.PING_WORKER_TAG).isEnqueued)
+            getWorkerStatus(context, PingUploadWorker.PING_WORKER_TAG).isEnqueued)
     }
 }

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -3,6 +3,7 @@
 
 package mozilla.components.service.glean.storages
 
+import android.content.Context
 import android.os.SystemClock
 import androidx.test.core.app.ApplicationProvider
 import mozilla.components.service.glean.Dispatchers
@@ -51,8 +52,12 @@ enum class TruncatedKeys {
 
 @RunWith(RobolectricTestRunner::class)
 class EventsStorageEngineTest {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @get:Rule
-    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+    val gleanRule = GleanTestRule(context)
 
     @Before
     fun setUp() {
@@ -284,7 +289,7 @@ class EventsStorageEngineTest {
             assertTrue(click.testHasValue())
 
             // Trigger worker task to upload the pings in the background
-            triggerWorkManager()
+            triggerWorkManager(context)
 
             val request = server.takeRequest(20L, TimeUnit.SECONDS)
             val applicationId = "mozilla-components-service-glean"
@@ -381,7 +386,7 @@ class EventsStorageEngineTest {
         )
 
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         val request = server.takeRequest(20L, TimeUnit.SECONDS)
         assertEquals("POST", request.method)
@@ -535,7 +540,7 @@ class EventsStorageEngineTest {
             ),
             clearStores = false
         )
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         event.record(mapOf(ExtraKeys.Key1 to "bip"))
 

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/storages/EventsStorageEngineTest.kt
@@ -453,7 +453,7 @@ class EventsStorageEngineTest {
         event.record(extra = mapOf(SomeExtraKeys.SomeExtra to "post-init"))
 
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         var request = server.takeRequest(20L, TimeUnit.SECONDS)
         var pingJsonData = request.body.readUtf8()
@@ -474,7 +474,7 @@ class EventsStorageEngineTest {
         Glean.sendPingsByName(listOf("events"))
 
         // Trigger worker task to upload the pings in the background
-        triggerWorkManager()
+        triggerWorkManager(context)
 
         request = server.takeRequest(20L, TimeUnit.SECONDS)
         pingJsonData = request.body.readUtf8()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ permalink: /changelog/
 * **feature-intent**
   * Added support for NFC tag intents to `TabIntentProcessor`.
 
+* **firefox-accounts**, **service-fretboard**
+  * ⚠️ **This is a breaking change**: Due to migration to WorkManager v2.2.0, some classes like `WorkManagerSyncScheduler` and `WorkManagerSyncDispatcher` now expects a `Context` in their constructors.
+
 # 15.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v14.0.0...v15.0.0)

--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
@@ -42,9 +42,11 @@ class BaselinePingTest {
         Configuration(serverEndpoint = getPingServerAddress())
     )
 
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
     @Before
     fun clearWorkManager() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
     }
 
@@ -82,12 +84,12 @@ class BaselinePingTest {
         runBlocking {
             withTimeout(reasonablyHighCITimeoutMs) {
                 do {
-                    val workInfoList = WorkManager.getInstance().getWorkInfosByTag(tag).get()
+                    val workInfoList = WorkManager.getInstance(context).getWorkInfosByTag(tag).get()
                     workInfoList.forEach { workInfo ->
                         if (workInfo.state === WorkInfo.State.ENQUEUED) {
                             // Trigger WorkManager using TestDriver
-                            val testDriver = WorkManagerTestInitHelper.getTestDriver()
-                            testDriver.setAllConstraintsMet(workInfo.id)
+                            val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
+                            testDriver?.setAllConstraintsMet(workInfo.id)
                             return@withTimeout
                         }
                     }


### PR DESCRIPTION
---
Upgraded the library into v2.2.0 and removed the deprecated access of WorkManager and now it expects a context to be able to get the instance of the WM.

Also starting from v2.1.0, the dependency on lifecycle_extensions was removed and I had to declare them explicitly to continue using ProcessLifecycleOwner.

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
