### PR TITLE
Closes #4313: Add subscribeAll support to RustPushConnection

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -123,10 +123,7 @@ class AutoPushFeature(
 
         DeliveryManager.with(connection) {
             job = scope.launch {
-                // TODO replace with unsubscribeAll API when available
-                PushType.values().forEach { type ->
-                    unsubscribe(type.toChannelId())
-                }
+                unsubscribeAll()
                 job.cancel()
             }
         }
@@ -276,7 +273,7 @@ class AutoPushFeature(
     internal fun verifyActiveSubscriptions() {
         DeliveryManager.with(connection) {
             job = scope.launchAndTry {
-                val notifyObservers = connection.verifyConnection()
+                val notifyObservers = verifyConnection()
 
                 if (notifyObservers) {
                     logger.info("Subscriptions have changed; notifying observers..")

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
@@ -63,8 +63,7 @@ internal class RustPushConnection(
     override suspend fun unsubscribeAll(): Boolean = synchronized(this) {
         val pushApi = api
         check(pushApi != null) { "Rust API is not initiated; updateToken hasn't been called yet." }
-        // TODO replace with unsubscribeAll when API exists
-        return pushApi.unsubscribe("")
+        return pushApi.unsubscribeAll()
     }
 
     @GuardedBy("this")

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -100,7 +100,7 @@ class AutoPushFeatureTest {
         }
 
         verify(service).stop()
-        verify(connection, times(PushType.values().size)).unsubscribe(anyString())
+        verify(connection).unsubscribeAll()
         assertTrue(feature.job.isCancelled)
     }
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
@@ -109,7 +109,7 @@ class RustPushConnectionTest {
             connection.unsubscribeAll()
         }
 
-        verify(api).unsubscribe("")
+        verify(api).unsubscribeAll()
     }
 
     @Test(expected = IllegalStateException::class)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,9 @@ permalink: /changelog/
     sitePermissions[Permission.LOCATION] //  ALLOWED will be returned
   ```
 
+* **feature-push**
+  * Added `unsubscribeAll` support from the Rust native layer.
+
 # 20.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v19.0.0...v20.0.0)


### PR DESCRIPTION
The API on the native Rust layer had been made available, so we can implement this on the feature level too.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Closes #4313 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
