### PR TITLE
Closes #5315 - Create a Top Sites storage component

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -92,6 +92,10 @@ projects:
     path: components/feature/toolbar
     description: 'Feature implementation connecting a toolbar implementation with the session module.'
     publish: true
+  feature-top-sites:
+    path: components/feature/top-sites
+    description: 'Feature implementation for saving and removing top sites.'
+    publish: true
   feature-downloads:
     path: components/feature/downloads
     description: 'Feature implementation for apps that want to use Android downloads manager.'

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ _Combined components to implement feature-specific use cases._
 
 * 🔴 [**Toolbar**](components/feature/toolbar/README.md) - A component that connects a (concept) toolbar implementation with the browser session module.
 
+* 🔴 [**Top Sites**](components/feature/top-sites/README.md) - Feature implementation for saving and removing top sites.
+
 * ⚪ [**Prompts**](components/feature/prompts/README.md) - A component that will handle all the common prompt dialogs from web content.
 
 * ⚪ [**Push**](components/feature/push/README.md) - A component that provides Autopush messages with help from a supported push service.
@@ -268,7 +270,7 @@ _Sample apps using various components._
 
 * [**Nearby Chat**](samples/nearby-chat) - An app demoing how to use the [**Nearby**](components/lib/nearby/README.md) library for peer-to-peer communication between devices.
 
-* [**Toolbar**](samples/toolbar) - An app demoing multiple customized toolbars using the [**browser-toolbar**](components/browser/toolbar/README.md) component. 
+* [**Toolbar**](samples/toolbar) - An app demoing multiple customized toolbars using the [**browser-toolbar**](components/browser/toolbar/README.md) component.
 
 # Building #
 
@@ -282,11 +284,11 @@ $ ./gradlew assemble
 
 ## Android Studio ##
 
-If the environment variable `JAVA_HOME` is not defined, you will need to set it. If you would like to use the JDK installed by Android Studio, here's how to find it: 
+If the environment variable `JAVA_HOME` is not defined, you will need to set it. If you would like to use the JDK installed by Android Studio, here's how to find it:
 
 1. Open Android Studio.
 2. Select "Configure".
-3. Select "Default Project Structure". You should now see the Android JDK location. 
+3. Select "Default Project Structure". You should now see the Android JDK location.
 4. Set the environment variable `JAVA_HOME` to the location. (How you set an environment variable depends on your OS.)
 5. Restart Android Studio.
 

--- a/components/feature/top-sites/README.md
+++ b/components/feature/top-sites/README.md
@@ -1,0 +1,19 @@
+# [Android Components](../../../README.md) > Feature > Top Sites
+
+Feature implementation for saving and removing top sites.
+
+## Usage
+
+### Setting up the dependency
+
+Use Gradle to download the library from [maven.mozilla.org](https://maven.mozilla.org/) ([Setup repository](../../../README.md#maven-repository)):
+
+```Groovy
+implementation "org.mozilla.components:feature-top-sites:{latest-version}"
+```
+
+## License
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/components/feature/top-sites/build.gradle
+++ b/components/feature/top-sites/build.gradle
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+
+android {
+    compileSdkVersion config.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas".toString())
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/proguard/androidx-annotations.pro'
+    }
+
+    sourceSets {
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
+    }
+}
+
+dependencies {
+    implementation project(':support-ktx')
+    implementation project(':support-base')
+
+    implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
+
+    implementation Dependencies.androidx_paging
+    implementation Dependencies.androidx_lifecycle_extensions
+    kapt Dependencies.androidx_lifecycle_compiler
+
+    implementation Dependencies.androidx_room_runtime
+    kapt Dependencies.androidx_room_compiler
+
+    testImplementation project(':support-test')
+
+    testImplementation Dependencies.androidx_test_core
+    testImplementation Dependencies.testing_junit
+    testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_robolectric
+    testImplementation Dependencies.kotlin_coroutines
+
+    androidTestImplementation project(':support-android-test')
+
+    androidTestImplementation Dependencies.androidx_room_testing
+    androidTestImplementation Dependencies.androidx_arch_core_testing
+    androidTestImplementation Dependencies.androidx_test_core
+    androidTestImplementation Dependencies.androidx_test_runner
+    androidTestImplementation Dependencies.androidx_test_rules
+}
+
+apply from: '../../../publish.gradle'
+ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/feature/top-sites/proguard-rules.pro
+++ b/components/feature/top-sites/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/1.json
+++ b/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/1.json
@@ -1,0 +1,52 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "ce733d9c47cd10312a1c13de8efb7e8d",
+    "entities": [
+      {
+        "tableName": "top_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ce733d9c47cd10312a1c13de8efb7e8d')"
+    ]
+  }
+}

--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/TopSiteStorageTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/TopSiteStorageTest.kt
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.paging.PagedList
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import mozilla.components.feature.top.sites.db.TopSiteDatabase
+import mozilla.components.support.android.test.awaitValue
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@Suppress("LargeClass")
+class TopSiteStorageTest {
+    private lateinit var context: Context
+    private lateinit var storage: TopSiteStorage
+    private lateinit var executor: ExecutorService
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+        executor = Executors.newSingleThreadExecutor()
+
+        context = ApplicationProvider.getApplicationContext()
+        val database = Room.inMemoryDatabaseBuilder(context, TopSiteDatabase::class.java).build()
+
+        storage = TopSiteStorage(context)
+        storage.database = lazy { database }
+    }
+
+    @After
+    fun tearDown() {
+        executor.shutdown()
+    }
+
+    @Test
+    fun testAddingTopSite() {
+        storage.addTopSite("Mozilla", "https://www.mozilla.org")
+        storage.addTopSite("Firefox", "https://www.firefox.com")
+
+        val topSites = getAllTopSites()
+
+        assertEquals(2, topSites.size)
+
+        assertEquals("Mozilla", topSites[0].title)
+        assertEquals("https://www.mozilla.org", topSites[0].url)
+        assertEquals("Firefox", topSites[1].title)
+        assertEquals("https://www.firefox.com", topSites[1].url)
+    }
+
+    @Test
+    fun testRemovingTopSites() {
+        storage.addTopSite("Mozilla", "https://www.mozilla.org")
+        storage.addTopSite("Firefox", "https://www.firefox.com")
+
+        getAllTopSites().let { topSites ->
+            assertEquals(2, topSites.size)
+
+            storage.removeTopSite(topSites[0])
+        }
+
+        getAllTopSites().let { topSites ->
+            assertEquals(1, topSites.size)
+
+            assertEquals("Firefox", topSites[0].title)
+            assertEquals("https://www.firefox.com", topSites[0].url)
+        }
+    }
+
+    @Test
+    fun testGettingTopSites() {
+        storage.addTopSite("Mozilla", "https://www.mozilla.org")
+        storage.addTopSite("Firefox", "https://www.firefox.com")
+
+        val topSites = storage.getTopSites().awaitValue()
+
+        assertNotNull(topSites!!)
+        assertEquals(2, topSites.size)
+
+        with(topSites[0]) {
+            assertEquals("Mozilla", title)
+            assertEquals("https://www.mozilla.org", url)
+        }
+
+        with(topSites[1]) {
+            assertEquals("Firefox", title)
+            assertEquals("https://www.firefox.com", url)
+        }
+    }
+
+    private fun getAllTopSites(): List<TopSite> {
+        val dataSource = storage.getTopSitesPaged().create()
+
+        val pagedList = PagedList.Builder(dataSource, 10)
+            .setNotifyExecutor(executor)
+            .setFetchExecutor(executor)
+            .build()
+
+        return pagedList.toList()
+    }
+}

--- a/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/db/TopSiteDaoTest.kt
+++ b/components/feature/top-sites/src/androidTest/java/mozilla/components/feature/top/sites/db/TopSiteDaoTest.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.paging.PagedList
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class TopSiteDaoTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private lateinit var database: TopSiteDatabase
+    private lateinit var topSiteDao: TopSiteDao
+    private lateinit var executor: ExecutorService
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(context, TopSiteDatabase::class.java).build()
+        topSiteDao = database.topSiteDao()
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        executor.shutdown()
+    }
+
+    @Test
+    fun testAddingTopSite() {
+        val topSite = TopSiteEntity(
+            title = "Mozilla",
+            url = "https://www.mozilla.org",
+            createdAt = 200
+        ).also {
+            it.id = topSiteDao.insertTopSite(it)
+        }
+
+        val dataSource = topSiteDao.getTopSitesPaged().create()
+
+        val pagedList = PagedList.Builder(dataSource, 10)
+            .setNotifyExecutor(executor)
+            .setFetchExecutor(executor)
+            .build()
+
+        assertEquals(1, pagedList.size)
+        assertEquals(topSite, pagedList[0]!!)
+    }
+
+    @Test
+    fun testRemovingTopSite() {
+        val topSite1 = TopSiteEntity(
+            title = "Mozilla",
+            url = "https://www.mozilla.org",
+            createdAt = 200
+        ).also {
+            it.id = topSiteDao.insertTopSite(it)
+        }
+
+        val topSite2 = TopSiteEntity(
+            title = "Firefox",
+            url = "https://www.firefox.com",
+            createdAt = 100
+        ).also {
+            it.id = topSiteDao.insertTopSite(it)
+        }
+
+        topSiteDao.deleteTopSite(topSite1)
+
+        val dataSource = topSiteDao.getTopSitesPaged().create()
+
+        val pagedList = PagedList.Builder(dataSource, 10)
+            .setNotifyExecutor(executor)
+            .setFetchExecutor(executor)
+            .build()
+
+        assertEquals(1, pagedList.size)
+        assertEquals(topSite2, pagedList[0])
+    }
+}

--- a/components/feature/top-sites/src/main/AndroidManifest.xml
+++ b/components/feature/top-sites/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.feature.top.sites" />

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSite.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSite.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites
+
+/**
+ * A top site.
+ */
+interface TopSite {
+    /**
+     * Unique ID of this top site.
+     */
+    val id: Long
+
+    /**
+     * The title of the top site.
+     */
+    val title: String
+
+    /**
+     * The URL of the top site.
+     */
+    val url: String
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSiteStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSiteStorage.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Transformations
+import androidx.paging.DataSource
+import mozilla.components.feature.top.sites.adapter.TopSiteAdapter
+import mozilla.components.feature.top.sites.db.TopSiteDatabase
+import mozilla.components.feature.top.sites.db.TopSiteEntity
+
+/**
+ * A storage implementation for organizing top sites.
+ */
+class TopSiteStorage(
+    context: Context
+) {
+    internal var database: Lazy<TopSiteDatabase> = lazy { TopSiteDatabase.get(context) }
+
+    /**
+     * Adds a new [TopSite].
+     */
+    fun addTopSite(title: String, url: String) {
+        TopSiteEntity(
+            title = title,
+            url = url,
+            createdAt = System.currentTimeMillis()
+        ).also { entity ->
+            entity.id = database.value.topSiteDao().insertTopSite(entity)
+        }
+    }
+
+    /**
+     * Returns a [LiveData] list of all the [TopSite] instances.
+     */
+    fun getTopSites(): LiveData<List<TopSite>> {
+        return Transformations.map(
+            database.value.topSiteDao().getTopSites()
+        ) { list ->
+            list.map { entity -> TopSiteAdapter(entity) }
+        }
+    }
+
+    /**
+     * Returns all [TopSite]s as a [DataSource.Factory].
+     */
+    fun getTopSitesPaged(): DataSource.Factory<Int, TopSite> = database.value
+        .topSiteDao()
+        .getTopSitesPaged()
+        .map { entity -> TopSiteAdapter(entity) }
+
+    /**
+     * Removes the given [TopSite].
+     */
+    fun removeTopSite(site: TopSite) {
+        val topSiteEntity = (site as TopSiteAdapter).entity
+        database.value.topSiteDao().deleteTopSite(topSiteEntity)
+    }
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/adapter/TopSiteAdapter.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/adapter/TopSiteAdapter.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.adapter
+
+import mozilla.components.feature.top.sites.TopSite
+import mozilla.components.feature.top.sites.db.TopSiteEntity
+
+internal class TopSiteAdapter(
+    internal val entity: TopSiteEntity
+) : TopSite {
+    override val id: Long
+        get() = entity.id!!
+
+    override val title: String
+        get() = entity.title
+
+    override val url: String
+        get() = entity.url
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is TopSiteAdapter) {
+            return false
+        }
+
+        return entity == other.entity
+    }
+
+    override fun hashCode(): Int {
+        return entity.hashCode()
+    }
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDao.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDao.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import androidx.lifecycle.LiveData
+import androidx.paging.DataSource
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+
+/**
+ * Internal DAO for accessing [TopSiteEntity] instances.
+ */
+@Dao
+internal interface TopSiteDao {
+    @Insert
+    fun insertTopSite(site: TopSiteEntity): Long
+
+    @Delete
+    fun deleteTopSite(site: TopSiteEntity)
+
+    @Transaction
+    @Query("SELECT * FROM top_sites")
+    fun getTopSites(): LiveData<List<TopSiteEntity>>
+
+    @Transaction
+    @Query("SELECT * FROM top_sites")
+    fun getTopSitesPaged(): DataSource.Factory<Int, TopSiteEntity>
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+/**
+ * Internal database for storing top sites.
+ */
+@Database(entities = [TopSiteEntity::class], version = 1)
+internal abstract class TopSiteDatabase : RoomDatabase() {
+    abstract fun topSiteDao(): TopSiteDao
+
+    companion object {
+        @Volatile private var instance: TopSiteDatabase? = null
+
+        @Synchronized
+        fun get(context: Context): TopSiteDatabase {
+            instance?.let { return it }
+
+            return Room.databaseBuilder(
+                context,
+                TopSiteDatabase::class.java,
+                "top_sites"
+            ).build().also {
+                instance = it
+            }
+        }
+    }
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteEntity.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteEntity.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.top.sites.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Internal entity representing a top site.
+ */
+@Entity(tableName = "top_sites")
+internal data class TopSiteEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    var id: Long? = null,
+
+    @ColumnInfo(name = "title")
+    var title: String,
+
+    @ColumnInfo(name = "url")
+    var url: String,
+
+    @ColumnInfo(name = "created_at")
+    var createdAt: Long = System.currentTimeMillis()
+)

--- a/components/feature/top-sites/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/feature/top-sites/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+// This allows mocking final classes (classes are final by default in Kotlin)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
This fixes #5315 by adding an initial Top Sites storage component using `Room` similar to `TabCollections`. The current use case that this currently solves is that it provides a simple storage for top sites that are manually added/removed. 
  
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
