### PR TITLE
Add externalAppType field

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
@@ -27,6 +27,7 @@ import java.util.UUID
  * @property navigationBarColor Background color for the navigation bar.
  * @property titleVisible Whether the title should be shown in the custom tab.
  * @property sessionToken The token associated with the custom tab.
+ * @property externalAppType How this custom tab is being displayed.
  */
 data class CustomTabConfig(
     val id: String = UUID.randomUUID().toString(),
@@ -40,13 +41,32 @@ data class CustomTabConfig(
     val exitAnimations: Bundle? = null,
     @ColorInt val navigationBarColor: Int? = null,
     val titleVisible: Boolean = false,
-    val sessionToken: CustomTabsSessionToken? = null
+    val sessionToken: CustomTabsSessionToken? = null,
+    val externalAppType: ExternalAppType = ExternalAppType.CUSTOM_TAB
 ) {
 
     companion object {
         const val EXTRA_NAVIGATION_BAR_COLOR = "androidx.browser.customtabs.extra.NAVIGATION_BAR_COLOR"
         const val EXTRA_ADDITIONAL_TRUSTED_ORIGINS = "android.support.customtabs.extra.ADDITIONAL_TRUSTED_ORIGINS"
     }
+}
+
+/**
+ * Represents different contexts that a custom tab session can be displayed in.
+ */
+enum class ExternalAppType {
+    /**
+     * Custom tab is displayed as a normal custom tab with toolbar.
+     */
+    CUSTOM_TAB,
+    /**
+     * Custom tab toolbar is hidden inside a Progressive Web App created by the browser.
+     */
+    PROGRESSIVE_WEB_APP,
+    /**
+     * Custom tab is displayed fullscreen inside a Trusted Web Activity from an external app.
+     */
+    TRUSTED_WEB_ACTIVITY
 }
 
 data class CustomTabActionButtonConfig(

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
@@ -35,6 +35,7 @@ import mozilla.components.browser.state.state.CustomTabActionButtonConfig
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
 import mozilla.components.browser.state.state.CustomTabMenuItem
+import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.toSafeBundle
 import mozilla.components.support.utils.toSafeIntent
@@ -101,7 +102,8 @@ fun createCustomTabConfigFromIntent(
             CustomTabsSessionToken.getSessionTokenFromIntent(intent)
         } else {
             null
-        }
+        },
+        externalAppType = ExternalAppType.CUSTOM_TAB
     )
 }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.net.toUri
 import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.support.utils.ColorUtils.isDark
 
@@ -42,7 +43,8 @@ fun WebAppManifest.toCustomTabConfig(): CustomTabConfig {
         actionButtonConfig = null,
         showCloseButton = false,
         showShareMenuItem = true,
-        menuItems = emptyList()
+        menuItems = emptyList(),
+        externalAppType = ExternalAppType.PROGRESSIVE_WEB_APP
     )
 }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_ADDITIONAL_TRUSTED_ORIGINS
+import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent
@@ -58,7 +59,7 @@ class TrustedWebActivityIntentProcessor(
         return if (!url.isNullOrEmpty() && matches(intent)) {
             val session = Session(url, private = false, source = Session.Source.HOME_SCREEN)
             val customTabConfig = createCustomTabConfigFromIntent(intent, null)
-            session.customTabConfig = customTabConfig
+            session.customTabConfig = customTabConfig.copy(externalAppType = ExternalAppType.TRUSTED_WEB_ACTIVITY)
 
             sessionManager.add(session)
             loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external())

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **browser-toolbar**
   * ⚠️ **This is a breaking change**: Refactored the internals to use `ConstraintLayout`. As part of this change the public API was simplified and unused methods/properties have been removed.
 
+* **browser-state**
+  * Added `externalAppType` to `CustomTabConfig` to indicate how the session is being used.
+
 # 18.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v17.0.0...v18.0.0)


### PR DESCRIPTION
This field is meant to make it easier to identify TWAs in Fenix so that we can show some "Running in Firefox Preview" UI.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
