### PR TITLE
Add Tabs engine to the sync manager

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.42.2"
+    const val mozilla_appservices = "0.44.0"
 
     const val mozilla_glean = "21.2.0"
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
@@ -14,6 +14,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.ArgumentMatchers.nullable
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.verify
 
@@ -65,7 +66,7 @@ class RustPushConnectionTest {
             connection.subscribe("123", "")
         }
 
-        verify(api).subscribe(anyString(), anyString())
+        verify(api).subscribe(anyString(), anyString(), nullable(String::class.java))
     }
 
     @Test(expected = IllegalStateException::class)

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -85,6 +85,11 @@ sealed class SyncEngine(val nativeName: String) {
     object Passwords : SyncEngine("passwords")
 
     /**
+     * A remote tabs engine.
+     */
+    object Tabs : SyncEngine("tabs")
+
+    /**
      * An engine that's none of the above, described by [name].
      */
     data class Other(val name: String) : SyncEngine(name)

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/Types.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/Types.kt
@@ -31,6 +31,7 @@ internal fun String.toSyncEngine(): SyncEngine {
         "history" -> SyncEngine.History
         "bookmarks" -> SyncEngine.Bookmarks
         "passwords" -> SyncEngine.Passwords
+        "tabs" -> SyncEngine.Tabs
         // This handles a case of engines that we don't yet model in SyncEngine.
         else -> SyncEngine.Other(this)
     }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -292,6 +292,7 @@ class WorkManagerSyncWorker(
                 SyncEngine.History.nativeName -> SyncEngine.History
                 SyncEngine.Bookmarks.nativeName -> SyncEngine.Bookmarks
                 SyncEngine.Passwords.nativeName -> SyncEngine.Passwords
+                SyncEngine.Tabs.nativeName -> SyncEngine.Tabs
                 else -> throw IllegalStateException("Invalid syncable store: $it")
             }
             engine to GlobalSyncableStoreProvider.getStore(engine.nativeName)!!
@@ -339,6 +340,7 @@ class WorkManagerSyncWorker(
                 SyncEngine.History -> RustSyncManager.setPlaces(it.value.getHandle())
                 SyncEngine.Bookmarks -> RustSyncManager.setPlaces(it.value.getHandle())
                 SyncEngine.Passwords -> RustSyncManager.setLogins(it.value.getHandle())
+                SyncEngine.Tabs -> RustSyncManager.setTabs(it.value.getHandle())
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/android-components/issues/5007.
This is fairly simple PR as it doesn't even need a direct dependency on the published a-s `tabs` component.