### PR TITLE
Closes #4987: feature-downloads: Emit facts.

### DIFF
--- a/components/feature/downloads/README.md
+++ b/components/feature/downloads/README.md
@@ -153,6 +153,18 @@ Customizing SimpleDownloadDialogFragment.
         downloadsFeature.start()
   ```
 
+## Facts
+
+This component emits the following [Facts](../../support/base/README.md#Facts):
+
+| Action | Item            |  Description                                    |
+|--------|-----------------|-------------------------------------------------|
+| RESUME | notification    | The user resumes a download.                    |
+| PAUSE  | notification    | The user pauses a download.                     |
+| CANCEL | notification    | The user cancels a download.                    |
+| RETRY  | notification    | The user taps on retry when a download fails.   |
+| OPEN   | notification    | The user opens a downloaded file.               |
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/feature/downloads/README.md
+++ b/components/feature/downloads/README.md
@@ -157,13 +157,13 @@ Customizing SimpleDownloadDialogFragment.
 
 This component emits the following [Facts](../../support/base/README.md#Facts):
 
-| Action | Item            |  Description                                    |
-|--------|-----------------|-------------------------------------------------|
-| RESUME | notification    | The user resumes a download.                    |
-| PAUSE  | notification    | The user pauses a download.                     |
-| CANCEL | notification    | The user cancels a download.                    |
-| RETRY  | notification    | The user taps on retry when a download fails.   |
-| OPEN   | notification    | The user opens a downloaded file.               |
+| Action     | Item            |  Description                                      |
+|------------|-----------------|---------------------------------------------------|
+| RESUME     | notification    | The user resumes a download.                      |
+| PAUSE      | notification    | The user pauses a download.                       |
+| CANCEL     | notification    | The user cancels a download.                      |
+| TRY_AGAIN  | notification    | The user taps on try again when a download fails. |
+| OPEN       | notification    | The user opens a downloaded file.                 |
 
 ## License
 

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -41,7 +41,7 @@ import mozilla.components.feature.downloads.ext.withResponse
 import mozilla.components.feature.downloads.facts.emitNotificationResumeFact
 import mozilla.components.feature.downloads.facts.emitNotificationPauseFact
 import mozilla.components.feature.downloads.facts.emitNotificationCancelFact
-import mozilla.components.feature.downloads.facts.emitNotificationRetryFact
+import mozilla.components.feature.downloads.facts.emitNotificationTryAgainFact
 import mozilla.components.feature.downloads.facts.emitNotificationOpenFact
 import java.io.File
 import java.io.FileOutputStream
@@ -137,7 +137,7 @@ abstract class AbstractFetchDownloadService : Service() {
                             startDownloadJob(currentDownloadJobState.state)
                         }
 
-                        emitNotificationRetryFact()
+                        emitNotificationTryAgainFact()
                     }
 
                     ACTION_OPEN -> {

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/facts/DownloadsFacts.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/facts/DownloadsFacts.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.downloads.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+/**
+ * Facts emitted for telemetry related to [DownloadsFeature]
+ */
+class DownloadsFacts {
+    /**
+     * Items that specify which portion of the [DownloadsFeature] was interacted with
+     */
+    object Items {
+        const val NOTIFICATION = "notification"
+    }
+}
+
+internal fun emitNotificationResumeFact() = emitNotificationFact(Action.RESUME)
+internal fun emitNotificationPauseFact() = emitNotificationFact(Action.PAUSE)
+internal fun emitNotificationCancelFact() = emitNotificationFact(Action.CANCEL)
+internal fun emitNotificationRetryFact() = emitNotificationFact(Action.RETRY)
+internal fun emitNotificationOpenFact() = emitNotificationFact(Action.OPEN)
+
+private fun emitNotificationFact(
+    action: Action
+) {
+    Fact(
+        Component.FEATURE_DOWNLOADS,
+        action,
+        DownloadsFacts.Items.NOTIFICATION
+    ).collect()
+}

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/facts/DownloadsFacts.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/facts/DownloadsFacts.kt
@@ -24,7 +24,7 @@ class DownloadsFacts {
 internal fun emitNotificationResumeFact() = emitNotificationFact(Action.RESUME)
 internal fun emitNotificationPauseFact() = emitNotificationFact(Action.PAUSE)
 internal fun emitNotificationCancelFact() = emitNotificationFact(Action.CANCEL)
-internal fun emitNotificationRetryFact() = emitNotificationFact(Action.RETRY)
+internal fun emitNotificationTryAgainFact() = emitNotificationFact(Action.TRY_AGAIN)
 internal fun emitNotificationOpenFact() = emitNotificationFact(Action.OPEN)
 
 private fun emitNotificationFact(

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/Action.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/Action.kt
@@ -54,7 +54,7 @@ enum class Action {
     /**
      * The user has retried something.
      */
-    RETRY,
+    TRY_AGAIN,
 
     /**
      * The user has opened something.

--- a/components/support/base/src/main/java/mozilla/components/support/base/facts/Action.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/facts/Action.kt
@@ -42,6 +42,26 @@ enum class Action {
     STOP,
 
     /**
+     * The user has resumed something.
+     */
+    RESUME,
+
+    /**
+     * The user has cancelled something.
+     */
+    CANCEL,
+
+    /**
+     * The user has retried something.
+     */
+    RETRY,
+
+    /**
+     * The user has opened something.
+     */
+    OPEN,
+
+    /**
      * A generic interaction that can be caused by a previous action (e.g. the user clicks on a button which causes a
      * [Fact] with [CLICK] action to be emitted. This click may causes something to load which emits a follow-up a
      * [Fact] with [INTERACTION] action.


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

In Fenix#5583, we want to add telemetry to know the following:

User pauses a download
User resumes a download
User cancels a download
User taps on retry when a download fails
User opens a downloaded file by tapping on the link in system notification

| Action | Item            |  Description                                    |
|--------|-----------------|-------------------------------------------------|
| RESUME | notification    | The user resumes a download.                    |
| PAUSE  | notification    | The user pauses a download.                     |
| CANCEL | notification    | The user cancels a download.                    |
| RETRY  | notification    | The user taps on retry when a download fails.   |
| OPEN   | notification    | The user opens a downloaded file.               |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
