### PR TITLE
Closes #4529: Add method to wait for all dispatched actions to complete

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -268,6 +268,10 @@ projects:
     path: components/support/test
     description: 'A collection of helpers for testing components (local unit tests).'
     publish: true
+  support-test-libstate:
+    path: components/support/test-libstate
+    description: 'A collection of helpers for testing functionality that relies on the lib-state component (local unit tests).'
+    publish: true
   support-android-test:
     path: components/support/android-test
     description: 'A collection of helpers for testing components from instrumented (on device) tests.'

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ _Supporting components with generic helper code._
 
 * 🔵 [**Test Appservices**](components/support/test-appservices/README.md) - A component for synchronizing Application Services' unit testing dependencies used in Android Components.
 
+* 🔵 [**Test LibState**](components/support/test-libstate/README.md) - A collection of helpers for testing functionality that relies on the lib-state component in local unit tests (`src/test`).
+
 * 🔵 [**Utils**](components/support/utils/README.md) - Generic utility classes to be shared between projects.
 
 * 🔵 [**Webextensions**](components/support/webextensions/README.md) - A component containing building blocks for features implemented as web extensions.

--- a/components/feature/contextmenu/build.gradle
+++ b/components/feature/contextmenu/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation Dependencies.testing_mockito
 
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -11,7 +11,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -19,7 +18,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.any
-import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -374,9 +373,7 @@ class ContextMenuCandidateTest {
             HitResult.IMAGE_SRC("https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png",
                 "https://firefox.com"))
 
-        // Dispatching a random unrelated action to block on it in order to wait for all other
-        // dispatched actions to have completed.
-        store.dispatch(SystemAction.LowMemoryAction).joinBlocking()
+        store.waitUntilIdle()
 
         assertNotNull(store.state.tabs.first().content.download)
         assertEquals(

--- a/components/feature/downloads/build.gradle
+++ b/components/feature/downloads/build.gradle
@@ -47,8 +47,9 @@ dependencies {
     testImplementation Dependencies.testing_coroutines
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
-    testImplementation project(':support-test')
     testImplementation project(':concept-engine')
+    testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
-import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.content.DownloadState
@@ -26,6 +25,7 @@ import mozilla.components.feature.downloads.manager.DownloadManager
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.grantPermission
 import mozilla.components.support.test.robolectric.testContext
@@ -312,9 +312,7 @@ class DownloadsFeatureTest {
             arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE),
             arrayOf(PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED).toIntArray())
 
-        // Dispatching a random unrelated action to block on it in order to wait for all other
-        // dispatched actions to have completed.
-        store.dispatch(SystemAction.LowMemoryAction).joinBlocking()
+        store.waitUntilIdle()
 
         assertNull(store.state.findTab("test-tab")!!.content.download)
 

--- a/components/feature/prompts/build.gradle
+++ b/components/feature/prompts/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.state.action.ContentAction
-import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createCustomTab
@@ -46,6 +45,7 @@ import mozilla.components.feature.prompts.share.ShareDelegate
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.After
@@ -210,7 +210,7 @@ class PromptFeatureTest {
         assertEquals(singleChoiceRequest, tab()?.content?.promptRequest)
         feature.onCancel(tabId)
 
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
     }
 
@@ -225,7 +225,7 @@ class PromptFeatureTest {
         assertEquals(singleChoiceRequest, tab()?.content?.promptRequest)
         feature.onConfirm(tabId, mock<Choice>())
 
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
     }
 
@@ -240,7 +240,7 @@ class PromptFeatureTest {
         assertEquals(menuChoiceRequest, tab()?.content?.promptRequest)
         feature.onConfirm(tabId, mock<Choice>())
 
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
     }
 
@@ -255,7 +255,7 @@ class PromptFeatureTest {
         assertEquals(multipleChoiceRequest, tab()?.content?.promptRequest)
         feature.onConfirm(tabId, arrayOf<Choice>())
 
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
     }
 
@@ -274,13 +274,13 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onConfirm(tabId, false)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onShowNoMoreAlertsWasCalled)
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertTrue(onDismissWasCalled)
     }
 
@@ -294,7 +294,7 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertTrue(onDismissWasCalled)
         assertNull(tab()?.content?.promptRequest)
     }
@@ -318,13 +318,13 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onConfirm(tabId, false to "")
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onConfirmWasCalled)
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onDismissWasCalled)
     }
@@ -346,7 +346,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onDismissWasCalled)
     }
@@ -378,7 +378,7 @@ class PromptFeatureTest {
 
             val now = Date()
             feature.onConfirm(tabId, now)
-            processActions()
+            store.waitUntilIdle()
 
             assertNull(tab()?.content?.promptRequest)
             assertEquals(now, selectedDate)
@@ -418,7 +418,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest)).joinBlocking()
 
         feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
-        processActions()
+        store.waitUntilIdle()
         assertTrue(onSingleFileSelectionWasCalled)
         assertNull(tab()?.content?.promptRequest)
     }
@@ -450,7 +450,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest)).joinBlocking()
 
         feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_OK, intent)
-        processActions()
+        store.waitUntilIdle()
         assertTrue(onMultipleFileSelectionWasCalled)
         assertNull(tab()?.content?.promptRequest)
     }
@@ -470,7 +470,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest)).joinBlocking()
 
         feature.onActivityResult(FILE_PICKER_ACTIVITY_REQUEST_CODE, RESULT_CANCELED, intent)
-        processActions()
+        store.waitUntilIdle()
         assertTrue(onDismissWasCalled)
         assertNull(tab()?.content?.promptRequest)
     }
@@ -501,14 +501,14 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onConfirm(tabId, "" to "")
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onConfirmWasCalled)
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertTrue(onDismissWasCalled)
     }
 
@@ -536,7 +536,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onDismissWasCalled)
     }
@@ -561,14 +561,14 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onConfirm(tabId, "#f6b73c")
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onConfirmWasCalled)
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onDismissWasCalled)
     }
@@ -595,7 +595,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onConfirm(tabId, null)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onConfirmWasCalled)
     }
@@ -621,7 +621,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onCancelWasCalled)
     }
@@ -661,21 +661,21 @@ class PromptFeatureTest {
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onConfirm(tabId, true to MultiButtonDialogFragment.ButtonType.POSITIVE)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onPositiveButtonWasCalled)
 
         feature.promptAbuserDetector.resetJSAlertAbuseState()
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onConfirm(tabId, true to MultiButtonDialogFragment.ButtonType.NEGATIVE)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onNegativeButtonWasCalled)
 
         feature.promptAbuserDetector.resetJSAlertAbuseState()
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.onConfirm(tabId, true to MultiButtonDialogFragment.ButtonType.NEUTRAL)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onNeutralButtonWasCalled)
     }
@@ -709,7 +709,7 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
 
         feature.onCancel(tabId)
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onCancelWasCalled)
     }
@@ -807,7 +807,7 @@ class PromptFeatureTest {
         assertEquals(shareRequest, tab()?.content?.promptRequest)
         feature.onConfirm(tabId, null)
 
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onSuccessCalled)
     }
@@ -831,7 +831,7 @@ class PromptFeatureTest {
         assertEquals(shareRequest, tab()?.content?.promptRequest)
         feature.onCancel(tabId)
 
-        processActions()
+        store.waitUntilIdle()
         assertNull(tab()?.content?.promptRequest)
         assertTrue(onDismissCalled)
     }
@@ -842,11 +842,5 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(fragmentManager).beginTransaction()
         doReturn(transaction).`when`(transaction).remove(any())
         return fragmentManager
-    }
-
-    private fun processActions() {
-        // Dispatching a random unrelated action to block on it in order to wait for all other
-        // dispatched actions to have completed: https://github.com/mozilla-mobile/android-components/issues/4529
-        store.dispatch(SystemAction.LowMemoryAction).joinBlocking()
     }
 }

--- a/components/support/test-libstate/README.md
+++ b/components/support/test-libstate/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Support > Test
+
+A collection of helpers for testing functionality that relies on the lib-state component in local unit tests (`src/test`).
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:support-test-libstate:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/support/test-libstate/build.gradle
+++ b/components/support/test-libstate/build.gradle
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt')
+        }
+    }
+
+    lintOptions {
+        // Disabled since this caused issues with Android Gradle Plugin 3.2.1+ (NullPointerException:InvalidPackageDetector)
+        tasks.lint.enabled = false
+
+        lintConfig file("lint.xml")
+    }
+}
+
+dependencies {
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+    implementation project(':lib-state')
+
+    testImplementation Dependencies.androidx_core
+    testImplementation Dependencies.androidx_test_junit
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
+

--- a/components/support/test-libstate/src/main/AndroidManifest.xml
+++ b/components/support/test-libstate/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.support.test.libstate" />

--- a/components/support/test-libstate/src/main/java/mozilla/components/support/test/libstate/ext/Store.kt
+++ b/components/support/test-libstate/src/main/java/mozilla/components/support/test/libstate/ext/Store.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.test.libstate.ext
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import mozilla.components.lib.state.Action
+import mozilla.components.lib.state.State
+import mozilla.components.lib.state.Store
+
+/**
+ * Blocks and returns once all dispatched actions have been processed
+ * i.e. the reducers have run and all observers have been notified of
+ * state changes.
+ */
+fun <S : State, A : Action> Store<S, A>.waitUntilIdle() {
+    val scopeField = Store::class.java.getDeclaredField("scope")
+    scopeField.isAccessible = true
+    val scope = scopeField.get(this) as CoroutineScope
+    runBlocking {
+        scope.coroutineContext[Job]?.children?.forEach { it.join() }
+    }
+}

--- a/components/support/test-libstate/src/test/java/mozilla/components/support/test/libstate/ext/StoreTest.kt
+++ b/components/support/test-libstate/src/test/java/mozilla/components/support/test/libstate/ext/StoreTest.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.test.libstate.ext
+
+import mozilla.components.lib.state.Action
+import mozilla.components.lib.state.State
+import mozilla.components.lib.state.Store
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StoreTest {
+
+    @Test
+    fun `waitUntilIdle blocks and returns once reducers were executed`() {
+        val store = Store(
+            TestState(counter = 23),
+            ::reducer
+        )
+
+        store.dispatch(TestAction.IncrementAction)
+        store.waitUntilIdle()
+        assertEquals(24, store.state.counter)
+
+        store.dispatch(TestAction.DecrementAction)
+        store.dispatch(TestAction.DecrementAction)
+        store.waitUntilIdle()
+        assertEquals(22, store.state.counter)
+    }
+}
+
+fun reducer(state: TestState, action: TestAction): TestState = when (action) {
+    is TestAction.IncrementAction -> state.copy(counter = state.counter + 1)
+    is TestAction.DecrementAction -> state.copy(counter = state.counter - 1)
+}
+
+data class TestState(val counter: Int) : State
+
+sealed class TestAction : Action {
+    object IncrementAction : TestAction()
+    object DecrementAction : TestAction()
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,9 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: `SendTabFeature` no longer takes an instance of `AutoPushFeature`.
     * `FxaPushSupportFeature` is now needed for integrating Firefox Accounts with Push support.
 
+* **support-test-libstate**
+  * 🆕 New component providing utilities to test functionality that relies on lib-state.    
+
 # 25.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v24.0.0...v25.0.0)


### PR DESCRIPTION
Putting this up for discussion. It fixes #4529, but doesn't restrict to tests. 

I had a case last week where I needed this (or something like it) outside of tests as well:
- `MethodA` dispatches actions
- `MethodB` awaits `MethodA`s completion and reads state from the store directly

=> There is no guarantee that `MethodB` sees the "latest" state in the store, as we're reducing on  a separate (dedicated) thread. In other words, `MethodB` can await `MethodA`'s completion, but not its desired state. This is definitely an edge case, as usually we'd be observing the store bound to a scope, but there are use cases where a method just wants to read the latest state from the store, and then it would be nice to be able to make sure it is in fact the latest state (includes state changes of already dispatched actions).

More specifically, my use case was getting the list of installed web extensions in an async callback from the engine, then dispatching actions to the store to save the extension's state, and having another component reading that state (just once). I wanted to guarantee that this state is always up-to-date.

@pocmo wdyt?
