### PR TITLE
Closes #5058: Migrate UserInteractionHandler from reference-browser to support-base

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -23,7 +23,7 @@ import mozilla.components.browser.state.state.CustomTabActionButtonConfig
 import mozilla.components.browser.state.state.CustomTabMenuItem
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.content.share
 import mozilla.components.support.ktx.android.view.setNavigationBarTheme
@@ -33,6 +33,7 @@ import mozilla.components.support.utils.ColorUtils.getReadableTextColor
 /**
  * Initializes and resets the Toolbar for a Custom Tab based on the CustomTabConfig.
  */
+@Suppress("LargeClass")
 class CustomTabsToolbarFeature(
     private val sessionManager: SessionManager,
     private val toolbar: BrowserToolbar,
@@ -42,7 +43,7 @@ class CustomTabsToolbarFeature(
     private val window: Window? = null,
     private val shareListener: (() -> Unit)? = null,
     private val closeListener: () -> Unit
-) : LifecycleAwareFeature, BackHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
     private val context
         get() = toolbar.context
     internal var initialized = false

--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/FindInPageFeature.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/FindInPageFeature.kt
@@ -11,7 +11,7 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.internal.FindInPageInteractor
 import mozilla.components.feature.findinpage.internal.FindInPagePresenter
 import mozilla.components.feature.findinpage.view.FindInPageView
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 /**
@@ -22,7 +22,7 @@ class FindInPageFeature(
     view: FindInPageView,
     engineView: EngineView,
     private val onClose: (() -> Unit)? = null
-) : LifecycleAwareFeature, BackHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
     @VisibleForTesting internal var presenter = FindInPagePresenter(store, view)
     @VisibleForTesting internal var interactor = FindInPageInteractor(this, view, engineView)
 

--- a/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFeature.kt
+++ b/components/feature/qr/src/main/java/mozilla/components/feature/qr/QrFeature.kt
@@ -9,7 +9,7 @@ import android.content.Context
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentManager
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.OnNeedToRequestPermissions
 import mozilla.components.support.base.feature.PermissionsFeature
@@ -35,7 +35,7 @@ class QrFeature(
     private val fragmentManager: FragmentManager,
     private val onScanResult: OnScanResult = { },
     override val onNeedToRequestPermissions: OnNeedToRequestPermissions = { }
-) : LifecycleAwareFeature, BackHandler, PermissionsFeature {
+) : LifecycleAwareFeature, UserInteractionHandler, PermissionsFeature {
     private var containerViewId: Int = 0
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -18,7 +18,7 @@ import mozilla.components.feature.readerview.internal.ReaderViewControlsPresente
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
 import mozilla.components.feature.readerview.ReaderViewFeature.ColorScheme.LIGHT
 import mozilla.components.feature.readerview.ReaderViewFeature.FontType.SERIF
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.webextensions.WebExtensionController
 import org.json.JSONObject
@@ -48,7 +48,7 @@ class ReaderViewFeature(
     private val sessionManager: SessionManager,
     controlsView: ReaderViewControlsView,
     private val onReaderViewAvailableChange: OnReaderViewAvailableChange = { }
-) : SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature, BackHandler {
+) : SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature, UserInteractionHandler {
 
     @VisibleForTesting
     // This is an internal var to make it mutable for unit testing purposes only

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/FullScreenFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/FullScreenFeature.kt
@@ -7,7 +7,7 @@ package mozilla.components.feature.session
 import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 /**
@@ -18,7 +18,7 @@ open class FullScreenFeature(
     private val sessionUseCases: SessionUseCases,
     private val sessionId: String? = null,
     private val fullScreenChanged: (Boolean) -> Unit
-) : SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature, BackHandler {
+) : SelectionAwareSessionObserver(sessionManager), LifecycleAwareFeature, UserInteractionHandler {
 
     /**
      * Starts the feature and a observer to listen for fullscreen changes.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.session
 
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 /**
@@ -17,7 +17,7 @@ class SessionFeature(
     private val goBackUseCase: SessionUseCases.GoBackUseCase,
     engineView: EngineView,
     private val sessionId: String? = null
-) : LifecycleAwareFeature, BackHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
     internal val presenter = EngineViewPresenter(sessionManager, engineView, sessionId)
 
     /**

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ToolbarFeature.kt
@@ -9,7 +9,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 /**
@@ -28,7 +28,7 @@ class ToolbarFeature(
     searchUseCase: SearchUseCase? = null,
     customTabId: String? = null,
     urlRenderConfiguration: UrlRenderConfiguration? = null
-) : LifecycleAwareFeature, BackHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
     private val presenter = ToolbarPresenter(toolbar, store, customTabId, urlRenderConfiguration)
     private val interactor = ToolbarInteractor(toolbar, loadUrlUseCase, searchUseCase)
 

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/UserInteractionHandler.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/UserInteractionHandler.kt
@@ -4,22 +4,25 @@
 
 package mozilla.components.support.base.feature
 
+import android.app.Activity
+
 /**
- * Generic interface for fragments, features and other components that want to handle 'back' button presses.
+ * Generic interface for fragments, features and other components that want to handle user
+ * interactions such as 'back' or 'home' button presses.
  */
-@Deprecated("Use `UserInteractionHandler` instead.")
-interface BackHandler {
+interface UserInteractionHandler {
     /**
      * Called when this [UserInteractionHandler] gets the option to handle the user pressing the back key.
      *
      * Returns true if this [UserInteractionHandler] consumed the event and no other components need to be notified.
      */
-    @Deprecated(
-        "Use `UserInteractionHandler` instead.",
-        ReplaceWith(
-            "onBackPressed()",
-            "mozilla.components.support.base.feature.UserInteractionHandler"
-        )
-    )
     fun onBackPressed(): Boolean
+
+    /**
+     * In most cases, when the home button is pressed, we invoke this callback to inform the app that the user
+     * is going to leave the app.
+     *
+     * See also [Activity.onUserLeaveHint] for more details.
+     */
+    fun onHomePressed(): Boolean = false
 }

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
@@ -138,14 +138,15 @@ class ViewBoundFeatureWrapper<T : LifecycleAwareFeature>() {
     }
 
     /**
-     * Convenient method for invoking [BackHandler.onBackPressed] on a wrapped [LifecycleAwareFeature] that implements
-     * [BackHandler]. Returns false if the [LifecycleAwareFeature] was cleared already.
+     * Convenient method for invoking [UserInteractionHandler.onBackPressed] on a wrapped
+     * [LifecycleAwareFeature] that implements [UserInteractionHandler]. Returns false if
+     * the [LifecycleAwareFeature] was cleared already.
      */
     @Synchronized
     fun onBackPressed(): Boolean {
         val feature = feature ?: return false
 
-        if (feature !is BackHandler) {
+        if (feature !is UserInteractionHandler) {
             throw IllegalAccessError("Feature does not implement BackHandler interface")
         }
 

--- a/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
@@ -36,7 +36,7 @@ class ViewBoundFeatureWrapperTest {
 
     @Test
     fun `onBackPressed is forwarded to feature`() {
-        val feature = MockFeatureWithBackHandler(onBackPressed = true)
+        val feature = MockFeatureWithUserInteractionHandler(onBackPressed = true)
 
         val wrapper = ViewBoundFeatureWrapper(
             feature = feature,
@@ -48,7 +48,7 @@ class ViewBoundFeatureWrapperTest {
         assertTrue(feature.onBackPressedInvoked)
 
         assertFalse(ViewBoundFeatureWrapper(
-            feature = MockFeatureWithBackHandler(onBackPressed = false),
+            feature = MockFeatureWithUserInteractionHandler(onBackPressed = false),
             owner = MockedLifecycleOwner(MockedLifecycle(Lifecycle.State.CREATED)),
             view = mock()
         ).onBackPressed())
@@ -379,9 +379,9 @@ private open class MockFeature : LifecycleAwareFeature {
     }
 }
 
-private class MockFeatureWithBackHandler(
+private class MockFeatureWithUserInteractionHandler(
     private val onBackPressed: Boolean = false
-) : MockFeature(), BackHandler {
+) : MockFeature(), UserInteractionHandler {
     var onBackPressedInvoked = false
         private set
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,6 +55,10 @@ permalink: /changelog/
       `.set()` (rather than `.add()`). This has been corrected, but it may result
       in changes in the sent data if using string list items longer than 20 bytes.
 
+* **support-base**
+  * Deprecated `BackHandler` interface. Use the `UserInteractionHandler.onBackPressed` instead.
+  * Added generic `UserInteractionHandler` interface for fragments, features and other components that want to handle user interactions such as ‘back’ or 'home' button presses.
+
 # 22.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v22.0.0...master)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -26,7 +26,7 @@ import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -41,7 +41,7 @@ import org.mozilla.samples.browser.integration.FindInPageIntegration
  * This class only contains shared code focused on the main browsing content.
  * UI code specific to the app or to custom tabs can be found in the subclasses.
  */
-abstract class BaseBrowserFragment : Fragment(), BackHandler {
+abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val toolbarFeature = ViewBoundFeatureWrapper<ToolbarFeature>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -15,7 +15,7 @@ import mozilla.components.feature.intent.ext.getSessionId
 import mozilla.components.browser.tabstray.BrowserTabsTray
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.tabstray.TabsTray
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.samples.browser.ext.components
 
@@ -51,7 +51,7 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
 
     override fun onBackPressed() {
         supportFragmentManager.fragments.forEach {
-            if (it is BackHandler && it.onBackPressed()) {
+            if (it is UserInteractionHandler && it.onBackPressed()) {
                 return
             }
         }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -16,7 +16,7 @@ import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.tabs.toolbar.TabsToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.feature.toolbar.WebExtensionToolbarFeature
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.samples.browser.ext.components
 import org.mozilla.samples.browser.integration.ReaderViewIntegration
@@ -24,7 +24,7 @@ import org.mozilla.samples.browser.integration.ReaderViewIntegration
 /**
  * Fragment used for browsing the web within the main app.
  */
-class BrowserFragment : BaseBrowserFragment(), BackHandler {
+class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val thumbnailsFeature = ViewBoundFeatureWrapper<ThumbnailsFeature>()
     private val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewIntegration>()
     private val webExtToolbarFeature = ViewBoundFeatureWrapper<WebExtensionToolbarFeature>()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -23,7 +23,7 @@ import mozilla.components.feature.pwa.feature.WebAppActivityFeature
 import mozilla.components.feature.pwa.feature.WebAppHideToolbarFeature
 import mozilla.components.feature.pwa.feature.WebAppSiteControlsFeature
 import mozilla.components.lib.state.ext.consumeFrom
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
 import org.mozilla.samples.browser.ext.components
@@ -31,7 +31,7 @@ import org.mozilla.samples.browser.ext.components
 /**
  * Fragment used for browsing within an external app, such as for custom tabs and PWAs.
  */
-class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
+class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val customTabsToolbarFeature = ViewBoundFeatureWrapper<CustomTabsToolbarFeature>()
     private val hideToolbarFeature = ViewBoundFeatureWrapper<WebAppHideToolbarFeature>()
 
@@ -123,7 +123,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
 
     /**
      * Calls [onBackPressed] for features in the base class first,
-     * before trying to call the external app [BackHandler].
+     * before trying to call the external app [UserInteractionHandler].
      */
     override fun onBackPressed(): Boolean =
         super.onBackPressed() || customTabsToolbarFeature.onBackPressed()

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -11,13 +11,13 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_tabstray.*
 import mozilla.components.feature.tabs.tabstray.TabsFeature
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import org.mozilla.samples.browser.ext.components
 
 /**
  * A fragment for displaying the tabs tray.
  */
-class TabsTrayFragment : Fragment(), BackHandler {
+class TabsTrayFragment : Fragment(), UserInteractionHandler {
     private var tabsFeature: TabsFeature? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/integration/FindInPageIntegration.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/integration/FindInPageIntegration.kt
@@ -10,14 +10,15 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
 import mozilla.components.feature.findinpage.view.FindInPageView
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
+@Suppress("UndocumentedPublicClass")
 class FindInPageIntegration(
     private val store: BrowserStore,
     private val view: FindInPageView,
     engineView: EngineView
-) : LifecycleAwareFeature, BackHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
     private val feature = FindInPageFeature(store, view, engineView, ::onClose)
 
     override fun start() {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
@@ -12,10 +12,11 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.feature.readerview.view.ReaderViewControlsView
-import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import org.mozilla.samples.browser.R
 
+@Suppress("UndocumentedPublicClass")
 class ReaderViewIntegration(
     context: Context,
     engine: Engine,
@@ -23,7 +24,7 @@ class ReaderViewIntegration(
     toolbar: BrowserToolbar,
     view: ReaderViewControlsView,
     readerViewAppearanceButton: FloatingActionButton
-) : LifecycleAwareFeature, BackHandler {
+) : LifecycleAwareFeature, UserInteractionHandler {
 
     private var readerViewButtonVisible = false
 


### PR DESCRIPTION
This fixes #5058. 

- Copies BackHandler to UserInteractionHandler, and add onHomePressed from [`UserInteractionHandler`](https://github.com/mozilla-mobile/reference-browser/blob/master/app/src/main/java/org/mozilla/reference/browser/UserInteractionHandler.kt).
- Added Deprecated message for BackHandler
- Introduces a generic UserInteractionHandler to handle any user interactions such as the existing 'back' button pressed, and 'home' button pressed.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
