### PR TITLE
For #3790: Add 'Open link in external app' to context menu

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -205,7 +205,13 @@ class AppLinksUseCases(
             includeInstallAppFallback = false
         )
     }
-
+    val appLinkRedirectIncludeInstall: GetAppLinkRedirect by lazy {
+        GetAppLinkRedirect(
+            includeHttpAppLinks = true,
+            ignoreDefaultBrowser = false,
+            includeInstallAppFallback = true
+        )
+    }
     private data class RedirectData(
         val appIntent: Intent? = null,
         val fallbackIntent: Intent? = null,

--- a/components/feature/contextmenu/build.gradle
+++ b/components/feature/contextmenu/build.gradle
@@ -30,6 +30,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     implementation project(':concept-engine')
     implementation project(':feature-tabs')
+    implementation project(':feature-app-links')
     implementation project(':browser-state')
     implementation project(':support-utils')
     implementation project(':support-ktx')

--- a/components/feature/contextmenu/src/main/res/values/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="mozac_feature_contextmenu_snackbar_link_copied">Link copied to clipboard</string>
     <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
     <string name="mozac_feature_contextmenu_snackbar_action_switch">Switch</string>
+    <string name="mozac_feature_contextmenu_open_link_in_external_app">Open link in external app</string>
 </resources>

--- a/components/support/test/src/main/java/mozilla/components/support/test/Matchers.kt
+++ b/components/support/test/src/main/java/mozilla/components/support/test/Matchers.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.support.test
 
+import org.mockito.AdditionalMatchers
 import org.mockito.Mockito
 
 /**
@@ -23,6 +24,15 @@ fun <T> any(): T {
  */
 fun <T> eq(value: T): T {
     return Mockito.eq(value) ?: value
+}
+
+/**
+ * Mockito matcher that matches if the argument is not the same as the provided value.
+ *
+ * (The version from Mockito doesn't work correctly with Kotlin code.)
+ */
+fun <T> not(value: T): T {
+    return AdditionalMatchers.not(value) ?: value
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,7 @@ permalink: /changelog/
       launchFromInterceptor = true
   )
   ```
+  * Introduce a `ContextMenuCandidate` to open links in the corresponding external app, if installed
 
 * **concept-storage**
   * Added classes related to login autofill

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.browser.session.SelectionAwareSessionObserver
 import mozilla.components.browser.session.Session
+import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
 import mozilla.components.feature.downloads.DownloadsFeature
@@ -123,14 +124,23 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
 
         val scrollFeature = CoordinateScrollingFeature(components.sessionManager, layout.engineView, layout.toolbar)
 
+        val contextMenuCandidateAppLinksUseCases = AppLinksUseCases(
+            requireContext(),
+            { true }
+        )
+
+        val contextMenuCandidates = ContextMenuCandidate.defaultCandidates(
+            requireContext(),
+            components.tabsUseCases,
+            components.contextMenuUseCases,
+            layout) +
+            ContextMenuCandidate.createOpenInExternalAppCandidate(
+                requireContext(), contextMenuCandidateAppLinksUseCases)
+
         val contextMenuFeature = ContextMenuFeature(
             fragmentManager = requireFragmentManager(),
             store = components.store,
-            candidates = ContextMenuCandidate.defaultCandidates(
-                requireContext(),
-                components.tabsUseCases,
-                components.contextMenuUseCases,
-                layout),
+            candidates = contextMenuCandidates,
             engineView = layout.engineView,
             useCases = components.contextMenuUseCases)
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

This PR extends the contextmenu feature with a "Open link in external app" button.
This can be used to fix https://github.com/mozilla-mobile/android-components/issues/3790 and also https://github.com/mozilla-mobile/fenix/issues/1754.

A problem that I still have is that it does not handle links like 

`https://www.google.com/url?q=https://www.reddit.com/&sa=U&ved=2ahUKEwi90a6L9NjmAhVKJ1AKHTbFDCwQFjAAegQIARAB&usg=AOvVaw2buqPqtLzY6gVHGR2cURcE`

correctly. I think the correct approach here would be to do a GET request and follow the redirection?

Screenshot:
![Anmerkung 2020-01-10 232717](https://user-images.githubusercontent.com/9115235/72190851-e1bb1500-3400-11ea-86d6-d9b63cec600f.png)
