### PR TITLE
Closes #5403: Add setDynamicToolbarMaxHeight to EngineViewBottomBehavior

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/behavior/EngineViewBottomBehavior.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/behavior/EngineViewBottomBehavior.kt
@@ -39,12 +39,12 @@ class EngineViewBottomBehavior(
     }
 
     /**
-     * Apply vertical clipping to [EngineView]. This requires [EngineViewBottomBehavior] to be set
-     * in/on the [EngineView] or its parent. Must be a direct descending child of [CoordinatorLayout].
+     * Apply dynamic toolbar max height to [EngineView]. This requires [EngineViewBottomBehavior] to be set
+     * in/on the [EngineView] or its parent.
      */
     override fun onDependentViewChanged(parent: CoordinatorLayout, child: View, dependency: View): Boolean {
         val engineView = child.findViewInHierarchy { it is EngineView } as EngineView?
-        engineView?.setVerticalClipping(-dependency.translationY.toInt())
+        engineView?.setDynamicToolbarMaxHeight(dependency.height - dependency.translationY.toInt())
         return true
     }
 }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBottomBehaviorTest.kt
@@ -36,7 +36,7 @@ class EngineViewBottomBehaviorTest {
 
         doReturn(42f).`when`(toolbar).translationY
         behavior.onDependentViewChanged(mock(), engineView.asView(), toolbar)
-        verify(engineView).setVerticalClipping(-42)
+        verify(engineView).setDynamicToolbarMaxHeight(100 - 42)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ permalink: /changelog/
 * **browser-menu**
   * Added `BrowserMenuHighlightableSwitch` to represent a highlightable item with a toggle switch.
 
+* **feature-session**
+  * Added setDynamicToolbarMaxHeight to EngineViewBottomBehavior.
+
 # 26.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v25.0.0...v26.0.0)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
