### PR TITLE
Add back the @JvmOverloads to the Glean SDK public API

### DIFF
--- a/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/Glean.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.glean
 
 import android.content.Context
+import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.private.RecordedExperimentData
@@ -31,6 +32,8 @@ object Glean {
      * as shared preferences
      * @param configuration A Glean [Configuration] object with global settings.
      */
+    @JvmOverloads
+    @MainThread
     fun initialize(
         applicationContext: Context,
         configuration: Configuration = Configuration()
@@ -82,6 +85,7 @@ object Glean {
      * @param branch The experiment branch (maximum 30 bytes)
      * @param extra Optional metadata to output with the ping
      */
+    @JvmOverloads
     fun setExperimentActive(
         experimentId: String,
         branch: String,

--- a/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -19,12 +19,17 @@ import mozilla.telemetry.glean.config.Configuration as GleanCoreConfiguration
  * @property maxEvents the number of events to store before the events ping is sent
  * @property httpClient The HTTP client implementation to use for uploading pings.
  */
-data class Configuration(
-    val serverEndpoint: String = GleanCoreConfiguration.DEFAULT_TELEMETRY_ENDPOINT,
+data class Configuration @JvmOverloads constructor (
+    val serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
     val channel: String? = null,
     val maxEvents: Int? = null,
     val httpClient: PingUploader = ConceptFetchHttpUploader(lazy { HttpURLConnectionClient() })
 ) {
+    // The following is required to support calling our API from Java.
+    companion object {
+        const val DEFAULT_TELEMETRY_ENDPOINT = GleanCoreConfiguration.DEFAULT_TELEMETRY_ENDPOINT
+    }
+
     /**
      * Convert the Android Components configuration object to the Glean SDK
      * configuration object.

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanFromJavaTest.java
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanFromJavaTest.java
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.service.glean;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import mozilla.components.service.glean.config.Configuration;
+
+@RunWith(RobolectricTestRunner.class)
+public class GleanFromJavaTest {
+    // The only purpose of these tests is to make sure the Glean API is
+    // callable from Java. If something goes wrong, it should complain about missing
+    // methods at build-time.
+
+    @Test
+    public void testInitGleanWithDefaults() {
+        Glean.INSTANCE.initialize(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    public void testInitGleanWithConfiguration() {
+        Configuration config =
+                new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT, "test-channel");
+        Glean.INSTANCE.initialize(ApplicationProvider.getApplicationContext(), config);
+    }
+
+    @Test
+    public void testGleanExperimentsAPIWithDefaults() {
+        Glean.INSTANCE.setExperimentActive("test-exp-id-1", "test-branch-1");
+    }
+
+    @Test
+    public void testGleanExperimentsAPIWithOptional() {
+        Map<String, String> experimentProperties = new HashMap<>();
+        experimentProperties.put("test-prop1", "test-prop-result1");
+
+        Glean.INSTANCE.setExperimentActive(
+                "test-exp-id-1",
+                "test-branch-1",
+                experimentProperties
+        );
+    }
+}


### PR DESCRIPTION
This additionally adds unit testing in Java to make sure we're not regressing this again.

Note: this restores the annotations that were removed by #4620

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
