### PR TITLE
Fix Glean SDK specific metrics API to be callable from Java

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/BooleanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/BooleanMetricType.kt
@@ -58,6 +58,7 @@ data class BooleanMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -76,6 +77,7 @@ data class BooleanMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/CounterMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/CounterMetricType.kt
@@ -34,6 +34,7 @@ data class CounterMetricType(
      * @param amount This is the amount to increment the counter by, defaulting to 1 if called
      * without parameters.
      */
+    @JvmOverloads
     fun add(amount: Int = 1) {
         if (!shouldRecord(logger)) {
             return
@@ -60,6 +61,7 @@ data class CounterMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -78,6 +80,7 @@ data class CounterMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): Int {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/DatetimeMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/DatetimeMetricType.kt
@@ -34,6 +34,7 @@ data class DatetimeMetricType(
      *
      * @param value The [Date] value to set. If not provided, will record the current time.
      */
+    @JvmOverloads
     fun set(value: Date = Date()) {
         if (!shouldRecord(logger)) {
             return
@@ -85,6 +86,7 @@ data class DatetimeMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -104,6 +106,7 @@ data class DatetimeMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValueAsString(pingName: String = sendInPings.first()): String {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -126,6 +129,7 @@ data class DatetimeMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): Date {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/EventMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/EventMetricType.kt
@@ -47,6 +47,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      *              identifiers. This is used for events where additional richer context is needed.
      *              The maximum length for values is defined by [MAX_LENGTH_EXTRA_KEY_VALUE]
      */
+    @JvmOverloads
     fun record(extra: Map<ExtraKeysEnum, String>? = null) {
         if (!shouldRecord(logger)) {
             return
@@ -96,6 +97,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -117,6 +119,7 @@ data class EventMetricType<ExtraKeysEnum : Enum<ExtraKeysEnum>>(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): List<RecordedEventData> {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/MemoryDistributionMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/MemoryDistributionMetricType.kt
@@ -85,6 +85,7 @@ data class MemoryDistributionMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -103,6 +104,7 @@ data class MemoryDistributionMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): FunctionalHistogram {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringListMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringListMetricType.kt
@@ -82,6 +82,7 @@ data class StringListMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -100,6 +101,7 @@ data class StringListMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): List<String> {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/StringMetricType.kt
@@ -60,6 +60,7 @@ data class StringMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -78,6 +79,7 @@ data class StringMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): String {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
@@ -151,6 +151,7 @@ data class TimespanMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         return TimespansStorageEngine.getSnapshotWithTimeUnit(pingName, false)?.get(identifier) != null
     }
@@ -165,6 +166,7 @@ data class TimespanMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): Long {
         return TimespansStorageEngine.getSnapshotWithTimeUnit(pingName, false)!![identifier]!!.second
     }

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimingDistributionMetricType.kt
@@ -128,6 +128,7 @@ data class TimingDistributionMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -146,6 +147,7 @@ data class TimingDistributionMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): FunctionalHistogram {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/UuidMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/UuidMetricType.kt
@@ -78,6 +78,7 @@ data class UuidMetricType(
      * @return true if metric value exists, otherwise false
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testHasValue(pingName: String = sendInPings.first()): Boolean {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()
@@ -96,6 +97,7 @@ data class UuidMetricType(
      * @throws [NullPointerException] if no value is stored
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @JvmOverloads
     fun testGetValue(pingName: String = sendInPings.first()): UUID {
         @Suppress("EXPERIMENTAL_API_USAGE")
         Dispatchers.API.assertInTestingMode()


### PR DESCRIPTION
This adds `@JvmOverloads` to the specific metrics API and the testing API.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
