### PR TITLE
Closes #4679 - lower download notification importance for Android O+

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -28,7 +28,8 @@ import kotlin.random.Random
 @Suppress("TooManyFunctions")
 internal object DownloadNotification {
 
-    private const val NOTIFICATION_CHANNEL_ID = "Downloads"
+    private const val NOTIFICATION_CHANNEL_ID = "mozac.feature.downloads.generic"
+    private const val LEGACY_NOTIFICATION_CHANNEL_ID = "Downloads"
 
     internal const val EXTRA_DOWNLOAD_ID = "downloadId"
 
@@ -49,6 +50,7 @@ internal object DownloadNotification {
             .setOngoing(true)
             .addAction(getPauseAction(context, downloadState.id))
             .addAction(getCancelAction(context, downloadState.id))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
     }
 
@@ -82,6 +84,7 @@ internal object DownloadNotification {
             .setContentText(context.getString(R.string.mozac_feature_downloads_completed_notification_text2))
             .setColor(ContextCompat.getColor(context, R.color.mozac_feature_downloads_notification))
             .setContentIntent(createPendingIntent(context, ACTION_OPEN, downloadState.id))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
     }
 
@@ -99,6 +102,7 @@ internal object DownloadNotification {
             .setCategory(NotificationCompat.CATEGORY_ERROR)
             .addAction(getTryAgainAction(context, downloadState.id))
             .addAction(getCancelAction(context, downloadState.id))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
     }
 
@@ -133,10 +137,12 @@ internal object DownloadNotification {
             val channel = NotificationChannel(
                 NOTIFICATION_CHANNEL_ID,
                 context.getString(R.string.mozac_feature_downloads_notification_channel),
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_LOW
             )
 
             notificationManager.createNotificationChannel(channel)
+
+            notificationManager.deleteNotificationChannel(LEGACY_NOTIFICATION_CHANNEL_ID)
         }
 
         return NOTIFICATION_CHANNEL_ID

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@ permalink: /changelog/
     * To open .apk files, you must still add the permisison `android.permission.INSTALL_PACKAGES` to your manifest.
   * Improved visuals of `SimpleDownloadDialogFragment` to better match `SitePermissionsDialogFragment`.
     * `SimpleDownloadDialogFragment` can similarly be themed by using `PromptsStyling` properties.
+  * Recreated download notification channel with lower importance for Android O+ so that the notification is not audibly intrusive.
 
 * **feature-webnotifications**
   * Adds feature implementation for configuring and displaying web notifications to the user


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

I think  [IMPORTANCE_LOW](https://developer.android.com/reference/android/app/NotificationManager.html#IMPORTANCE_LOW) is the right one but I am not sure if this requires ux-feedback.
https://material.io/design/platform-guidance/android-notifications.html#settings

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
