### PR TITLE
For #4758: Remove min API of M for dataprotect

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -14,8 +14,5 @@ class Config(val componentsVersion: String) {
         const val compileSdkVersion = 29
         const val minSdkVersion = 21
         const val targetSdkVersion = 28
-
-        // Component lib-dataprotect requires functionality from API 23.
-        const val minSdkVersion_dataprotect = 23
     }
 }

--- a/components/lib/dataprotect/build.gradle
+++ b/components/lib/dataprotect/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion config.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion config.minSdkVersion_dataprotect
+        minSdkVersion config.minSdkVersion
         targetSdkVersion config.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -25,6 +25,7 @@ android {
 
 dependencies {
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.androidx_annotation
 
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **lib-dataprotect**
+  * ⚠️ **This is a breaking change**: Refactored to remove the 23 min SDK by implementing RSA + AES workaround for <23, `KeyStore` now needs a context.
+
 * **browser-toolbar**
   * ⚠️ **This is a breaking change**: Refactored the internals to use `ConstraintLayout`. As part of this change the public API was simplified and unused methods/properties have been removed.
 

--- a/samples/dataprotect/build.gradle
+++ b/samples/dataprotect/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "org.mozilla.samples.dataprotect"
 
-        minSdkVersion config.minSdkVersion_dataprotect
+        minSdkVersion config.minSdkVersion
         targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"

--- a/samples/dataprotect/src/main/java/org/mozilla/samples/dataprotect/MainActivity.kt
+++ b/samples/dataprotect/src/main/java/org/mozilla/samples/dataprotect/MainActivity.kt
@@ -19,7 +19,8 @@ import java.nio.charset.StandardCharsets
 
 class MainActivity : AppCompatActivity() {
     private val logger: Logger = Logger("dataprotect")
-    private val keystore: Keystore = Keystore(KEYSTORE_LABEL)
+    private val keystore: Keystore by lazy { Keystore(context = this, label = KEYSTORE_LABEL) }
+
     @Suppress("MagicNumber")
     private val itemKeys: List<String> = List(5) { "protected item ${it + 1}" }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Trying to remove the min SDK of 23 dependency to use these for Fenix so looking for feedback because I don't know much about the history here :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
