### PR TITLE
feature-contextmenu: Do not show download confirmation dialog for "save image".

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -26,5 +26,6 @@ data class DownloadState(
     val userAgent: String? = null,
     val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
     val referrerUrl: String? = null,
+    val skipConfirmation: Boolean = false,
     val id: String = UUID.randomUUID().toString()
 )

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -151,7 +151,7 @@ data class ContextMenuCandidate(
             action = { tab, hitResult ->
                 contextMenuUseCases.injectDownload(
                     tab.id,
-                    DownloadState(hitResult.src)
+                    DownloadState(hitResult.src, skipConfirmation = true)
                 )
             }
         )

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -382,6 +382,8 @@ class ContextMenuCandidateTest {
         assertEquals(
             "https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png",
             store.state.tabs.first().content.download!!.url)
+        assertTrue(
+            store.state.tabs.first().content.download!!.skipConfirmation)
     }
 
     @Test

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -107,7 +107,7 @@ class DownloadsFeature(
      */
     private fun processDownload(tab: SessionState, download: DownloadState): Boolean {
         return if (applicationContext.isPermissionGranted(downloadManager.permissions.asIterable())) {
-            if (fragmentManager != null) {
+            if (fragmentManager != null && !download.skipConfirmation) {
                 showDialog(tab, download)
                 false
             } else {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -153,6 +153,43 @@ class DownloadsFeatureTest {
     }
 
     @Test
+    fun `Adding a Download with skipConfirmation flag will start download immediately`() {
+        val fragmentManager: FragmentManager = mockFragmentManager()
+
+        grantPermissions()
+
+        val downloadManager: DownloadManager = mock()
+        doReturn(
+            arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE)
+        ).`when`(downloadManager).permissions
+
+        val feature = DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            fragmentManager = fragmentManager,
+            downloadManager = downloadManager
+        )
+
+        feature.start()
+
+        verify(fragmentManager, never()).beginTransaction()
+
+        val download = DownloadState(
+            url = "https://www.mozilla.org",
+            skipConfirmation = true
+        )
+
+        store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
+            .joinBlocking()
+
+        testDispatcher.advanceUntilIdle()
+
+        verify(fragmentManager, never()).beginTransaction()
+        verify(downloadManager).download(eq(download), anyString())
+    }
+
+    @Test
     fun `When starting the feature will reattach to already existing dialog`() {
         grantPermissions()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-contextmenu**
+  * The "Save Image" context menu item will no longer prompt before downloading the image.
+
 # 16.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v15.0.0...v16.0.0)


### PR DESCRIPTION
Fixing Fenix issue: https://github.com/mozilla-mobile/fenix/issues/952

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
