### PR TITLE
Closes #4824: Throw exceptions on certain Rust errors

### DIFF
--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -44,7 +44,7 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 @RunWith(AndroidJUnit4::class)
 class AutoPushFeatureTest {
 
-    var lastVerified: Long
+    private var lastVerified: Long
         get() = preference(testContext).getLong(LAST_VERIFIED, System.currentTimeMillis())
         set(value) = preference(testContext).edit().putLong(LAST_VERIFIED, value).apply()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,12 +39,15 @@ permalink: /changelog/
 
 * **concept-engine**
   * Adds support for WebPush abstraction to the Engine.
-  
+
 * **support-webextensions**
   * Adds support for sending messages to background pages and scripts in WebExtensions.
-  
+
 * **service-firefox-accounts**
   * Adds `authorizeOAuthCode` method for generating scoped OAuth codes.
+
+* **feature-push**
+  * ⚠️ The `AutoPushFeature` now throws when reaching exceptions in the native layer that are unrecoverable.
 
 # 19.0.0
 
@@ -66,7 +69,7 @@ permalink: /changelog/
 * **service-glean**
    * The Rust implementation of the Glean SDK is now being used.
    * ⚠️ **This is a breaking change**: the `GleanDebugActivity` is no longer exposed from service-glean. Users need to use the one in `mozilla.telemetry.glean.debug.GleanDebugActivity` from the `adb` command line.
-   
+
 * **lib-push-firebase**
    * Fixes a potential bug where we receive a message for another push service that we cannot process.
 


### PR DESCRIPTION
Moved the internal `CoroutineScope.launchAndTry` extension to be a bit more generic for easier testing.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
