### PR TITLE
Deprecate StorageSync class

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/StorageSync.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/StorageSync.kt
@@ -20,6 +20,7 @@ import mozilla.components.support.base.observer.ObserverRegistry
 /**
  * Orchestrates data synchronization of a set of [SyncableStore]-s.
  */
+@Deprecated("Use SyncManager instead.")
 class StorageSync(
     private val syncableStores: Map<String, SyncableStore>
 ) : Observable<SyncStatusObserver> by ObserverRegistry() {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ permalink: /changelog/
 * **service-firefox-accounts**
   * Account profile cache is now used, removing a network call from most instances of account manager instantiation.
   * Fixed a bug where account would disappear after restarting an app which hit authentication problems.
+  * Deprecated the `StorageSync` class. Please use the `SyncManager` class instead.
   
 * **service-glean**
   * Glean was updated to v21.1.1


### PR DESCRIPTION
It is not used by any of our products anymore (fenix, lockwise, fxr).