### PR TITLE
Update jacoco to version 0.8.5.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
     afterEvaluate {
         if (it.hasProperty('android')) {
             jacoco {
-                toolVersion = "0.8.4"
+                toolVersion = "0.8.5"
             }
 
             // Format test output


### PR DESCRIPTION
A new version of jacoco was released and there's at least one improvement for Kotlin code:
> Branches added by the Kotlin compiler for functions with default arguments and containing arguments of type long or double should be filtered out during generation of report (GitHub #908).

Let's see if this works in automation and how that affects our coverage.