### PR TITLE
Update GeckoView Nightly to 72.0.20191113095525.

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "72.0.20191109093718"
+    const val nightly_version = "72.0.20191113095525"
 
     /**
      * GeckoView Beta Version.


### PR DESCRIPTION
Our hooks are not running anymore so I am updating manually.