### PR TITLE
Closes #5229: Remove the Need to Have Atleast One Engine Observer to Load URI

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -366,6 +366,8 @@ class GeckoEngineSession(
 
             return if (response != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
+            } else if (!isObserved()) {
+                GeckoResult.fromValue(AllowOrDeny.ALLOW)
             } else {
                 val geckoResult: GeckoResult<AllowOrDeny> = GeckoResult()
                 val allowOrDeny: (Boolean, String) -> Unit = { shouldAllow, _ ->

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1964,6 +1964,17 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `onLoadRequest will complete GeckoResult if no observer is available`() {
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+        captureDelegates()
+
+        val geckoResult = navigationDelegate.value.onLoadRequest(
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
+
+        assertEquals(geckoResult!!, GeckoResult.fromValue(AllowOrDeny.ALLOW))
+    }
+
+    @Test
     fun `onLoadRequest will not notify observers if request was intercepted`() {
         val defaultSettings = DefaultSettings(requestInterceptor = object : RequestInterceptor {
             override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -365,6 +365,8 @@ class GeckoEngineSession(
 
             return if (response != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
+            } else if (!isObserved()) {
+                GeckoResult.fromValue(AllowOrDeny.ALLOW)
             } else {
                 val geckoResult: GeckoResult<AllowOrDeny> = GeckoResult()
                 var completedBy: String? = null

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1965,6 +1965,17 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `onLoadRequest will complete GeckoResult if no observer is available`() {
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+        captureDelegates()
+
+        val geckoResult = navigationDelegate.value.onLoadRequest(
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
+
+        assertEquals(geckoResult!!, GeckoResult.fromValue(AllowOrDeny.ALLOW))
+    }
+
+    @Test
     fun `onLoadRequest will not notify observers if request was intercepted`() {
         val defaultSettings = DefaultSettings(requestInterceptor = object : RequestInterceptor {
             override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -367,6 +367,8 @@ class GeckoEngineSession(
 
             return if (response != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
+            } else if (!isObserved()) {
+                GeckoResult.fromValue(AllowOrDeny.ALLOW)
             } else {
                 val geckoResult: GeckoResult<AllowOrDeny> = GeckoResult()
                 val allowOrDeny: (Boolean, String) -> Unit = { shouldAllow, _ ->

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1966,6 +1966,17 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `onLoadRequest will complete GeckoResult if no observer is available`() {
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider)
+        captureDelegates()
+
+        val geckoResult = navigationDelegate.value.onLoadRequest(
+            mock(), mockLoadRequest("sample:about", triggeredByRedirect = true))
+
+        assertEquals(geckoResult!!, GeckoResult.fromValue(AllowOrDeny.ALLOW))
+    }
+
+    @Test
     fun `onLoadRequest will not notify observers if request was intercepted`() {
         val defaultSettings = DefaultSettings(requestInterceptor = object : RequestInterceptor {
             override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {


### PR DESCRIPTION
Tested with sample browser to confirm the feature is still working as expected.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
