### PR TITLE
1586881: Fix baseline duration errors

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -496,7 +496,8 @@ open class GleanInternalAPI internal constructor () {
     /**
      * Handle the background event and send the appropriate pings.
      */
-    internal fun handleBackgroundEvent() {
+    @Suppress("EXPERIMENTAL_API_USAGE")
+    internal fun handleBackgroundEvent() = Dispatchers.API.launch {
         // Schedule the baseline and event pings
         sendPings(listOf(Pings.baseline, Pings.events))
     }


### PR DESCRIPTION
The error was happening because the sending of the baseline ping was not happening in the same dispatcher task queue as the recording of the duration timespan.

Normally you would expect to see:

1. start timespan
2. stop timespan
3. collect ping (clearing timespan)

But since ping collection was happening on the main thread (!!!) rather than the task queue, it was possible to get into this situation:

1. start timespan
2. stop timespan
3. start timespan
4. stop timespan <-- **error:** Timespan value already recorded. New value discarded
5. collect ping (clearing timespan)

This bug doesn't seem to exist in glean-core.  Which raises the question of whether to merge this fix to glean-ac given that glean-core migration is imminent.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
