### PR TITLE
Enable the Glean SDK in sample-browser

### DIFF
--- a/samples/browser/README.md
+++ b/samples/browser/README.md
@@ -12,6 +12,22 @@ The browser app uses a product flavor:
 
 * **channel**: Using different release channels of GeckoView: _nightly_, _beta_, _production_. In most cases you want to use the _nightly_ flavor as this will support all of the latest functionality.
 
+## Glean SDK support
+
+This sample application comes with Glean SDK telemetry initialized by default, but with upload disabled (no data is being sent).
+This is for creating a simpler metric testing workflow for Gecko engineers that need to add their metrics to Gecko and expose them to Mozilla mobile products.
+See [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1592935) for more context.
+
+In order to enable data upload for testing purposes, change the `Glean.setUploadEnabled(false)` to `Glean.setUploadEnabled(true)` in [`SampleApplication.kt`](src/main/java/org/mozilla/samples/browser/SampleApplication.kt).
+
+Glean will send metrics from any Glean-enabled component used in this sample application:
+
+- [engine-gecko-nightly](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/engine-gecko-nightly/docs/metrics.md);
+- [engine-gecko-beta](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/engine-gecko-beta/docs/metrics.md);
+- [engine-gecko](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/engine-gecko/docs/metrics.md);
+
+Data review for enabling the Glean SDK for this application can be found [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1592935#c6).
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -101,6 +101,11 @@ dependencies {
 
     implementation project(':ui-autocomplete')
 
+    // Add a dependency on service-glean to simplify the testing workflow
+    // for engineers that want to test Gecko metrics exfiltrated via the Glean
+    // SDK. See bug 1592935 for more context.
+    implementation project(":service-glean")
+
     implementation project(':support-utils')
     implementation project(':feature-downloads')
     implementation project(':support-ktx')

--- a/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
@@ -6,15 +6,23 @@ package org.mozilla.samples.browser
 
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
+import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings).also {
+        // Allow for exfiltrating Gecko metrics through the Glean SDK.
+        val builder = GeckoRuntimeSettings.Builder()
+        builder.telemetryDelegate(GeckoAdapter())
+        val runtime = GeckoRuntime.create(applicationContext, builder.build())
+
+        GeckoEngine(applicationContext, engineSettings, runtime).also {
             WebCompatFeature.install(it)
         }
     }

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -5,16 +5,24 @@ package org.mozilla.samples.browser
 
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
+import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.support.base.log.Log
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings).also {
+        // Allow for exfiltrating Gecko metrics through the Glean SDK.
+        val builder = GeckoRuntimeSettings.Builder()
+        builder.telemetryDelegate(GeckoAdapter())
+        val runtime = GeckoRuntime.create(applicationContext, builder.build())
+
+        GeckoEngine(applicationContext, engineSettings, runtime).also {
             it.installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }

--- a/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
@@ -5,15 +5,23 @@ package org.mozilla.samples.browser
 
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
+import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 
 /**
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
     override val engine: Engine by lazy {
-        GeckoEngine(applicationContext, engineSettings).also {
+        // Allow for exfiltrating Gecko metrics through the Glean SDK.
+        val builder = GeckoRuntimeSettings.Builder()
+        builder.telemetryDelegate(GeckoAdapter())
+        val runtime = GeckoRuntime.create(applicationContext, builder.build())
+
+        GeckoEngine(applicationContext, engineSettings, runtime).also {
             WebCompatFeature.install(it)
         }
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.browser
 
 import android.app.Application
 import mozilla.components.browser.session.Session
+import mozilla.components.service.glean.Glean
 import mozilla.components.support.base.facts.Facts
 import mozilla.components.support.base.facts.processor.LogFactProcessor
 import mozilla.components.support.base.log.Log
@@ -25,6 +26,13 @@ class SampleApplication : Application() {
         if (!isMainProcess()) {
             return
         }
+
+        // IMPORTANT: the following lines initialize the Glean SDK but disable upload
+        // of pings. If, for testing purposes, upload is required to be on, change the
+        // next line to `Glean.setUploadEnabled(true)`
+        Glean.setUploadEnabled(false)
+
+        Glean.initialize(applicationContext)
 
         Facts.registerProcessor(LogFactProcessor())
 


### PR DESCRIPTION
This enables the Glean SDK in the sample browser, but makes upload default off. This makes it less surprising for people building the sample application (so that no data is sent) but also enables Gecko engineer to test that Gecko metrics are correctly sent without the requirement of building Fenix.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
