### PR TITLE
Migrate fennec telemetry setting

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecSettingsMigrator.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecSettingsMigrator.kt
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * Helper for migrating all common Fennec - Fenix settings.
+ */
+internal object FennecSettingsMigration {
+    private val logger = Logger("FennecSettingsMigration")
+    private lateinit var fenixAppPrefs: SharedPreferences
+    private lateinit var fennecAppPrefs: SharedPreferences
+
+    @VisibleForTesting const val FENNEC_APP_SHARED_PREFS_NAME = "GeckoApp"
+    @VisibleForTesting const val FENIX_SHARED_PREFS_NAME = "fenix_preferences"
+    const val FENNEC_PREFS_FHR_KEY = "android.not_a_preference.healthreport.uploadEnabled"
+    const val FENIX_PREFS_TELEMETRY_KEY = "pref_key_telemetry"
+
+    /**
+     * Migrate all Fennec - Fenix common SharedPreferences.
+     */
+    fun migrateSharedPrefs(context: Context): Result<SettingsMigrationResult> {
+        fennecAppPrefs = context.getSharedPreferences(FENNEC_APP_SHARED_PREFS_NAME, MODE_PRIVATE)
+        fenixAppPrefs = context.getSharedPreferences(FENIX_SHARED_PREFS_NAME, MODE_PRIVATE)
+
+        if (fennecAppPrefs.all.isEmpty()) {
+            logger.info("No Fennec prefs, bailing out.")
+            return Result.Success(SettingsMigrationResult.Success.NoFennecPrefs)
+        }
+
+        return migrateAppPreferences()
+    }
+
+    private fun migrateAppPreferences(): Result<SettingsMigrationResult> {
+        return migrateTelemetryOptInStatus(fennecAppPrefs, fenixAppPrefs)
+    }
+
+    private fun migrateTelemetryOptInStatus(
+        fennecPrefs: SharedPreferences,
+        fenixPrefs: SharedPreferences
+    ): Result<SettingsMigrationResult> {
+        // Sanity check: make sure we actually have an FHR value set.
+        if (!fennecPrefs.contains(FENNEC_PREFS_FHR_KEY)) {
+            logger.warn("Missing FHR pref value")
+            return Result.Failure(SettingsMigrationException(SettingsMigrationResult.Failure.MissingFHRPrefValue))
+        }
+
+        // Fennec has two telemetry settings:
+        // - Firefox Health Report (FHR) - defaults to 'on',
+        // - Telemetry - defaults to 'off'.
+        // These two settings control different parts of the telemetry systems in Fennec. The reality is that even
+        // though default for "telemetry" is off, since FHR defaults to "on", by default Fennec collects a non-trivial
+        // subset of available in-product telemetry.
+        // Since the Telemetry pref defaults to 'off', it's impossible to distinguish between "user disabled telemetry"
+        // and "user didn't touch the setting".
+        // So we use FHR value as a proxy for telemetry overall.
+        // If FHR is disabled by the user, we'll disable telemetry in Fenix. Otherwise, it will be enabled.
+
+        // Read Fennec prefs.
+        val fennecFHRState = fennecPrefs.getBoolean(FENNEC_PREFS_FHR_KEY, false)
+        logger.info("Fennec FHR state is: $fennecFHRState")
+
+        // Update Fenix prefs.
+        fenixPrefs.edit()
+            .putBoolean(FENIX_PREFS_TELEMETRY_KEY, fennecFHRState)
+            .apply()
+
+        // Make sure it worked.
+        if (fenixPrefs.getBoolean(FENIX_PREFS_TELEMETRY_KEY, !fennecFHRState) != fennecFHRState) {
+            logger.warn("Wrong telemetry value after migration")
+            return Result.Failure(
+                SettingsMigrationException(
+                    SettingsMigrationResult.Failure.WrongTelemetryValueAfterMigration(expected = fennecFHRState)
+                )
+            )
+        }
+
+        // Done!
+        return Result.Success(SettingsMigrationResult.Success.SettingsMigrated(telemetry = fennecFHRState))
+    }
+}
+
+/**
+ * Wraps [SettingsMigrationResult] in an exception so that it can be returned via [Result.Failure].
+ *
+ * @property failure Wrapped [SettingsMigrationResult] indicating exact failure reason.
+ */
+class SettingsMigrationException(val failure: SettingsMigrationResult.Failure) : Exception(failure.toString())
+
+/**
+ * Result of Fennec settings migration.
+ */
+sealed class SettingsMigrationResult {
+    /**
+     * Successful setting migration.
+     */
+    sealed class Success : SettingsMigrationResult() {
+        /**
+         * Fennec app SharedPreference file is not accessible.
+         *
+         * This means this is a fresh install of Fenix, not an update from Fennec.
+         * Nothing to migrate.
+         */
+        object NoFennecPrefs : Success() {
+            override fun toString(): String {
+                return "No previous app settings. Nothing to migrate."
+            }
+        }
+
+        /**
+         * Migration work completed successfully.
+         */
+        data class SettingsMigrated(val telemetry: Boolean) : Success() {
+            override fun toString(): String {
+                return "Previous Fennec settings migrated successfully; value: $telemetry"
+            }
+        }
+    }
+
+    /**
+     * Failed settings migrations.
+     */
+    sealed class Failure : SettingsMigrationResult() {
+        /**
+         * Couldn't find FHR pref value in non-empty Fennec prefs.
+         */
+        object MissingFHRPrefValue : Failure() {
+            override fun toString(): String {
+                return "Missing FHR pref value"
+            }
+        }
+
+        /**
+         * Wrong telemetry value in Fenix after migration.
+         */
+        data class WrongTelemetryValueAfterMigration(val expected: Boolean) : Failure() {
+            override fun toString(): String {
+                return "Wrong telemetry pref value after migration. Expected $expected."
+            }
+        }
+    }
+}

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationResultsStore.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationResultsStore.kt
@@ -43,6 +43,7 @@ internal class MigrationResultsStore(context: Context) : SharedPreferencesCache<
         }
     }
 
+    @Suppress("ComplexMethod")
     override fun fromJSON(obj: JSONObject): MigrationResults {
         val result = mutableMapOf<Migration, MigrationRun>()
         val list = obj.optJSONArray("list") ?: throw IllegalStateException("Corrupt migration history")
@@ -59,6 +60,7 @@ internal class MigrationResultsStore(context: Context) : SharedPreferencesCache<
                 Migration.Gecko.javaClass.simpleName -> Migration.Gecko
                 Migration.FxA.javaClass.simpleName -> Migration.FxA
                 Migration.Logins.javaClass.simpleName -> Migration.Logins
+                Migration.Settings.javaClass.simpleName -> Migration.Settings
                 else -> throw IllegalStateException("Unrecognized migration type: $migrationName")
             }
             result[migration] = MigrationRun(version = migrationVersion, success = migrationSuccess)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecSettingsMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecSettingsMigrationTest.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.migration.FennecSettingsMigration.FENIX_PREFS_TELEMETRY_KEY
+import mozilla.components.support.migration.FennecSettingsMigration.FENIX_SHARED_PREFS_NAME
+import mozilla.components.support.migration.FennecSettingsMigration.FENNEC_APP_SHARED_PREFS_NAME
+import mozilla.components.support.migration.FennecSettingsMigration.FENNEC_PREFS_FHR_KEY
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class FennecSettingsMigrationTest {
+    @After
+    fun `Clean up all SharedPreferences`() {
+        File(testContext.filesDir.parent, "shared_prefs").delete()
+    }
+
+    @Test
+    fun `Missing Fennec preferences entirely is treated as success`() {
+        with(FennecSettingsMigration.migrateSharedPrefs(testContext) as Result.Success) {
+            assertEquals(SettingsMigrationResult.Success.NoFennecPrefs::class, this.value::class)
+        }
+    }
+
+    @Test
+    fun `Missing FHR pref value is treated as failure`() {
+        val fennecAppPrefs = testContext.getSharedPreferences(FENNEC_APP_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+
+        // Make prefs non-empty.
+        fennecAppPrefs.edit().putString("dummy", "key").apply()
+
+        with(FennecSettingsMigration.migrateSharedPrefs(testContext) as Result.Failure) {
+            val unwrapped = this.throwables.first() as SettingsMigrationException
+            assertEquals(SettingsMigrationResult.Failure.MissingFHRPrefValue::class, unwrapped.failure::class)
+        }
+    }
+
+    @Test
+    fun `Fennec FHR disabled will set Fenix telemetry as stopped and return SUCCESS`() {
+        assertFHRMigration(isFHREnabled = false)
+    }
+
+    @Test
+    fun `Fennec FHR enabled will set Fenix telemetry as active and return SUCCESS`() {
+        assertFHRMigration(isFHREnabled = true)
+    }
+
+    private fun assertFHRMigration(isFHREnabled: Boolean) {
+        val fennecAppPrefs = testContext.getSharedPreferences(FENNEC_APP_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+        val fenixPrefs = testContext.getSharedPreferences(FENIX_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+
+        fennecAppPrefs.edit().putBoolean(FENNEC_PREFS_FHR_KEY, isFHREnabled).commit()
+
+        with(FennecSettingsMigration.migrateSharedPrefs(testContext) as Result.Success) {
+            assertEquals(SettingsMigrationResult.Success.SettingsMigrated::class, this.value::class)
+            val v = this.value as SettingsMigrationResult.Success.SettingsMigrated
+            assertEquals(isFHREnabled, v.telemetry)
+        }
+
+        assertEquals(isFHREnabled, fenixPrefs.getBoolean(FENIX_PREFS_TELEMETRY_KEY, !isFHREnabled))
+    }
+}


### PR DESCRIPTION
Introduces a new "FennecSettingsMigrator" which will be responsible for
migrating all common Fennec - Fenix settings.
Starting with the telemetry opt-in status which in Fenix will be "true" only
if both "Telemetry" and "Firefox Health Report" were enabled on Fennec.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
