### PR TITLE
Closes #5389 - Added tooltips to browser toolbar images when long pressed

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -10,6 +10,7 @@ import android.widget.LinearLayout
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.TooltipCompat
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
@@ -75,6 +76,7 @@ class BrowserMenuItemToolbar(
         internal open fun bind(view: ImageView) {
             view.setImageResource(imageResource)
             view.contentDescription = contentDescription
+            TooltipCompat.setTooltipText(view, contentDescription)
             view.setTintResource(iconTintColorResource)
             view.isEnabled = isEnabled()
         }
@@ -124,6 +126,7 @@ class BrowserMenuItemToolbar(
             } else {
                 view.setImageResource(secondaryImageResource)
                 view.contentDescription = secondaryContentDescription
+                TooltipCompat.setTooltipText(view, secondaryContentDescription)
                 view.setTintResource(secondaryImageTintResource)
                 view.isEnabled = !disableInSecondaryState
             }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Added tooltips to browser items - Closes [#5389](https://github.com/mozilla-mobile/android-components/issues/5389)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
