### PR TITLE
Replace underscores with dashes in the sync pings

### DIFF
--- a/components/support/sync-telemetry/docs/metrics.md
+++ b/components/support/sync-telemetry/docs/metrics.md
@@ -4,15 +4,14 @@
 This document enumerates the metrics collected by this project.
 This project may depend on other projects which also collect metrics.
 This means you might have to go searching through the dependency tree to get a full picture of everything collected by this project.
-Sorry about that.
 
 # Pings
 
- - [bookmarks_sync](#bookmarks_sync)
- - [history_sync](#history_sync)
+ - [bookmarks-sync](#bookmarks-sync)
+ - [history-sync](#history-sync)
 
 
-## bookmarks_sync
+## bookmarks-sync
 A ping sent for every bookmarks sync. It doesn't include the `client_id` because it reports a hashed version of the user's Firefox Account ID.
 
 The following metrics are added to the ping:
@@ -28,7 +27,7 @@ The following metrics are added to the ping:
 | bookmarks_sync.started_at |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |Records when the bookmark sync started.  |[1](https://github.com/mozilla-mobile/android-components/pull/3092)||never |
 | bookmarks_sync.uid |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The user's hashed Firefox Account ID.  |[1](https://github.com/mozilla-mobile/android-components/pull/3092)||never |
 
-## history_sync
+## history-sync
 A ping sent for every history sync. It doesn't include the `client_id` because it reports a hashed version of the user's Firefox Account ID.
 
 The following metrics are added to the ping:

--- a/components/support/sync-telemetry/metrics.yaml
+++ b/components/support/sync-telemetry/metrics.yaml
@@ -14,7 +14,7 @@ history_sync:
     description: >
       The user's hashed Firefox Account ID.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -29,7 +29,7 @@ history_sync:
     description: >
       Records when the history sync started.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -45,7 +45,7 @@ history_sync:
       Records when the history sync finished. This includes the time to
       download, apply, and upload all records.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -67,7 +67,7 @@ history_sync:
       ignored due to errors. `reconciled` is the number of pages with new visits
       locally and remotely, and had their visits merged.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -87,7 +87,7 @@ history_sync:
       is the number of records that weren't uploaded, and will be retried
       on the next sync.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -104,7 +104,7 @@ history_sync:
       bytes) on the number of records that can fit into a single batch, and
       large syncs may require multiple batches.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -124,7 +124,7 @@ history_sync:
       error, unexpected exception, or other error. The error strings are
       truncated and sanitized to omit PII, like URLs and file system paths.
     send_in_pings:
-    - history_sync
+    - history-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -140,7 +140,7 @@ bookmarks_sync:
     description: >
       The user's hashed Firefox Account ID.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -155,7 +155,7 @@ bookmarks_sync:
     description: >
       Records when the bookmark sync started.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -170,7 +170,7 @@ bookmarks_sync:
     description: >
       Records when the bookmark sync finished.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -188,7 +188,7 @@ bookmarks_sync:
     description: >
       Records incoming bookmark record counts.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -205,7 +205,7 @@ bookmarks_sync:
     description: >
       Records outgoing bookmark record counts.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -219,7 +219,7 @@ bookmarks_sync:
     description: >
       Records the number of batches needed to upload all outgoing records.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -237,7 +237,7 @@ bookmarks_sync:
     description: >
       Records bookmark sync failure reasons.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:
@@ -261,7 +261,7 @@ bookmarks_sync:
       bookmarks tree. These are documented in
       https://github.com/mozilla/dogear/blob/fbade15f2a4f11215e30b8f428a0a8df3defeaec/src/tree.rs#L1273-L1294.
     send_in_pings:
-    - bookmarks_sync
+    - bookmarks-sync
     bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
     data_reviews:

--- a/components/support/sync-telemetry/pings.yaml
+++ b/components/support/sync-telemetry/pings.yaml
@@ -4,7 +4,7 @@
 
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 
-history_sync:
+history-sync:
   description: >
     A ping sent for every history sync. It doesn't include the `client_id`
     because it reports a hashed version of the user's Firefox Account ID.
@@ -15,7 +15,7 @@ history_sync:
   - sync-core@mozilla.com
   data_reviews:
   - https://github.com/mozilla-mobile/android-components/pull/3092
-bookmarks_sync:
+bookmarks-sync:
   description: >
     A ping sent for every bookmarks sync. It doesn't include the `client_id`
     because it reports a hashed version of the user's Firefox Account ID.


### PR DESCRIPTION
**Note**: Please wait with merging this until I verified that the pipeline properly handles this and puts them in the right table.