### PR TITLE
Add setDynamicToolbarMaxHeight API

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -141,6 +141,10 @@ class GeckoEngineView @JvmOverloads constructor(
         currentGeckoView.setVerticalClipping(clippingHeight)
     }
 
+    override fun setDynamicToolbarMaxHeight(height: Int) {
+        // no-op
+    }
+
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         val geckoResult = currentGeckoView.capturePixels()
         geckoResult.then({ bitmap ->

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -141,6 +141,10 @@ class GeckoEngineView @JvmOverloads constructor(
         currentGeckoView.setVerticalClipping(clippingHeight)
     }
 
+    override fun setDynamicToolbarMaxHeight(height: Int) {
+        currentGeckoView.setDynamicToolbarMaxHeight(height)
+    }
+
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         val geckoResult = currentGeckoView.capturePixels()
         geckoResult.then({ bitmap ->

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -86,6 +86,16 @@ class GeckoEngineViewTest {
     }
 
     @Test
+    fun `setDynamicToolbarMaxHeight is forwarded to GeckoView instance`() {
+        val engineView = GeckoEngineView(context)
+        engineView.currentGeckoView = mock()
+
+        engineView.setDynamicToolbarMaxHeight(42)
+
+        verify(engineView.currentGeckoView).setDynamicToolbarMaxHeight(42)
+    }
+
+    @Test
     fun `release method releases session from GeckoView`() {
         val engineView = GeckoEngineView(context)
         val engineSession = mock<GeckoEngineSession>()

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -118,6 +118,10 @@ class GeckoEngineView @JvmOverloads constructor(
         currentGeckoView.setVerticalClipping(clippingHeight)
     }
 
+    override fun setDynamicToolbarMaxHeight(height: Int) {
+        // no-op
+    }
+
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         val geckoResult = currentGeckoView.capturePixels()
         geckoResult.then({ bitmap ->

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -654,6 +654,10 @@ class SystemEngineView @JvmOverloads constructor(
         // no-op
     }
 
+    override fun setDynamicToolbarMaxHeight(height: Int) {
+        // no-op
+    }
+
     override fun canScrollVerticallyUp() = session?.webView?.canScrollVertically(-1) ?: false
 
     override fun canScrollVerticallyDown() = session?.webView?.canScrollVertically(1) ?: false

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -95,6 +95,13 @@ interface EngineView {
      * @param clippingHeight The height of the bottom clipped space in screen pixels.
      */
     fun setVerticalClipping(clippingHeight: Int)
+
+    /**
+     * Sets the maximum height of the dynamic toolbar(s).
+     *
+     * @param height The maximum possible height of the toolbar.
+     */
+    fun setDynamicToolbarMaxHeight(height: Int)
 }
 
 /**

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
@@ -61,6 +61,7 @@ class EngineViewTest {
 
     open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
+        override fun setDynamicToolbarMaxHeight(height: Int) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}
@@ -69,6 +70,7 @@ class EngineViewTest {
     // Class it not actually a View!
     open class BrokenEngineView : EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
+        override fun setDynamicToolbarMaxHeight(height: Int) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
@@ -94,6 +94,7 @@ class SwipeRefreshFeatureTest {
     private open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
         override fun canScrollVerticallyUp() = scrollY > 0
         override fun setVerticalClipping(clippingHeight: Int) {}
+        override fun setDynamicToolbarMaxHeight(height: Int) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -63,6 +63,8 @@ class FakeEngineView(context: Context) : TextView(context), EngineView {
 
     override fun setVerticalClipping(clippingHeight: Int) {}
 
+    override fun setDynamicToolbarMaxHeight(height: Int) {}
+
     override fun release() {}
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ permalink: /changelog/
 
     sitePermissions[Permission.LOCATION] //  ALLOWED will be returned
   ```
+* **engine-gecko-nightly**
+  * Adds setDynamicToolbarMaxHeight ApI.
+
 
 # 20.0.0
 


### PR DESCRIPTION
---
To make dynamic toolbar behavior compatible with other browsers, we did introduce a new API to specify the maximum height of the dynamic toolbar in [bug 1586144](https://bugzilla.mozilla.org/show_bug.cgi?id=1586144).

To be honest, I don't know what we should do for engine-gecko-beta or engine-gecko in this kind of situation (i.e. introducing a new API in gecko-nightly).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) **I am totally unsure whether dynamic toolbar is accessibility friendly or not.**

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
