### PR TITLE
No issue: bump a-s to 0.41.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.40.0"
+    const val mozilla_appservices = "0.41.0"
 
     const val material = "1.0.0"
 


### PR DESCRIPTION
Release notes: https://github.com/mozilla/application-services/releases

cc @grigoryk 