### PR TITLE
Closes #5425 Support the ACTION_SEARCH Android intent components

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -132,14 +132,9 @@ class Session(
         ACTION_SEND,
 
         /**
-         * Created to handle an ACTION_SEARCH intent
+         * Created to handle an ACTION_SEARCH and ACTION_WEB_SEARCH intent
          */
         ACTION_SEARCH,
-
-        /**
-         * Created to handle an ACTION_WEB_SEARCH intent
-         */
-        ACTION_WEB_SEARCH,
 
         /**
          * Created to handle an ACTION_VIEW intent

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -132,6 +132,16 @@ class Session(
         ACTION_SEND,
 
         /**
+         * Created to handle an ACTION_SEARCH intent
+         */
+        ACTION_SEARCH,
+
+        /**
+         * Created to handle an ACTION_WEB_SEARCH intent
+         */
+        ACTION_WEB_SEARCH,
+
+        /**
          * Created to handle an ACTION_VIEW intent
          */
         ACTION_VIEW,

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -18,6 +18,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.ktx.kotlin.isUrl
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.WebURLFinder
 
@@ -99,8 +100,7 @@ class TabIntentProcessor(
     }
 
     private fun resolveSearch(query : String, source: Source) {
-        val queryIsAnUrl = WebURLFinder.isWebURL(query)
-        if (queryIsAnUrl) {
+        if (query.isUrl()) {
             val session = createSession(query, private = isPrivate, source = source)
             loadUrlUseCase(query, session, LoadUrlFlags.external())
         } else {

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -83,28 +83,13 @@ class TabIntentProcessor(
         return if (searchQuery.isNullOrBlank()) {
             false
         } else {
-            resolveSearch(searchQuery, Source.ACTION_SEARCH)
+            if (searchQuery.isUrl()) {
+                val session = createSession(searchQuery, private = isPrivate, source = Source.ACTION_SEARCH)
+                loadUrlUseCase(searchQuery, session, LoadUrlFlags.external())
+            } else {
+                newTabSearchUseCase(searchQuery, Source.ACTION_SEARCH, openNewTab)
+            }
             true
-        }
-    }
-
-    private fun processWebSearchIntent(intent: SafeIntent): Boolean {
-        val searchQuery = intent.getStringExtra(SearchManager.QUERY)
-
-        return if (searchQuery.isNullOrBlank()) {
-            false
-        } else {
-            resolveSearch(searchQuery, Source.ACTION_WEB_SEARCH)
-            true
-        }
-    }
-
-    private fun resolveSearch(query: String, source: Source) {
-        if (query.isUrl()) {
-            val session = createSession(query, private = isPrivate, source = source)
-            loadUrlUseCase(query, session, LoadUrlFlags.external())
-        } else {
-            newTabSearchUseCase(query, source, openNewTab)
         }
     }
 
@@ -136,8 +121,7 @@ class TabIntentProcessor(
         return when (safeIntent.action) {
             ACTION_VIEW, ACTION_NDEF_DISCOVERED -> processViewIntent(safeIntent)
             ACTION_SEND -> processSendIntent(safeIntent)
-            ACTION_SEARCH -> processSearchIntent(safeIntent)
-            ACTION_WEB_SEARCH -> processWebSearchIntent(safeIntent)
+            ACTION_SEARCH, ACTION_WEB_SEARCH -> processSearchIntent(safeIntent)
             else -> false
         }
     }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -99,7 +99,7 @@ class TabIntentProcessor(
         }
     }
 
-    private fun resolveSearch(query : String, source: Source) {
+    private fun resolveSearch(query: String, source: Source) {
         if (query.isUrl()) {
             val session = createSession(query, private = isPrivate, source = source)
             loadUrlUseCase(query, session, LoadUrlFlags.external())
@@ -121,8 +121,8 @@ class TabIntentProcessor(
         return safeIntent.action == ACTION_VIEW ||
             safeIntent.action == ACTION_SEND ||
             safeIntent.action == ACTION_NDEF_DISCOVERED ||
-                safeIntent.action == ACTION_SEARCH ||
-                safeIntent.action == ACTION_WEB_SEARCH
+            safeIntent.action == ACTION_SEARCH ||
+            safeIntent.action == ACTION_WEB_SEARCH
     }
 
     /**

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -300,7 +300,6 @@ class TabIntentProcessorTest {
         assertEquals(searchTerms, sessionManager.selectedSession?.searchTerms)
     }
 
-
     @Test
     fun `processor handles ACTION_WEB_SEARCH with empty text`() = runBlockingTest {
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This PR adds support for the Intents ACTION_SEARCH and ACTION_WEB_SEARCH.
If we send the intents with a query extra string will open a URL if the query is an URL or a search engine page if the query is just a string.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
