### PR TITLE
Closes #4913: Add background message support for WebExtensions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ permalink: /changelog/
 
 * **concept-engine**
   * Adds support for WebPush abstraction to the Engine.
+  
+* **support-webextensions**
+  * Adds support for sending messages to background pages and scripts in WebExtensions.
 
 # 19.0.0
 


### PR DESCRIPTION
This adds the missing support for background messages in `WebExtensionController` needed for Secure Proxy WebExtension work.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
