### PR TITLE
Closes #4938: DownloadsFeatureTest: Join and block on store dispatch.

### DIFF
--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -288,7 +288,7 @@ class DownloadsFeatureTest {
 
         store.dispatch(ContentAction.UpdateDownloadAction(
             "test-tab", DownloadState("https://www.mozilla.org")
-        ))
+        )).joinBlocking()
 
         val downloadManager: DownloadManager = mock()
         doReturn(


### PR DESCRIPTION
In this case we did not join and block on the store dispatch which could cause an intermittent failure if the dispatch wasn't completed before we assert later in the test.