### PR TITLE
Fix sample-sync-logins to work with new dataprotect requirement.

### DIFF
--- a/samples/sync-logins/build.gradle
+++ b/samples/sync-logins/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':service-sync-logins')
     implementation project(':support-rustlog')
     implementation project(':support-rusthttp')
+    implementation project(':lib-dataprotect')
     implementation project(':lib-fetch-httpurlconnection')
 
     implementation Dependencies.kotlin_stdlib


### PR DESCRIPTION
The global sync manager now requires that you provide a secure keystore object in order to sync the logins store. This updates the sync-logins sample to do so, so that it can sync logins successfully.

(The sync-logins sample still doesn't actually *work* after this change, but I believe the remaining issues are due to a bug in appservices, ref https://github.com/mozilla/application-services/issues/2312).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
  - Just fixing a sample app, which does not itself have any tests.
- [ ] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one~~
  - The changelog doesn't seem to call out changes in sample apps, but I'm happy to add one if you think it's worthwhile.
- [ ] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
  - Does not include any user-facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
