### PR TITLE
Closes #5004: Improve SecureAbove22Preferences API

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -67,8 +67,10 @@ sealed class SyncEngine(val nativeName: String) {
     object Bookmarks : SyncEngine("bookmarks")
 
     /**
-     * A 'logins/passwords' engine. When using this engine, make sure to set an encryption key used to unlock the store
-     * as 'passwords_key' via [SecureAbove22Preferences].
+     * A 'logins/passwords' engine.
+     *
+     * When using this engine, make sure to pass a [SecureAbove22Preferences] instance to
+     * [GlobalSyncableStoreProvider.configureKeyStorage] with a key storage instance that has a "passwords" key set.
      */
     object Passwords : SyncEngine("passwords")
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
@@ -5,6 +5,7 @@
 package mozilla.components.service.fxa.sync
 
 import mozilla.components.concept.sync.SyncableStore
+import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.service.fxa.SyncConfig
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
@@ -77,14 +78,30 @@ interface SyncStatusObserver {
  */
 object GlobalSyncableStoreProvider {
     private val stores: MutableMap<String, SyncableStore> = mutableMapOf()
+    private var keyStorage: SecureAbove22Preferences? = null
 
+    /**
+     * Configure an instance of [SyncableStore] for a [SyncEngine] enum.
+     * @param storePair A pair associating [SyncableStore] with a [SyncEngine].
+     */
     fun configureStore(storePair: Pair<SyncEngine, SyncableStore>) {
         stores[storePair.first.nativeName] = storePair.second
+    }
+
+    /**
+     * Set an instance of [SecureAbove22Preferences] used for accessing an encryption key for [SyncEngine.Passwords].
+     *
+     * @param ks An instance of [SecureAbove22Preferences].
+     */
+    fun configureKeyStorage(ks: SecureAbove22Preferences) {
+        keyStorage = ks
     }
 
     internal fun getStore(name: String): SyncableStore? {
         return stores[name]
     }
+
+    internal fun getKeyStorage() = keyStorage
 }
 
 /**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,7 @@ permalink: /changelog/
   * Added new `SecureAbove22Preferences` helper class, which is an encryption-aware wrapper for `SharedPreferences`. Only actually encrypts stored values when running on API23+.
 
 * **service-firefox-accounts**
-  * Support for keeping `SyncEngine.Passwords` engine unlocked during sync.
+  * Support for keeping `SyncEngine.Passwords` engine unlocked during sync. If you're syncing this engine, you must use `SecureAbove22Preferences` to store encryption key (stored under "passwords" key), and pass an instance of these secure prefs to `GlobalSyncableStoreProvider.configureKeyStorage`.
 
 * **concept-sync**
   * Added new `LockableStore` to facilitate syncing of "lockable" stores (such as `SyncableLoginsStore`).

--- a/samples/dataprotect/src/main/java/org/mozilla/samples/dataprotect/MainActivity.kt
+++ b/samples/dataprotect/src/main/java/org/mozilla/samples/dataprotect/MainActivity.kt
@@ -21,7 +21,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val prefs = SecureAbove22Preferences(this)
+        val prefs = SecureAbove22Preferences(this, "secret-data-storage")
 
         prepareProtectedData(prefs)
 


### PR DESCRIPTION
This changes `SecureAbove22Preferences` to allow isolating its instances by a name. Entries in an instance with name "a" won't be affected by (or visible to) an instance with name "b", and vice versa.

Migration logic for the encrypted version was simplified as well. It's now expressed in terms of basic `SecureAbove22Preferences` operations.

Lack of test coverage for the secure version is starting to become a problem here, so let's address #4956 soon.

Another change that's present here is a new method on `GlobalSyncableStoreProvider`: `configureKeyStorage`. It takes an instance of `SecureAbove22Preferences`, which is then used by the sync worker to obtain an encryption key for passwords storage, if it's configured.

The contract here is that if password syncing is enabled, then a "passwords" key must be available from the configured `SecureAbove22Preferences` instance.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
