### PR TITLE
Make ShareData parcelable

### DIFF
--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/ShareData.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/ShareData.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.concept.engine.prompt
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
  * Represents data to share for the Web Share and Web Share Target APIs.
  * https://w3c.github.io/web-share/
@@ -11,8 +14,9 @@ package mozilla.components.concept.engine.prompt
  * @property text Text for the share request.
  * @property url URL for the share request.
  */
+@Parcelize
 data class ShareData(
-    val title: String?,
-    val text: String?,
-    val url: String?
-)
+    val title: String? = null,
+    val text: String? = null,
+    val url: String? = null
+) : Parcelable

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/ShareDataTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/ShareDataTest.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.prompt
+
+import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShareDataTest {
+
+    @Test
+    fun `Create share data`() {
+        val onlyTitle = ShareData(title = "Title")
+        assertEquals("Title", onlyTitle.title)
+
+        val onlyText = ShareData(text = "Text")
+        assertEquals("Text", onlyText.text)
+
+        val onlyUrl = ShareData(url = "https://mozilla.org")
+        assertEquals("https://mozilla.org", onlyUrl.url)
+    }
+
+    @Test
+    fun `Save to bundle`() {
+        val noText = ShareData(title = "Title", url = "https://mozilla.org")
+        val noUrl = ShareData(title = "Title", text = "Text")
+        val bundle = Bundle().apply {
+            putParcelable("noText", noText)
+            putParcelable("noUrl", noUrl)
+        }
+        assertEquals(noText, bundle.getParcelable<ShareData>("noText"))
+        assertEquals(noUrl, bundle.getParcelable<ShareData>("noUrl"))
+    }
+}


### PR DESCRIPTION
Adding parcel support so that `ShareData` can be passed between fragments in bundles. This will let ShareData be used with Fenix's ShareFragment.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
