### PR TITLE
Closes #5063: better exception reporting during migrations

### DIFF
--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecProfileTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecProfileTest.kt
@@ -6,6 +6,8 @@ package mozilla.components.support.migration
 
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -14,92 +16,109 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.verifyZeroInteractions
 import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class FennecProfileTest {
     @Test
     fun `default fennec profile`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "fennec_default.txt")
+            testContext, crashReporter, getTestPath("profiles"), "fennec_default.txt")
 
         assertNotNull(profile!!)
         assertTrue(profile.default)
         assertEquals("default", profile.name)
         Log.w("SKDBG", profile.path)
         assertTrue(profile.path.endsWith("/profiles/10aaayu4.default"))
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `mozillazine default profile`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "mozillazine_default.txt")
+            testContext, crashReporter, getTestPath("profiles"), "mozillazine_default.txt")
 
         assertNotNull(profile!!)
         assertFalse(profile.default)
         assertEquals("default", profile.name)
         assertTrue(profile.path.endsWith("/profiles/Profiles/qioxtndq.default"))
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `mozillazine multiple profiles`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "mozillazine_multiple.txt")
+            testContext, crashReporter, getTestPath("profiles"), "mozillazine_multiple.txt")
 
         assertNotNull(profile!!)
         assertTrue(profile.default)
         assertEquals("alicew", profile.name)
         assertEquals("D:\\Mozilla\\Firefox\\Profiles\\alicew", profile.path)
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `desktop profiles`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "desktop.txt")
+            testContext, crashReporter, getTestPath("profiles"), "desktop.txt")
 
         assertNotNull(profile!!)
         assertTrue(profile.default)
         assertEquals("default", profile.name)
         assertTrue(profile.path.endsWith("/profiles/Profiles/xvcf5yup.default"))
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `profiles-ini not existing in path`() {
-        val profile = FennecProfile.findDefault(testContext, getTestPath("profiles"))
+        val crashReporter: CrashReporter = mock()
+        val profile = FennecProfile.findDefault(testContext, crashReporter, getTestPath("profiles"))
         assertNull(profile)
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `with comments`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "with_comments.txt")
+            testContext, crashReporter, getTestPath("profiles"), "with_comments.txt")
 
         assertNotNull(profile!!)
         assertTrue(profile.default)
         assertEquals("default", profile.name)
         assertTrue(profile.path.endsWith("/profiles/10aaayu4.default"))
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `weird broken`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "broken.txt")
+            testContext, crashReporter, getTestPath("profiles"), "broken.txt")
 
         assertNotNull(profile!!)
         assertEquals("Fennec", profile.name)
         assertTrue(profile.default)
         assertTrue(profile.path.endsWith("/profiles/fennec-default"))
+        verifyZeroInteractions(crashReporter)
     }
 
     @Test
     fun `multiple profiles without default`() {
+        val crashReporter: CrashReporter = mock()
         val profile = FennecProfile.findDefault(
-            testContext, getTestPath("profiles"), "no_default.txt")
+            testContext, crashReporter, getTestPath("profiles"), "no_default.txt")
 
         assertNotNull(profile!!)
         assertEquals("default", profile.name)
         assertFalse(profile.default)
         assertTrue(profile.path.endsWith("/profiles/Profiles/default"))
+        verifyZeroInteractions(crashReporter)
     }
 }
 


### PR DESCRIPTION
Patch 1:
>
    We are logging exceptions when no profile is found, which is actually a legit case.
    There will be no profile on a fresh install, for example.
    
    This patch makes these kinds of exceptions more precise/useful: we'll only send a report
    in case there's a profile but a missing dbPath. We'll now also send an exception in case
    of an IOException while parsing profiles.

Patch 2:
>
    Submit unexpected exceptions during migrations


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
