### PR TITLE
FxA cleanup: remove authErrorRegistry, and other simplifications

### DIFF
--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -86,14 +86,14 @@ interface OAuthAccount : AutoCloseable {
      * @param state the state token string
      * @param accessType the accessType method to be used by the returned code, determines whether
      * the code can be exchanged for a refresh token to be used offline or not
-     * @return the authorized auth code string
+     * @return Deferred authorized auth code string, or `null` in case of failure.
      */
-    fun authorizeOAuthCode(
+    fun authorizeOAuthCodeAsync(
         clientId: String,
         scopes: Array<String>,
         state: String,
         accessType: AccessType = AccessType.ONLINE
-    ): String?
+    ): Deferred<String?>
 
     /**
      * Fetches the profile object for the current client either from the existing cached state

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/Sync.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/Sync.kt
@@ -16,7 +16,7 @@ sealed class SyncStatus {
     /**
      * Sync completed with an error.
      */
-    data class Error(val exception: Throwable) : SyncStatus()
+    data class Error(val exception: Exception) : SyncStatus()
 }
 
 /**
@@ -53,7 +53,7 @@ interface LockableStore : SyncableStore {
      * to key the store.
      * @param block A lambda to execute while the store is unlocked.
      */
-    suspend fun <T> unlocked(encryptionKey: String, block: (store: LockableStore) -> T): T
+    suspend fun <T> unlocked(encryptionKey: String, block: suspend (store: LockableStore) -> T): T
 }
 
 /**

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -8,16 +8,13 @@ import android.net.Uri
 import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
 import mozilla.appservices.fxaclient.FirefoxAccount as InternalFxAcct
-import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.AccessType
 import mozilla.components.concept.sync.AuthFlowUrl
 import mozilla.components.concept.sync.DeviceConstellation
 import mozilla.components.concept.sync.OAuthAccount
-import mozilla.components.concept.sync.Profile
 import mozilla.components.concept.sync.StatePersistenceCallback
 import mozilla.components.support.base.log.logger.Logger
 
@@ -100,62 +97,66 @@ class FirefoxAccount internal constructor(
         persistCallback.setCallback(callback)
     }
 
-    override fun beginOAuthFlowAsync(scopes: Set<String>): Deferred<AuthFlowUrl?> {
-        return scope.async {
-            handleFxaExceptions(logger, "begin oauth flow", { null }) {
-                val url = inner.beginOAuthFlow(scopes.toTypedArray())
-                val state = Uri.parse(url).getQueryParameter("state")!!
-                AuthFlowUrl(state, url)
-            }
+    override fun beginOAuthFlowAsync(scopes: Set<String>) = scope.async {
+        handleFxaExceptions(logger, "begin oauth flow", { null }) {
+            val url = inner.beginOAuthFlow(scopes.toTypedArray())
+            val state = Uri.parse(url).getQueryParameter("state")!!
+            AuthFlowUrl(state, url)
         }
     }
 
-    override fun beginPairingFlowAsync(pairingUrl: String, scopes: Set<String>): Deferred<AuthFlowUrl?> {
-        return scope.async {
-            handleFxaExceptions(logger, "begin oauth pairing flow", { null }) {
-                val url = inner.beginPairingFlow(pairingUrl, scopes.toTypedArray())
-                val state = Uri.parse(url).getQueryParameter("state")!!
-                AuthFlowUrl(state, url)
-            }
+    override fun beginPairingFlowAsync(pairingUrl: String, scopes: Set<String>) = scope.async {
+        handleFxaExceptions(logger, "begin oauth pairing flow", { null }) {
+            val url = inner.beginPairingFlow(pairingUrl, scopes.toTypedArray())
+            val state = Uri.parse(url).getQueryParameter("state")!!
+            AuthFlowUrl(state, url)
         }
     }
 
-    override fun getProfileAsync(ignoreCache: Boolean): Deferred<Profile?> {
-        return scope.async {
-            handleFxaExceptions(logger, "getProfile", { null }) {
-                inner.getProfile(ignoreCache).into()
-            }
+    override fun getProfileAsync(ignoreCache: Boolean) = scope.async {
+        handleFxaExceptions(logger, "getProfile", { null }) {
+            inner.getProfile(ignoreCache).into()
         }
     }
 
     override fun getCurrentDeviceId(): String? {
-        return handleFxaExceptions(logger, "getCurrentDeviceId", { null }) {
+        // This is awkward, yes. Underlying method simply reads some data from in-memory state, and yet it throws
+        // in case that data isn't there. See https://github.com/mozilla/application-services/issues/2202.
+        return try {
             inner.getCurrentDeviceId()
+        } catch (e: FxaPanicException) {
+            throw e
+        } catch (e: FxaException) {
+            null
         }
     }
 
-    override fun authorizeOAuthCode(
+    override fun authorizeOAuthCodeAsync(
         clientId: String,
         scopes: Array<String>,
         state: String,
         accessType: AccessType
-    ): String? {
-        return handleFxaExceptions(logger, "authorizeOAuthCode", { null }) {
+    ) = scope.async {
+        handleFxaExceptions(logger, "authorizeOAuthCode", { null }) {
             inner.authorizeOAuthCode(clientId, scopes, state, accessType.msg)
         }
     }
 
     override fun getSessionToken(): String? {
-        return handleFxaExceptions(logger, "getSessionToken", { null }) {
+        // This is awkward, yes. Underlying method simply reads some data from in-memory state, and yet it throws
+        // in case that data isn't there. See https://github.com/mozilla/application-services/issues/2202.
+        return try {
             inner.getSessionToken()
+        } catch (e: FxaPanicException) {
+            throw e
+        } catch (e: FxaException) {
+            null
         }
     }
 
-    override fun migrateFromSessionTokenAsync(sessionToken: String, kSync: String, kXCS: String): Deferred<Boolean> {
-        return scope.async {
-            handleFxaExceptions(logger, "migrateFromSessionToken") {
-                inner.migrateFromSessionToken(sessionToken, kSync, kXCS)
-            }
+    override fun migrateFromSessionTokenAsync(sessionToken: String, kSync: String, kXCS: String) = scope.async {
+        handleFxaExceptions(logger, "migrateFromSessionToken") {
+            inner.migrateFromSessionToken(sessionToken, kSync, kXCS)
         }
     }
 
@@ -170,23 +171,19 @@ class FirefoxAccount internal constructor(
         return inner.getConnectionSuccessURL()
     }
 
-    override fun completeOAuthFlowAsync(code: String, state: String): Deferred<Boolean> {
-        return scope.async {
-            handleFxaExceptions(logger, "complete oauth flow") {
-                inner.completeOAuthFlow(code, state)
-            }
+    override fun completeOAuthFlowAsync(code: String, state: String) = scope.async {
+        handleFxaExceptions(logger, "complete oauth flow") {
+            inner.completeOAuthFlow(code, state)
         }
     }
 
-    override fun getAccessTokenAsync(singleScope: String): Deferred<AccessTokenInfo?> {
-        return scope.async {
-            handleFxaExceptions(logger, "get access token", { null }) {
-                inner.getAccessToken(singleScope).into()
-            }
+    override fun getAccessTokenAsync(singleScope: String) = scope.async {
+        handleFxaExceptions(logger, "get access token", { null }) {
+            inner.getAccessToken(singleScope).into()
         }
     }
 
-    override fun checkAuthorizationStatusAsync(singleScope: String): Deferred<Boolean?> {
+    override fun checkAuthorizationStatusAsync(singleScope: String) = scope.async {
         // fxalib maintains some internal token caches that need to be cleared whenever we
         // hit an auth problem. Call below makes that clean-up happen.
         inner.clearAccessTokenCache()
@@ -195,33 +192,29 @@ class FirefoxAccount internal constructor(
         // Do so by requesting a new access token using an internally-stored "refresh token".
         // Success here means that we're still able to connect - our cached access token simply expired.
         // Failure indicates that we need to re-authenticate.
-        return scope.async {
-            try {
-                inner.getAccessToken(singleScope)
-                // We were able to obtain a token, so we're in a good authorization state.
-                true
-            } catch (e: FxaUnauthorizedException) {
-                // We got back a 401 while trying to obtain a new access token, which means our refresh
-                // token is also in a bad state. We need re-authentication for the tested scope.
-                false
-            } catch (e: FxaPanicException) {
-                // Re-throw any panics we may encounter.
-                throw e
-            } catch (e: FxaException) {
-                // On any other FxaExceptions (networking, etc) we have to return an indeterminate result.
-                null
-            }
-            // Re-throw all other exceptions.
+        try {
+            inner.getAccessToken(singleScope)
+            // We were able to obtain a token, so we're in a good authorization state.
+            true
+        } catch (e: FxaUnauthorizedException) {
+            // We got back a 401 while trying to obtain a new access token, which means our refresh
+            // token is also in a bad state. We need re-authentication for the tested scope.
+            false
+        } catch (e: FxaPanicException) {
+            // Re-throw any panics we may encounter.
+            throw e
+        } catch (e: FxaException) {
+            // On any other FxaExceptions (networking, etc) we have to return an indeterminate result.
+            null
         }
+        // Re-throw all other exceptions.
     }
 
-    override fun disconnectAsync(): Deferred<Boolean> {
-        return scope.async {
-            // TODO can this ever throw FxaUnauthorizedException? would that even make sense? or is that a bug?
-            handleFxaExceptions(logger, "disconnect", { false }) {
-                inner.disconnect()
-                true
-            }
+    override fun disconnectAsync() = scope.async {
+        // TODO can this ever throw FxaUnauthorizedException? would that even make sense? or is that a bug?
+        handleFxaExceptions(logger, "disconnect", { false }) {
+            inner.disconnect()
+            true
         }
     }
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/StorageSync.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/StorageSync.kt
@@ -7,14 +7,12 @@ package mozilla.components.service.fxa.sync
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import mozilla.components.concept.sync.AuthException
-import mozilla.components.concept.sync.AuthExceptionType
 import mozilla.components.concept.sync.StoreSyncStatus
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.concept.sync.SyncResult
 import mozilla.components.concept.sync.SyncStatus
-import mozilla.components.service.fxa.manager.authErrorRegistry
+import mozilla.components.service.fxa.manager.GlobalAccountManager
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -67,9 +65,7 @@ class StorageSync(
             // See https://github.com/mozilla-mobile/android-components/issues/3322
             if (message != null && message.contains("401")) {
                 logger.error("Hit an auth error during syncing")
-                authErrorRegistry.notifyObservers {
-                    onAuthErrorAsync(AuthException(AuthExceptionType.UNAUTHORIZED))
-                }
+                GlobalAccountManager.authError(it.exception)
             } else {
                 logger.error("Error synchronizing a $storeName store", it.exception)
             }

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
@@ -400,7 +400,7 @@ data class SyncableLoginsStore(
         }
     }
 
-    override suspend fun <T> unlocked(encryptionKey: String, block: (store: LockableStore) -> T): T {
+    override suspend fun <T> unlocked(encryptionKey: String, block: suspend (store: LockableStore) -> T): T {
         return try {
             store.ensureUnlocked(encryptionKey).await()
             block(this)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,9 @@ permalink: /changelog/
 * **feature-customtabs**
   * ⚠️ `CustomTabWindowFeature` now takes `Activity` instead of `Context`.
 
+* **concept-sync**, **service-firefox-accounts**
+  * `OAuthAccount@authorizeOAuthCode` method is now `authorizeOAuthCodeAsync`.
+
 # 21.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v20.0.0...v21.0.0)


### PR DESCRIPTION
(splitting this off from a larger clean-up branch)

The sole reason for authErrorRegistry was to expose an instance of FxaAccountManager
to internal components which don't have direct access to it. The registry acted
an internal singleton, but with a bunch of overhead and conceptual complexity around it.

This patch simplifies this: it adds an actual singleton instead of the registry, with a
simple API for components to call into if they encounter authentication errors.

Behaviour of `handleFxaExceptions` also changed slightly, to reduce cognitive overhead:
- instead of calling into an Async function on the observer, and ignoring the result,
this API is now simply `suspend`, which is a first step on the way to reasoning about error handling within the FxA state machine in terms of structured concurrency.

Other cleanup involves marking an expensive OAuthAccount method as async, as well as some
simplification of error handling in FirefoxAccount.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
