### PR TITLE
1586881: Fix high error rate on glean.baseline.duration

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/private/TimespanMetricType.kt
@@ -83,11 +83,11 @@ data class TimespanMetricType(
                 @Suppress("EXPERIMENTAL_API_USAGE")
                 Dispatchers.API.launch {
                     TimespansStorageEngine.set(this@TimespanMetricType, timeUnit, elapsedNanos)
-
-                    // Reset the timerId.
-                    timerId = null
                 }
             }
+
+            // Reset the timerId.
+            timerId = null
         }
     }
 


### PR DESCRIPTION
There is a race condition in how the TimingManager is used here.
When stopping a timer, we dispatch a task to actually record the value in the
timespan, and only reset the TimingManager in that async task after the
recording, which requires I/O, is complete.

If the timespan is started in the meantime, an error will be recorded, rather
than safely starting a new timespan measurement.

This change could be considered on the principle (followed elsewhere), that
we do timing management and measurement synchronously, and only recording
asynchronously.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
