### PR TITLE
Issue #4500: Integrate GV API to list installed web extensions

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -29,9 +29,9 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
 class GeckoWebExtension(
     id: String,
     url: String,
+    webExtensionController: WebExtensionController,
     allowContentMessaging: Boolean = true,
     supportActions: Boolean = false,
-    webExtensionController: WebExtensionController,
     val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
         url,
         id,
@@ -44,7 +44,7 @@ class GeckoWebExtension(
     private val logger = Logger("GeckoWebExtension")
 
     constructor(native: GeckoNativeWebExtension, webExtensionController: WebExtensionController) :
-        this(native.id, native.location, true, true, webExtensionController, native)
+        this(native.id, native.location, webExtensionController, true, true, native)
 
     /**
      * Uniquely identifies a port using its name and the session it

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -227,9 +227,9 @@ class GeckoWebExtensionTest {
         val extensionWithActions = GeckoWebExtension(
             "mozacTest",
             "url",
-            false,
-            false,
             webExtensionController,
+            false,
+            false,
             nativeGeckoWebExt
         )
         extensionWithActions.registerActionHandler(actionHandler)


### PR DESCRIPTION
Just wiring up the "real" method call now that we have it. With this the installed addon keeps working after a restart now.