### PR TITLE
sample-browser: Use same Gecko runtime for engine and client

### DIFF
--- a/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoBeta/java/org/mozilla/samples/browser/Components.kt
@@ -17,16 +17,18 @@ import org.mozilla.geckoview.GeckoRuntimeSettings
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(applicationContext: Context) : DefaultComponents(applicationContext) {
-    override val engine: Engine by lazy {
+    private val runtime by lazy {
         // Allow for exfiltrating Gecko metrics through the Glean SDK.
         val builder = GeckoRuntimeSettings.Builder()
         builder.telemetryDelegate(GeckoAdapter())
-        val runtime = GeckoRuntime.create(applicationContext, builder.build())
+        GeckoRuntime.create(applicationContext, builder.build())
+    }
 
+    override val engine: Engine by lazy {
         GeckoEngine(applicationContext, engineSettings, runtime).also {
             WebCompatFeature.install(it)
         }
     }
 
-    override val client by lazy { GeckoViewFetchClient(applicationContext) }
+    override val client by lazy { GeckoViewFetchClient(applicationContext, runtime) }
 }

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -17,12 +17,14 @@ import org.mozilla.geckoview.GeckoRuntimeSettings
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
-    override val engine: Engine by lazy {
+    private val runtime by lazy {
         // Allow for exfiltrating Gecko metrics through the Glean SDK.
         val builder = GeckoRuntimeSettings.Builder()
         builder.telemetryDelegate(GeckoAdapter())
-        val runtime = GeckoRuntime.create(applicationContext, builder.build())
+        GeckoRuntime.create(applicationContext, builder.build())
+    }
 
+    override val engine: Engine by lazy {
         GeckoEngine(applicationContext, engineSettings, runtime).also {
             it.installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
@@ -32,5 +34,5 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
         }
     }
 
-    override val client by lazy { GeckoViewFetchClient(applicationContext) }
+    override val client by lazy { GeckoViewFetchClient(applicationContext, runtime) }
 }

--- a/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoRelease/java/org/mozilla/samples/browser/Components.kt
@@ -16,16 +16,18 @@ import org.mozilla.geckoview.GeckoRuntimeSettings
  * Helper class for lazily instantiating components needed by the application.
  */
 class Components(private val applicationContext: Context) : DefaultComponents(applicationContext) {
-    override val engine: Engine by lazy {
+    private val runtime by lazy {
         // Allow for exfiltrating Gecko metrics through the Glean SDK.
         val builder = GeckoRuntimeSettings.Builder()
         builder.telemetryDelegate(GeckoAdapter())
-        val runtime = GeckoRuntime.create(applicationContext, builder.build())
+        GeckoRuntime.create(applicationContext, builder.build())
+    }
 
+    override val engine: Engine by lazy {
         GeckoEngine(applicationContext, engineSettings, runtime).also {
             WebCompatFeature.install(it)
         }
     }
 
-    override val client by lazy { GeckoViewFetchClient(applicationContext) }
+    override val client by lazy { GeckoViewFetchClient(applicationContext, runtime) }
 }


### PR DESCRIPTION
@jonalmeida a quick follow-up to https://github.com/mozilla-mobile/android-components/pull/5003. We'll want to use the same runtime for `engine` and `client`. Noticed that on my way home, but you were too fast :).