### PR TITLE
Closes #4240 - Clear the selection on back press

### DIFF
--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -89,6 +89,17 @@ class GeckoEngineViewTest {
     }
 
     @Test
+    fun `clearSelection is forwarded to BasicSelectionAction instance`() {
+        val engineView = GeckoEngineView(context)
+        engineView.currentGeckoView = mock()
+        engineView.currentSelection = mock()
+
+        engineView.clearSelection()
+
+        verify(engineView.currentSelection)?.clearSelection()
+    }
+
+    @Test
     fun `setVerticalClipping is forwarded to GeckoView instance`() {
         val engineView = GeckoEngineView(context)
         engineView.currentGeckoView = mock()

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -677,6 +677,10 @@ class SystemEngineView @JvmOverloads constructor(
         }
     }
 
+    override fun clearSelection() {
+        // no-op
+    }
+
     private fun createThumbnailUsingDrawingView(view: View, onFinish: (Bitmap?) -> Unit) {
         val outBitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(outBitmap)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -71,6 +71,12 @@ interface EngineView {
     fun onDestroy() = Unit
 
     /**
+     * Check if [EngineView] can clear the selection.
+     * true if can and false otherwise.
+     */
+    fun canClearSelection(): Boolean = false
+
+    /**
      * Check if [EngineView] can be scrolled vertically up.
      * true if can and false otherwise.
      */
@@ -87,6 +93,11 @@ interface EngineView {
      * @param onFinish A callback to inform that process of capturing a thumbnail has finished.
      */
     fun captureThumbnail(onFinish: (Bitmap?) -> Unit)
+
+    /**
+     * Clears the current selection if possible.
+     */
+    fun clearSelection() = Unit
 
     /**
      * Updates the amount of vertical space that is clipped or visibly obscured in the bottom portion of the view.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -15,7 +15,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 class SessionFeature(
     private val sessionManager: SessionManager,
     private val goBackUseCase: SessionUseCases.GoBackUseCase,
-    engineView: EngineView,
+    private val engineView: EngineView,
     private val sessionId: String? = null
 ) : LifecycleAwareFeature, UserInteractionHandler {
     internal val presenter = EngineViewPresenter(sessionManager, engineView, sessionId)
@@ -47,7 +47,10 @@ class SessionFeature(
             sessionManager.findSessionById(it)
         } ?: sessionManager.selectedSession
 
-        if (session?.canGoBack == true) {
+        if (engineView.canClearSelection()) {
+            engineView.clearSelection()
+            return true
+        } else if (session?.canGoBack == true) {
             goBackUseCase(session)
             return true
         }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -70,6 +70,25 @@ class SessionFeatureTest {
     }
 
     @Test
+    fun `handleBackPressed clears selection when a selection is found`() {
+        val session = Session("https://www.mozilla.org")
+        whenever(sessionManager.selectedSession).thenReturn(session)
+        whenever(sessionManager.selectedSessionOrThrow).thenReturn(session)
+
+        val engineSession = mock<EngineSession>()
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        val feature = SessionFeature(sessionManager, sessionUseCases, engineView)
+
+        whenever(engineView.canClearSelection()).thenReturn(true)
+
+        val result = feature.onBackPressed()
+
+        verify(engineView).clearSelection()
+        assertTrue(result)
+    }
+
+    @Test
     fun `handleBackPressed does nothing when sessionId provided but no session found`() {
         val engineSession = mock<EngineSession>()
         val sessionId = "123"

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
@@ -96,6 +96,7 @@ class SwipeRefreshFeatureTest {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
+        override fun clearSelection() {}
         override fun render(session: EngineSession) {}
         override fun release() {}
     }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -61,6 +61,8 @@ class FakeEngineView(context: Context) : TextView(context), EngineView {
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {}
 
+    override fun clearSelection() {}
+
     override fun setVerticalClipping(clippingHeight: Int) {}
 
     override fun setDynamicToolbarMaxHeight(height: Int) {}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
     * `browser-engine-gecko-beta`: GeckoView 72.0
     * `browser-engine-gecko-nightly`: GeckoView 73.0
 
+* **browser-engine-system** and **browser-engine-gecko-nightly**
+  * Added `EngineView.canClearSelection()` and `EngineView.clearSelection()` for clearing the selection.
+
 * **feature-accounts**
   * ⚠️ **This is a breaking change**: Migrated `FxaPushSupportFeature` to the `feature-accounts-push` component.
 


### PR DESCRIPTION
- Adds a reference to the current session's BasicSelectionActionDelegate in GeckoEngineView


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This fixes #4240.

I didn't have much luck initializing `BasicSelectionActionDelegate` with the `context as Activity` of the `GeckoEngineView`. In this instance, the `Selection` was null. 

Digging deeper into the internals of `GeckoView`, I found that it initializes `BasicSelectionActionDelegate` (https://searchfox.org/mozilla-central/source/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoView.java#254) and is set when `GeckoView.setSession()` is called (https://searchfox.org/mozilla-central/source/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoView.java#471-473). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
