### PR TITLE
Use minus offset for vertical clipping.

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -80,9 +80,9 @@ class GeckoEngineViewTest {
         val engineView = GeckoEngineView(context)
         engineView.currentGeckoView = mock()
 
-        engineView.setVerticalClipping(42)
+        engineView.setVerticalClipping(-42)
 
-        verify(engineView.currentGeckoView).setVerticalClipping(42)
+        verify(engineView.currentGeckoView).setVerticalClipping(-42)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -80,9 +80,9 @@ class GeckoEngineViewTest {
         val engineView = GeckoEngineView(context)
         engineView.currentGeckoView = mock()
 
-        engineView.setVerticalClipping(42)
+        engineView.setVerticalClipping(-42)
 
-        verify(engineView.currentGeckoView).setVerticalClipping(42)
+        verify(engineView.currentGeckoView).setVerticalClipping(-42)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -80,9 +80,9 @@ class GeckoEngineViewTest {
         val engineView = GeckoEngineView(context)
         engineView.currentGeckoView = mock()
 
-        engineView.setVerticalClipping(42)
+        engineView.setVerticalClipping(-42)
 
-        verify(engineView.currentGeckoView).setVerticalClipping(42)
+        verify(engineView.currentGeckoView).setVerticalClipping(-42)
     }
 
     @Test

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/behavior/EngineViewBottomBehavior.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/behavior/EngineViewBottomBehavior.kt
@@ -44,7 +44,7 @@ class EngineViewBottomBehavior(
      */
     override fun onDependentViewChanged(parent: CoordinatorLayout, child: View, dependency: View): Boolean {
         val engineView = child.findViewInHierarchy { it is EngineView } as EngineView?
-        engineView?.setVerticalClipping(dependency.height - dependency.translationY.toInt())
+        engineView?.setVerticalClipping(-dependency.translationY.toInt())
         return true
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -36,7 +36,7 @@ class EngineViewBottomBehaviorTest {
 
         doReturn(42f).`when`(toolbar).translationY
         behavior.onDependentViewChanged(mock(), engineView.asView(), toolbar)
-        verify(engineView).setVerticalClipping(58)
+        verify(engineView).setVerticalClipping(-42)
     }
 
     @Test


### PR DESCRIPTION
After bug 1586144 the area which is initially covered by the dynamic toolbar
is outside of the ICB so that we need to use minus offsets.

https://bugzilla.mozilla.org/show_bug.cgi?id=1586144


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
