### PR TITLE
Closes #4682: Add support for browser.tabs.remove

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -28,6 +28,7 @@ import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import org.json.JSONObject
+import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.ContentBlockingController
 import org.mozilla.geckoview.ContentBlockingController.Event
@@ -38,6 +39,7 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebExtensionController
 import java.lang.IllegalStateException
+import java.util.WeakHashMap
 
 /**
  * Gecko-based implementation of Engine interface.
@@ -160,6 +162,13 @@ class GeckoEngine(
         this.webExtensionDelegate = webExtensionDelegate
 
         val tabsDelegate = object : WebExtensionController.TabDelegate {
+            // We use this map to find the engine session of a given gecko
+            // session, as we currently have no other way of accessing the
+            // list of engine sessions. This will change once the engine
+            // gets access to the browser store:
+            // https://github.com/mozilla-mobile/android-components/issues/4965
+            private val tabs = WeakHashMap<GeckoEngineSession, String>()
+
             override fun onNewTab(
                 webExtension: org.mozilla.geckoview.WebExtension?,
                 url: String?
@@ -168,7 +177,26 @@ class GeckoEngine(
                 val geckoWebExtension = webExtension?.let { GeckoWebExtension(it.id, it.location) }
                 webExtensionDelegate.onNewTab(geckoWebExtension, url ?: "", geckoEngineSession)
 
+                tabs[geckoEngineSession] = webExtension?.id
                 return GeckoResult.fromValue(geckoEngineSession.geckoSession)
+            }
+
+            override fun onCloseTab(
+                webExtension: org.mozilla.geckoview.WebExtension?,
+                session: GeckoSession
+            ): GeckoResult<AllowOrDeny> {
+                val geckoEngineSession = tabs.keys.find { it.geckoSession == session } ?: return GeckoResult.DENY
+
+                return if (webExtension != null && tabs[geckoEngineSession] == webExtension.id) {
+                    val geckoWebExtension = GeckoWebExtension(webExtension.id, webExtension.location)
+                    if (webExtensionDelegate.onCloseTab(geckoWebExtension, geckoEngineSession)) {
+                        GeckoResult.ALLOW
+                    } else {
+                        GeckoResult.DENY
+                    }
+                } else {
+                    GeckoResult.DENY
+                }
             }
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -473,7 +473,7 @@ class GeckoEngineTest {
     }
 
     @Test
-    fun `register web extension delegate`() {
+    fun `web extension delegate handles opening a new tab`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
@@ -482,17 +482,16 @@ class GeckoEngineTest {
         val engine = GeckoEngine(context, runtime = runtime)
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
-        // Verify we set the delegate and notify onNewTab
-        val captor = argumentCaptor<WebExtensionController.TabDelegate>()
-        verify(webExtensionController).tabDelegate = captor.capture()
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.TabDelegate>()
+        verify(webExtensionController).tabDelegate = geckoDelegateCaptor.capture()
 
         val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
-        captor.value.onNewTab(null, null)
+        geckoDelegateCaptor.value.onNewTab(null, null)
         verify(webExtensionsDelegate).onNewTab(eq(null), eq(""), engineSessionCaptor.capture())
         assertNotNull(engineSessionCaptor.value)
         assertFalse(engineSessionCaptor.value.geckoSession.isOpen)
 
-        captor.value.onNewTab(null, "https://www.mozilla.org")
+        geckoDelegateCaptor.value.onNewTab(null, "https://www.mozilla.org")
         verify(webExtensionsDelegate).onNewTab(eq(null), eq("https://www.mozilla.org"),
             engineSessionCaptor.capture())
         assertNotNull(engineSessionCaptor.value)
@@ -500,15 +499,58 @@ class GeckoEngineTest {
 
         val webExt = org.mozilla.geckoview.WebExtension("test")
         val geckoExtCap = argumentCaptor<mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension>()
-        captor.value.onNewTab(webExt, "https://test-moz.org")
+        geckoDelegateCaptor.value.onNewTab(webExt, "https://test-moz.org")
         verify(webExtensionsDelegate).onNewTab(geckoExtCap.capture(), eq("https://test-moz.org"),
             engineSessionCaptor.capture())
         assertNotNull(geckoExtCap.value)
         assertEquals(geckoExtCap.value.id, webExt.id)
         assertNotNull(engineSessionCaptor.value)
         assertFalse(engineSessionCaptor.value.geckoSession.isOpen)
+    }
 
-        // Verify we notify onInstalled
+    @Test
+    fun `web extension delegate handles closing tab`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExt = org.mozilla.geckoview.WebExtension("test")
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.TabDelegate>()
+        verify(webExtensionController).tabDelegate = geckoDelegateCaptor.capture()
+
+        // Web extension never opened a tab so call will not be acted on
+        geckoDelegateCaptor.value.onCloseTab(webExt, mock())
+        verify(webExtensionsDelegate, never()).onCloseTab(eq(null), any())
+
+        // Let web extension open a new tab
+        val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
+        val geckoExtCap = argumentCaptor<mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension>()
+        geckoDelegateCaptor.value.onNewTab(webExt, "https://test-moz.org")
+        verify(webExtensionsDelegate).onNewTab(any(), eq("https://test-moz.org"), engineSessionCaptor.capture())
+        engineSessionCaptor.value.geckoSession.open(runtime)
+        assertTrue(engineSessionCaptor.value.geckoSession.isOpen)
+
+        // Web extension should be able to close tab it opened
+        geckoDelegateCaptor.value.onCloseTab(webExt, engineSessionCaptor.value.geckoSession)
+        verify(webExtensionsDelegate).onCloseTab(geckoExtCap.capture(), eq(engineSessionCaptor.value))
+        assertNotNull(geckoExtCap.value)
+        assertEquals(geckoExtCap.value.id, webExt.id)
+    }
+
+    @Test
+    fun `web extension delegate handles installation`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
         val result = GeckoResult<Void>()
         whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension("test-webext", "resource://android/assets/extensions/test")

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -508,7 +508,7 @@ class GeckoEngineTest {
     }
 
     @Test
-    fun `register web extension tab delegate`() {
+    fun `web extension delegate handles opening a new tab`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
@@ -516,32 +516,76 @@ class GeckoEngineTest {
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
-        val captor = argumentCaptor<WebExtensionController.TabDelegate>()
-        verify(webExtensionController).tabDelegate = captor.capture()
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.TabDelegate>()
+        verify(webExtensionController).tabDelegate = geckoDelegateCaptor.capture()
 
         val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
-        captor.value.onNewTab(null, null)
+        geckoDelegateCaptor.value.onNewTab(null, null)
         verify(webExtensionsDelegate).onNewTab(eq(null), eq(""), engineSessionCaptor.capture())
         assertNotNull(engineSessionCaptor.value)
         assertFalse(engineSessionCaptor.value.geckoSession.isOpen)
 
-        captor.value.onNewTab(null, "https://www.mozilla.org")
+        geckoDelegateCaptor.value.onNewTab(null, "https://www.mozilla.org")
         verify(webExtensionsDelegate).onNewTab(eq(null), eq("https://www.mozilla.org"),
-            engineSessionCaptor.capture())
+                engineSessionCaptor.capture())
         assertNotNull(engineSessionCaptor.value)
         assertFalse(engineSessionCaptor.value.geckoSession.isOpen)
 
         val webExt = org.mozilla.geckoview.WebExtension("test")
         val geckoExtCap = argumentCaptor<mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension>()
-        captor.value.onNewTab(webExt, "https://test-moz.org")
+        geckoDelegateCaptor.value.onNewTab(webExt, "https://test-moz.org")
         verify(webExtensionsDelegate).onNewTab(geckoExtCap.capture(), eq("https://test-moz.org"),
-            engineSessionCaptor.capture())
+                engineSessionCaptor.capture())
         assertNotNull(geckoExtCap.value)
         assertEquals(geckoExtCap.value.id, webExt.id)
         assertNotNull(engineSessionCaptor.value)
         assertFalse(engineSessionCaptor.value.geckoSession.isOpen)
+    }
 
-        // Verify we notify onInstalled
+    @Test
+    fun `web extension delegate handles closing tab`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExt = org.mozilla.geckoview.WebExtension("test")
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.TabDelegate>()
+        verify(webExtensionController).tabDelegate = geckoDelegateCaptor.capture()
+
+        // Web extension never opened a tab so call will not be acted on
+        geckoDelegateCaptor.value.onCloseTab(webExt, mock())
+        verify(webExtensionsDelegate, never()).onCloseTab(eq(null), any())
+
+        // Let web extension open a new tab
+        val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
+        val geckoExtCap = argumentCaptor<mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension>()
+        geckoDelegateCaptor.value.onNewTab(webExt, "https://test-moz.org")
+        verify(webExtensionsDelegate).onNewTab(any(), eq("https://test-moz.org"), engineSessionCaptor.capture())
+        engineSessionCaptor.value.geckoSession.open(runtime)
+        assertTrue(engineSessionCaptor.value.geckoSession.isOpen)
+
+        // Web extension should be able to close tab it opened
+        geckoDelegateCaptor.value.onCloseTab(webExt, engineSessionCaptor.value.geckoSession)
+        verify(webExtensionsDelegate).onCloseTab(geckoExtCap.capture(), eq(engineSessionCaptor.value))
+        assertNotNull(geckoExtCap.value)
+        assertEquals(geckoExtCap.value.id, webExt.id)
+    }
+
+    @Test
+    fun `web extension delegate handles installation`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
         val result = GeckoResult<Void>()
         whenever(runtime.registerWebExtension(any())).thenReturn(result)
         engine.installWebExtension("test-webext", "resource://android/assets/extensions/test")

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -22,9 +22,7 @@ interface WebExtensionDelegate {
 
     /**
      * Invoked when a web extension attempts to open a new tab via
-     * browser.tabs.create. Note that browser.tabs.remove is currently
-     * not supported:
-     * https://github.com/mozilla-mobile/android-components/issues/4682
+     * browser.tabs.create.
      *
      * @param webExtension An instance of [WebExtension] or null if extension
      * was not registered with the engine.
@@ -32,4 +30,14 @@ interface WebExtensionDelegate {
      * @param engineSession an instance of engine session to open a new tab with.
      */
     fun onNewTab(webExtension: WebExtension?, url: String, engineSession: EngineSession) = Unit
+
+    /**
+     * Invoked when a web extension attempts to close a tab via browser.tabs.remove.
+     *
+     * @param webExtension An instance of [WebExtension] or null if extension
+     * was not registered with the engine.
+     * @param engineSession then engine session fo the tab to be closed.
+     * @return true if the tab was closed, otherwise false.
+     */
+    fun onCloseTab(webExtension: WebExtension?, engineSession: EngineSession) = false
 }

--- a/components/support/webextensions/build.gradle
+++ b/components/support/webextensions/build.gradle
@@ -26,6 +26,11 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
 
 dependencies {
     implementation project(':concept-engine')
@@ -37,6 +42,7 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_coroutines
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,6 +52,19 @@ permalink: /changelog/
 * **feature-prompts**
   * Adds support for Web Share API using `ShareDelegate`.
 
+* **engine**, **engine-gecko-***, **support-webextensions**
+  * Added support `browser.tabs.remove()` in web extensions.
+  ```kotlin
+  val engine = GeckoEngine(applicationContext, engineSettings)
+  engine.registerWebExtensionTabDelegate(object : WebExtensionTabDelegate {
+    override fun onCloseTab(webExtension: WebExtension?, engineSession: EngineSession) {
+      store.state.tabs.find { it.engineState.engineSession === engineSession }?.let {
+        store.dispatch(RemoveTabAction(tab.id))
+      }
+    }
+  }  
+  ```  
+
 # 19.0.1
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v19.0.0...v19.0.1)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -36,6 +36,9 @@ class SampleApplication : Application() {
                 components.store,
                 onNewTabOverride = {
                     _, engineSession, url -> components.sessionManager.add(Session(url), true, engineSession)
+                },
+                onCloseTabOverride = {
+                    _, sessionId -> components.tabsUseCases.removeTab(sessionId)
                 }
             )
         } catch (e: UnsupportedOperationException) {


### PR DESCRIPTION
Brings in support for `browser.tabs.remove`. All very similar to what we did for `browser.tabs.add`. Refactored / Broke apart the tests so each one only verifies one behaviour.