### PR TITLE
Fix Glean intermittents related to WorkManager

### DIFF
--- a/components/service/glean/src/test/java/mozilla/components/service/glean/GleanFromJavaTest.java
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/GleanFromJavaTest.java
@@ -5,6 +5,9 @@
 package mozilla.components.service.glean;
 
 import androidx.test.core.app.ApplicationProvider;
+import androidx.work.testing.WorkManagerTestInitHelper;
+
+import android.content.Context;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,14 +26,18 @@ public class GleanFromJavaTest {
 
     @Test
     public void testInitGleanWithDefaults() {
-        Glean.INSTANCE.initialize(ApplicationProvider.getApplicationContext());
+        Context context = ApplicationProvider.getApplicationContext();
+        WorkManagerTestInitHelper.initializeTestWorkManager(context);
+        Glean.INSTANCE.initialize(context);
     }
 
     @Test
     public void testInitGleanWithConfiguration() {
+        Context context = ApplicationProvider.getApplicationContext();
+        WorkManagerTestInitHelper.initializeTestWorkManager(context);
         Configuration config =
                 new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT, "test-channel");
-        Glean.INSTANCE.initialize(ApplicationProvider.getApplicationContext(), config);
+        Glean.INSTANCE.initialize(context, config);
     }
 
     @Test


### PR DESCRIPTION
This is an attempt to fix the intermittent failures in some Glean tests related
to WorkManager.  (See #4929)

This is just a theory -- I haven't been able to reproduce the failure locally.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
