### PR TITLE
Closes #3963 - Use stable AndroidX Browser lib

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -37,7 +37,7 @@ object Versions {
     object AndroidX {
         const val annotation = "1.1.0"
         const val appcompat = "1.1.0"
-        const val browser = "1.2.0-alpha07"
+        const val browser = "1.2.0"
         const val cardview = "1.0.0"
         const val constraintlayout = "1.1.3"
         const val core = "1.1.0"

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabConfig.kt
@@ -43,13 +43,7 @@ data class CustomTabConfig(
     val titleVisible: Boolean = false,
     val sessionToken: CustomTabsSessionToken? = null,
     val externalAppType: ExternalAppType = ExternalAppType.CUSTOM_TAB
-) {
-
-    companion object {
-        const val EXTRA_NAVIGATION_BAR_COLOR = "androidx.browser.customtabs.extra.NAVIGATION_BAR_COLOR"
-        const val EXTRA_ADDITIONAL_TRUSTED_ORIGINS = "android.support.customtabs.extra.ADDITIONAL_TRUSTED_ORIGINS"
-    }
-}
+)
 
 /**
  * Represents different contexts that a custom tab session can be displayed in.

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/AbstractCustomTabsService.kt
@@ -65,7 +65,7 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
         }
     }
 
-    override fun requestPostMessageChannel(sessionToken: CustomTabsSessionToken, postMessageOrigin: Uri?): Boolean {
+    override fun requestPostMessageChannel(sessionToken: CustomTabsSessionToken, postMessageOrigin: Uri): Boolean {
         return false
     }
 
@@ -84,20 +84,18 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
         return true
     }
 
-    override fun extraCommand(commandName: String?, args: Bundle?): Bundle? {
-        return null
-    }
+    override fun extraCommand(commandName: String, args: Bundle?): Bundle? = null
 
     override fun mayLaunchUrl(
         sessionToken: CustomTabsSessionToken,
-        url: Uri?,
+        url: Uri,
         extras: Bundle?,
-        otherLikelyBundles: MutableList<Bundle>?
+        otherLikelyBundles: List<Bundle>?
     ): Boolean {
         logger.debug("Opening speculative connections")
 
         // Most likely URL for a future navigation: Open a speculative connection.
-        url?.let { engine.speculativeConnect(it.toString()) }
+        engine.speculativeConnect(url.toString())
 
         // A list of other likely URLs. Let's open a speculative connection for them up to a limit.
         otherLikelyBundles?.take(MAX_SPECULATIVE_URLS)?.forEach { bundle ->
@@ -109,9 +107,8 @@ abstract class AbstractCustomTabsService : CustomTabsService() {
         return true
     }
 
-    override fun postMessage(sessionToken: CustomTabsSessionToken, message: String?, extras: Bundle?): Int {
-        return RESULT_FAILURE_DISALLOWED
-    }
+    override fun postMessage(sessionToken: CustomTabsSessionToken, message: String, extras: Bundle?) =
+        RESULT_FAILURE_DISALLOWED
 
     override fun validateRelationship(
         sessionToken: CustomTabsSessionToken,

--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabConfigHelper.kt
@@ -17,6 +17,7 @@ import androidx.browser.customtabs.CustomTabsIntent.EXTRA_DEFAULT_SHARE_MENU_ITE
 import androidx.browser.customtabs.CustomTabsIntent.EXTRA_ENABLE_URLBAR_HIDING
 import androidx.browser.customtabs.CustomTabsIntent.EXTRA_EXIT_ANIMATION_BUNDLE
 import androidx.browser.customtabs.CustomTabsIntent.EXTRA_MENU_ITEMS
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_NAVIGATION_BAR_COLOR
 import androidx.browser.customtabs.CustomTabsIntent.EXTRA_SESSION
 import androidx.browser.customtabs.CustomTabsIntent.EXTRA_TINT_ACTION_BUTTON
 import androidx.browser.customtabs.CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE
@@ -33,7 +34,6 @@ import androidx.browser.customtabs.CustomTabsSessionToken
 import androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY
 import mozilla.components.browser.state.state.CustomTabActionButtonConfig
 import mozilla.components.browser.state.state.CustomTabConfig
-import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
 import mozilla.components.browser.state.state.CustomTabMenuItem
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.support.utils.SafeIntent

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt
@@ -12,9 +12,9 @@ import android.graphics.Color
 import android.os.Binder
 import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsIntent.EXTRA_NAVIGATION_BAR_COLOR
 import androidx.browser.customtabs.TrustedWebUtils
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_NAVIGATION_BAR_COLOR
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -23,12 +23,23 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
 
 @RunWith(AndroidJUnit4::class)
 class CustomTabConfigHelperTest {
+
+    private lateinit var resources: Resources
+
+    @Before
+    fun setup() {
+        resources = spy(testContext.resources)
+        doReturn(24f).`when`(resources).getDimension(R.dimen.mozac_feature_customtabs_max_close_button_size)
+    }
 
     @Test
     fun isCustomTabIntent() {

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsService.RELATION_HANDLE_ALL_URLS
 import androidx.browser.customtabs.CustomTabsSessionToken
+import androidx.browser.trusted.TrustedWebActivityIntentBuilder.EXTRA_ADDITIONAL_TRUSTED_ORIGINS
 import androidx.core.net.toUri
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
@@ -17,7 +18,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.state.state.CustomTabConfig.Companion.EXTRA_ADDITIONAL_TRUSTED_ORIGINS
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.fetch.Client

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
@@ -59,12 +59,12 @@ class WebAppShortcutManagerTest {
         initMocks(this)
         context = spy(testContext)
 
-        `when`(context.packageManager).thenReturn(packageManager)
-        `when`(context.getSystemService(ShortcutManager::class.java)).thenReturn(shortcutManager)
-        `when`(context.getString(R.string.mozac_feature_pwa_default_shortcut_label)).thenReturn("")
+        doReturn(packageManager).`when`(context).packageManager
+        doReturn(shortcutManager).`when`(context).getSystemService(ShortcutManager::class.java)
+        doReturn("").`when`(context).getString(R.string.mozac_feature_pwa_default_shortcut_label)
 
         manager = spy(WebAppShortcutManager(context, httpClient, storage))
-        `when`(manager.icons).thenReturn(icons)
+        doReturn(icons).`when`(manager).icons
     }
 
     @After


### PR DESCRIPTION
The AndroidX Browser library (for Custom Tabs and Trusted Web Activities) is finally stable.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
