### PR TITLE
Closes #4120 - Test helper for creating attached fragment

### DIFF
--- a/components/support/test/build.gradle
+++ b/components/support/test/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     implementation Dependencies.androidx_test_junit
     implementation Dependencies.testing_mockito
+    implementation Dependencies.androidx_fragment
     implementation (Dependencies.testing_robolectric) {
         exclude group: 'org.apache.maven'
     }

--- a/components/support/test/src/main/java/mozilla/components/support/test/robolectric/Fragments.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/robolectric/Fragments.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.test.robolectric
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import org.robolectric.Robolectric
+
+/**
+ * Set up an added [Fragment] to a [FragmentActivity] that has been initialized to a resumed state.
+ *
+ * @param fragmentTag the name that will be used to tag the fragment inside the [FragmentManager].
+ * @param fragmentFactory a lambda function that returns a Fragment that will be added to the Activity.
+ *
+ * @return The same [Fragment] that was returned from [fragmentFactory] after it got added to the
+ * Activity.
+ */
+inline fun <T : Fragment> createAddedTestFragment(fragmentTag: String = "test", fragmentFactory: () -> T): T {
+    val activity = Robolectric.buildActivity(FragmentActivity::class.java)
+            .create()
+            .start()
+            .resume()
+            .get()
+
+    return fragmentFactory().also {
+        activity.supportFragmentManager.beginTransaction()
+                .add(it, fragmentTag)
+                .commitNow()
+    }
+}

--- a/components/support/test/src/test/java/mozilla/components/support/test/robolectric/FragmentsTest.kt
+++ b/components/support/test/src/test/java/mozilla/components/support/test/robolectric/FragmentsTest.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.test.robolectric
+
+import androidx.fragment.app.Fragment
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FragmentsTest {
+
+    @Test
+    fun `setupFragment should add fragment correctly`() {
+        val addedFragment = createAddedTestFragment { Fragment() }
+
+        assertTrue(addedFragment.isAdded)
+    }
+
+    @Test
+    fun `setupFragment should add fragment with correct tag`() {
+        val fragment = createAddedTestFragment(fragmentTag = "aTag") { Fragment() }
+
+        assertNotNull(fragment.fragmentManager?.findFragmentByTag("aTag"))
+    }
+}


### PR DESCRIPTION
---
I tried searching for `Robolectric.buildActivity(FragmentActivity::class.java)` uses and see if they need customization in terms of which lifecycle method they need to be in when initialized, but found that they were all created in a resumed state, so no need to add such customization for that (at least for now).

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
