### PR TITLE
Closes #4774: Link addons to their installed extensions

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -243,6 +243,14 @@ class GeckoEngine(
     }
 
     /**
+     * See [Engine.listInstalledWebExtensions].
+     */
+    override fun listInstalledWebExtensions(onSuccess: (List<WebExtension>) -> Unit, onError: (Throwable) -> Unit) {
+        // TODO https://github.com/mozilla-mobile/android-components/issues/4500
+        onSuccess(emptyList())
+    }
+
+    /**
      * See [Engine.registerWebNotificationDelegate].
      */
     override fun registerWebNotificationDelegate(

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -602,6 +602,22 @@ class GeckoEngineTest {
         assertNotNull(actionHandlerCaptor.value.onToggleBrowserActionPopup(extension, browserAction))
     }
 
+    @Test
+    fun `list web extensions successfully`() {
+        val runtime = mock<GeckoRuntime>()
+        val engine = GeckoEngine(context, runtime = runtime)
+        var extensions: List<WebExtension>? = null
+        var onErrorCalled = false
+
+        engine.listInstalledWebExtensions(
+            onSuccess = { extensions = it },
+            onError = { onErrorCalled = true }
+        )
+
+        assertFalse(onErrorCalled)
+        assertNotNull(extensions)
+    }
+
     @Test(expected = RuntimeException::class)
     fun `WHEN GeckoRuntime is shutting down THEN GeckoEngine throws runtime exception`() {
         val runtime: GeckoRuntime = mock()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -266,10 +266,9 @@ sealed class TrackingProtectionAction : BrowserAction() {
  */
 sealed class WebExtensionAction : BrowserAction() {
     /**
-     * Installs the given [extension] and adds it to the [BrowserState.extensions].
+     * Updates [BrowserState.extensions] to register the given [extension] as installed.
      */
-    data class InstallWebExtension(val extension: WebExtensionState) :
-        WebExtensionAction()
+    data class InstallWebExtensionAction(val extension: WebExtensionState) : WebExtensionAction()
 
     /**
      * Updates a browser action of a given [extensionId].

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
@@ -17,7 +17,7 @@ internal object WebExtensionReducer {
      */
     fun reduce(state: BrowserState, action: WebExtensionAction): BrowserState {
         return when (action) {
-            is WebExtensionAction.InstallWebExtension -> {
+            is WebExtensionAction.InstallWebExtensionAction -> {
                 val existingExtension = state.extensions[action.extension.id]
                 if (existingExtension == null) {
                     state.copy(

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
@@ -28,14 +28,14 @@ class WebExtensionActionTest {
         assertTrue(store.state.extensions.isEmpty())
 
         val extension = WebExtensionState("id", "url")
-        store.dispatch(WebExtensionAction.InstallWebExtension(extension)).joinBlocking()
+        store.dispatch(WebExtensionAction.InstallWebExtensionAction(extension)).joinBlocking()
 
         assertFalse(store.state.extensions.isEmpty())
         assertEquals(extension, store.state.extensions.values.first())
 
         // Installing the same extension twice should have no effect
         val state = store.state
-        store.dispatch(WebExtensionAction.InstallWebExtension(extension)).joinBlocking()
+        store.dispatch(WebExtensionAction.InstallWebExtensionAction(extension)).joinBlocking()
         assertSame(state, store.state)
     }
 
@@ -47,7 +47,7 @@ class WebExtensionActionTest {
         assertTrue(store.state.extensions.isEmpty())
 
         val extension = WebExtensionState("id", "url")
-        store.dispatch(WebExtensionAction.InstallWebExtension(extension)).joinBlocking()
+        store.dispatch(WebExtensionAction.InstallWebExtensionAction(extension)).joinBlocking()
 
         assertFalse(store.state.extensions.isEmpty())
 
@@ -125,7 +125,7 @@ class WebExtensionActionTest {
         val store = BrowserStore()
 
         val extension = WebExtensionState("id", "url")
-        store.dispatch(WebExtensionAction.InstallWebExtension(extension)).joinBlocking()
+        store.dispatch(WebExtensionAction.InstallWebExtensionAction(extension)).joinBlocking()
 
         assertEquals(extension, store.state.extensions[extension.id])
         assertNull(store.state.extensions[extension.id]?.browserActionPopupSession)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -139,6 +139,19 @@ interface Engine {
     ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
 
     /**
+     * Lists the currently installed web extensions in this engine.
+     *
+     * @param onSuccess callback invoked with the list of of installed [WebExtension]s.
+     * @param onError (optional) callback invoked if there was an error querying
+     * the installed extensions. This callback is invoked with an [UnsupportedOperationException]
+     * in case the engine doesn't have web extension support.
+     */
+    fun listInstalledWebExtensions(
+        onSuccess: ((List<WebExtension>) -> Unit),
+        onError: ((Throwable) -> Unit) = { }
+    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
      * Registers a [WebExtensionDelegate] to be notified of engine events
      * related to web extensions
      *

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
@@ -63,6 +63,11 @@ class EngineTest {
         testEngine.installWebExtension("my-ext", "resource://path", onError = { _, e -> exception = e })
         assertNotNull(exception)
         assertTrue(exception is UnsupportedOperationException)
+
+        exception = null
+        testEngine.listInstalledWebExtensions(onSuccess = { }, onError = { e -> exception = e })
+        assertNotNull(exception)
+        assertTrue(exception is UnsupportedOperationException)
     }
 
     @Test

--- a/components/feature/addons/build.gradle
+++ b/components/feature/addons/build.gradle
@@ -33,9 +33,12 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
 
+    implementation project(':browser-state')
+    implementation project(':concept-engine')
     implementation project(':concept-fetch')
     implementation project(':support-base')
     implementation project(':support-ktx')
+    implementation project(':support-webextensions')
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -13,9 +13,6 @@ import kotlinx.android.parcel.Parcelize
  *
  * @property id The unique ID of this add-on.
  * @property authors List holding information about the add-on authors.
- * @property installed Indicates if this [Addon] is installed or not, defaults to false.
- * @property enabled Indicates if this [Addon] is enabled to interact with web content or not,
- * defaults to false.
  * @property categories List of categories the add-on belongs to.
  * @property downloadUrl The (absolute) URL to download the add-on file (eg xpi).
  * @property version The add-on version e.g "1.23.0".
@@ -31,14 +28,14 @@ import kotlinx.android.parcel.Parcelize
  * @property rating The rating information of this add-on.
  * @property createdAt The date the add-on was created.
  * @property updatedAt The date of the last time the add-on was updated by its developer(s).
+ * @property installedState Holds the state of the installed web extension for this add-on. Null, if
+ * the [Addon] is not installed.
  */
 @Parcelize
 data class Addon(
     val id: String,
     val authors: List<Author>,
     val categories: List<String>,
-    val installed: Boolean = false,
-    val enabled: Boolean = false,
     val downloadUrl: String,
     val version: String,
     val permissions: List<String> = emptyList(),
@@ -49,7 +46,8 @@ data class Addon(
     val siteUrl: String = "",
     val rating: Rating? = null,
     val createdAt: String,
-    val updatedAt: String
+    val updatedAt: String,
+    val installedState: InstalledState? = null
 ) : Parcelable {
     /**
      * Represents an add-on author.
@@ -69,6 +67,7 @@ data class Addon(
 
     /**
      * Holds all the rating information of this add-on.
+     *
      * @property average An average score from 1 to 5 of how users scored this add-on.
      * @property reviews The number of users that has scored this add-on.
      */
@@ -80,10 +79,39 @@ data class Addon(
 
     /**
      * Returns a list of id resources per each item on the [Addon.permissions] list.
+     * Holds the state of the installed web extension of this add-on.
+     *
+     * @property id The ID of the installed web extension.
+     * @property version The installed version.
+     * @property enabled Indicates if this [Addon] is enabled to interact with web content or not,
+     * defaults to false.
+     * @property optionsPageUrl the URL of the page displaying the
+     * options page (options_ui in the extension's manifest).
+     */
+    @Parcelize
+    data class InstalledState(
+        val id: String,
+        val version: String,
+        val optionsPageUrl: String,
+        val enabled: Boolean = false
+    ) : Parcelable
+
+    /**
+     * Returns a list of id resources per each item on the [AddOn.permissions] list.
      */
     fun translatePermissions(): List<Int> {
-        return permissions.mapNotNull { it -> permissionToTranslation[it] }
+        return permissions.mapNotNull { permissionToTranslation[it] }
     }
+
+    /**
+     * Returns whether or not this [Addon] is currently installed.
+     */
+    fun isInstalled() = installedState != null
+
+    /**
+     * Returns whether or not this [Addon] is currently enabled.
+     */
+    fun isEnabled() = installedState?.enabled == true
 
     companion object {
         /**

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons
+
+import mozilla.components.browser.state.action.WebExtensionAction
+import mozilla.components.browser.state.state.WebExtensionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.webextensions.WebExtensionSupport
+
+/**
+ * Provides access to installed and recommended [Addon]s and manages their states.
+ *
+ * @property store The application's [BrowserStore].
+ * @property addonsProvider The [AddonsProvider] to query available [Addon]s.
+ */
+class AddonManager(
+    private val store: BrowserStore,
+    private val addonsProvider: AddonsProvider
+) {
+
+    /**
+     * Returns the list of all installed and recommended add-ons.
+     *
+     * @return list of all [Addon]s with up-to-date [Addon.installedState].
+     * @throws AddonManagerException in case of a problem reading from
+     * the [addonsProvider] or querying web extension state from the engine / store.
+     */
+    @Throws(AddonManagerException::class)
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun getAddons(): List<Addon> {
+        try {
+            // Make sure extension support is initialized, i.e. the state of all installed extensions is known.
+            WebExtensionSupport.awaitInitialization()
+
+            // TODO for testing purposes -> remove once management API lands
+            val ublockId = "607454"
+            store.dispatch(WebExtensionAction.InstallWebExtensionAction(WebExtensionState(ublockId))).join()
+
+            return addonsProvider.getAvailableAddons().map { addon ->
+                store.state.extensions[addon.id]?.let { installedAddon ->
+                    // TODO Add fields once we get the management API:
+                    // https://github.com/mozilla-mobile/android-components/issues/4500
+                    addon.copy(installedState = Addon.InstalledState(installedAddon.id, "1.0", "https://mozilla.org"))
+                } ?: addon
+            }
+        } catch (throwable: Throwable) {
+            throw AddonManagerException(throwable)
+        }
+    }
+}
+
+/**
+ * Wraps exceptions thrown by either the initialization process or an [AddonsProvider].
+ */
+class AddonManagerException(throwable: Throwable) : Exception(throwable)

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -62,7 +62,7 @@ class AddonCollectionProvider(
      *
      * @param allowCache whether or not the result may be provided
      * from a previously cached response, defaults to true.
-     * @throws IOException if the request could not be executed due to cancellation,
+     * @throws IOException if the request failed, or could not be executed due to cancellation,
      * a connectivity problem or a timeout.
      */
     @Throws(IOException::class)
@@ -85,8 +85,9 @@ class AddonCollectionProvider(
                         }
                     }
                 } else {
-                    logger.error("Failed to fetch addon collection. Status code: ${response.status}")
-                    emptyList()
+                    val errorMessage = "Failed to fetch addon collection. Status code: ${response.status}"
+                    logger.error(errorMessage)
+                    throw IOException(errorMessage)
                 }
             }
     }

--- a/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import java.io.IOException
 import java.util.Date
 import java.io.InputStream
 
@@ -138,8 +139,8 @@ class AddonCollectionProviderTest {
         }
     }
 
-    @Test
-    fun `getAvailableAddons - with a not successful status will return an empty list`() {
+    @Test(expected = IOException::class)
+    fun `getAvailableAddons - with unexpected status will throw exception`() {
         val mockedClient = mock<Client>()
         val mockedResponse = mock<Response>()
         val mockedMockedBody = mock<Response.Body>()
@@ -151,8 +152,7 @@ class AddonCollectionProviderTest {
         val provider = AddonCollectionProvider(testContext, client = mockedClient)
 
         runBlocking {
-            val addons = provider.getAvailableAddons()
-            assertTrue(addons.isEmpty())
+            provider.getAvailableAddons()
         }
     }
 

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.amo
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.WebExtensionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonManager
+import mozilla.components.feature.addons.AddonManagerException
+import mozilla.components.feature.addons.AddonsProvider
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import mozilla.components.support.webextensions.WebExtensionSupport
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import java.lang.IllegalStateException
+
+@RunWith(AndroidJUnit4::class)
+class AddonManagerTest {
+
+    @Test
+    fun `getAddons - queries addons from provider and updates installation state`() = runBlocking {
+        // Prepare addons provider
+        val addon1 = Addon(
+            id = "ext1",
+            authors = emptyList(),
+            categories = emptyList(),
+            downloadUrl = "",
+            version = "",
+            createdAt = "",
+            updatedAt = ""
+        )
+        val addon2 = Addon(
+            id = "ext2",
+            authors = emptyList(),
+            categories = emptyList(),
+            downloadUrl = "",
+            version = "",
+            createdAt = "",
+            updatedAt = ""
+        )
+        val addonsProvider: AddonsProvider = mock()
+        whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenReturn(listOf(addon1, addon2))
+
+        // Prepare engine
+        val engine: Engine = mock()
+        val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
+            callbackCaptor.value.invoke(emptyList())
+        }
+        val store = BrowserStore(
+            BrowserState(
+                extensions = mapOf("ext1" to WebExtensionState("ext1", "url"))
+            )
+        )
+        WebExtensionSupport.initialize(engine, store)
+
+        // Verify add-ons were updated with state provided by the engine/store
+        val addons = AddonManager(store, addonsProvider).getAddons()
+        assertEquals(2, addons.size)
+        assertEquals("ext1", addons[0].id)
+        assertNotNull(addons[0].installedState)
+        assertEquals("ext1", addons[0].installedState!!.id)
+
+        assertEquals("ext2", addons[1].id)
+        assertNull(addons[1].installedState)
+    }
+
+    @Test(expected = AddonManagerException::class)
+    fun `getAddons - wraps exceptions and rethrows them`() = runBlocking {
+        val store = BrowserStore()
+
+        val engine: Engine = mock()
+        val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
+            callbackCaptor.value.invoke(emptyList())
+        }
+
+        val addonsProvider: AddonsProvider = mock()
+        whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenThrow(IllegalStateException("test"))
+        WebExtensionSupport.initialize(engine, store)
+
+        AddonManager(store, addonsProvider).getAddons()
+        Unit
+    }
+}

--- a/components/feature/addons/src/test/java/AddonTest.kt
+++ b/components/feature/addons/src/test/java/AddonTest.kt
@@ -8,6 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -78,5 +80,45 @@ class AddonTest {
             R.string.mozac_feature_addons_permissions_top_sites_description
         )
         assertEquals(expectedPermissions, translatedPermissions)
+    }
+
+    @Test
+    fun `isInstalled - true if installed state present and otherwise false`() {
+        val addon = Addon(
+            id = "id",
+            authors = emptyList(),
+            categories = emptyList(),
+            downloadUrl = "downloadUrl",
+            version = "version",
+            permissions = emptyList(),
+            createdAt = "",
+            updatedAt = ""
+        )
+        assertFalse(addon.isInstalled())
+
+        val installedAddon = addon.copy(installedState = Addon.InstalledState("id", "1.0", ""))
+        assertTrue(installedAddon.isInstalled())
+    }
+
+    @Test
+    fun `isEnabled - true if installed state enabled and otherwise false`() {
+        val addon = Addon(
+            id = "id",
+            authors = emptyList(),
+            categories = emptyList(),
+            downloadUrl = "downloadUrl",
+            version = "version",
+            permissions = emptyList(),
+            createdAt = "",
+            updatedAt = ""
+
+        )
+        assertFalse(addon.isEnabled())
+
+        val installedAddon = addon.copy(installedState = Addon.InstalledState("id", "1.0", ""))
+        assertFalse(installedAddon.isEnabled())
+
+        val enabledAddon = addon.copy(installedState = Addon.InstalledState("id", "1.0", "", enabled = true))
+        assertTrue(enabledAddon.isEnabled())
     }
 }

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -5,6 +5,8 @@
 package mozilla.components.support.webextensions
 
 import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.action.EngineAction
@@ -20,6 +22,7 @@ import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.filterChanged
 
 /**
@@ -28,8 +31,16 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.filterChanged
  * corresponding actions to the [BrowserStore].
  */
 object WebExtensionSupport {
+    private val logger = Logger("mozac-webextensions")
+
     @VisibleForTesting
-    internal val installedExtensions = mutableSetOf<WebExtension>()
+    internal val installedExtensions = mutableMapOf<String, WebExtension>()
+
+    /**
+     * A [Deferred] completed during [initialize] once the state of all
+     * installed extensions is known.
+     */
+    private val initializationResult = CompletableDeferred<Unit>()
 
     /**
      * [ActionHandler] for session-specific overrides. Forwards actions to the
@@ -75,6 +86,9 @@ object WebExtensionSupport {
         onCloseTabOverride: ((WebExtension?, String) -> Unit)? = null,
         onSelectTabOverride: ((WebExtension?, String) -> Unit)? = null
     ) {
+        // Queries the engine for installed extensions and adds them to the store
+        registerInstalledExtensions(store, engine)
+
         // Observe the store and register action handlers for newly added engine sessions
         registerActionHandlersForNewSessions(store)
 
@@ -119,19 +133,47 @@ object WebExtensionSupport {
             }
 
             override fun onInstalled(webExtension: WebExtension) {
-                installedExtensions.add(webExtension)
-                store.dispatch(WebExtensionAction.InstallWebExtension(webExtension.toState()))
-
-                // Register action handler for all existing engine sessions on the new extension
-                store.state.tabs
-                    .forEach {
-                        val session = it.engineState.engineSession
-                        if (session != null) {
-                            registerSessionActionHandler(webExtension, session, SessionActionHandler(store, it.id))
-                        }
-                    }
+                registerInstalledExtension(store, webExtension)
             }
         })
+    }
+
+    /**
+     * Awaits for completion of the initialization process (completes when the
+     * state of all installed extensions is known).
+     */
+    suspend fun awaitInitialization() = initializationResult.await()
+
+    /**
+     * Queries the [engine] for installed web extensions and adds them to the [store].
+     */
+    private fun registerInstalledExtensions(store: BrowserStore, engine: Engine) {
+        engine.listInstalledWebExtensions(
+            onSuccess = {
+                extensions -> extensions.forEach { registerInstalledExtension(store, it) }
+                initializationResult.complete(Unit)
+            },
+            onError = {
+                throwable -> logger.error("Failed to query installed extension", throwable)
+                initializationResult.completeExceptionally(throwable)
+            }
+        )
+    }
+
+    /**
+     * Marks the provided [webExtension] as installed by adding it to the [store].
+     */
+    private fun registerInstalledExtension(store: BrowserStore, webExtension: WebExtension) {
+        installedExtensions[webExtension.id] = webExtension
+        store.dispatch(WebExtensionAction.InstallWebExtensionAction(webExtension.toState()))
+
+        // Register action handler for all existing engine sessions on the new extension
+        store.state.tabs
+            .forEach { tab ->
+                tab.engineState.engineSession?.let { session ->
+                    registerSessionActionHandler(webExtension, session, SessionActionHandler(store, tab.id))
+                }
+            }
     }
 
     /**
@@ -148,7 +190,7 @@ object WebExtensionSupport {
                 }
                 .collect { state ->
                     state.engineState.engineSession?.let { session ->
-                        installedExtensions.forEach {
+                        installedExtensions.values.forEach {
                             registerSessionActionHandler(it, session, SessionActionHandler(store, state.id))
                         }
                     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -34,6 +34,7 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
+import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
@@ -127,11 +128,16 @@ open class DefaultComponents(private val applicationContext: Context) {
         }
     }
 
-    val addonProvider by lazy {
-        AddonCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
+    val sessionUseCases by lazy { SessionUseCases(sessionManager) }
+
+    // Addons
+    val addonManager by lazy {
+        AddonManager(store, addonCollectionProvider)
     }
 
-    val sessionUseCases by lazy { SessionUseCases(sessionManager) }
+    val addonCollectionProvider by lazy {
+        AddonCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
+    }
 
     // Search
     val searchEngineManager by lazy {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonSettingsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonSettingsActivity.kt
@@ -73,9 +73,7 @@ class AddonSettingsActivity : AppCompatActivity() {
             super.onViewCreated(view, savedInstanceState)
 
             addonSettingsEngineView.render(engineSession)
-
-            // update the url after add_on and web_extension link
-            engineSession.loadUrl(addon.siteUrl)
+            engineSession.loadUrl(addon.installedState!!.optionsPageUrl)
         }
 
         override fun onDestroyView() {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
@@ -28,9 +28,7 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
     private fun bind(addon: Addon) {
         title = addon.translatableName.translate()
 
-        bindEnableSwitch(addon.enabled)
-
-        bindSettings(addon)
+        bindEnableSwitch(addon)
 
         bindSettings(addon)
 
@@ -44,18 +42,20 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
         versionView.text = addon.version
     }
 
-    private fun bindEnableSwitch(enabled: Boolean) {
+    private fun bindEnableSwitch(addon: Addon) {
         val switch = findViewById<Switch>(R.id.enable_switch)
-        switch.setState(enabled)
+        switch.setState(addon.isEnabled())
         switch.setOnCheckedChangeListener { _, isChecked ->
             switch.setState(isChecked)
         }
     }
 
-    private fun bindSettings(addon: Addon) {
-        findViewById<View>(R.id.settings).setOnClickListener {
+    private fun bindSettings(addOn: Addon) {
+        val view = findViewById<View>(R.id.settings)
+        view.isEnabled = addOn.installedState?.optionsPageUrl != null
+        view.setOnClickListener {
             val intent = Intent(this, AddonSettingsActivity::class.java)
-            intent.putExtra("add_on", addon)
+            intent.putExtra("add_on", addOn)
             this.startActivity(intent)
         }
     }

--- a/samples/browser/src/main/res/drawable/addon_textview_selector.xml
+++ b/samples/browser/src/main/res/drawable/addon_textview_selector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:color="@android:color/black" />
+    <item android:state_checked="false" android:color="@color/photonGrey40" />
+</selector>

--- a/samples/browser/src/main/res/layout/activity_installed_add_on_details.xml
+++ b/samples/browser/src/main/res/layout/activity_installed_add_on_details.xml
@@ -37,7 +37,7 @@
                 android:drawablePadding="10dp"
                 android:padding="16dp"
                 android:text="@string/add_on_settings"
-                android:textColor="@android:color/black"
+                android:textColor="@drawable/addon_textview_selector"
                 android:textSize="18sp"
                 app:drawableStartCompat="@drawable/mozac_ic_preferences"
                 app:drawableTint="@android:color/black" />
@@ -51,7 +51,7 @@
                 android:drawablePadding="6dp"
                 android:padding="16dp"
                 android:text="@string/add_on_details"
-                android:textColor="@android:color/black"
+                android:textColor="@drawable/addon_textview_selector"
                 android:textSize="18sp"
                 app:drawableStartCompat="@drawable/mozac_ic_information"
                 app:drawableTint="@android:color/black" />
@@ -65,7 +65,7 @@
                 android:drawablePadding="6dp"
                 android:padding="16dp"
                 android:text="@string/add_on_permissions"
-                android:textColor="@android:color/black"
+                android:textColor="@drawable/addon_textview_selector"
                 android:textSize="18sp"
                 app:drawableStartCompat="@drawable/mozac_ic_permissions" />
 


### PR DESCRIPTION
We don't have the actual `engine.listInstalledExtensions` yet but this brings in functionality to query installed extensions via the engine and allows us to add the installed extension state to the addons. 

This state will ultimately capture more extension metadata (enabled/blocked etc.), but for now it is just the installed version and the `optionsPageUrl`, which I used here for our settings page. I've also moved our `enabled` state to this new installed extension state.

The UI will use the new `AddonManager` to query `Addons` which will make sure they have this new state set. Instead of returning an `emptyList` when something goes wrong, we now wrap all exceptions and throw them. We need to be able to distinguish between "there are no addons" and "there was a problem fetching them".   