### PR TITLE
Closes #5351: Use Info level for caught exception crashes in Sentry reports.

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SentryService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SentryService.kt
@@ -78,7 +78,7 @@ class SentryService(
 
     override fun report(throwable: Throwable) {
         val eventBuilder = EventBuilder().withMessage(createMessage(throwable))
-                .withLevel(Event.Level.ERROR)
+                .withLevel(Event.Level.INFO)
                 .withSentryInterface(ExceptionInterface(throwable))
         client.sendEvent(eventBuilder)
     }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
