### PR TITLE
Closes #5134 - Defensive PushType lookup from the incoming channelId

### DIFF
--- a/components/feature/push/src/test/java/mozilla/components/feature/push/DeliveryManagerTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/DeliveryManagerTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.push
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
@@ -19,9 +20,9 @@ class DeliveryManagerTest {
         assertEquals(PushType.Services, pushType)
     }
 
-    @Test(expected = NoSuchElementException::class)
-    fun `exception thrown if serviceType not found`() {
-        DeliveryManager.serviceForChannelId("992a0f0542383f1ea5ef51b7cf4ea6c4")
+    @Test
+    fun `unknown channelIDs handled gracefully`() {
+        assertNull(DeliveryManager.serviceForChannelId("992a0f0542383f1ea5ef51b7cf4ea6c4"))
     }
 
     @Test


### PR DESCRIPTION
`channelId` comes to us from the "outside world", so to speak - as part of an
incoming push message. Don't crash in case we couldn't map it to a PushType.

@jonalmeida what do you think? I reckon we need to do something like this regardless of migration crashes - but it's particularly annoying with those :)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
