### PR TITLE
Closes #5253: Intermittent test failure in WebExtensionSupportTest

### DIFF
--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -290,7 +290,7 @@ class WebExtensionSupportTest {
         assertNotNull(popupSessionId)
 
         // Select different tab
-        store.dispatch(TabListAction.SelectTabAction("otherTab"))
+        store.dispatch(TabListAction.SelectTabAction("otherTab")).joinBlocking()
 
         // Toggling again should select popup tab
         delegateCaptor.value.onToggleBrowserActionPopup(ext, engineSession, browserAction)


### PR DESCRIPTION
Was just missing a `joinBlocking` for the last dispatched action.