### PR TITLE
Closes #4378 - Refactor AbstractFetchDownloadService

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -308,7 +308,22 @@ sealed class EngineAction : BrowserAction() {
  */
 sealed class DownloadAction : BrowserAction() {
     /**
-     * Adds the [downloadId] into the set of completed downloads inside the [BrowserState].
+     * Adds the [download] to the queued downloads action.
      */
-    data class DownloadCompletedAction(val downloadId: Long) : DownloadAction()
+    data class AddDownloadAction(val download: DownloadState): DownloadAction()
+
+    /**
+     * Marks the [download] as started.
+     */
+    data class DownloadStartedAction(val download: DownloadState): DownloadAction()
+
+    /**
+     * Marks the [download] as completed.
+     */
+    data class DownloadCompletedAction(val download: DownloadState) : DownloadAction()
+
+    /**
+     * Marks the [download] as failure
+     */
+    data class DownloadFailedAction(val download: DownloadState): DownloadAction()
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -302,3 +302,13 @@ sealed class EngineAction : BrowserAction() {
         val engineSessionState: EngineSessionState
     ) : EngineAction()
 }
+
+/**
+ * [BrowserAction] implementations relating to update the completed DownloadState inside [BrowserState]
+ */
+sealed class DownloadAction : BrowserAction() {
+    /**
+     * Adds the [downloadId] into the set of completed downloads inside the [BrowserState].
+     */
+    data class DownloadCompletedAction(val downloadId: Long) : DownloadAction()
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
+import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.action.WebExtensionAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
@@ -32,6 +33,7 @@ internal object BrowserStateReducer {
             is TrackingProtectionAction -> TrackingProtectionStateReducer.reduce(state, action)
             is EngineAction -> EngineStateReducer.reduce(state, action)
             is WebExtensionAction -> WebExtensionReducer.reduce(state, action)
+            is DownloadAction -> DownloadStateReducer.reduce(state, action)
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.DownloadAction
+import mozilla.components.browser.state.state.BrowserState
+
+internal object DownloadStateReducer {
+
+    /**
+     * [DownloadAction] Reducer function for modifying [BrowserState.completedDownloads].
+     */
+    fun reduce(state: BrowserState, action: DownloadAction): BrowserState = when (action) {
+        is DownloadAction.DownloadCompletedAction ->
+            state.copy(completedDownloads = state.completedDownloads + action.downloadId)
+    }
+}

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
@@ -6,14 +6,43 @@ package mozilla.components.browser.state.reducer
 
 import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.state.content.DownloadStatus
 
 internal object DownloadStateReducer {
 
     /**
-     * [DownloadAction] Reducer function for modifying [BrowserState.completedDownloads].
+     * [DownloadAction] Reducer function for modifying [BrowserState.queuedDownloads].
      */
     fun reduce(state: BrowserState, action: DownloadAction): BrowserState = when (action) {
-        is DownloadAction.DownloadCompletedAction ->
-            state.copy(completedDownloads = state.completedDownloads + action.downloadId)
+        is DownloadAction.DownloadStartedAction -> {
+            state.changeDownloadStatusOf(downloadState = action.download, newState = DownloadStatus.RUNNING)
+        }
+        is DownloadAction.AddDownloadAction -> {
+            state.changeDownloadStatusOf(downloadState = action.download, newState = DownloadStatus.QUEUED)
+        }
+        is DownloadAction.DownloadCompletedAction -> {
+            state.changeDownloadStatusOf(downloadState = action.download, newState = DownloadStatus.COMPLETED)
+        }
+        is DownloadAction.DownloadFailedAction -> {
+            state.changeDownloadStatusOf(downloadState = action.download, newState = DownloadStatus.FAILED)
+        }
     }
+}
+
+/**
+ * Retrieves the [downloadState] from [BrowserState.queuedDownloads] and change its status to the
+ * [newState].
+ *
+ * @return a new copy of [BrowserState] with newly updated [downloadState] status.
+ */
+private fun BrowserState.changeDownloadStatusOf(downloadState: DownloadState,
+                                                newState: DownloadStatus): BrowserState {
+    return copy(queuedDownloads = queuedDownloads.map { queuedDownloadState ->
+        if (downloadState.id == queuedDownloadState.id) {
+            queuedDownloadState.copy(status = newState)
+        } else {
+            queuedDownloadState
+        }
+    })
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.state.state
 
+import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.lib.state.State
 
 /**
@@ -11,7 +12,7 @@ import mozilla.components.lib.state.State
  *
  * @property tabs the list of open tabs, defaults to an empty list.
  * @property selectedTabId the ID of the currently selected (active) tab.
- * @property completedDownloads a set of ids of the completed downloads.
+ * @property queuedDownloads a list of [DownloadState]s that shows the current queued downloads.
  * @property customTabs the list of custom tabs, defaults to an empty list.
  * @property extensions A map of extension ids and web extensions of all installed web extensions.
  * The extensions here represent the default values for all [BrowserState.extensions] and can
@@ -20,7 +21,7 @@ import mozilla.components.lib.state.State
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
     val selectedTabId: String? = null,
-    val completedDownloads: Set<Long> = emptySet(),
+    val queuedDownloads: List<DownloadState> = emptyList(),
     val customTabs: List<CustomTabSessionState> = emptyList(),
     val extensions: Map<String, WebExtensionState> = emptyMap()
 ) : State

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -11,6 +11,7 @@ import mozilla.components.lib.state.State
  *
  * @property tabs the list of open tabs, defaults to an empty list.
  * @property selectedTabId the ID of the currently selected (active) tab.
+ * @property completedDownloads a set of ids of the completed downloads.
  * @property customTabs the list of custom tabs, defaults to an empty list.
  * @property extensions A map of extension ids and web extensions of all installed web extensions.
  * The extensions here represent the default values for all [BrowserState.extensions] and can
@@ -19,6 +20,7 @@ import mozilla.components.lib.state.State
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
     val selectedTabId: String? = null,
+    val completedDownloads: Set<Long> = emptySet(),
     val customTabs: List<CustomTabSessionState> = emptyList(),
     val extensions: Map<String, WebExtensionState> = emptyMap()
 ) : State

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -16,6 +16,7 @@ import java.util.UUID
  * @property contentLength The file size reported by the server.
  * @property userAgent The user agent to be used for the download.
  * @property destinationDirectory The matching destination directory for this type of download.
+ * @property status The current download status of this download.
  * @property referrerUrl The site that linked to this download.
  */
 data class DownloadState(
@@ -27,5 +28,6 @@ data class DownloadState(
     val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
     val referrerUrl: String? = null,
     val skipConfirmation: Boolean = false,
+    val status: DownloadStatus? = null,
     val id: String = UUID.randomUUID().toString()
 )

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadStatus.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadStatus.kt
@@ -1,0 +1,14 @@
+package mozilla.components.browser.state.state.content
+
+/**
+ * Enum to describe the current status of a [DownloadState].
+ *
+ * @property QUEUED means that the [DownloadState] is registered with the DownloadManager and ready
+ * to be executed.
+ * @property RUNNING means that the [DownloadState] is currently ongoing the downloading process.
+ * @property COMPLETED means that the [DownloadState] has been completed successfully.
+ * @property FAILED means that the [DownloadState] has been completed but with failure.
+ */
+enum class DownloadStatus {
+    QUEUED, RUNNING, COMPLETED, FAILED
+}

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadActionTest {
+
+    @Test
+    fun `DownloadCompletedAction - Appends to completedDownload set`() {
+        val store = BrowserStore()
+
+        assertEquals(0, store.state.completedDownloads.count())
+
+        store.dispatch(DownloadAction.DownloadCompletedAction(1L)).joinBlocking()
+        store.dispatch(DownloadAction.DownloadCompletedAction(2L)).joinBlocking()
+
+        assertEquals(setOf(1L, 2L), store.state.completedDownloads)
+    }
+}

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
@@ -17,8 +17,6 @@ import androidx.core.util.isEmpty
 import androidx.core.util.set
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -6,10 +6,11 @@ package mozilla.components.feature.downloads
 
 import android.app.DownloadManager.EXTRA_DOWNLOAD_ID
 import android.content.Intent
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Request
@@ -34,7 +35,7 @@ import org.mockito.MockitoAnnotations.initMocks
 class AbstractFetchDownloadServiceTest {
 
     @Mock private lateinit var client: Client
-    @Mock private lateinit var broadcastManager: LocalBroadcastManager
+    @Mock private lateinit var store: BrowserStore
     private lateinit var service: AbstractFetchDownloadService
 
     @Before
@@ -42,8 +43,8 @@ class AbstractFetchDownloadServiceTest {
         initMocks(this)
         service = spy(object : AbstractFetchDownloadService() {
             override val httpClient = client
+            override val browserStore: BrowserStore = store
         })
-        doReturn(broadcastManager).`when`(service).broadcastManager
         doReturn(testContext).`when`(service).context
     }
 
@@ -71,7 +72,7 @@ class AbstractFetchDownloadServiceTest {
         assertEquals(download.url, providedDownload.value.url)
         assertEquals(download.fileName, providedDownload.value.fileName)
 
-        verify(broadcastManager).sendBroadcast(any())
+        verify(store).dispatch(DownloadAction.DownloadCompletedAction(1L))
         Unit
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -113,6 +113,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler {
                 },
                 downloadManager = FetchDownloadManager(
                     requireContext().applicationContext,
+                    components.store,
                     DownloadService::class
                 ),
                 onNeedToRequestPermissions = { permissions ->

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/downloads/DownloadService.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/downloads/DownloadService.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.samples.browser.downloads
 
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import org.mozilla.samples.browser.ext.components
 
 class DownloadService : AbstractFetchDownloadService() {
     override val httpClient by lazy { components.client }
+    override val browserStore: BrowserStore by lazy { components.store }
 }


### PR DESCRIPTION
---
I've removed the dependency on `LocalBroadcastManager` and added a field in the `BrowserState` to maintain the completedDownloads ids. 

When the download completes I dispatch an action through the `BrowserStore` which has a subscription in `FetchDownloadManager` which in turn invokes `onDownloadCompleted`.

I'm not sure if the modeling of the `BrowserState` is optimal or not, I'm open for better ideas however.

EDIT: Added more explanation about what I have done. 

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
