### PR TITLE
Closes #4830: DownloadsFeature: Consume download from state if download is started without confirmation dialog.

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -111,6 +111,7 @@ class DownloadsFeature(
                 showDialog(tab, download)
                 false
             } else {
+                useCases.consumeDownload(tab.id, download.id)
                 startDownload(download)
             }
         } else {

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -135,7 +135,7 @@ class DownloadsFeatureTest {
         val feature = DownloadsFeature(
             testContext,
             store,
-            useCases = mock(),
+            useCases = DownloadsUseCases(store),
             downloadManager = downloadManager
         )
 
@@ -143,7 +143,7 @@ class DownloadsFeatureTest {
 
         verify(downloadManager, never()).download(any(), anyString())
 
-        val download: DownloadState = mock()
+        val download = DownloadState(url = "https://www.mozilla.org")
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 
@@ -166,7 +166,7 @@ class DownloadsFeatureTest {
         val feature = DownloadsFeature(
             testContext,
             store,
-            useCases = mock(),
+            useCases = DownloadsUseCases(store),
             fragmentManager = fragmentManager,
             downloadManager = downloadManager
         )
@@ -187,6 +187,8 @@ class DownloadsFeatureTest {
 
         verify(fragmentManager, never()).beginTransaction()
         verify(downloadManager).download(eq(download), anyString())
+
+        assertNull(store.state.findTab("test-tab")!!.content.download)
     }
 
     @Test
@@ -224,7 +226,7 @@ class DownloadsFeatureTest {
 
     @Test
     fun `onPermissionsResult will start download if permissions were granted`() {
-        val download: DownloadState = mock()
+        val download = DownloadState(url = "https://www.mozilla.org")
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download = download))
             .joinBlocking()
 
@@ -236,7 +238,7 @@ class DownloadsFeatureTest {
         val feature = DownloadsFeature(
             testContext,
             store,
-            useCases = mock(),
+            useCases = DownloadsUseCases(store),
             downloadManager = downloadManager
         )
 
@@ -330,7 +332,7 @@ class DownloadsFeatureTest {
         val feature = spy(DownloadsFeature(
             testContext,
             store,
-            useCases = mock(),
+            useCases = DownloadsUseCases(store),
             downloadManager = downloadManager
         ))
 
@@ -341,7 +343,7 @@ class DownloadsFeatureTest {
         verify(downloadManager, never()).download(any(), anyString())
         verify(feature, never()).showDownloadNotSupportedError()
 
-        val download: DownloadState = mock()
+        val download = DownloadState(url = "https://www.mozilla.org")
         store.dispatch(ContentAction.UpdateDownloadAction("test-tab", download))
             .joinBlocking()
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
