### PR TITLE
Closes #4969: Provide API to observe browser state changes on all tabs

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -195,7 +195,7 @@ internal class EngineObserver(
     override fun onWindowRequest(windowRequest: WindowRequest) {
         store?.dispatch(
             ContentAction.UpdateWindowRequestAction(
-                store.state.selectedTabId ?: session.id,
+                session.id,
                 windowRequest
             )
         )

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -24,7 +24,8 @@ android {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.freeCompilerArgs += [
-            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi",
+            "-Xuse-experimental=kotlinx.coroutines.FlowPreview"
     ]
 }
 

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/WindowFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/WindowFeature.kt
@@ -9,12 +9,11 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.action.ContentAction
-import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.filterChanged
 
 /**
  * Feature implementation for handling window requests by opening and closing tabs.
@@ -32,8 +31,8 @@ class WindowFeature(
      */
     override fun start() {
         scope = store.flowScoped { flow ->
-            flow.mapNotNull { state -> state.selectedTab }
-                .ifChanged {
+            flow.mapNotNull { state -> state.tabs }
+                .filterChanged {
                     it.content.windowRequest
                 }
                 .collect { state ->

--- a/components/support/ktx/build.gradle
+++ b/components/support/ktx/build.gradle
@@ -23,6 +23,13 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi",
+            "-Xuse-experimental=kotlinx.coroutines.FlowPreview"
+    ]
+}
+
 dependencies {
     implementation project(':support-base')
     implementation project(':support-utils')

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
@@ -5,7 +5,9 @@
 package mozilla.components.support.ktx.kotlinx.coroutines.flow
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapConcat
 
 /**
  * Returns a [Flow] containing only values of the original [Flow] that have changed compared to
@@ -29,7 +31,7 @@ fun <T> Flow<T>.ifChanged(): Flow<T> = ifChanged { it }
  * Original Flow: "banana", "bus", "apple", "big", "coconut", "circle", "home"
  * Mapped: b, b, a, b, c, c, h
  * Returned Flow: "banana", "apple", "big", "coconut", "home"
- * ``
+ * ```
  */
 fun <T, R> Flow<T>.ifChanged(transform: (T) -> R): Flow<T> {
     var observedValueOnce = false
@@ -44,6 +46,61 @@ fun <T, R> Flow<T>.ifChanged(transform: (T) -> R): Flow<T> {
         } else {
             false
         }
+    }
+}
+
+/**
+ * Returns a [Flow] containing only changed elements of the lists of the original [Flow].
+ *
+ * ```
+ * Example: Identity function
+ * Transform: x -> x (transformed values are the same as original)
+ * Original Flow: list(0), list(0, 1), list(0, 1, 2, 3), list(4), list(5, 6, 7, 8)
+ * Transformed:
+ * (0)          -> (0 emitted because it is a new value)
+ *
+ * (0, 1)       -> (0 not emitted because same as previous value,
+ *                  1 emitted because it is a new value),
+ *
+ * (0, 1, 2, 3) -> (0 and 1 not emitted because same as previous values,
+ *                  2 and 3 emitted because they are new values),
+ *
+ * (4)          -> (4 emitted because because it is a new value)
+ *
+ * (5, 6, 7, 8) -> (5, 6, 7, 8 emitted because they are all new values)
+ * Returned Flow: 0, 1, 2, 3, 4, 5, 6, 7, 8
+ * ---
+ *
+ * Example: Modulo 2
+ * Transform: x -> x % 2 (emit changed values if the result of modulo 2 changed)
+ * Original Flow: listOf(1), listOf(1, 2), listOf(3, 4, 5), listOf(3, 4)
+ * Transformed:
+ * (1)          -> (1 emitted because it is a new value)
+ *
+ * (1, 0)       -> (1 not emitted because same as previous value with the same transformed value,
+ *                  2 emitted because it is a new value),
+ *
+ * (1, 0, 1)    -> (3, 4, 5 emitted because they are all new values)
+ *
+ * (1, 0)       -> (3, 4 not emitted because same as previous values with same transformed values)
+ *
+ * Returned Flow: 1, 2, 3, 4, 5
+ * ---
+ * ```
+ */
+fun <T, R> Flow<List<T>>.filterChanged(transform: (T) -> R): Flow<T> {
+    var lastMappedValues: Map<T, R>? = null
+    return flatMapConcat { values ->
+        val lastMapped = lastMappedValues
+        val changed = if (lastMapped == null) {
+            values
+        } else {
+            values.filter {
+                !lastMapped.containsKey(it) || lastMapped[it] !== transform(it)
+            }
+        }
+        lastMappedValues = values.map { Pair(it, transform(it)) }.toMap()
+        changed.asFlow()
     }
 }
 

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/FlowKtTest.kt
@@ -45,8 +45,26 @@ class FlowKtTest {
         }
 
         assertEquals(
-                listOf("banana", "bus", "apple", "big", "coconut", "circle", "home"),
-                items
+            listOf("banana", "bus", "apple", "big", "coconut", "circle", "home"),
+            items
         )
+    }
+
+    @Test
+    fun `filterChanged operator`() {
+        val intFlow = flowOf(listOf(0), listOf(0, 1), listOf(0, 1, 2, 3), listOf(4), listOf(5, 6, 7, 8))
+        val identityItems = runBlocking { intFlow.filterChanged { item -> item }.toList() }
+        assertEquals(listOf(0, 1, 2, 3, 4, 5, 6, 7, 8), identityItems)
+
+        val moduloFlow = flowOf(listOf(1), listOf(1, 2), listOf(3, 4, 5), listOf(3, 4))
+        val moduloItems = runBlocking { moduloFlow.filterChanged { item -> item % 2 }.toList() }
+        assertEquals(listOf(1, 2, 3, 4, 5), moduloItems)
+
+        // Here we simulate a non-pure transform function (a function with a side-effect), causing
+        // the transformed values to be different for the same input.
+        var counter = 0
+        val sideEffectFlow = flowOf(listOf(0), listOf(0, 1), listOf(0, 1, 2, 3), listOf(4), listOf(5, 6, 7, 8))
+        val sideEffectItems = runBlocking { sideEffectFlow.filterChanged { item -> item + counter++ }.toList() }
+        assertEquals(listOf(0, 0, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8), sideEffectItems)
     }
 }


### PR DESCRIPTION
This allows us to map a flow to a list (e.g. to a list of tabs as in `state.tabs`) and `collect` individual elements for which a specific attribute has changed (e.g. only tabs for which `windowRequest` has changed).

@pocmo this is pretty much as discussed, relying on the new `flatMap` flow operators. I did verify that this works and allows me to get rid of the workaround, but curious what you think. I also need to sleep over this :). In general, I think it does make sense that we have a `ifChanged` for flows of states, and `filterChanged` for flows of list of states. 