### PR TITLE
Create wrapper for Glean gradle plugin

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -400,3 +400,7 @@ projects:
     path: samples/dataprotect
     description: 'An app demoing how to use the Dataprotect component to load and store encrypted data in SharedPreferences.'
     publish: false
+  tooling-glean-gradle-plugin:
+    path: components/tooling/glean-gradle-plugin
+    description: 'A Gradle plugin to generate code for Glean metrics.'
+    publish: true

--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -352,7 +352,6 @@ projects:
     path: components/tooling/detekt
     description: 'Custom Detekt rules for internal use.'
     publish: false
-    artifact-type: jar
   tooling-lint:
     path: components/tooling/lint
     description: 'Custom Lint checks for using and writing components.'
@@ -405,3 +404,4 @@ projects:
     path: components/tooling/glean-gradle-plugin
     description: 'A Gradle plugin to generate code for Glean metrics.'
     publish: true
+    artifact-type: jar

--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -400,7 +400,7 @@ projects:
     path: samples/dataprotect
     description: 'An app demoing how to use the Dataprotect component to load and store encrypted data in SharedPreferences.'
     publish: false
-  tooling-glean-gradle-plugin:
+  tooling-glean-gradle:
     path: components/tooling/glean-gradle-plugin
     description: 'A Gradle plugin to generate code for Glean metrics.'
     publish: true

--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -352,6 +352,7 @@ projects:
     path: components/tooling/detekt
     description: 'Custom Detekt rules for internal use.'
     publish: false
+    artifact-type: jar
   tooling-lint:
     path: components/tooling/lint
     description: 'Custom Lint checks for using and writing components.'

--- a/automation/taskcluster/rename_snapshot_artifacts.py
+++ b/automation/taskcluster/rename_snapshot_artifacts.py
@@ -16,7 +16,7 @@ import re
 import sys
 
 
-AAR_EXTENSIONS = ('.aar', '.pom', '-sources.jar')
+ARTIFACT_EXTENSIONS = ('.aar', '.pom', '-sources.jar', '.jar')
 HASH_EXTENSIONS = ('', '.sha1', '.md5')
 SNAPSHOT_TIMESTAMP_REGEX = r'\d{8}\.\d{6}-\d{1}'
 
@@ -71,10 +71,10 @@ def _extract_old_timestamp(files):
 
 
 def does_file_name_contain_timestamp(filename):
-    """Function to filter out filenames that are part of the snapshot releae but
+    """Function to filter out filenames that are part of the snapshot release but
     they are not timestamped."""
 
-    for extension, hash_extension in itertools.product(AAR_EXTENSIONS, HASH_EXTENSIONS):
+    for extension, hash_extension in itertools.product(ARTIFACT_EXTENSIONS, HASH_EXTENSIONS):
         if filename.endswith(extension + hash_extension):
             return True
     return False

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SentryService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SentryService.kt
@@ -78,7 +78,7 @@ class SentryService(
 
     override fun report(throwable: Throwable) {
         val eventBuilder = EventBuilder().withMessage(createMessage(throwable))
-                .withLevel(Event.Level.ERROR)
+                .withLevel(Event.Level.INFO)
                 .withSentryInterface(ExceptionInterface(throwable))
         client.sendEvent(eventBuilder)
     }

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -2,6 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**********************************************************************
+  THIS FILE IS OBSOLETE AND UNMAINTAINED.
+  The functionality in this file has moved to a proper Gradle plugin
+  in https://github.com/mozilla/glean
+  However, this file must remain on the master branch indefinitely so that
+  Glean-using applications can continue to build historical revisions from
+  prior to the existence of the plugin.
+**********************************************************************/
+
 /*
  * IMPORTANT DEVELOPER'S NOTE:
  *
@@ -13,9 +22,13 @@
  * of android-components rather than tracking snapshots.)
  */
 
-import org.apache.tools.ant.taskdefs.condition.Os
 import groovy.json.JsonOutput
+import java.util.logging.Logger
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.internal.artifacts.ArtifactAttributes
+
+Logger logger = Logger.getLogger("Glean sdk_generator.gradle")
+logger.warning("The Glean sdk_generator.gradle script is deprecated. Use the Glean Gradle plugin instead")
 
 // This installs a Miniconda3 environment into the gradle user home directory
 // so that it will be shared between all libraries that use Glean.  This is

--- a/components/tooling/glean-gradle-plugin/README.md
+++ b/components/tooling/glean-gradle-plugin/README.md
@@ -1,3 +1,5 @@
-This provides a Gradle plugin that generates Glean metrics from metrics.yaml and pings.yaml files.
+This directory contains a Gradle plugin for build-time functionality, such as generating specific metrics and documentation.
 
-This is just a thin wrapper around the actual plugin implementation that is published as part of [Glean itself.](https://github.com/mozilla/glean/)
+See [the Glean documentation](https://mozilla.github.io/glean/user/adding-glean-to-your-project.md) for information about using this plugin.
+
+This is just a thin wrapper around the actual plugin implementation that is published as part of [Glean itself.](https://github.com/mozilla/glean/).

--- a/components/tooling/glean-gradle-plugin/README.md
+++ b/components/tooling/glean-gradle-plugin/README.md
@@ -1,0 +1,3 @@
+This provides a Gradle plugin that generates Glean metrics from metrics.yaml and pings.yaml files.
+
+This is just a thin wrapper around the actual plugin implementation that is published as part of [Glean itself.](https://github.com/mozilla/glean/)

--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+plugins {
+    id 'groovy'
+    id 'maven-publish'
+    id 'java-gradle-plugin'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation gradleApi()
+    implementation localGroovy()
+    implementation "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+
+            pom {
+                groupId = config.componentsGroupId
+                artifactId = archivesBaseName
+                description = project.ext.description
+                version = config.componentsVersion + (project.hasProperty('snapshot') ? '-SNAPSHOT' : '')
+
+                licenses {
+                    license {
+                        name = libLicense
+                        url = libLicenseUrl
+                    }
+                }
+
+                developers {
+                    developer {
+                        name = 'Mozilla Glean Team'
+                        email = 'glean-team@mozilla.com'
+                    }
+                }
+
+                scm {
+                    connection = libVcsUrl
+                    developerConnection = libVcsUrl
+                    url = libUrl
+                }
+            }
+        }
+    }
+}
+
+task lintRelease {
+  doLast {
+    // Do nothing. We execute the same set of tasks for all our modules in parallel on taskcluster.
+    // This project doesn't have a lint task. To avoid special casing our automation I just added
+    // an empty lint task here.
+  }
+}
+
+task assembleAndroidTest {
+  doLast {
+    // Do nothing. Like the `lint` task above this is just a dummy task so that this module
+    // behaves like our others and we do not need to special case it in automation.
+  }
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+

--- a/components/tooling/glean-gradle-plugin/src/main/java/mozilla/components/tooling/glean-gradle-plugin/GleanGradlePlugin.kt
+++ b/components/tooling/glean-gradle-plugin/src/main/java/mozilla/components/tooling/glean-gradle-plugin/GleanGradlePlugin.kt
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.glean.gradle
+
+import GleanPlugin // ktlint-disable no-unused-imports

--- a/components/tooling/glean-gradle-plugin/src/main/resources/META-INF/gradle-plugins/mozilla.components.tooling.glean-gradle-plugin.properties
+++ b/components/tooling/glean-gradle-plugin/src/main/resources/META-INF/gradle-plugins/mozilla.components.tooling.glean-gradle-plugin.properties
@@ -1,0 +1,1 @@
+implementation-class=GleanPlugin

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ permalink: /changelog/
   * Glean was updated to v22.1.0 ([Full changelog](https://github.com/mozilla/glean/compare/v21.3.0...v22.1.0))
     * Attempt to re-send the deletion ping on init even if upload is disabled.
     * Introduce the `InvalidOverflow` error for `TimingDistribution`s.
+  * Glean now provides a Gradle plugin for automating the conversion from `metrics.yaml` and `pings.yaml` files to Kotlin code. This should be used instead of the deprecated Gradle script.  See [integrating with the build system docs](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project.html#integrating-with-the-build-system) for more information.
 
 * **feature-app-links**
   * ⚠️ **This is a breaking change**:
@@ -99,7 +100,6 @@ permalink: /changelog/
 * **service-sync-logins**
   * `AsyncLoginsStorage` interface gained a new method: `importLoginsAsync`, used for bulk-inserting logins (for example, during a migration).
 
-* **service-glean**: Glean now provides a Gradle plugin for automating the conversion from metrics.yaml and pings.yaml files to Kotlin code. This should be used instead of the deprecated Gradle script.  See [integrating with the build system docs](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project.html#integrating-with-the-build-system) for more information.
 
 # 24.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -99,6 +99,8 @@ permalink: /changelog/
 * **service-sync-logins**
   * `AsyncLoginsStorage` interface gained a new method: `importLoginsAsync`, used for bulk-inserting logins (for example, during a migration).
 
+* **service-glean**: Glean now provides a Gradle plugin for automating the conversion from metrics.yaml and pings.yaml files to Kotlin code. This should be used instead of the deprecated Gradle script.  See [integrating with the build system docs](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project.html#integrating-with-the-build-system) for more information.
+
 # 24.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v23.0.0...v24.0.0)
@@ -250,7 +252,6 @@ permalink: /changelog/
   ```
 * **engine-gecko-nightly**
   * Adds setDynamicToolbarMaxHeight ApI.
-
 
 * **feature-push**
   * Added `unsubscribeAll` support from the Rust native layer.

--- a/taskcluster/ac_taskgraph/build_config.py
+++ b/taskcluster/ac_taskgraph/build_config.py
@@ -10,7 +10,10 @@ import yaml
 from taskgraph.util.memoize import memoize
 
 
-AAR_EXTENSIONS = ('.aar', '.pom', '-sources.jar')
+EXTENSIONS = {
+    'aar': ('.aar', '.pom', '-sources.jar'),
+    'jar': ('.jar', '.pom', '-sources.jar')
+}
 CHECKSUMS_EXTENSIONS = ('.sha1', '.md5')
 
 
@@ -29,6 +32,22 @@ def get_version(is_snapshot=False):
 
 def get_path(component):
     return _read_build_config()["projects"][component]["path"]
+
+
+def get_extensions(component):
+    artifact_type = _read_build_config()["projects"][component].get("artifact-type", "aar")
+    if artifact_type not in EXTENSIONS:
+        raise ValueError(
+            "For '{}', 'artifact-type' must be one of {}".format(
+                component, repr(EXTENSIONS.keys())
+            )
+        )
+
+    return [
+        extension + checksum_extension
+        for extension in EXTENSIONS[artifact_type]
+        for checksum_extension in ('',) + CHECKSUMS_EXTENSIONS
+    ]
 
 
 @memoize

--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -11,7 +11,7 @@ from six import text_type
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
 
-from ..build_config import get_version, get_path, AAR_EXTENSIONS, CHECKSUMS_EXTENSIONS
+from ..build_config import get_version, get_path, get_extensions
 
 
 transforms = TransformSequence()
@@ -104,11 +104,7 @@ def add_artifacts(config, tasks):
             component = task["attributes"]["component"]
             build_artifact_definitions = task.setdefault("worker", {}).setdefault("artifacts", [])
 
-            all_extensions = [
-                extension + checksum_extension
-                for extension in AAR_EXTENSIONS
-                for checksum_extension in ('',) + CHECKSUMS_EXTENSIONS
-            ]
+            all_extensions = get_extensions(component)
             artifact_file_names_per_extension = {
                 extension: '{component}-{version}{timestamp}{extension}'.format(
                     component=component,


### PR DESCRIPTION
Glean now has a Gradle plugin for generating metrics from metrics.yaml files.

Since this is built and published alongside Glean itself, we need a way to load the plugin so that the version of the plugin matches the version of Glean being used.  Unfortunately, most of our users are using Glean *through* android-components, so they don't know the Glean version.  This wrapper plugin will allow it to be loaded using the android-components version, and the publishing will happen on the same cadence as android-components itself.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
