### PR TITLE
Issue #4618: Do not publish tooling-detekt

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -331,7 +331,7 @@ projects:
   tooling-detekt:
     path: components/tooling/detekt
     description: 'Custom Detekt rules for internal use.'
-    publish: true
+    publish: false
   tooling-lint:
     path: components/tooling/lint
     description: 'Custom Lint checks for using and writing components.'


### PR DESCRIPTION
- We first need to configure a publish task that supports
publishing .jar files. We only publish .aar right now.