### PR TITLE
Closes #4923: Deny permissions when the dialog is dismissed

### DIFF
--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragment.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragment.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.sitepermissions
 
 import android.annotation.SuppressLint
 import android.app.Dialog
+import android.content.DialogInterface
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -95,6 +96,11 @@ internal class SitePermissionsDialogFragment : AppCompatDialogFragment() {
         }
 
         return sheetDialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        feature?.onDismiss(sessionId)
     }
 
     private fun Dialog.setContainerView(rootView: View) {

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -161,6 +161,15 @@ class SitePermissionsFeature(
         }
     }
 
+    internal fun onDismiss(sessionId: String) {
+        sessionManager.runWithSession(sessionId) { session ->
+            session.contentPermissionRequest.consume {
+                onContentPermissionDeny(session, false)
+                true
+            }
+        }
+    }
+
     @Synchronized
     internal fun storeSitePermissions(
         session: Session,

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
@@ -149,6 +149,31 @@ class SitePermissionsDialogFragmentTest {
     }
 
     @Test
+    fun `dismissing the dialog notifies the feature`() {
+        val mockFeature: SitePermissionsFeature = mock()
+
+        val fragment = spy(
+                SitePermissionsDialogFragment.newInstance(
+                        "sessionId",
+                        "title",
+                        R.drawable.notification_icon_background,
+                        mockFeature,
+                        shouldShowDoNotAskAgainCheckBox = false,
+                        shouldSelectDoNotAskAgainCheckBox = false
+                )
+        )
+
+        fragment.feature = mockFeature
+
+        doReturn(testContext).`when`(fragment).requireContext()
+        doReturn(mockFragmentManager()).`when`(fragment).fragmentManager
+
+        fragment.onDismiss(mock())
+
+        verify(mockFeature).onDismiss("sessionId")
+    }
+
+    @Test
     fun `clicking on negative button notifies the feature (temporary)`() {
         val mockFeature: SitePermissionsFeature = mock()
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)

**I think this passes, but ktlint is throwing weird errors about missing newlines in my console**

- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one

**Does this need a changelog entry?**

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
