### PR TITLE
Issue #4928: Gradle: Force jacoco out of process..

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,6 @@ libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableUnitTestBinaryResources=true
+
+android.forceJacocoOutOfProcess=true
+


### PR DESCRIPTION
Trying to find a solution to our intermittent jacoco problems (#4928) I came across this flag that with AGP 3.5+ should move jacoco to a separate JVM. There's no guarantee that this actually helps but let's try how it behaves on taskcluster..