### PR TITLE
Regenerate metrics.md. (Sorry, not sorry)

### DIFF
--- a/components/browser/engine-gecko/docs/metrics.md
+++ b/components/browser/engine-gecko/docs/metrics.md
@@ -4,7 +4,6 @@
 This document enumerates the metrics collected by this project.
 This project may depend on other projects which also collect metrics.
 This means you might have to go searching through the dependency tree to get a full picture of everything collected by this project.
-Sorry about that.
 
 # Pings
 

--- a/components/lib/crash/docs/metrics.md
+++ b/components/lib/crash/docs/metrics.md
@@ -4,7 +4,6 @@
 This document enumerates the metrics collected by this project.
 This project may depend on other projects which also collect metrics.
 This means you might have to go searching through the dependency tree to get a full picture of everything collected by this project.
-Sorry about that.
 
 # Pings
 


### PR DESCRIPTION
The Glean plugin changed how `metrics.md` files are generated and so we should push the new version to avoid it updating all the time locally.