### PR TITLE
For #5296 Improve a11y for error pages

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -36,6 +36,7 @@ object ErrorPages {
             .replace("%button%", context.getString(errorType.refreshButtonRes))
             .replace("%messageShort%", context.getString(errorType.titleRes))
             .replace("%messageLong%", context.getString(errorType.messageRes, uri))
+            .replace("<ul>", "<ul role=\"presentation\">")
             .replace("%css%", css)
     }
 }

--- a/components/browser/errorpages/src/main/res/raw/error_pages.html
+++ b/components/browser/errorpages/src/main/res/raw/error_pages.html
@@ -5,8 +5,8 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <html xmlns="http://www.w3.org/1999/xhtml">
-    <meta charset="UTF-8">
     <head>
+        <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width; user-scalable=false;" />
         <title>%pageTitle%</title>
         <style>%css%</style>
@@ -26,7 +26,7 @@
 
                 <!-- Short Description -->
                 <div id="errorShortDesc">
-                    <p id="errorShortDescText">%messageLong%</p>
+                   %messageLong%
                 </div>
 
             </div>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,7 +34,10 @@ permalink: /changelog/
     * `FxaPushSupportFeature` is now needed for integrating Firefox Accounts with Push support.
 
 * **support-test-libstate**
-  * 🆕 New component providing utilities to test functionality that relies on lib-state.    
+  * 🆕 New component providing utilities to test functionality that relies on lib-state.
+  
+* **browser-errorpages**
+  * Removed list items semantics to improve a11y for unordered lists, preventing items being read twice.
 
 # 25.0.0
 


### PR DESCRIPTION
Use role="presentation" for `<ul>` to remove `<li>` semantics for screen reader.
Remove `<p>` from errorShortDesc because paragraphs cannot contain lists.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
