### PR TITLE
Closes #5112: Allow App to Specify Behavior when App Intent Failed to Launch.

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -38,7 +38,8 @@ class AppLinksFeature(
     private val fragmentManager: FragmentManager? = null,
     private val dialog: RedirectDialogFragment = SimpleRedirectDialogFragment.newInstance(),
     private val launchInApp: () -> Boolean = { false },
-    private val useCases: AppLinksUseCases = AppLinksUseCases(context, launchInApp)
+    private val useCases: AppLinksUseCases = AppLinksUseCases(context, launchInApp),
+    private val failedToLaunchAction: () -> Unit = {}
 ) : LifecycleAwareFeature {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -53,7 +54,7 @@ class AppLinksFeature(
             }
 
             val doOpenApp = {
-                useCases.openAppLink(appIntent)
+                useCases.openAppLink(appIntent, failedToLaunchAction)
             }
 
             if (!session.private || fragmentManager == null) {

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -38,6 +38,7 @@ private const val MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id="
 class AppLinksUseCases(
     private val context: Context,
     private val launchInApp: () -> Boolean = { false },
+    private val failedToLunch: () -> Unit = { },
     browserPackageNames: Set<String>? = null,
     unguessableWebUrl: String = "https://${UUID.randomUUID()}.net"
 ) {
@@ -173,11 +174,12 @@ class AppLinksUseCases(
     class OpenAppLinkRedirect internal constructor(
         private val context: Context
     ) {
-        operator fun invoke(appIntent: Intent?) {
+        operator fun invoke(appIntent: Intent?, failedToLaunchAction: () -> Unit = {}) {
             appIntent?.let {
                 try {
                     context.startActivity(it)
                 } catch (e: ActivityNotFoundException) {
+                    failedToLaunchAction()
                     Logger.error("failed to start third party app activity", e)
                 }
             }

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -141,7 +141,7 @@ class AppLinksFeatureTest {
         userTapsOnSession(intentUrl, false)
 
         verifyNoMoreInteractions(mockDialog)
-        verify(mockOpenRedirect).invoke(any())
+        verify(mockOpenRedirect).invoke(any(), any())
     }
 
     @Test

--- a/config/detekt-baseline.xml
+++ b/config/detekt-baseline.xml
@@ -262,7 +262,7 @@
     <ID>UndocumentedPublicFunction:AppLinkRedirect.kt$AppLinkRedirect$fun hasFallback()</ID>
     <ID>UndocumentedPublicFunction:AppLinkRedirect.kt$AppLinkRedirect$fun isRedirect()</ID>
     <ID>UndocumentedPublicFunction:AppLinksUseCases.kt$AppLinksUseCases.GetAppLinkRedirect$operator fun invoke(url: String): AppLinkRedirect</ID>
-    <ID>UndocumentedPublicFunction:AppLinksUseCases.kt$AppLinksUseCases.OpenAppLinkRedirect$operator fun invoke(appIntent: Intent?)</ID>
+    <ID>UndocumentedPublicFunction:AppLinksUseCases.kt$AppLinksUseCases.OpenAppLinkRedirect$operator fun invoke(appIntent: Intent?, failedToLaunchAction: () -> Unit = {})</ID>
     <ID>UndocumentedPublicFunction:Arguments.kt$Arguments$fun assertIsNotBlank(input: String, exceptionIdentifier: String)</ID>
     <ID>UndocumentedPublicFunction:Arguments.kt$Arguments$fun assertIsValidUserAgent(userAgent: String)</ID>
     <ID>UndocumentedPublicFunction:AutoPushFeature.kt$DeliveryManager$fun serviceForChannelId(channelId: String): PushType</ID>

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.annotation.CallSuper
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_browser.view.*
@@ -186,7 +187,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                 sessionManager = components.sessionManager,
                 sessionId = sessionId,
                 fragmentManager = requireFragmentManager(),
-                launchInApp = { components.preferences.getBoolean(DefaultComponents.PREF_LAUNCH_EXTERNAL_APP, false) }
+                launchInApp = { components.preferences.getBoolean(DefaultComponents.PREF_LAUNCH_EXTERNAL_APP, false) },
+                failedToLaunchAction = { Toast.makeText(context, "Failed to open in app", Toast.LENGTH_LONG).show() }
             ),
             owner = this,
             view = layout


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
