### PR TITLE
Closes #4870: Provide caching mechanism for AMO collection response 

### DIFF
--- a/components/feature/addons/build.gradle
+++ b/components/feature/addons/build.gradle
@@ -33,8 +33,10 @@ dependencies {
     implementation Dependencies.kotlin_coroutines
 
     implementation project(':concept-fetch')
-    testImplementation project(':support-test')
+    implementation project(':support-base')
+    implementation project(':support-ktx')
 
+    testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddOnsProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddOnsProvider.kt
@@ -8,8 +8,12 @@ package mozilla.components.feature.addons
  * A contract that indicate how an add-on provider must behave.
  */
 interface AddOnsProvider {
+
     /**
      * Provides a list of all available add-ons.
+     *
+     * @param allowCache whether or not the result may be provided
+     * from a previously cached response, defaults to true.
      */
-    suspend fun getAvailableAddOns(): List<AddOn>
+    suspend fun getAvailableAddOns(allowCache: Boolean = true): List<AddOn>
 }

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddOnCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddOnCollectionProvider.kt
@@ -29,7 +29,7 @@ internal const val DEFAULT_COLLECTION_NAME = "7e8d6dc651b54ab385fb8791bf9dac"
  * to [DEFAULT_COLLECTION_NAME].
  * @property client A reference of [Client] for interacting with the AMO HTTP api.
  */
-class AddOnsCollectionsProvider(
+class AddOnCollectionProvider(
     private val serverURL: String = DEFAULT_SERVER_URL,
     private val collectionName: String = DEFAULT_COLLECTION_NAME,
     private val client: Client

--- a/components/feature/addons/src/test/java/AddOnCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/AddOnCollectionProviderTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
-class AddOnsCollectionsProviderTest {
+class AddOnCollectionProviderTest {
 
     @Test
     fun `getAvailableAddOns - with a successful status response must contain add-ons`() {
@@ -35,7 +35,7 @@ class AddOnsCollectionsProviderTest {
         whenever(mockedResponse.status).thenReturn(200)
         whenever(mockedClient.fetch(any())).thenReturn(mockedResponse)
 
-        val provider = AddOnsCollectionsProvider(client = mockedClient)
+        val provider = AddOnCollectionProvider(client = mockedClient)
 
         runBlocking {
             val addOns = provider.getAvailableAddOns()
@@ -101,7 +101,7 @@ class AddOnsCollectionsProviderTest {
         whenever(mockedResponse.status).thenReturn(200)
         whenever(mockedClient.fetch(any())).thenReturn(mockedResponse)
 
-        val provider = AddOnsCollectionsProvider(client = mockedClient)
+        val provider = AddOnCollectionProvider(client = mockedClient)
 
         runBlocking {
             val addOns = provider.getAvailableAddOns()
@@ -141,7 +141,7 @@ class AddOnsCollectionsProviderTest {
         whenever(mockedResponse.status).thenReturn(500)
         whenever(mockedClient.fetch(any())).thenReturn(mockedResponse)
 
-        val provider = AddOnsCollectionsProvider(client = mockedClient)
+        val provider = AddOnCollectionProvider(client = mockedClient)
 
         runBlocking {
             val addOns = provider.getAvailableAddOns()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,22 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-addons**
+  *  ⚠️ **This is a breaking change**:
+  * Renamed to `AddOnsCollectionsProvider` to `AddOnCollectionProvider` and added caching support:
+  ```Kotlin
+  val addOnsProvider by lazy {
+    // Keeps addon collection response cached and valid for one day
+    AddOnCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = 24 * 60)      
+  }
+
+  // May return a cached result, if available
+  val addOns = addOnsProvider.getAvailableAddOns()
+
+  // Will never return a cached result
+  val addOns = addOnsProvider.getAvailableAddOns(allowCache = false)
+  ```
+
 # 21.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v20.0.0...v21.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -55,6 +55,8 @@ import org.mozilla.samples.browser.integration.FindInPageIntegration
 import org.mozilla.samples.browser.request.SampleRequestInterceptor
 import java.util.concurrent.TimeUnit
 
+private const val DAY_IN_MINUTES = 24 * 60L
+
 @Suppress("LargeClass")
 open class DefaultComponents(private val applicationContext: Context) {
 
@@ -114,7 +116,9 @@ open class DefaultComponents(private val applicationContext: Context) {
         }
     }
 
-    val addOnProvider by lazy { AddOnCollectionProvider(client = client) }
+    val addOnProvider by lazy {
+        AddOnCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
+    }
 
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -30,7 +30,7 @@ import mozilla.components.browser.storage.memory.InMemoryHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
-import mozilla.components.feature.addons.amo.AddOnsCollectionsProvider
+import mozilla.components.feature.addons.amo.AddOnCollectionProvider
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
@@ -114,7 +114,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         }
     }
 
-    val addOnsProvider by lazy { AddOnsCollectionsProvider(client = client) }
+    val addOnProvider by lazy { AddOnCollectionProvider(client = client) }
 
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddOnsFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddOnsFragment.kt
@@ -47,7 +47,7 @@ class AddOnsFragment : Fragment(), View.OnClickListener {
         recyclerView = rootView.findViewById(R.id.add_ons_list)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         scope.launch {
-            val addOns = requireContext().components.addOnsProvider.getAvailableAddOns()
+            val addOns = requireContext().components.addOnProvider.getAvailableAddOns()
 
             scope.launch(Dispatchers.Main) {
                 val adapter = AddOnsAdapter(


### PR DESCRIPTION
If a `maxCacheAge` is configured, `AddOnCollectionProvider` will now cache the AMO collection response. `getAvailableAddOns` may therefore return a cached result, but also has a new parameter to disallow cached results entirely to support cases where we always want a fresh addon list.