### PR TITLE
For #4672: Fix background ripple of Switch in BrowserMenuImageSwitch

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_switch.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_switch.xml
@@ -23,6 +23,7 @@
         style="@style/Mozac.Browser.Menu.Item.Text"
         android:layout_width="match_parent"
         android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
         android:orientation="vertical"
         android:paddingStart="@dimen/mozac_browser_menu_item_image_text_label_padding_start"
         android:paddingEnd="0dp"/>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,6 +48,9 @@ permalink: /changelog/
   })
   ```
 
+* **browser-menu**
+   * Fixes background ripple of Switch in BrowserMenuImageSwitch
+
 # 16.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v15.0.0...v16.0.0)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Fix for #4672 and related issue in https://github.com/mozilla-mobile/fenix/issues/5820

Ripple in fenix after fix:
<img src="https://user-images.githubusercontent.com/5179255/66557702-cbf24580-ebae-11e9-8915-baac730c44ec.png" width="240">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
