### PR TITLE
Use GeckoViewFetchClient for Gecko variants in sample browser

### DIFF
--- a/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
@@ -7,6 +7,7 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
+import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import org.mozilla.geckoview.GeckoRuntime
@@ -26,4 +27,6 @@ class Components(applicationContext: Context) : DefaultComponents(applicationCon
             WebCompatFeature.install(it)
         }
     }
+
+    override val client by lazy { GeckoViewFetchClient(applicationContext) }
 }

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
+import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.support.base.log.Log
@@ -30,4 +31,6 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
             WebCompatFeature.install(it)
         }
     }
+
+    override val client by lazy { GeckoViewFetchClient(applicationContext) }
 }

--- a/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.browser
 import android.content.Context
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
+import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.webcompat.WebCompatFeature
 import org.mozilla.geckoview.GeckoRuntime
@@ -25,4 +26,6 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
             WebCompatFeature.install(it)
         }
     }
+
+    override val client by lazy { GeckoViewFetchClient(applicationContext) }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -29,6 +29,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.addons.amo.AddOnsCollectionsProvider
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
@@ -72,7 +73,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         SystemEngine(applicationContext, engineSettings)
     }
 
-    val client by lazy { HttpURLConnectionClient() }
+    open val client: Client by lazy { HttpURLConnectionClient() }
 
     val icons by lazy { BrowserIcons(applicationContext, client) }
 


### PR DESCRIPTION
Let's use the GeckoViewFetch client for our gecko engine build variants. This hurt us when testing downloads: https://github.com/mozilla-mobile/android-components/issues/4999#issuecomment-551288072