### PR TITLE
Add shortcut category to window feature

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabWindowFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabWindowFeature.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.customtabs
 
-import android.content.Context
+import android.app.Activity
 import androidx.annotation.VisibleForTesting
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
@@ -21,11 +21,13 @@ import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 
+const val SHORTCUT_CATEGORY = "mozilla.components.pwa.category.SHORTCUT"
+
 /**
  * Feature implementation for handling window requests by opening custom tabs.
  */
 class CustomTabWindowFeature(
-    private val context: Context,
+    private val activity: Activity,
     private val store: BrowserStore,
     private val sessionId: String
 ) : LifecycleAwareFeature {
@@ -51,7 +53,8 @@ class CustomTabWindowFeature(
             config?.menuItems?.forEach { addMenuItem(it.name, it.pendingIntent) }
         }.build()
 
-        intent.intent.`package` = context.packageName
+        intent.intent.`package` = activity.packageName
+        intent.intent.addCategory(SHORTCUT_CATEGORY)
 
         return intent
     }
@@ -69,7 +72,7 @@ class CustomTabWindowFeature(
                     val windowRequest = state.content.windowRequest
                     if (windowRequest?.type == WindowRequest.Type.OPEN) {
                         val intent = configToIntent(state.config)
-                        intent.launchUrl(context, windowRequest.url.toUri())
+                        intent.launchUrl(activity, windowRequest.url.toUri())
                         store.dispatch(ContentAction.ConsumeWindowRequestAction(sessionId))
                     }
                 }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -39,7 +39,7 @@ import mozilla.components.feature.pwa.ext.installableManifest
 
 private val pwaIconMemoryCache = IconMemoryCache()
 
-const val SHORTCUT_CATEGORY = "mozilla.components.pwa.category.SHORTCUT"
+const val SHORTCUT_CATEGORY = mozilla.components.feature.customtabs.SHORTCUT_CATEGORY
 
 /**
  * Helper to manage pinned shortcuts for websites.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,7 @@ permalink: /changelog/
   ```Kotlin
   val addOnsProvider by lazy {
     // Keeps addon collection response cached and valid for one day
-    AddOnCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = 24 * 60)      
+    AddOnCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = 24 * 60)
   }
 
   // May return a cached result, if available
@@ -31,9 +31,12 @@ permalink: /changelog/
 * **lib-nearby**
   * 🆕 New component for communicating directly between two devices
   using Google Nearby API.
-  
+
 * **sample-nearby-chat**
   * 🆕 New sample program demonstrating use of `lib-nearby`.
+
+* **feature-customtabs**
+  * ⚠️ `CustomTabWindowFeature` now takes `Activity` instead of `Context`.
 
 # 21.0.0
 
@@ -105,7 +108,7 @@ permalink: /changelog/
 * **concept-engine**
   * Adds support for WebPush abstraction to the Engine.
   * Adds support for WebShare abstraction as a PromptRequest.
-  
+
 * **engine-gecko-nightly**
   * Adds support for WebPush in GeckoEngine.
 
@@ -120,7 +123,7 @@ permalink: /changelog/
 
 * **feature-prompts**
   * Adds support for Web Share API using `ShareDelegate`.
-  
+
 * **experiments**
   * Fixes a crash when the app version or the experiment's version specifiers are not in the expected format.
 
@@ -134,8 +137,8 @@ permalink: /changelog/
         store.dispatch(RemoveTabAction(tab.id))
       }
     }
-  }  
-  ```  
+  }
+  ```
 
 # 19.0.1
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -65,7 +65,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
             view = layout.toolbar)
 
         val windowFeature = CustomTabWindowFeature(
-            requireContext(),
+            requireActivity(),
             components.store,
             sessionId!!
         )


### PR DESCRIPTION
Prevents "Open in private mode" option from appearing when opening a window.

Changed the first parameter to be `Activity` since the app crashes when you try to pass in application context instead.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
