### PR TITLE
Fixes #5283: Keeps same fileName when appending to resumed download

### DIFF
--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -37,7 +37,9 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mock
@@ -49,6 +51,9 @@ import org.mockito.MockitoAnnotations.initMocks
 
 @RunWith(AndroidJUnit4::class)
 class AbstractFetchDownloadServiceTest {
+
+    @Rule @JvmField
+    val folder = TemporaryFolder()
 
     @Mock private lateinit var client: Client
     @Mock private lateinit var broadcastManager: LocalBroadcastManager
@@ -411,5 +416,33 @@ class AbstractFetchDownloadServiceTest {
 
         service.downloadJobs[providedDownload.value.id]?.job?.join()
         assertEquals(FAILED, service.downloadJobs[providedDownload.value.id]?.status)
+    }
+
+    @Test
+    fun `makeUniqueFileNameIfNecessary transforms fileName when appending FALSE`() {
+        folder.newFile("example.apk")
+
+        val download = DownloadState(
+            url = "mozilla.org",
+            fileName = "example.apk",
+            destinationDirectory = folder.root.path
+        )
+        val transformedDownload = service.makeUniqueFileNameIfNecessary(download, false)
+
+        assertNotEquals(download, transformedDownload)
+    }
+
+    @Test
+    fun `makeUniqueFileNameIfNecessary does NOT transform fileName when appending TRUE`() {
+        folder.newFile("example.apk")
+
+        val download = DownloadState(
+            url = "mozilla.org",
+            fileName = "example.apk",
+            destinationDirectory = folder.root.path
+        )
+        val transformedDownload = service.makeUniqueFileNameIfNecessary(download, true)
+
+        assertEquals(download, transformedDownload)
     }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
