### PR TITLE
Closes #5090: Wire up GeckoView action delegate for BrowserActions

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -136,10 +136,11 @@ class GeckoEngine(
         id: String,
         url: String,
         allowContentMessaging: Boolean,
+        supportActions: Boolean,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ) {
-        GeckoWebExtension(id, url, allowContentMessaging).also { ext ->
+        GeckoWebExtension(id, url, allowContentMessaging, supportActions).also { ext ->
             runtime.registerWebExtension(ext.nativeExtension).then({
                 webExtensionDelegate?.onInstalled(ext)
                 onSuccess(ext)

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
@@ -21,13 +22,14 @@ class GeckoWebExtension(
     id: String,
     url: String,
     allowContentMessaging: Boolean = true,
+    supportActions: Boolean = false,
     val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
         url,
         id,
         createWebExtensionFlags(allowContentMessaging)
     ),
     private val connectedPorts: MutableMap<PortId, Port> = mutableMapOf()
-) : WebExtension(id, url) {
+) : WebExtension(id, url, supportActions) {
 
     /**
      * Uniquely identifies a port using its name and the session it
@@ -142,6 +144,11 @@ class GeckoWebExtension(
             connectedPorts.remove(portId)
         }
     }
+
+    // Not yet supported in beta
+    override fun registerActionHandler(actionHandler: ActionHandler) = Unit
+    override fun registerActionHandler(session: EngineSession, actionHandler: ActionHandler) = Unit
+    override fun hasActionHandler(session: EngineSession) = false
 }
 
 /**

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -35,7 +35,13 @@ class GeckoWebExtensionTest {
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
 
         verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
@@ -86,7 +92,13 @@ class GeckoWebExtensionTest {
 
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
         verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
@@ -138,7 +150,13 @@ class GeckoWebExtensionTest {
 
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
         verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
 
@@ -158,7 +176,13 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
 
         verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -144,10 +144,11 @@ class GeckoEngine(
         id: String,
         url: String,
         allowContentMessaging: Boolean,
+        supportActions: Boolean,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ) {
-        GeckoWebExtension(id, url, allowContentMessaging).also { ext ->
+        GeckoWebExtension(id, url, allowContentMessaging, supportActions).also { ext ->
             runtime.registerWebExtension(ext.nativeExtension).then({
                 webExtensionDelegate?.onInstalled(ext)
                 onSuccess(ext)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,6 +6,8 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.webextension.ActionHandler
+import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor
@@ -17,8 +19,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoSession
@@ -35,9 +39,15 @@ class GeckoWebExtensionTest {
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
-        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
 
+        extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
         verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
 
         // Verify messages are forwarded to message handler
@@ -86,7 +96,13 @@ class GeckoWebExtensionTest {
 
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
         verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
@@ -138,7 +154,13 @@ class GeckoWebExtensionTest {
 
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
         verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
 
@@ -158,7 +180,13 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
 
         verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
@@ -172,5 +200,83 @@ class GeckoWebExtensionTest {
         extension.disconnectPort("mozacTest")
         verify(port).disconnect()
         assertNull(extension.getConnectedPort("mozacTest"))
+    }
+
+    @Test
+    fun `register global default action handler`() {
+        val nativeGeckoWebExt: WebExtension = mock()
+        val actionHandler: ActionHandler = mock()
+        val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
+        val actionCaptor = argumentCaptor<BrowserAction>()
+        val nativeBrowserAction: WebExtension.Action = mock()
+
+        // Verify actions will not be acted on when not supported
+        val extensionWithActions = GeckoWebExtension(
+            "mozacTest",
+            "url",
+            false,
+            false,
+            nativeGeckoWebExt
+        )
+        extensionWithActions.registerActionHandler(actionHandler)
+        verify(nativeGeckoWebExt, never()).setActionDelegate(actionDelegateCaptor.capture())
+
+        // Create extension and register global default action handler
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
+        extension.registerActionHandler(actionHandler)
+        verify(nativeGeckoWebExt).setActionDelegate(actionDelegateCaptor.capture())
+
+        // Verify that browser actions are forwarded to the handler
+        actionDelegateCaptor.value.onBrowserAction(nativeGeckoWebExt, null, nativeBrowserAction)
+        verify(actionHandler).onBrowserAction(eq(extension), eq(null), actionCaptor.capture())
+
+        // We don't have access to the native WebExtension.Action fields and
+        // can't mock them either, but we can verify that we've linked
+        // the actions by simulating a click.
+        actionCaptor.value.onClick()
+        verify(nativeBrowserAction).click()
+    }
+
+    @Test
+    fun `register session-specific action handler`() {
+        val session: GeckoEngineSession = mock()
+        val geckoSession: GeckoSession = mock()
+        whenever(session.geckoSession).thenReturn(geckoSession)
+
+        val nativeGeckoWebExt: WebExtension = mock()
+        val actionHandler: ActionHandler = mock()
+        val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
+        val actionCaptor = argumentCaptor<BrowserAction>()
+        val nativeBrowserAction: WebExtension.Action = mock()
+
+        // Create extension and register action handler for session
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
+        extension.registerActionHandler(session, actionHandler)
+        verify(geckoSession).setWebExtensionActionDelegate(eq(nativeGeckoWebExt), actionDelegateCaptor.capture())
+
+        whenever(geckoSession.getWebExtensionActionDelegate(nativeGeckoWebExt)).thenReturn(actionDelegateCaptor.value)
+        assertTrue(extension.hasActionHandler(session))
+
+        // Verify that browser actions are forwarded to the handler
+        actionDelegateCaptor.value.onBrowserAction(nativeGeckoWebExt, null, nativeBrowserAction)
+        verify(actionHandler).onBrowserAction(eq(extension), eq(session), actionCaptor.capture())
+
+        // We don't have access to the native WebExtension.Action fields and
+        // can't mock them either, but we can verify that we've linked
+        // the actions by simulating a click.
+        actionCaptor.value.onClick()
+        verify(nativeBrowserAction).click()
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -136,10 +136,11 @@ class GeckoEngine(
         id: String,
         url: String,
         allowContentMessaging: Boolean,
+        supportActions: Boolean,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ) {
-        GeckoWebExtension(id, url, allowContentMessaging).also { ext ->
+        GeckoWebExtension(id, url, allowContentMessaging, supportActions).also { ext ->
             runtime.registerWebExtension(ext.nativeExtension).then({
                 webExtensionDelegate?.onInstalled(ext)
                 onSuccess(ext)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
@@ -21,13 +22,14 @@ class GeckoWebExtension(
     id: String,
     url: String,
     allowContentMessaging: Boolean = true,
+    supportActions: Boolean = false,
     val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
         url,
         id,
         createWebExtensionFlags(allowContentMessaging)
     ),
     private val connectedPorts: MutableMap<PortId, Port> = mutableMapOf()
-) : WebExtension(id, url) {
+) : WebExtension(id, url, supportActions) {
 
     /**
      * Uniquely identifies a port using its name and the session it
@@ -132,6 +134,11 @@ class GeckoWebExtension(
             connectedPorts.remove(portId)
         }
     }
+
+    // Not yet supported in release
+    override fun registerActionHandler(actionHandler: ActionHandler) = Unit
+    override fun registerActionHandler(session: EngineSession, actionHandler: ActionHandler) = Unit
+    override fun hasActionHandler(session: EngineSession) = false
 }
 
 /**

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -35,7 +35,13 @@ class GeckoWebExtensionTest {
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
 
         verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))
@@ -86,7 +92,13 @@ class GeckoWebExtensionTest {
 
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
         verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
@@ -138,7 +150,13 @@ class GeckoWebExtensionTest {
 
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
         verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
 
@@ -158,7 +176,13 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
-        val extension = GeckoWebExtension("mozacTest", "url", true, nativeGeckoWebExt)
+        val extension = GeckoWebExtension(
+            id = "mozacTest",
+            url = "url",
+            allowContentMessaging = true,
+            supportActions = true,
+            nativeExtension = nativeGeckoWebExt
+        )
         extension.registerBackgroundMessageHandler("mozacTest", messageHandler)
 
         verify(nativeGeckoWebExt).setMessageDelegate(messageDelegateCaptor.capture(), eq("mozacTest"))

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -13,7 +13,6 @@ import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
-import mozilla.components.browser.state.action.WebExtensionAction
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
@@ -24,7 +23,6 @@ import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.media.RecordingDevice
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Consumable
 
@@ -218,16 +216,6 @@ internal class EngineObserver(
             it.remove(media)
         }
         media.unregisterObservers()
-    }
-
-    override fun onBrowserActionChange(webExtensionId: String, action: BrowserAction) {
-        store?.dispatch(
-            WebExtensionAction.UpdateTabBrowserAction(
-                session.id,
-                webExtensionId,
-                action
-            )
-        )
     }
 
     override fun onWebAppManifestLoaded(manifest: WebAppManifest) {

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -10,7 +10,6 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
-import mozilla.components.browser.state.action.WebExtensionAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
@@ -21,7 +20,6 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.any
@@ -191,25 +189,6 @@ class EngineObserverTest {
             TrackingProtectionAction.ToggleExclusionListAction(
                 session.id,
                 true
-            )
-        )
-    }
-
-    @Test
-    fun engineSessionObserverOnBrowserActionChange() {
-        val session = Session("")
-        val store = mock(BrowserStore::class.java)
-        val browserAction = BrowserAction("", true, mock(), "", "", 0, 0) {}
-        val observer = EngineObserver(session, store)
-
-        whenever(store.dispatch(any())).thenReturn(mock())
-        observer.onBrowserActionChange("extensionId", browserAction)
-
-        verify(store).dispatch(
-            WebExtensionAction.UpdateTabBrowserAction(
-                session.id,
-                "extensionId",
-                browserAction
             )
         )
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -120,16 +120,20 @@ interface Engine {
      * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
      * @param allowContentMessaging whether or not the web extension is allowed
      * to send messages from content scripts, defaults to true.
+     * @param supportActions whether or not browser and page actions are handled when
+     * received from the web extension, defaults to false.
      * @param onSuccess (optional) callback invoked if the extension was installed successfully,
      * providing access to the [WebExtension] object for bi-directional messaging.
      * @param onError (optional) callback invoked if there was an error installing the extension.
      * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
      * have web extension support.
      */
+    @Suppress("LongParameterList")
     fun installWebExtension(
         id: String,
         url: String,
         allowContentMessaging: Boolean = true,
+        supportActions: Boolean = false,
         onSuccess: ((WebExtension) -> Unit) = { },
         onError: ((String, Throwable) -> Unit) = { _, _ -> }
     ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -15,7 +15,6 @@ import mozilla.components.concept.engine.media.Media
 import mozilla.components.concept.engine.media.RecordingDevice
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -68,12 +67,6 @@ abstract class EngineSession(
 
         fun onMediaAdded(media: Media) = Unit
         fun onMediaRemoved(media: Media) = Unit
-
-        /**
-         * Event to notify that a web extension browser action has changed.
-         */
-        fun onBrowserActionChange(webExtensionId: String, action: BrowserAction) = Unit
-
         fun onWebAppManifestLoaded(manifest: WebAppManifest) = Unit
         fun onCrash() = Unit
         fun onProcessKilled() = Unit

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/BrowserAction.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/BrowserAction.kt
@@ -4,15 +4,14 @@
 
 package mozilla.components.concept.engine.webextension
 
-import android.graphics.drawable.Drawable
+import android.graphics.Bitmap
 
 /**
  * Value type that represents the state of a browser action within a [WebExtension].
  *
  * @property title The title of the browser action to be visible in the user interface.
  * @property enabled Indicates if the browser action should be enabled or disabled.
- * @property icon The image for this browser icon.
- * @property uri The url to get the HTML document, representing the internal user interface of the extension.
+ * @property loadIcon A suspending function returning the icon in the provided size.
  * @property badgeText The browser action's badge text.
  * @property badgeTextColor The browser action's badge text color.
  * @property badgeBackgroundColor The browser action's badge background color.
@@ -21,8 +20,7 @@ import android.graphics.drawable.Drawable
 data class BrowserAction(
     val title: String,
     val enabled: Boolean,
-    val icon: Drawable,
-    val uri: String,
+    val loadIcon: suspend (Int) -> Bitmap?,
     val badgeText: String,
     val badgeTextColor: Int,
     val badgeBackgroundColor: Int,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -14,10 +14,13 @@ import org.json.JSONObject
  * @property id the unique ID of this extension.
  * @property url the url pointing to a resources path for locating the extension
  * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ * @property supportActions whether or not browser and page actions are handled when
+ * received from the web extension
  */
 abstract class WebExtension(
     val id: String,
-    val url: String
+    val url: String,
+    val supportActions: Boolean
 ) {
     /**
      * Registers a [MessageHandler] for message events from background scripts.
@@ -81,6 +84,53 @@ abstract class WebExtension(
      * null if port is from a background script.
      */
     abstract fun disconnectPort(name: String, session: EngineSession? = null)
+
+    /**
+     * Registers an [ActionHandler] for this web extension. The handler will
+     * be invoked whenever browser and page action defaults change. To listen
+     * for session-specific overrides see registerActionHandler(
+     * EngineSession, ActionHandler).
+     */
+    abstract fun registerActionHandler(actionHandler: ActionHandler)
+
+    /**
+     * Registers an [ActionHandler] for the provided [EngineSession]. The handler
+     * will be invoked whenever browser and page action overrides are received
+     * for the provided session.
+     *
+     * @param session the [EngineSession] the handler should be registered for.
+     * @param actionHandler the [ActionHandler] to invoked when a browser or
+     * page action is received.
+     */
+    abstract fun registerActionHandler(session: EngineSession, actionHandler: ActionHandler)
+
+    /**
+     * Checks whether there is an existing action handler for the provided
+     * session.
+     *
+     * @param session the session the action handler was registered for.
+     * @return true if an action handler is registered, otherwise false.
+     */
+    abstract fun hasActionHandler(session: EngineSession): Boolean
+}
+
+/**
+ * A handler for web extension (browser and page) actions.
+ *
+ * Page action support will be addressed in:
+ * https://github.com/mozilla-mobile/android-components/issues/4470
+ */
+interface ActionHandler {
+
+    /**
+     * Invoked when a browser action is defined or updated.
+     *
+     * @param webExtension the extension that defined the browser action.
+     * @param session the [EngineSession] if this action is to be updated for a
+     * specific session, or null if this is to set a new default value.
+     * @param action the [BrowserAction]
+     */
+    fun onBrowserAction(webExtension: WebExtension, session: EngineSession?, action: BrowserAction) = Unit
 }
 
 /**

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -25,7 +25,6 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.verifyZeroInteractions
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
-import mozilla.components.concept.engine.webextension.BrowserAction
 
 class EngineSessionTest {
     private val unknownHitResult = HitResult.UNKNOWN("file://foobar")
@@ -38,7 +37,6 @@ class EngineSessionTest {
         val observer = mock(EngineSession.Observer::class.java)
         val emptyBitmap = spy(Bitmap::class.java)
         val permissionRequest = mock(PermissionRequest::class.java)
-        val browserAction = mock(BrowserAction::class.java)
         val windowRequest = mock(WindowRequest::class.java)
         session.register(observer)
 
@@ -70,7 +68,6 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCrash() }
         session.notifyInternalObservers { onLoadRequest("https://www.mozilla.org", true, true, allowOrDeny) }
         session.notifyInternalObservers { onProcessKilled() }
-        session.notifyInternalObservers { onBrowserActionChange("extensionId", browserAction) }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
@@ -96,7 +93,6 @@ class EngineSessionTest {
         verify(observer).onCrash()
         verify(observer).onLoadRequest("https://www.mozilla.org", true, true, allowOrDeny)
         verify(observer).onProcessKilled()
-        verify(observer).onBrowserActionChange("extensionId", browserAction)
         verifyNoMoreInteractions(observer)
     }
 
@@ -654,7 +650,6 @@ class EngineSessionTest {
         defaultObserver.onMediaAdded(mock())
         defaultObserver.onMediaRemoved(mock())
         defaultObserver.onCrash()
-        defaultObserver.onBrowserActionChange("", mock())
     }
 
     @Test

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
@@ -60,6 +60,7 @@ class FxaWebChannelFeatureTest {
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_URL),
             eq(true),
+            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -72,6 +73,7 @@ class FxaWebChannelFeatureTest {
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_URL),
             eq(true),
+            eq(false),
             any(),
             any()
         )

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -62,6 +62,7 @@ class ReaderViewFeatureTest {
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID),
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_URL),
             eq(true),
+            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -74,6 +75,7 @@ class ReaderViewFeatureTest {
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID),
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_URL),
             eq(true),
+            eq(false),
             any(),
             any()
         )

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
@@ -50,9 +50,9 @@ class WebExtensionToolbarFeatureTest {
     @Test
     fun `render overridden web extension action from browser state`() {
         val defaultBrowserAction =
-            WebExtensionBrowserAction("default_title", false, mock(), "", "", 0, 0) {}
+            WebExtensionBrowserAction("default_title", false, mock(), "", 0, 0) {}
         val overriddenBrowserAction =
-            WebExtensionBrowserAction("overridden_title", false, mock(), "", "", 0, 0) {}
+            WebExtensionBrowserAction("overridden_title", false, mock(), "", 0, 0) {}
         val toolbar: Toolbar = mock()
         val extensions: Map<String, WebExtensionState> = mapOf(
             "id" to WebExtensionState("id", "url", defaultBrowserAction)
@@ -94,22 +94,20 @@ class WebExtensionToolbarFeatureTest {
 
         val browserAction = BrowserAction(
             title = "title",
-            icon = mock(),
+            loadIcon = { mock() },
             enabled = true,
             badgeText = "badgeText",
             badgeTextColor = Color.WHITE,
-            badgeBackgroundColor = Color.BLUE,
-            uri = "uri"
+            badgeBackgroundColor = Color.BLUE
         ) {}
 
         val browserActionDisabled = BrowserAction(
             title = "title",
-            icon = mock(),
+            loadIcon = { mock() },
             enabled = false,
             badgeText = "badgeText",
             badgeTextColor = Color.WHITE,
-            badgeBackgroundColor = Color.BLUE,
-            uri = "uri"
+            badgeBackgroundColor = Color.BLUE
         ) {}
 
         // Verify browser extension toolbar rendering

--- a/components/support/webextensions/build.gradle
+++ b/components/support/webextensions/build.gradle
@@ -36,7 +36,10 @@ dependencies {
     implementation project(':concept-engine')
     implementation project(':browser-state')
     implementation project(':support-base')
+    implementation project(':support-ktx')
+    implementation Dependencies.androidx_lifecycle_extensions
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
@@ -44,6 +44,7 @@ class WebExtensionControllerTest {
             eq(extensionId),
             eq(extensionUrl),
             eq(true),
+            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -57,6 +58,7 @@ class WebExtensionControllerTest {
             eq(extensionId),
             eq(extensionUrl),
             eq(true),
+            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -86,6 +88,7 @@ class WebExtensionControllerTest {
             eq(extensionId),
             eq(extensionUrl),
             eq(true),
+            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -144,6 +147,7 @@ class WebExtensionControllerTest {
                 eq(extensionId),
                 eq(extensionUrl),
                 eq(true),
+                eq(false),
                 onSuccess.capture(),
                 onError.capture()
         )


### PR DESCRIPTION
This follows the same pattern as content/background messaging, with the only difference that we have to be able to register action handlers for each extension on every session. The latter is the reason I moved the session-specific action out of the `EngineObserver` into our web extension module. Ultimately, we want to get rid of`EngineObserver` anyway once we fully migrated to browser-state.

I am also going to add a browser action to our sample-browser extension, but I will do this as part of #4791, as this PR is already pretty big.

We will get new GV API for installing extensions i.e different calls for built-in and third-party extensions. For now I've also introduced a `supportActions` boolean, similar to our `allowContentMessaging` to be able to configure per extension if we need to hook up action delegates. We really don't need that for our current extensions, so it makes sense not to register all these handlers.
