### PR TITLE
For bug1562865: Add setOnTouchCallback to EngineView

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -14,11 +15,11 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.permission.PermissionRequest
 import org.mozilla.geckoview.GeckoResult
-import java.lang.IllegalStateException
 
 /**
  * Gecko-based EngineView implementation.
  */
+@Suppress("TooManyFunctions")
 class GeckoEngineView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -143,6 +144,16 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun setDynamicToolbarMaxHeight(height: Int) {
         currentGeckoView.setDynamicToolbarMaxHeight(height)
+    }
+
+    private var touchCallback: (MotionEvent?) -> Boolean = { false }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        return if (touchCallback.invoke(ev)) true else super.dispatchTouchEvent(ev)
+    }
+
+    override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {
+        touchCallback = callback
     }
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -7,12 +7,15 @@ package mozilla.components.browser.engine.gecko
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -167,5 +170,17 @@ class GeckoEngineViewTest {
         engineView.observer.onCrash()
 
         verify(geckoView).setSession(geckoSession)
+    }
+
+    @Test
+    fun `dispatchTouchEvent will call touchCallback before super`() {
+        val engineView = GeckoEngineView(context)
+        val motionEvent = mock<MotionEvent>()
+
+        assertFalse(engineView.dispatchTouchEvent(motionEvent))
+
+        engineView.setOnTouchCallback { true }
+
+        assertTrue(engineView.dispatchTouchEvent(motionEvent))
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -155,6 +156,16 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun setDynamicToolbarMaxHeight(height: Int) {
         currentGeckoView.setDynamicToolbarMaxHeight(height)
+    }
+
+    private var touchCallback: (MotionEvent?) -> Boolean = { false }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        return if (touchCallback(ev)) true else super.dispatchTouchEvent(ev)
+    }
+
+    override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {
+        touchCallback = callback
     }
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -7,12 +7,15 @@ package mozilla.components.browser.engine.gecko
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -178,5 +181,17 @@ class GeckoEngineViewTest {
         engineView.observer.onCrash()
 
         verify(geckoView).setSession(geckoSession)
+    }
+
+    @Test
+    fun `dispatchTouchEvent will call touchCallback before super`() {
+        val engineView = GeckoEngineView(context)
+        val motionEvent = mock<MotionEvent>()
+
+        assertFalse(engineView.dispatchTouchEvent(motionEvent))
+
+        engineView.setOnTouchCallback { true }
+
+        assertTrue(engineView.dispatchTouchEvent(motionEvent))
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -19,6 +20,7 @@ import java.lang.IllegalStateException
 /**
  * Gecko-based EngineView implementation.
  */
+@Suppress("TooManyFunctions")
 class GeckoEngineView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -143,6 +145,16 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun setDynamicToolbarMaxHeight(height: Int) {
         // no-op
+    }
+
+    private var touchCallback: (MotionEvent?) -> Boolean = { false }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        return if (touchCallback(ev)) true else super.dispatchTouchEvent(ev)
+    }
+
+    override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {
+        touchCallback = callback
     }
 
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -7,12 +7,15 @@ package mozilla.components.browser.engine.gecko
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
@@ -144,5 +147,17 @@ class GeckoEngineViewTest {
         engineView.observer.onCrash()
 
         verify(geckoView).setSession(geckoSession)
+    }
+
+    @Test
+    fun `dispatchTouchEvent will call touchCallback before super`() {
+        val engineView = GeckoEngineView(context)
+        val motionEvent = mock<MotionEvent>()
+
+        assertFalse(engineView.dispatchTouchEvent(motionEvent))
+
+        engineView.setOnTouchCallback { true }
+
+        assertTrue(engineView.dispatchTouchEvent(motionEvent))
     }
 }

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -16,6 +16,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Message
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.view.PixelCopy
 import android.view.View
 import android.webkit.CookieManager
@@ -736,6 +737,16 @@ class SystemEngineView @JvmOverloads constructor(
             credentialsPair = user to pass
         }
         return credentialsPair
+    }
+
+    private var touchCallback: (MotionEvent?) -> Boolean = { false }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        return if (touchCallback(ev)) true else super.dispatchTouchEvent(ev)
+    }
+
+    override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {
+        touchCallback = callback
     }
 
     companion object {

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -12,6 +12,7 @@ import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
 import android.os.Message
+import android.view.MotionEvent
 import android.view.PixelCopy
 import android.view.View
 import android.webkit.HttpAuthHandler
@@ -33,7 +34,9 @@ import mozilla.components.browser.engine.system.matcher.UrlMatcher
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
@@ -68,11 +71,9 @@ import org.mockito.Mockito.verifyZeroInteractions
 import org.robolectric.Robolectric
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import java.io.StringReader
 import java.util.Calendar
 import java.util.Date
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
-import mozilla.components.concept.engine.content.blocking.Tracker
-import java.io.StringReader
 
 @RunWith(AndroidJUnit4::class)
 class SystemEngineViewTest {
@@ -1545,6 +1546,18 @@ class SystemEngineViewTest {
         val authRequest = request as PromptRequest.Authentication
         assertEquals(authRequest.userName, userName)
         assertEquals(authRequest.password, password)
+    }
+
+    @Test
+    fun `dispatchTouchEvent will call touchCallback before super`() {
+        val engineView = SystemEngineView(testContext)
+        val motionEvent = mock<MotionEvent>()
+
+        assertFalse(engineView.dispatchTouchEvent(motionEvent))
+
+        engineView.setOnTouchCallback { true }
+
+        assertTrue(engineView.dispatchTouchEvent(motionEvent))
     }
 
     private fun Date.add(timeUnit: Int, amountOfTime: Int): Date {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.engine
 
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
@@ -113,6 +114,13 @@ interface EngineView {
      * @param height The maximum possible height of the toolbar.
      */
     fun setDynamicToolbarMaxHeight(height: Int)
+
+    /**
+     * Allows the client application to listen to touch events inside the EngineView.
+     *
+     * @param callback A callback to call on every MotionEvent to decide if it proceeds
+     */
+    fun setOnTouchCallback(callback: ((MotionEvent?) -> Boolean))
 }
 
 /**

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.concept.engine
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.robolectric.testContext
@@ -62,6 +63,7 @@ class EngineViewTest {
     open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}
@@ -71,6 +73,7 @@ class EngineViewTest {
     open class BrokenEngineView : EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.session
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -95,6 +96,7 @@ class SwipeRefreshFeatureTest {
         override fun canScrollVerticallyUp() = scrollY > 0
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun clearSelection() {}
         override fun render(session: EngineSession) {}

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.session.behavior
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.view.MotionEvent
 import android.view.View
 import android.widget.EditText
 import android.widget.ImageView
@@ -66,6 +67,8 @@ class FakeEngineView(context: Context) : TextView(context), EngineView {
     override fun setVerticalClipping(clippingHeight: Int) {}
 
     override fun setDynamicToolbarMaxHeight(height: Int) {}
+
+    override fun setOnTouchCallback(callback: (MotionEvent?) -> Boolean) {}
 
     override fun release() {}
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
