### PR TITLE
Closes #3857: Use `hasUserGesture` to determine if Content is Triggered by User

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -85,8 +85,6 @@ class GeckoEngineSession(
 
     private var initialLoad = true
 
-    private var requestFromWebContent = false
-
     override val coroutineContext: CoroutineContext
         get() = context + job
 
@@ -98,7 +96,6 @@ class GeckoEngineSession(
      * See [EngineSession.loadUrl]
      */
     override fun loadUrl(url: String, parent: EngineSession?, flags: LoadUrlFlags) {
-        requestFromWebContent = false
         geckoSession.loadUri(url, (parent as? GeckoEngineSession)?.geckoSession, flags.value)
     }
 
@@ -106,7 +103,6 @@ class GeckoEngineSession(
      * See [EngineSession.loadData]
      */
     override fun loadData(data: String, mimeType: String, encoding: String) {
-        requestFromWebContent = false
         when (encoding) {
             "base64" -> geckoSession.loadData(data.toByteArray(), mimeType)
             else -> geckoSession.loadString(data, mimeType)
@@ -124,7 +120,6 @@ class GeckoEngineSession(
      * See [EngineSession.reload]
      */
     override fun reload() {
-        requestFromWebContent = false
         geckoSession.reload()
     }
 
@@ -132,7 +127,6 @@ class GeckoEngineSession(
      * See [EngineSession.goBack]
      */
     override fun goBack() {
-        requestFromWebContent = false
         geckoSession.goBack()
     }
 
@@ -140,7 +134,6 @@ class GeckoEngineSession(
      * See [EngineSession.goForward]
      */
     override fun goForward() {
-        requestFromWebContent = false
         geckoSession.goForward()
     }
 
@@ -374,7 +367,7 @@ class GeckoEngineSession(
                     onLoadRequest(
                         url = request.uri,
                         triggeredByRedirect = request.isRedirect,
-                        triggeredByWebContent = requestFromWebContent
+                        triggeredByWebContent = request.hasUserGesture
                     )
                 }
 
@@ -454,7 +447,6 @@ class GeckoEngineSession(
             // by the time we reach here, any new request will come from web content.
             // If it comes from the chrome, loadUrl(url) or loadData(string) will set it to
             // false.
-            requestFromWebContent = true
             notifyObservers {
                 onProgress(PROGRESS_STOP)
                 onLoadingStateChange(false)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1897,7 +1897,8 @@ class GeckoEngineSessionTest {
             observedTriggeredByWebContent = null
             observedUrl = null
             navigationDelegate.value.onLoadRequest(
-                mock(), mockLoadRequest(fakeUrl, triggeredByRedirect = true))
+                mock(), mockLoadRequest(fakeUrl, triggeredByRedirect = true,
+                hasUserGesture = expectedTriggeredByWebContent))
             progressDelegate.value.onPageStop(mock(), true)
             assertNotNull(observedTriggeredByWebContent)
             assertEquals(expectedTriggeredByWebContent, observedTriggeredByWebContent!!)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
