### PR TITLE
No issue: Adds button padding to downloads prompt

### DIFF
--- a/components/feature/downloads/src/main/res/layout/mozac_downloads_prompt.xml
+++ b/components/feature/downloads/src/main/res/layout/mozac_downloads_prompt.xml
@@ -1,84 +1,89 @@
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:ignore="Overdraw"
     android:background="?android:windowBackground"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:ignore="Overdraw">
 
     <ImageView
         android:id="@+id/icon"
         android:layout_width="32dp"
         android:layout_height="32dp"
+        android:layout_alignParentTop="true"
         android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:importantForAccessibility="no"
         android:scaleType="center"
         android:src="@drawable/mozac_feature_download_ic_download"
-        android:importantForAccessibility="no"
-        android:layout_alignParentTop="true"
-        android:layout_marginTop="16dp"
-        android:tint="?android:attr/textColorPrimary"/>
+        android:tint="?android:attr/textColorPrimary" />
 
     <TextView
         android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="11dp"
-        android:layout_marginStart="3dp"
-        tools:textColor="#000000"
-        android:textColor="?android:attr/textColorPrimary"
-        android:paddingTop="4dp"
-        android:paddingStart="5dp"
-        android:paddingEnd="5dp"
-        android:layout_alignParentTop="true"
-        android:layout_marginTop="16dp"
-        android:layout_toEndOf="@id/icon"
-        android:layout_toStartOf="@id/close_button"
         android:layout_alignBaseline="@id/icon"
-        tools:text="Download (85.7 MB)"/>
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="3dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="11dp"
+        android:layout_toStartOf="@id/close_button"
+        android:layout_toEndOf="@id/icon"
+        android:paddingStart="5dp"
+        android:paddingTop="4dp"
+        android:paddingEnd="5dp"
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="Download (85.7 MB)"
+        tools:textColor="#000000" />
 
     <ImageButton
         android:id="@+id/close_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="12dp"
-        android:layout_marginStart="3dp"
-        tools:textColor="#000000"
-        android:contentDescription="@string/mozac_feature_downloads_button_close"
-        android:background="@null"
-        android:tint="?android:attr/textColorPrimary"
-        android:src="@drawable/mozac_ic_close"
+        android:layout_alignBaseline="@id/icon"
         android:layout_alignParentTop="true"
-        android:layout_marginTop="16dp"
         android:layout_alignParentEnd="true"
-        android:layout_alignBaseline="@id/icon"/>
+        android:layout_marginStart="3dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="12dp"
+        android:background="@null"
+        android:contentDescription="@string/mozac_feature_downloads_button_close"
+        android:src="@drawable/mozac_ic_close"
+        android:tint="?android:attr/textColorPrimary"
+        tools:textColor="#000000" />
 
     <TextView
         android:id="@+id/filename"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="3dp"
-        tools:textColor="#000000"
-        android:textColor="?android:attr/textColorPrimary"
-        android:paddingTop="4dp"
-        android:paddingStart="5dp"
-        android:paddingEnd="5dp"
         android:layout_below="@id/title"
+        android:layout_alignBaseline="@id/icon"
+        android:layout_marginStart="3dp"
         android:layout_marginTop="16dp"
         android:layout_toEndOf="@id/icon"
-        android:layout_alignBaseline="@id/icon"
-        tools:text="Firefox_Preview_v2.1.apk"/>
+        android:paddingStart="5dp"
+        android:paddingTop="4dp"
+        android:paddingEnd="5dp"
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="Firefox_Preview_v2.1.apk"
+        tools:textColor="#000000" />
 
     <Button
         android:id="@+id/download_button"
-        android:layout_alignParentEnd="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_below="@id/filename"
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:layout_marginStart="8dp"
-        android:textAllCaps="false"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/mozac_feature_downloads_dialog_download"/>
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="@string/mozac_feature_downloads_dialog_download"
+        android:textAllCaps="false" />
 </RelativeLayout>


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Only change is adding `8dp` padding to the download_button
Also reformats and adds license to layout file 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
