### PR TITLE
Closes #5155: Don't drop 'failure' details for FxaMigrationException

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
@@ -40,7 +40,7 @@ private data class FennecAuthenticationInfo(
  *
  * @property failure Wrapped [FxaMigrationResult] indicating exact failure reason.
  */
-class FxaMigrationException(val failure: Failure) : Exception()
+class FxaMigrationException(val failure: Failure) : Exception(failure.toString())
 
 /**
  * Result of an FxA migration.
@@ -106,7 +106,11 @@ sealed class FxaMigrationResult {
          * Failed to sign in into an authenticated account. Currently, this could be either due to network failures,
          * invalid credentials, or server-side issues.
          */
-        data class FailedToSignIntoAuthenticatedAccount(val email: String, val stateLabel: String) : Failure()
+        data class FailedToSignIntoAuthenticatedAccount(val email: String, val stateLabel: String) : Failure() {
+            override fun toString(): String {
+                return "Failed to sign-into authenticated account in state $stateLabel"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Currently even though FxaMigrationException contains an instance of a 'Failure',
when it's submitted to Sentry any information about the captured 'Failure' instance is lost.

This patch makes sure we will see 'toString' output for the wrapped 'Failure' instances
in our Sentry reports.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
