### PR TITLE
Fixes #5150: Passes most recent download state to notification

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -72,7 +72,7 @@ abstract class AbstractFetchDownloadService : Service() {
 
     internal data class DownloadJobState(
         var job: Job? = null,
-        var state: DownloadState,
+        @Volatile var state: DownloadState,
         var currentBytesCopied: Long = 0,
         @Volatile var status: DownloadJobStatus,
         var foregroundServiceId: Int = 0,
@@ -108,7 +108,7 @@ abstract class AbstractFetchDownloadService : Service() {
                         currentDownloadJobState.status = DownloadJobStatus.ACTIVE
 
                         currentDownloadJobState.job = CoroutineScope(IO).launch {
-                            startDownloadJob(currentDownloadJobState.state)
+                            startDownloadJob(downloadId)
                         }
 
                         emitNotificationResumeFact()
@@ -137,7 +137,7 @@ abstract class AbstractFetchDownloadService : Service() {
                         currentDownloadJobState.status = DownloadJobStatus.ACTIVE
 
                         currentDownloadJobState.job = CoroutineScope(IO).launch {
-                            startDownloadJob(currentDownloadJobState.state)
+                            startDownloadJob(downloadId)
                         }
 
                         emitNotificationTryAgainFact()
@@ -179,7 +179,7 @@ abstract class AbstractFetchDownloadService : Service() {
         )
 
         downloadJobs[download.id]?.job = CoroutineScope(IO).launch {
-            startDownloadJob(download)
+            startDownloadJob(download.id)
         }
 
         return super.onStartCommand(intent, flags, startId)
@@ -192,30 +192,30 @@ abstract class AbstractFetchDownloadService : Service() {
         }
     }
 
-    internal fun startDownloadJob(download: DownloadState) {
-        val currentDownloadJobState = downloadJobs[download.id] ?: return
+    internal fun startDownloadJob(downloadId: Long) {
+        val currentDownloadJobState = downloadJobs[downloadId] ?: return
 
         val notification = try {
-            performDownload(download)
+            performDownload(currentDownloadJobState.state)
             when (currentDownloadJobState.status) {
                 DownloadJobStatus.PAUSED -> {
-                    DownloadNotification.createPausedDownloadNotification(context, download)
+                    DownloadNotification.createPausedDownloadNotification(context, currentDownloadJobState.state)
                 }
 
                 DownloadJobStatus.ACTIVE -> {
                     currentDownloadJobState.status = DownloadJobStatus.COMPLETED
-                    DownloadNotification.createDownloadCompletedNotification(context, download)
+                    DownloadNotification.createDownloadCompletedNotification(context, currentDownloadJobState.state)
                 }
 
                 DownloadJobStatus.FAILED -> {
-                    DownloadNotification.createDownloadFailedNotification(context, download)
+                    DownloadNotification.createDownloadFailedNotification(context, currentDownloadJobState.state)
                 }
 
                 else -> return
             }
         } catch (e: IOException) {
             currentDownloadJobState.status = DownloadJobStatus.FAILED
-            DownloadNotification.createDownloadFailedNotification(context, download)
+            DownloadNotification.createDownloadFailedNotification(context, currentDownloadJobState.state)
         }
 
         NotificationManagerCompat.from(context).notify(
@@ -223,7 +223,7 @@ abstract class AbstractFetchDownloadService : Service() {
             notification
         )
 
-        sendDownloadCompleteBroadcast(download.id, currentDownloadJobState.status)
+        sendDownloadCompleteBroadcast(downloadId, currentDownloadJobState.status)
     }
 
     internal fun deleteDownloadingFile(downloadState: DownloadState) {
@@ -343,6 +343,8 @@ abstract class AbstractFetchDownloadService : Service() {
                 it
             ))
         } ?: download
+
+        downloadJobs[download.id]?.state = downloadWithUniqueName
 
         if (SDK_INT >= Build.VERSION_CODES.Q) {
             useFileStreamScopedStorage(downloadWithUniqueName, block)

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -341,7 +341,7 @@ class AbstractFetchDownloadServiceTest {
         service.downloadJobs[providedDownload.value.id]?.job?.join()
 
         assertEquals(ACTIVE, service.downloadJobs[providedDownload.value.id]?.status)
-        verify(service).startDownloadJob(providedDownload.value)
+        verify(service).startDownloadJob(providedDownload.value.id)
     }
 
     @Test
@@ -384,7 +384,7 @@ class AbstractFetchDownloadServiceTest {
         service.downloadJobs[providedDownload.value.id]?.job?.join()
 
         assertEquals(ACTIVE, service.downloadJobs[providedDownload.value.id]?.status)
-        verify(service).startDownloadJob(providedDownload.value)
+        verify(service).startDownloadJob(providedDownload.value.id)
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

I was passing the download state that was passed into this function to the notification. This download state goes stale when the download performs, so we need to pass the `currentDownloadState` instead. 

Not sure we can add a test for this functionality 😅 

That being said, I changed the function to accept a downloadId instead of a download so people won't make this mistake down the road :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
