### PR TITLE
Closes #4935: Tracking protection state not updated on browser session

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -189,7 +189,7 @@ class GeckoEngineSession(
         if (!enabled) {
             disableTrackingProtectionOnGecko()
         }
-        notifyObservers { onTrackerBlockingEnabledChange(enabled) }
+        notifyAtLeastOneObserver { onTrackerBlockingEnabledChange(enabled) }
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -189,7 +189,7 @@ class GeckoEngineSession(
         if (!enabled) {
             disableTrackingProtectionOnGecko()
         }
-        notifyObservers { onTrackerBlockingEnabledChange(enabled) }
+        notifyAtLeastOneObserver { onTrackerBlockingEnabledChange(enabled) }
     }
 
     /**

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -189,7 +189,7 @@ class GeckoEngineSession(
             disableTrackingProtectionOnGecko()
         }
         geckoSession.settings.useTrackingProtection = shouldBlockContent
-        notifyObservers { onTrackerBlockingEnabledChange(enabled) }
+        notifyAtLeastOneObserver { onTrackerBlockingEnabledChange(enabled) }
     }
 
     /**

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -292,6 +292,8 @@ private class MockedTabsTray : TabsTray {
 
     override fun notifyObservers(block: TabsTray.Observer.() -> Unit) {}
 
+    override fun notifyAtLeastOneObserver(block: TabsTray.Observer.() -> Unit) {}
+
     override fun <R> wrapConsumers(block: TabsTray.Observer.(R) -> Boolean): List<(R) -> Boolean> = emptyList()
 
     override fun isObserved(): Boolean = false

--- a/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/observer/Observable.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.LifecycleOwner
  *     }
  * </code>
  */
+@Suppress("TooManyFunctions")
 interface Observable<T> {
     /**
      * Registers an observer to get notified about changes.
@@ -69,6 +70,15 @@ interface Observable<T> {
      * @param block the notification (method on the observer to be invoked).
      */
     fun notifyObservers(block: T.() -> Unit)
+
+    /**
+     * Notifies all registered observers about a change. If there is no observer
+     * the notification is queued and sent to the first observer that is
+     * registered.
+     *
+     * @param block the notification (method on the observer to be invoked).
+     */
+    fun notifyAtLeastOneObserver(block: T.() -> Unit)
 
     /**
      * Pauses the provided observer. No notifications will be sent to this

--- a/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/observer/ObserverRegistryTest.kt
@@ -46,6 +46,29 @@ class ObserverRegistryTest {
     }
 
     @Test
+    fun `observer gets queued notifications when registered`() {
+        val registry = ObserverRegistry<TestIntObserver>()
+
+        val observer = TestIntObserver()
+        val anotherObserver = TestIntObserver()
+        registry.notifyAtLeastOneObserver {
+            somethingChanged(1)
+        }
+        registry.notifyAtLeastOneObserver {
+            somethingChanged(2)
+        }
+        registry.notifyAtLeastOneObserver {
+            somethingChanged(3)
+        }
+        assertEquals(emptyList<Int>(), observer.notified)
+
+        registry.register(observer)
+        registry.register(anotherObserver)
+        assertEquals(listOf(1, 2, 3), observer.notified)
+        assertEquals(emptyList<Int>(), anotherObserver.notified)
+    }
+
+    @Test
     fun `observer does not get notified again after unregistering`() {
         val registry = ObserverRegistry<TestObserver>()
 


### PR DESCRIPTION
The cause of this problem is a bit of a gap in our design. When a `GeckoEngineSession` is created we enable (or disable) tracking protection based on settings, and also call `notifyObservers` to make sure the corresponding browser session (`trackerBlockingEnabled` field) is updated. However, when the `GeckoEngineSession` is created no browser session is linked to it yet and therefore there's no observer. The notification is simply lost and the browser session is never updated.

We looked into a few ways to work around this e.g. setting the field in [onLocationChange](https://github.com/mozilla-mobile/android-components/blob/master/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt#L41) instead, as we do for `title`, `url`, `webAppManifest`. This would be a bit of a hack though as we'd be doing it way too often, or in an unrelated method / event.

So, how about this idea instead: We introduce a new `notifyAtLeastOneObserver` (or similar) method which queues up the notification if there's no observer and sends it to the first observer that's registered. Wdyt?

@pocmo @Amejia481 
