### PR TITLE
Closes #4803: TrackingProtectionIconView: Assign individual drawables instead of using state list drawable.

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/TrackingProtectionIconView.kt
@@ -7,18 +7,17 @@ package mozilla.components.browser.toolbar.display
 import android.content.Context
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.StateListDrawable
 import android.util.AttributeSet
-import android.view.View
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.isVisible
 import mozilla.components.browser.toolbar.R
 import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection
+import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection.OFF_FOR_A_SITE
 import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection.OFF_GLOBALLY
 import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection.ON_NO_TRACKERS_BLOCKED
 import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection.ON_TRACKERS_BLOCKED
-import mozilla.components.concept.toolbar.Toolbar.SiteTrackingProtection.OFF_FOR_A_SITE
 
 /**
  * Internal widget to display the different icons of tracking protection, relies on the
@@ -30,88 +29,50 @@ internal class TrackingProtectionIconView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : AppCompatImageView(context, attrs, defStyleAttr) {
 
-    var siteTrackingProtection: SiteTrackingProtection = OFF_GLOBALLY
+    var siteTrackingProtection: SiteTrackingProtection = ON_NO_TRACKERS_BLOCKED
         set(value) {
             if (value != field) {
                 field = value
-                refreshDrawableState()
                 updateIcon()
             }
-
-            field = value
         }
+
+    private var iconOnNoTrackersBlocked: Drawable =
+        requireNotNull(AppCompatResources.getDrawable(context, DEFAULT_ICON_ON_NO_TRACKERS_BLOCKED))
+    private var iconOnTrackersBlocked: Drawable =
+        requireNotNull(AppCompatResources.getDrawable(context, DEFAULT_ICON_ON_TRACKERS_BLOCKED))
+    private var disabledForSite: Drawable =
+        requireNotNull(AppCompatResources.getDrawable(context, DEFAULT_ICON_OFF_FOR_A_SITE))
 
     fun setIcons(
         iconOnNoTrackersBlocked: Drawable,
         iconOnTrackersBlocked: Drawable,
         disabledForSite: Drawable
     ) {
-        val stateList = StateListDrawable()
+        this.iconOnNoTrackersBlocked = iconOnNoTrackersBlocked
+        this.iconOnTrackersBlocked = iconOnTrackersBlocked
+        this.disabledForSite = disabledForSite
 
-        stateList.addState(intArrayOf(R.attr.stateOnNoTrackersBlocked), iconOnNoTrackersBlocked)
-        stateList.addState(intArrayOf(R.attr.stateOnTrackersBlocked), iconOnTrackersBlocked)
-        stateList.addState(intArrayOf(R.attr.stateOffForASite), disabledForSite)
-
-        setImageDrawable(stateList)
-        refreshDrawableState()
         updateIcon()
     }
 
-    @Suppress("SENSELESS_COMPARISON")
-    override fun onCreateDrawableState(extraSpace: Int): IntArray {
-        // We need this here because in some situations, this function is getting called from
-        // the super() constructor on the View class, way before this class properties get
-        // initialized causing a null pointer exception.
-        // See for more details: https://github.com/mozilla-mobile/android-components/issues/4058
-        if (siteTrackingProtection == null) return super.onCreateDrawableState(extraSpace)
-
-        val drawableState = when (siteTrackingProtection) {
-            ON_NO_TRACKERS_BLOCKED -> R.attr.stateOnNoTrackersBlocked
-            ON_TRACKERS_BLOCKED -> R.attr.stateOnTrackersBlocked
-            OFF_FOR_A_SITE -> R.attr.stateOffForASite
-            OFF_GLOBALLY -> {
-                // the icon will be hidden, no state needed.
-                return super.onCreateDrawableState(extraSpace)
-            }
-        }
-
-        val drawableStates = super.onCreateDrawableState(extraSpace + 1)
-
-        View.mergeDrawableStates(drawableStates, intArrayOf(drawableState))
-        return drawableStates
-    }
-
+    @Synchronized
     private fun updateIcon() {
-        val descriptionId = when (siteTrackingProtection) {
-            ON_NO_TRACKERS_BLOCKED -> {
-                isVisible = true
-                R.string.mozac_browser_toolbar_content_description_tracking_protection_on_no_trackers_blocked
-            }
-            ON_TRACKERS_BLOCKED -> {
-                isVisible = true
-                R.string.mozac_browser_toolbar_content_description_tracking_protection_on_trackers_blocked1
-            }
-            OFF_FOR_A_SITE -> {
-                isVisible = true
-                R.string.mozac_browser_toolbar_content_description_tracking_protection_off_for_a_site1
-            }
+        val update = siteTrackingProtection.toUpdate()
 
-            OFF_GLOBALLY -> {
-                isVisible = false
-                null
-            }
+        isVisible = update.visible
+
+        contentDescription = if (update.contentDescription != null) {
+            context.getString(update.contentDescription)
+        } else {
+            null
         }
 
-        setContentDescription(descriptionId)
+        setImageDrawable(update.drawable)
 
-        val currentDrawable = drawable?.current
-        if (currentDrawable is Animatable) {
-            currentDrawable.start()
+        if (update.drawable is Animatable) {
+            update.drawable.start()
         }
-    }
-
-    private fun setContentDescription(@StringRes id: Int?) {
-        contentDescription = if (id != null) context.getString(id) else null
     }
 
     companion object {
@@ -122,4 +83,35 @@ internal class TrackingProtectionIconView @JvmOverloads constructor(
         val DEFAULT_ICON_OFF_FOR_A_SITE =
             R.drawable.mozac_ic_tracking_protection_on_trackers_blocked
     }
+
+    private fun SiteTrackingProtection.toUpdate(): Update = when (this) {
+        ON_NO_TRACKERS_BLOCKED -> Update(
+            iconOnNoTrackersBlocked,
+            R.string.mozac_browser_toolbar_content_description_tracking_protection_on_no_trackers_blocked,
+            true)
+
+        ON_TRACKERS_BLOCKED -> Update(
+            iconOnTrackersBlocked,
+            R.string.mozac_browser_toolbar_content_description_tracking_protection_on_trackers_blocked1,
+            true
+        )
+
+        OFF_FOR_A_SITE -> Update(
+            disabledForSite,
+            R.string.mozac_browser_toolbar_content_description_tracking_protection_off_for_a_site1,
+            true
+        )
+
+        OFF_GLOBALLY -> Update(
+            null,
+            null,
+            false
+        )
+    }
 }
+
+private class Update(
+    val drawable: Drawable?,
+    @StringRes val contentDescription: Int?,
+    val visible: Boolean
+)

--- a/components/browser/toolbar/src/main/res/drawable/mozac_tracking_protection_state_list.xml
+++ b/components/browser/toolbar/src/main/res/drawable/mozac_tracking_protection_state_list.xml
@@ -1,8 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:ac="http://schemas.android.com/apk/res-auto">
-    <item android:drawable="@drawable/mozac_ic_tracking_protection_on_no_trackers_blocked" ac:stateOnTrackersBlocked="false" />
-    <item android:drawable="@drawable/mozac_ic_tracking_protection_on_trackers_blocked" ac:stateOnNoTrackersBlocked="false" />
-    <item android:drawable="@drawable/mozac_ic_tracking_protection_off_for_a_site" ac:stateOffForASite="false" />
-</selector>

--- a/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -57,9 +57,9 @@
             android:layout_marginTop="8dp"
             android:scaleType="center"
             android:visibility="gone"
+            android:src="@drawable/mozac_ic_tracking_protection_on_no_trackers_blocked"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toEndOf="@id/mozac_browser_toolbar_empty_indicator"
-            android:src="@drawable/mozac_tracking_protection_state_list" />
+            app:layout_constraintStart_toEndOf="@id/mozac_browser_toolbar_empty_indicator" />
 
         <ImageView
             android:id="@+id/mozac_browser_toolbar_separator"

--- a/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
+++ b/components/browser/toolbar/src/main/res/values/attrs_browser_toolbar.xml
@@ -23,12 +23,6 @@
     </attr>
   </declare-styleable>
 
-  <declare-styleable name="BrowserToolbarTrackingProtectionState">
-    <attr name="stateOnTrackersBlocked" format="boolean"/>
-    <attr name="stateOnNoTrackersBlocked" format="boolean"/>
-    <attr name="stateOffForASite" format="boolean"/>
-  </declare-styleable>
-
   <declare-styleable name="BrowserToolbarSiteSecurityState">
     <attr name="state_site_secure" format="boolean"/>
   </declare-styleable>

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -146,12 +146,23 @@ class DisplayToolbarTest {
             trackingProtectionException = drawable3
         )
 
-        val newTrackingProtectionIcon = displayToolbar.views.trackingProtectionIndicator.drawable
-        assertNotNull(newTrackingProtectionIcon)
+        assertNotEquals(
+            oldTrackingProtectionIcon,
+            displayToolbar.views.trackingProtectionIndicator.drawable
+        )
+
+        assertEquals(drawable2, displayToolbar.views.trackingProtectionIndicator.drawable)
+
+        displayToolbar.setTrackingProtectionState(SiteTrackingProtection.ON_TRACKERS_BLOCKED)
 
         assertNotEquals(
             oldTrackingProtectionIcon,
-            newTrackingProtectionIcon
+            displayToolbar.views.trackingProtectionIndicator.drawable
+        )
+
+        assertEquals(
+            drawable1,
+            displayToolbar.views.trackingProtectionIndicator.drawable
         )
     }
 


### PR DESCRIPTION
Unfortunately using the state list drawable with vectors caused issues on API 21. Only going back to
individual drawables prevented the issue. On the bright side this is only an internal change and
the public API doesn't need to change.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
