### PR TITLE
Closes #4757: Add special-use domains to the list of top level domains

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
@@ -192,6 +192,11 @@ class WebURLFinder {
                         "|(?:yachts|yamaxun|yandex|yodobashi|yoga|yokohama|youtube|y[et])" +
                         "|(?:zara|zip|zone|zuerich|z[amw]))")
 
+        /**
+         * Reserved top level DNS Names for special use (defined in RFC 6761 and 6762)
+         */
+        private const val SPECIAL_DOMAINS = "(?:local|test|example|invalid|localhost)"
+
         private const val IP_ADDRESS = (
                 "((25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9])\\.(25[0-5]|2[0-4]" +
                         "[0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(25[0-5]|2[0-4][0-9]|[0-1]" +
@@ -245,7 +250,7 @@ class WebURLFinder {
         /**
          * Regular expression that matches known TLDs and punycode TLDs
          */
-        private const val STRICT_TLD = "(?:$IANA_TOP_LEVEL_DOMAINS|$PUNYCODE_TLD)"
+        private const val STRICT_TLD = "(?:$IANA_TOP_LEVEL_DOMAINS|$SPECIAL_DOMAINS|$PUNYCODE_TLD)"
 
         /**
          * RFC 1035 Section 2.3.4 limits the labels to a maximum 63 octets.

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
@@ -44,6 +44,8 @@ class URLStringUtilsTest {
         assertTrue(isURLLike("https://mozilla-mobile.com"))
 
         assertTrue(isURLLike("link.info"))
+        assertTrue(isURLLike("link.local"))
+        assertTrue(isURLLike("link.xn--e1a4c"))
         assertFalse(isURLLike("link.unknown"))
 
         assertFalse(isURLLike("mozilla"))


### PR DESCRIPTION
This change adds special-use domain names to the list of top level domains. So that for example "intranet.local" would be considered as valid domain name and it could be used in fenix (Firefox Preview) without any problems described in original issue #4757 


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
