### PR TITLE
Issue #4500: Add API for installing/uninstalling third-party extensions

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.support.base.log.logger.Logger
@@ -218,6 +219,9 @@ class GeckoWebExtension(
         val geckoSession = (session as GeckoEngineSession).geckoSession
         return geckoSession.getWebExtensionActionDelegate(nativeExtension) != null
     }
+
+    // Not yet supported
+    override fun getMetadata(): Metadata? = null
 }
 
 /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.support.base.log.logger.Logger
@@ -38,6 +39,9 @@ class GeckoWebExtension(
 ) : WebExtension(id, url, supportActions) {
 
     private val logger = Logger("GeckoWebExtension")
+
+    constructor(native: GeckoNativeWebExtension) :
+        this(native.id, native.location, true, true, native)
 
     /**
      * Uniquely identifies a port using its name and the session it
@@ -217,6 +221,26 @@ class GeckoWebExtension(
     override fun hasActionHandler(session: EngineSession): Boolean {
         val geckoSession = (session as GeckoEngineSession).geckoSession
         return geckoSession.getWebExtensionActionDelegate(nativeExtension) != null
+    }
+
+    /**
+     * See [WebExtension.getMetadata].
+     */
+    override fun getMetadata(): Metadata? {
+        return nativeExtension.metaData?.let {
+            Metadata(
+                name = it.name,
+                description = it.description,
+                developerName = it.creatorName,
+                developerUrl = it.creatorUrl,
+                homePageUrl = it.homepageUrl,
+                version = it.version,
+                permissions = it.permissions.toList(),
+                hostPermissions = it.origins.toList(),
+                optionsPageUrl = null, // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
+                openOptionsPageInTab = null // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
+            )
+        }
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/org/mozilla/geckoview/MockWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/org/mozilla/geckoview/MockWebExtension.kt
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.geckoview
+
+import org.mozilla.gecko.util.GeckoBundle
+
+class MockWebExtension(bundle: GeckoBundle) : WebExtension(bundle)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -8,6 +8,7 @@ import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtension
 import org.json.JSONObject
@@ -145,10 +146,11 @@ class GeckoWebExtension(
         }
     }
 
-    // Not yet supported in beta
+    // Not yet supported
     override fun registerActionHandler(actionHandler: ActionHandler) = Unit
     override fun registerActionHandler(session: EngineSession, actionHandler: ActionHandler) = Unit
     override fun hasActionHandler(session: EngineSession) = false
+    override fun getMetadata(): Metadata? = null
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -271,6 +271,12 @@ sealed class WebExtensionAction : BrowserAction() {
     data class InstallWebExtensionAction(val extension: WebExtensionState) : WebExtensionAction()
 
     /**
+     * Removes all state of the uninstalled extension from [BrowserState.extensions]
+     * and [TabSessionState.extensionState].
+     */
+    data class UninstallWebExtensionAction(val extensionId: String) : WebExtensionAction()
+
+    /**
      * Updates the [WebExtensionState.enabled] flag.
      */
     data class UpdateWebExtensionEnabledAction(val extensionId: String, val enabled: Boolean) :

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
@@ -26,6 +26,12 @@ internal object WebExtensionReducer {
                     state
                 }
             }
+            is WebExtensionAction.UninstallWebExtensionAction -> {
+                state.copy(
+                    extensions = state.extensions - action.extensionId,
+                    tabs = state.tabs.map { it.copy(extensionState = it.extensionState - action.extensionId) }
+                )
+            }
             is WebExtensionAction.UpdateWebExtensionEnabledAction -> {
                 state.updateWebExtensionState(action.extensionId) {
                     it.copy(enabled = action.enabled)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -116,8 +116,10 @@ interface Engine {
      * Installs the provided extension in this engine.
      *
      * @param id the unique ID of the extension.
-     * @param url the url pointing to a resources path for locating the extension
-     * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+     * @param url the url pointing to either a resources path for locating the extension
+     * within the APK file (e.g. resource://android/assets/extensions/my_web_ext) or to a
+     * local (e.g. resource://android/assets/extensions/my_web_ext.xpi) or remote
+     * (e.g. https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi) XPI file.
      * @param allowContentMessaging whether or not the web extension is allowed
      * to send messages from content scripts, defaults to true.
      * @param supportActions whether or not browser and page actions are handled when
@@ -137,6 +139,21 @@ interface Engine {
         onSuccess: ((WebExtension) -> Unit) = { },
         onError: ((String, Throwable) -> Unit) = { _, _ -> }
     ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
+     * Uninstalls the provided extension from this engine.
+     *
+     * @param ext the [WebExtension] to uninstall.
+     * @param onSuccess (optional) callback invoked if the extension was uninstalled successfully.
+     * @param onError (optional) callback invoked if there was an error uninstalling the extension.
+     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
+     * have web extension support.
+     */
+    fun uninstallWebExtension(
+        ext: WebExtension,
+        onSuccess: (() -> Unit) = { },
+        onError: ((String, Throwable) -> Unit) = { _, _ -> }
+    ): Unit = onError(ext.id, UnsupportedOperationException("Web extension support is not available in this engine"))
 
     /**
      * Lists the currently installed web extensions in this engine.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.engine.webextension
 
+import android.net.Uri
 import mozilla.components.concept.engine.EngineSession
 import org.json.JSONObject
 
@@ -112,6 +113,20 @@ abstract class WebExtension(
      * @return true if an action handler is registered, otherwise false.
      */
     abstract fun hasActionHandler(session: EngineSession): Boolean
+
+    /**
+     * Returns additional information about this extension.
+     *
+     * @return extension [Metadata], or null if the extension isn't
+     * installed and there is no meta data available.
+     */
+    abstract fun getMetadata(): Metadata?
+
+    /**
+     * Checks whether or not this extension is built-in (packaged with the
+     * APK file) or coming from an external source.
+     */
+    fun isBuiltIn(): Boolean = Uri.parse(url).scheme == "resource"
 }
 
 /**
@@ -217,3 +232,68 @@ abstract class Port(val engineSession: EngineSession? = null) {
      */
     abstract fun disconnect()
 }
+
+/**
+ * Provides information about a [WebExtension].
+ */
+data class Metadata(
+    /**
+     * Version string:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version
+     */
+    val version: String,
+
+    /**
+     * Required extension permissions:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#API_permissions
+     */
+    val permissions: List<String>,
+
+    /**
+     * Required host permissions:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions
+     */
+    val hostPermissions: List<String>,
+
+    /**
+     * Name of the extension:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name
+     */
+    val name: String?,
+
+    /**
+     * Description of the extension:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description
+     */
+    val description: String?,
+
+    /**
+     * Name of the extension developer:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer
+     */
+    val developerName: String?,
+
+    /**
+     * Url of the developer:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer
+     */
+    val developerUrl: String?,
+
+    /**
+     * Url of extension's homepage:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url
+     */
+    val homePageUrl: String?,
+
+    /**
+     * Options page:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui
+     */
+    val optionsPageUrl: String?,
+
+    /**
+     * Whether or not the options page should be opened in a new tab:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui#syntax
+     */
+    val openOptionsPageInTab: Boolean?
+)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -21,6 +21,13 @@ interface WebExtensionDelegate {
     fun onInstalled(webExtension: WebExtension) = Unit
 
     /**
+     * Invoked when a web extension was uninstalled successfully.
+     *
+     * @param webExtension The uninstalled extension.
+     */
+    fun onUninstalled(webExtension: WebExtension) = Unit
+
+    /**
      * Invoked when a web extension attempts to open a new tab via
      * browser.tabs.create.
      *
@@ -65,4 +72,14 @@ interface WebExtensionDelegate {
         engineSession: EngineSession,
         action: BrowserAction
     ): EngineSession? = null
+
+    /**
+     * Invoked during installation of a [WebExtension] to confirm the required permissions.
+     *
+     * @param webExtension the extension being installed. The required permissions can be
+     * accessed using [WebExtension.getMetadata] and [Metadata.permissions].
+     * @return whether or not installation should process i.e. the permissions have been
+     * granted.
+     */
+    fun onInstallPermissionRequest(webExtension: WebExtension): Boolean = false
 }


### PR DESCRIPTION
This brings in the engine/store APIs to install third-party extensions, as well as uninstall (for both built-in and external extensions). I prefer having a single `installWebExtension` method (as opposed to separate ones for built-in and external extensions), because it keeps install/uninstall symmetric and the API surface smaller. We can revisit that later though once the new `installBuiltIn` lands in GV.

I am going to add the `AddonManager` and sample-browser bits in a separate PR. 