### PR TITLE
Closes #4971: Use structural equality for ifChanged

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlinx/coroutines/flow/Flow.kt
@@ -39,7 +39,7 @@ fun <T, R> Flow<T>.ifChanged(transform: (T) -> R): Flow<T> {
 
     return filter { value ->
         val mapped = transform(value)
-        if (!observedValueOnce || mapped !== lastMappedValue) {
+        if (!observedValueOnce || mapped != lastMappedValue) {
             lastMappedValue = mapped
             observedValueOnce = true
             true
@@ -96,7 +96,7 @@ fun <T, R> Flow<List<T>>.filterChanged(transform: (T) -> R): Flow<T> {
             values
         } else {
             values.filter {
-                !lastMapped.containsKey(it) || lastMapped[it] !== transform(it)
+                !lastMapped.containsKey(it) || lastMapped[it] != transform(it)
             }
         }
         lastMappedValues = values.map { Pair(it, transform(it)) }.toMap()
@@ -124,7 +124,7 @@ fun <T, R> Flow<T>.ifAnyChanged(transform: (T) -> Array<R>): Flow<T> {
         val mapped = transform(value)
         val hasChanges = lastMappedValues
             ?.asSequence()
-            ?.filterIndexed { i, r -> mapped[i] !== r }
+            ?.filterIndexed { i, r -> mapped[i] != r }
             ?.any()
 
         if (!observedValueOnce || hasChanges == true) {


### PR DESCRIPTION
As discussed in #4971, this makes the use of `ifChanged` more intuitive as `equals` will be used, if it exists. I tested and went over our existing features to make sure we don't need a change:

- `HitResult`, `Download`, `PromptRequest`: Are all data classes with a generated `equals`, which will now be used. Since we're following the same pattern though, where we process one, then consume it (set it to null) before processing a new request, there should be no change in behaviour.

- `WindowRequest`: Will still use reference equality as before. Implementations are immutable and have no custom `equals` . So, there's also no change in behaviour.

- `FindResults`: An immutable list where we now check for structural equality. There's no change in behaviour when triggering new find operation, as we always set to an empty list `onFind`. There is a change in behaviour for `findNext`, but it's a good one. If the result is the same as before we no longer notify and update the UI, which makes sense.

- `SessionState`: We're using `ifChanged` on session state directly too. Since all states are immutable types, we're always creating new instances for changes. There would be a change in behaviour in case the applied action doesn't affect the state but since we always had this check (https://github.com/mozilla-mobile/android-components/blob/master/components/lib/state/src/main/java/mozilla/components/lib/state/Store.kt#L104-L107), there should also be no change here.