### PR TITLE
Issue #4500: Add action / state to enable and disable extension

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -271,6 +271,12 @@ sealed class WebExtensionAction : BrowserAction() {
     data class InstallWebExtensionAction(val extension: WebExtensionState) : WebExtensionAction()
 
     /**
+     * Updates the [WebExtensionState.enabled] flag.
+     */
+    data class UpdateWebExtensionEnabledAction(val extensionId: String, val enabled: Boolean) :
+        WebExtensionAction()
+
+    /**
      * Updates a browser action of a given [extensionId].
      */
     data class UpdateBrowserAction(

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/WebExtensionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/WebExtensionState.kt
@@ -12,6 +12,7 @@ typealias WebExtensionBrowserAction = mozilla.components.concept.engine.webexten
  * @property id The unique identifier for this web extension.
  * @property url The url pointing to a resources path for locating the extension
  * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ * @property enabled Whether or not this web extension is enabled, defaults to true.
  * @property browserAction A list browser action that this web extension has.
  * @property browserActionPopupSession The ID of the session displaying
  * the browser action popup.
@@ -19,6 +20,7 @@ typealias WebExtensionBrowserAction = mozilla.components.concept.engine.webexten
 data class WebExtensionState(
     val id: String,
     val url: String? = null,
+    val enabled: Boolean = true,
     val browserAction: WebExtensionBrowserAction? = null,
     val browserActionPopupSession: String? = null
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
@@ -43,20 +43,19 @@ class WebExtensionActionTest {
     fun `UpdateGlobalBrowserAction - Updates a browser action of an existing WebExtensionState on the BrowserState`() {
         val store = BrowserStore()
         val mockedBrowserAction = mock<WebExtensionBrowserAction>()
+        val mockedBrowserAction2 = mock<WebExtensionBrowserAction>()
 
         assertTrue(store.state.extensions.isEmpty())
+        store.dispatch(WebExtensionAction.UpdateBrowserAction("id", mockedBrowserAction)).joinBlocking()
+        assertEquals(mockedBrowserAction, store.state.extensions.values.first().browserAction)
 
         val extension = WebExtensionState("id", "url")
         store.dispatch(WebExtensionAction.InstallWebExtensionAction(extension)).joinBlocking()
-
         assertFalse(store.state.extensions.isEmpty())
-
-        assertEquals(extension, store.state.extensions.values.first())
-
-        store.dispatch(WebExtensionAction.UpdateBrowserAction("id", mockedBrowserAction))
-            .joinBlocking()
-
         assertEquals(mockedBrowserAction, store.state.extensions.values.first().browserAction)
+
+        store.dispatch(WebExtensionAction.UpdateBrowserAction("id", mockedBrowserAction2)).joinBlocking()
+        assertEquals(mockedBrowserAction2, store.state.extensions.values.first().browserAction)
     }
 
     @Test
@@ -97,6 +96,7 @@ class WebExtensionActionTest {
                 "extensionId" to WebExtensionState(
                     "extensionId",
                     "url",
+                    true,
                     mockedBrowserAction1
                 )
             )
@@ -132,5 +132,20 @@ class WebExtensionActionTest {
 
         store.dispatch(WebExtensionAction.UpdateBrowserActionPopupSession(extension.id, "popupId")).joinBlocking()
         assertEquals("popupId", store.state.extensions[extension.id]?.browserActionPopupSession)
+    }
+
+    @Test
+    fun `UpdateWebExtensionEnabledAction - Updates enabled state of an existing web extension`() {
+        val store = BrowserStore()
+        val extension = WebExtensionState("id", "url")
+
+        store.dispatch(WebExtensionAction.InstallWebExtensionAction(extension)).joinBlocking()
+        assertTrue(store.state.extensions[extension.id]?.enabled!!)
+
+        store.dispatch(WebExtensionAction.UpdateWebExtensionEnabledAction(extension.id, false)).joinBlocking()
+        assertFalse(store.state.extensions[extension.id]?.enabled!!)
+
+        store.dispatch(WebExtensionAction.UpdateWebExtensionEnabledAction(extension.id, true)).joinBlocking()
+        assertTrue(store.state.extensions[extension.id]?.enabled!!)
     }
 }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
@@ -46,10 +46,10 @@ class WebExtensionToolbarFeatureTest {
             WebExtensionBrowserAction("overridden_title", false, mock(), "", 0, 0) {}
         val toolbar: Toolbar = mock()
         val extensions: Map<String, WebExtensionState> = mapOf(
-            "id" to WebExtensionState("id", "url", defaultBrowserAction)
+            "id" to WebExtensionState("id", "url", true, defaultBrowserAction)
         )
         val overriddenExtensions: Map<String, WebExtensionState> = mapOf(
-            "id" to WebExtensionState("id", "url", overriddenBrowserAction)
+            "id" to WebExtensionState("id", "url", true, overriddenBrowserAction)
         )
         val store = spy(
             BrowserStore(


### PR DESCRIPTION
Included a small refactoring to add re-usable methods for updating both the global and tab-specific web extension state.