### PR TITLE
Closes #5041: Fix migration post-processing to understand FxA migrations

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationResultsStore.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationResultsStore.kt
@@ -57,6 +57,7 @@ internal class MigrationResultsStore(context: Context) : SharedPreferencesCache<
                 Migration.Bookmarks.javaClass.simpleName -> Migration.Bookmarks
                 Migration.OpenTabs.javaClass.simpleName -> Migration.OpenTabs
                 Migration.Gecko.javaClass.simpleName -> Migration.Gecko
+                Migration.FxA.javaClass.simpleName -> Migration.FxA
                 else -> throw IllegalStateException("Unrecognized migration type: $migrationName")
             }
             result[migration] = MigrationRun(version = migrationVersion, success = migrationSuccess)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -30,6 +30,7 @@ import java.lang.IllegalStateException
 import kotlinx.coroutines.CompletableDeferred
 import mozilla.components.service.fxa.sharing.ShareableAccount
 import mozilla.components.support.test.argumentCaptor
+import org.mockito.Mockito.reset
 
 @RunWith(AndroidJUnit4::class)
 class FennecMigratorTest {
@@ -422,6 +423,13 @@ class FennecMigratorTest {
         }
 
         verifyZeroInteractions(accountManager)
+
+        // Does not run FxA migration again.
+        with(migrator.migrateAsync().await()) {
+            assertEquals(0, this.size)
+        }
+
+        verifyZeroInteractions(accountManager)
     }
 
     @Test
@@ -438,6 +446,13 @@ class FennecMigratorTest {
             assertEquals(1, this.size)
             assertTrue(this.containsKey(Migration.FxA))
             assertTrue(this.getValue(Migration.FxA).success)
+        }
+
+        verifyZeroInteractions(accountManager)
+
+        // Does not run FxA migration again.
+        with(migrator.migrateAsync().await()) {
+            assertEquals(0, this.size)
         }
 
         verifyZeroInteractions(accountManager)
@@ -469,6 +484,14 @@ class FennecMigratorTest {
         assertEquals("252fsvj8932vj32movj97325hjfksdhfjstrg23yurt267r23", captor.value.authInfo.kSync)
         assertEquals("0b3ba79bfxdf32f3of32jowef7987f", captor.value.authInfo.kXCS)
         assertEquals("fjsdkfksf3e8f32f23f832fwf32jf89o327u2843gj23", captor.value.authInfo.sessionToken)
+
+        // Does not run FxA migration again.
+        reset(accountManager)
+        with(migrator.migrateAsync().await()) {
+            assertEquals(0, this.size)
+        }
+
+        verifyZeroInteractions(accountManager)
     }
 
     @Test
@@ -498,5 +521,13 @@ class FennecMigratorTest {
         assertEquals("252bc4ccc3a239fsdfsdf32fg32wf3w4e3472d41d1a204890", captor.value.authInfo.kSync)
         assertEquals("0b3ba79b18bd9fsdfsdf4g234adedd87", captor.value.authInfo.kXCS)
         assertEquals("fsdfjsdffsdf342f23g3ogou97328uo23ij", captor.value.authInfo.sessionToken)
+
+        // Does not run FxA migration again.
+        reset(accountManager)
+        with(migrator.migrateAsync().await()) {
+            assertEquals(0, this.size)
+        }
+
+        verifyZeroInteractions(accountManager)
     }
 }


### PR DESCRIPTION
When FxA migration was added, I forgot to adjust "read and parse past migrations" code
to account for a new migration type. This patch fixes that problem, and adds tests that
would have cought it.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
