### PR TITLE
Issue #4872: Add lib-state based store for observing migration state.

### DIFF
--- a/components/support/migration/build.gradle
+++ b/components/support/migration/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':service-sync-logins')
 
     implementation project(':lib-crash')
+    implementation project(':lib-state')
 
     implementation project(':support-ktx')
 

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationAction.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationAction.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration.state
+
+import mozilla.components.lib.state.Action
+import mozilla.components.support.migration.MigrationResults
+
+/**
+ * Actions supported by the [MigrationStore].
+ */
+sealed class MigrationAction : Action {
+    /**
+     * A migration is needed and has been started.
+     */
+    object Started : MigrationAction()
+
+    /**
+     * A migration was completed.
+     */
+    object Completed : MigrationAction()
+
+    /**
+     * Clear (or reset) the migration state.
+     */
+    object Clear : MigrationAction()
+
+    /**
+     * Set the [MigrationResults] of a completed migration.
+     */
+    data class Result(val results: MigrationResults) : MigrationAction()
+}

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationReducer.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationReducer.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration.state
+
+internal object MigrationReducer {
+    internal fun reduce(state: MigrationState, action: MigrationAction): MigrationState {
+        return when (action) {
+            is MigrationAction.Started -> state.copy(
+                progress = MigrationProgress.MIGRATING
+            )
+            is MigrationAction.Completed -> state.copy(
+                progress = MigrationProgress.COMPLETED
+            )
+            is MigrationAction.Clear -> state.copy(
+                progress = MigrationProgress.NONE
+            )
+            is MigrationAction.Result -> state.copy(
+                results = action.results
+            )
+        }
+    }
+}

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationState.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationState.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration.state
+
+import mozilla.components.lib.state.State
+import mozilla.components.support.migration.MigrationResults
+
+/**
+ * Value type that represents the state of the migration.
+ */
+data class MigrationState(
+    val progress: MigrationProgress = MigrationProgress.NONE,
+    val results: MigrationResults? = null
+) : State
+
+/**
+ * The progress of the migration.
+ */
+enum class MigrationProgress {
+    /**
+     * No migration is happening.
+     */
+    NONE,
+
+    /**
+     * Migration is in progress.
+     */
+    MIGRATING,
+
+    /**
+     * Migration has completed.
+     */
+    COMPLETED
+}

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationStore.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/state/MigrationStore.kt
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration.state
+
+import mozilla.components.lib.state.Store
+
+/**
+ * [Store] keeping track of the current [MigrationState].
+ */
+class MigrationStore : Store<MigrationState, MigrationAction>(
+    MigrationState(),
+    MigrationReducer::reduce
+)


### PR DESCRIPTION
Introducing a `MigrationStore` to observe the state of the migration. With that we can start build the migration UI in Fenix. I expect us to extend the state once we have more requirements.