### PR TITLE
Update to latest app-services, including metrics from logins component

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.44.0"
+    const val mozilla_appservices = "0.47.0"
 
     const val mozilla_glean = "22.1.0"
 

--- a/components/service/sync-logins/README.md
+++ b/components/service/sync-logins/README.md
@@ -15,6 +15,16 @@ The **Firefox Sync - Logins Component** provides a way for Android applications 
 
 ## Usage
 
+### Before using this component
+
+The `mozilla.appservices.logins` component collects telemetry using the [Glean SDK](https://mozilla.github.io/glean/).
+Applications that send telemetry via Glean *must ensure* they have received appropriate data-review following
+[the Firefox Data Collection process](https://wiki.mozilla.org/Firefox/Data_Collection) before integrating this component.
+
+Details on the metrics collected by the `mozilla.appservices.logins` component are available
+[here](https://github.com/mozilla/application-services/tree/master/docs/metrics/logins/metrics.md)
+
+
 ### Setting up the dependency
 
 Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
@@ -78,7 +88,7 @@ When inserting records (e.g. creating records for use with `AsyncLoginsStorage.a
 
 The hostname this record corresponds to. It is an error to attempt to insert or update a record to have a blank hostname, and attempting to do so `InvalidRecordException` being thrown.
 
-#### `username: String? = null`
+#### `username: String = ""`
 
 The username associated with this record, which may be blank if no username is asssociated with this login.
 
@@ -124,11 +134,11 @@ A lower bound on the time that the `password` field was last changed in millisec
 
 This is a metadata field, and as such, is ignored by `AsyncLoginsStorage.add` and `AsyncLoginsStorage.update`.
 
-#### `usernameField: String? = null`
+#### `usernameField: String = ""`
 
 HTML field name of the username, if known.
 
-#### `passwordField: String? = null`
+#### `passwordField: String = ""`
 
 HTML field name of the password, if known.
 
@@ -153,8 +163,6 @@ The errors reported as "raw" `LoginsStorageException` are things like Rust panic
 Yes, sort of. This works, however due to the fact that `lock` closes the database connection, *all data is lost when the database is locked*. This means that doing so will result in a database with different behavior around lock/unlock than one stored on disk.
 
 That said, doing so is simple: Just create a `DatabaseLoginsStorage` with the path `:memory:`, and it will work. You may also use a [SQLite URI filename](https://www.sqlite.org/uri.html) with the parameter `mode=memory`. See https://www.sqlite.org/inmemorydb.html for more options and further information.
-
-Note that we offer a `MemoryLoginsStorage` class which doesn't come with the same limitations (however it cannot sync).
 
 ### How do I set a key for the `DatabaseLoginsStorage`?
 

--- a/components/service/sync-logins/build.gradle
+++ b/components/service/sync-logins/build.gradle
@@ -29,7 +29,11 @@ android {
 
 dependencies {
     // Parts of this dependency are typealiase'd or are otherwise part of this module's public API.
-    api Dependencies.mozilla_sync_logins
+    api(Dependencies.mozilla_sync_logins) {
+      // Use our own version of the Glean dependency,
+      // which might be different from the version declared by A-S.
+      exclude group: 'org.mozilla.components', module: 'service-glean'
+    }
     api Dependencies.mozilla_sync15
 
     // Types defined in concept-sync are part of this module's public API.
@@ -37,6 +41,7 @@ dependencies {
 
     implementation project(':concept-storage')
     implementation project(':support-sync-telemetry')
+    implementation project(':service-glean')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
 import mozilla.appservices.logins.DatabaseLoginsStorage
 import mozilla.appservices.logins.LoginsStorage
-import mozilla.appservices.logins.MemoryLoginsStorage
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
 import mozilla.appservices.sync15.SyncTelemetryPing
@@ -210,8 +209,7 @@ interface AsyncLoginsStorage : AutoCloseable {
      * generated automatically. The format of generated guids
      * are left up to the implementation of LoginsStorage (in
      * practice the [DatabaseLoginsStorage] generates 12-character
-     * base64url (RFC 4648) encoded strings, and [MemoryLoginsStorage]
-     * generates strings using [java.util.UUID.toString])
+     * base64url (RFC 4648) encoded strings.
      *
      * This will return an error result if a GUID is provided but
      * collides with an existing record, or if the provided record
@@ -385,13 +383,6 @@ open class AsyncLoginsStorageAdapter<T : LoginsStorage>(private val wrapped: T) 
          */
         fun forDatabase(dbPath: String): AsyncLoginsStorageAdapter<DatabaseLoginsStorage> {
             return AsyncLoginsStorageAdapter(DatabaseLoginsStorage(dbPath))
-        }
-
-        /**
-         * Creates an [AsyncLoginsStorage] that is backed by a [MemoryLoginsStorage].
-         */
-        fun inMemory(items: List<ServerPassword>): AsyncLoginsStorageAdapter<MemoryLoginsStorage> {
-            return AsyncLoginsStorageAdapter(MemoryLoginsStorage(items))
         }
     }
 }

--- a/components/support/migration/build.gradle
+++ b/components/support/migration/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     jnaForTest Dependencies.thirdparty_jna
     testImplementation files(configurations.jnaForTest.copyRecursive().files)
     testImplementation Dependencies.mozilla_full_megazord_forUnitTests
+    testImplementation Dependencies.mozilla_glean_forUnitTests
 }
 
 apply from: '../../../publish.gradle'

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -584,13 +584,13 @@ class FennecMigratorTest {
                     timeCreated = 1574735368749,
                     timeLastUsed = 1574735368749,
                     timePasswordChanged = 1574735368749,
-                    usernameField = null,
-                    passwordField = null
+                    usernameField = "",
+                    passwordField = ""
                 ),
                 ServerPassword(
                     id = "{cf7cabe4-ec82-4800-b077-c6d97ffcd63a}",
                     hostname = "https://html.com",
-                    username = null,
+                    username = "",
                     password = "testp",
                     httpRealm = null,
                     formSubmitURL = "https://html.com",
@@ -598,7 +598,7 @@ class FennecMigratorTest {
                     timeCreated = 1574735237274,
                     timeLastUsed = 1574735237274,
                     timePasswordChanged = 1574735237274,
-                    usernameField = null,
+                    usernameField = "",
                     passwordField = "password"
                 )
             ), this)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,13 @@ permalink: /changelog/
 * **sync-logins**
   * 🕵️  **New Telemetry Notice**
   * Added telemetry for password sync, via the new `passwords_sync` in **support-telemetry-sync**
+  * The `service-sync-logins` component now collects some basic performance and quality metrics via Glean.
+    Applications that send telemetry via Glean *must ensure* they have received appropriate data-review before integrating this component.
+  * ⚠️ **This is a breaking change**: The `ServerPassword` fields `username`, `usernameField` and `passwordField` can no longer by `null`.
+    Use the empty string to indicate an absent value for these fields.
+  * ⚠️ **This is a breaking change**: The `AsyncLoginsStorageAdapter.inMemory` method has been removed.
+    Use `AsyncLoginsStorageAdapter.forDatabase(":memory:")` instead.
+
 
 * **samples-sync**
   * Added support for password synchronization (not reflected in the UI, but demonstrates how to integrate the component).


### PR DESCRIPTION
(Top-level bug comment edited for clarity)

This updates a-c to use the latest a-s release, which includes some new metrics from the logins component. There was a lot of back-end-forth about the implications of landing such a thing, which you can read about below. The resolution is that we have data-review+ for landing these metrics in Fenix and Lockwise, and any new consumers of the logins component will need to get data-review for logins-component metrics.

----

Over in https://github.com/mozilla/application-services/pull/2225 we're working on adding some basic performance and quality metrics to the appservices logins component, instrumented via Glean.  I'm happy with how that change has shaped in *in isolation*, but before we land it I want to understand whether it's going to work out as part of our broader component ecosystem.

Here is what I think it would look like to update android-components to this new version of the logins component. There are no new APIs, but there is a new behaviour that consumers need to be aware of, and it's probably important enough to be called out as a breaking change.

I tested this by building the sync-logins sample app (ref https://github.com/mozilla-mobile/android-components/pull/5222, https://github.com/mozilla/application-services/issues/2312) and confirm that it still worked, then adding some additional logging output in glean to confirmed that the expected metrics-gathering was taking place.  Notably, the sync-logins sample app does not actually submit any metrics via glean, so IIUC it would have been gathering the metrics but discarding them without submitting anything to Mozilla. I don't know whether they would have been gathered in memory, or written to disk; I should see if I can find that out.

@grigoryk @pocmo what's your gut reaction to this? Will it be workable as-is, or should we consider some more nuanced API to let consumers opt in or out of getting metrics-gathering behaviour from this component?