### PR TITLE
Closes #5009: Add RemoteTabsStorageSuggestionProvider

### DIFF
--- a/components/feature/remotetabs/build.gradle
+++ b/components/feature/remotetabs/build.gradle
@@ -29,8 +29,12 @@ android {
 
 dependencies {
     implementation project(':service-firefox-accounts')
+    implementation project(':browser-icons')
     implementation project(':browser-state')
     implementation project(':browser-storage-sync')
+    implementation project(':concept-awesomebar')
+    implementation project(':concept-engine')
+    implementation project(':feature-session')
     implementation project(':support-ktx')
     implementation project(':support-base')
 

--- a/components/feature/remotetabs/src/main/java/mozilla/components/feature/remotetabs/RemoteTabsStorageSuggestionProvider.kt
+++ b/components/feature/remotetabs/src/main/java/mozilla/components/feature/remotetabs/RemoteTabsStorageSuggestionProvider.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.remotetabs
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.browser.storage.sync.TabEntry
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.session.SessionUseCases
+import java.util.UUID
+
+/**
+ * A [AwesomeBar.SuggestionProvider] implementation that provides suggestions for remote tabs
+ * based on [RemoteTabsFeature].
+ */
+@ExperimentalCoroutinesApi
+class RemoteTabsStorageSuggestionProvider(
+    private val remoteTabs: RemoteTabsFeature,
+    private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
+    private val icons: BrowserIcons? = null
+) : AwesomeBar.SuggestionProvider {
+
+    override val id: String = UUID.randomUUID().toString()
+
+    override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
+        if (text.isEmpty()) {
+            return emptyList()
+        }
+
+        val results = mutableListOf<ClientTabPair>()
+        for ((client, tabs) in remoteTabs.getRemoteTabs()) {
+            for (tab in tabs) {
+                val activeTabEntry = tab.active()
+                // This is a fairly naive match implementation, but this is what we do on Desktop 🤷.
+                if (activeTabEntry.url.contains(text, ignoreCase = true) ||
+                    activeTabEntry.title.contains(text, ignoreCase = true)) {
+                    results.add(ClientTabPair(
+                        clientName = client.displayName,
+                        tab = activeTabEntry,
+                        lastUsed = tab.lastUsed
+                    ))
+                }
+            }
+        }
+        return results.sortedByDescending { it.lastUsed }.into()
+    }
+
+    /**
+     * Expects list of BookmarkNode to be specifically of bookmarks (e.g. nodes with a url).
+     */
+    private suspend fun List<ClientTabPair>.into(): List<AwesomeBar.Suggestion> {
+        val iconRequests = this.map { client ->
+            client.tab.iconUrl?.let { iconUrl -> icons?.loadIcon(IconRequest(iconUrl)) }
+        }
+
+        return this.zip(iconRequests) { result, icon ->
+            AwesomeBar.Suggestion(
+                provider = this@RemoteTabsStorageSuggestionProvider,
+                icon = icon?.await()?.bitmap,
+                title = result.tab.title,
+                description = result.clientName,
+                onSuggestionClicked = { loadUrlUseCase.invoke(result.tab.url) }
+            )
+        }
+    }
+}
+
+private data class ClientTabPair(val clientName: String, val tab: TabEntry, val lastUsed: Long)

--- a/components/feature/remotetabs/src/test/java/mozilla/components/feature/remotetabs/RemoteTabsStorageSuggestionProviderTest.kt
+++ b/components/feature/remotetabs/src/test/java/mozilla/components/feature/remotetabs/RemoteTabsStorageSuggestionProviderTest.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.remotetabs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.storage.sync.Tab
+import mozilla.components.browser.storage.sync.TabEntry
+import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.DeviceType
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class RemoteTabsStorageSuggestionProviderTest {
+    private lateinit var remoteTabs: RemoteTabsFeature
+
+    @Before
+    fun setup() {
+        remoteTabs = mock()
+    }
+
+    @Test
+    fun `matches remote tabs`() = runBlocking {
+        val provider = RemoteTabsStorageSuggestionProvider(remoteTabs, mock())
+        val deviceTabs1 = Device(
+            id = "client1",
+            displayName = "Foo Client",
+            deviceType = DeviceType.DESKTOP,
+            isCurrentDevice = false,
+            lastAccessTime = null,
+            capabilities = listOf(),
+            subscriptionExpired = false,
+            subscription = null
+        ) to listOf(
+            Tab(listOf(
+                TabEntry("Foo", "https://foo.bar", null), /* active tab */
+                TabEntry("Bobo", "https://foo.bar", null),
+                TabEntry("Foo", "https://bobo.bar", null)
+            ), 0, 1),
+            Tab(listOf(
+                TabEntry("Hello Bobo", "https://foo.bar", null) /* active tab */
+            ), 0, 5),
+            Tab(listOf(
+                TabEntry("In URL", "https://bobo.bar", null) /* active tab */
+            ), 0, 2)
+        )
+        val deviceTabs2 = Device(
+            id = "client2",
+            displayName = "Bar Client",
+            deviceType = DeviceType.MOBILE,
+            isCurrentDevice = false,
+            lastAccessTime = null,
+            capabilities = listOf(),
+            subscriptionExpired = false,
+            subscription = null
+        ) to listOf(
+            Tab(listOf(
+                TabEntry("Bar", "https://bar.bar", null),
+                TabEntry("BOBO in CAPS", "https://obob.bar", null) /* active tab */
+            ), 1, 1)
+        )
+        whenever(remoteTabs.getRemoteTabs()).thenReturn(mapOf(deviceTabs1, deviceTabs2))
+
+        val suggestions = provider.onInputChanged("bobo")
+        assertEquals(3, suggestions.size)
+        assertEquals("Hello Bobo", suggestions[0].title)
+        assertEquals("Foo Client", suggestions[0].description)
+        assertEquals("In URL", suggestions[1].title)
+        assertEquals("Foo Client", suggestions[1].description)
+        assertEquals("BOBO in CAPS", suggestions[2].title)
+        assertEquals("Bar Client", suggestions[2].description)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ permalink: /changelog/
 
 * **feature-remotetabs**
   * Add new `RemoteTabsFeature` to view tabs from other synced devices and upload our own.
+  * Add `RemoteTabsStorageSuggestionProvider` class to match remote tabs in awesomebar suggestions.
 
 # 24.0.0
 


### PR DESCRIPTION
Depends on #5190.
Fixes #5009.
This is a naive implementation of remote tabs matching in the awesome bar.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
