### PR TITLE
For #4999: Adds download failure condition for less than content length

### DIFF
--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -32,6 +32,7 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -100,6 +101,72 @@ class AbstractFetchDownloadServiceTest {
         val intentCode = service.onStartCommand(downloadIntent, 0, 0)
 
         assertEquals(Service.START_REDELIVER_INTENT, intentCode)
+    }
+
+    @Test
+    fun `verifyDownload sets the download to failed if it is not complete`() = runBlocking {
+        val downloadState = DownloadState(
+            url = "mozilla.org/mozilla.txt",
+            filePath = "mozilla.txt",
+            contentLength = 50L
+        )
+
+        val downloadJobState = AbstractFetchDownloadService.DownloadJobState(
+            job = null,
+            state = downloadState,
+            currentBytesCopied = 5,
+            status = ACTIVE,
+            foregroundServiceId = 1,
+            downloadDeleted = false
+        )
+
+        service.verifyDownload(downloadJobState)
+
+        assertEquals(FAILED, downloadJobState.status)
+    }
+
+    @Test
+    fun `verifyDownload does NOT set the download to failed if it is paused`() = runBlocking {
+        val downloadState = DownloadState(
+            url = "mozilla.org/mozilla.txt",
+            filePath = "mozilla.txt",
+            contentLength = 50L
+        )
+
+        val downloadJobState = AbstractFetchDownloadService.DownloadJobState(
+            job = null,
+            state = downloadState,
+            currentBytesCopied = 5,
+            status = PAUSED,
+            foregroundServiceId = 1,
+            downloadDeleted = false
+        )
+
+        service.verifyDownload(downloadJobState)
+
+        assertEquals(PAUSED, downloadJobState.status)
+    }
+
+    @Test
+    fun `verifyDownload does NOT set the download to failed if it is complete`() = runBlocking {
+        val downloadState = DownloadState(
+            url = "mozilla.org/mozilla.txt",
+            filePath = "mozilla.txt",
+            contentLength = 50L
+        )
+
+        val downloadJobState = AbstractFetchDownloadService.DownloadJobState(
+            job = null,
+            state = downloadState,
+            currentBytesCopied = 50,
+            status = ACTIVE,
+            foregroundServiceId = 1,
+            downloadDeleted = false
+        )
+
+        service.verifyDownload(downloadJobState)
+
+        assertNotEquals(FAILED, downloadJobState.status)
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

I'm unsure how to add a test for this. It's adding a small incremental change to the download failed condition. The only way I could think to test is if there's a way to send a mock response that only let's it read a few bytes? Unsure how to do that 😅 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
