### PR TITLE
For #4907 - RTL url no margin set

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -14,6 +14,8 @@ import android.widget.ImageView
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.isVisible
@@ -104,6 +106,9 @@ class EditToolbar internal constructor(
             setOnTextChangeListener { text, _ ->
                 onTextChanged(text)
             }
+
+            setUrlGoneMargin(ConstraintSet.END,
+                    context.resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_gone_margin_end))
 
             setOnDispatchKeyEventPreImeListener { event ->
                 if (event?.keyCode == KeyEvent.KEYCODE_BACK && editListener?.onCancelEditing() != false) {
@@ -251,8 +256,28 @@ class EditToolbar internal constructor(
         views.url.setText("")
     }
 
+    private fun setUrlGoneMargin(anchor: Int, dimen: Int) {
+        val set = ConstraintSet()
+        val container = rootView.findViewById<ConstraintLayout>(
+                R.id.mozac_browser_toolbar_container)
+        set.clone(container)
+        set.setGoneMargin(R.id.mozac_browser_toolbar_edit_url_view, anchor, dimen)
+        set.applyTo(container)
+    }
+
     private fun onTextChanged(text: String) {
         views.clear.isVisible = text.isNotBlank()
+        /*
+        We use margin_gone instead of margin to take into account both the actionContainer(which in
+        most cases is gone) and the clear button.
+         */
+        if (text.isNotBlank()) {
+            setUrlGoneMargin(ConstraintSet.END, 0)
+        } else {
+            setUrlGoneMargin(ConstraintSet.END, rootView.resources.getDimensionPixelSize(
+                    R.dimen.mozac_browser_toolbar_url_gone_margin_end
+            ))
+        }
         editListener?.onTextChanged(text)
     }
 }

--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_edittoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_edittoolbar.xml
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/mozac_browser_toolbar_container"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:mozac="http://schemas.android.com/apk/res-auto"

--- a/components/browser/toolbar/src/main/res/values/dimens.xml
+++ b/components/browser/toolbar/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <!-- EditToolbar -->
     <dimen name="mozac_browser_toolbar_url_horizontal_padding">8dp</dimen>
     <dimen name="mozac_browser_toolbar_url_vertical_padding">0dp</dimen>
+    <dimen name="mozac_browser_toolbar_url_gone_margin_end">8dp</dimen>
     <dimen name="mozac_browser_toolbar_cancel_padding">16dp</dimen>
 
     <dimen name="mozac_browser_toolbar_url_textsize">15sp</dimen>


### PR DESCRIPTION
This change takes into account all four possible scenarios:
Legend:
X button = X
ActionContainer = A
UrlView = U

1. (X GONE) (A GONE) <- 8dp -> (U)
2. (X GONE) (A) (U)
3. (X) (A) (U)
4. (X) (A GONE) (U)

So basically, this adds 8dp only when both views in its anchoring chain are GONE.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR has only a visual change, no tests needed
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

<table style="width:100%">
  <tr>
    <th>RTL</th>
    <th>RTL with X button</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/1709373/68126081-a80af100-ff1b-11e9-8209-f4389088a314.png" width="250px"/></td>
    <td><img src="https://user-images.githubusercontent.com/1709373/68126108-b78a3a00-ff1b-11e9-9e42-2540e1a7b5b8.png" width="250px"/></td>
  </tr>
</table>

