### PR TITLE
Auto-publication workflow support

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -8,6 +8,11 @@ def libVcsUrl = properties.libVcsUrl
 def libLicense = properties.libLicense
 def libLicenseUrl = properties.libLicenseUrl
 
+def getTimestamp() {
+    def date = new Date()
+    return date.format('yyyyMMddHHmmss')
+}
+
 ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
     apply plugin: 'digital.wup.android-maven-publish'
 
@@ -26,7 +31,8 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
                     groupId = groupIdArg
                     artifactId = artifactIdArg
                     description = descriptionArg
-                    version = config.componentsVersion + (project.hasProperty('snapshot') ? '-SNAPSHOT' : '')
+                    // 'local' is for streamlining local publication workflow.
+                    version = config.componentsVersion + (project.hasProperty('snapshot') ? '-SNAPSHOT' : (project.hasProperty('local') ? '-local' + getTimestamp() : ''))
 
                     licenses {
                         license {

--- a/substitute-local-ac.gradle
+++ b/substitute-local-ac.gradle
@@ -1,0 +1,32 @@
+logger.lifecycle("[local-ac] adjusting project to use locally published android-components modules")
+
+// Inject mavenLocal repository. This is where we're expected to publish modules.
+repositories {
+    mavenLocal()
+}
+
+configurations.all { config ->
+    if (config.isCanBeResolved()) {
+        config.resolutionStrategy { strategy ->
+            dependencySubstitution {
+                all { dependency ->
+                    if (!(dependency.requested instanceof ModuleComponentSelector)) {
+                        // We only care about substituting for a module, not a project.
+                        return
+                    }
+
+                    // For every org.mozilla.components.* module, substitute its version for '+'.
+                    // '+' version tells gradle to resolve the latest available version.
+                    // As long as 'mavenLocal' is in the repositories list, gradle should pick out
+                    // latest published module during dependency resolution phase.
+                    def group = dependency.requested.group
+                    if (group == 'org.mozilla.components') {
+                        def name = dependency.requested.module
+                        dependency.useTarget([group: group, name: name, version: '+'])
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This requires a Fenix counterpart: https://github.com/mozilla-mobile/fenix/pull/5801

Initially, I went down the "make composite builds work well with a-c" rabbithole, and while they generally worked, experience in Android Studio was horrible. It would get _very_ confused and broken. So instead, I've settled for automating a publication workflow.

This patch enabled support for an auto-publication workflow for android-components.
It automates a common pattern seen in local development:

Old way:
- after every change in a-c, publish it locally with a unique version (bumping it manually)
- manually modify Fenix to consume a custom version of a-c from a mavenLocal repository
- this involves modifying Dependencies.kt for each new a-c version, fixing a few things in `app/build.gradle`, and specifying a new repository in `build.gradle`. 

New way:
- set a flag in fenix's local.properties to enable auto-publication
- run Fenix builds after making changes to a-c. Changes in a-c will be automatically picked up.
- no other changes are necessary to any Fenix files other than a single flag in local.properties!
- manually bumping android-components is no longer needed!