### PR TITLE
Closes #5329: FennecMigrator: Use startForegroundService().

### DIFF
--- a/components/support/migration/src/main/AndroidManifest.xml
+++ b/components/support/migration/src/main/AndroidManifest.xml
@@ -2,4 +2,8 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="mozilla.components.support.migration" />
+    package="mozilla.components.support.migration">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+</manifest>

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
@@ -7,6 +7,7 @@ package mozilla.components.support.migration
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -375,7 +376,7 @@ class FennecMigrator private constructor(
     fun <T> startMigrationServiceIfNeeded(service: Class<T>) where T : AbstractMigrationService {
         if (hasMigrationsToRun()) {
             logger.debug("Has migrations to run. Starting service.")
-            context.startService(Intent(context, service))
+            ContextCompat.startForegroundService(context, Intent(context, service))
         } else {
             logger.debug("No migrations to run. Not starting service.")
         }


### PR DESCRIPTION
Whenever the app is in the background while we start a migration - for example when using a widget or some other background action triggers an Application object being created - then we try to launch the migration service and we see a crash since that is not allowed. Since we are using a foreground service anyways we can just use `startForegroundService()` here.