### PR TITLE
Do not publish glean gradle plugin to fix snapshot builds

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -403,5 +403,5 @@ projects:
   tooling-glean-gradle:
     path: components/tooling/glean-gradle-plugin
     description: 'A Gradle plugin to generate code for Glean metrics.'
-    publish: true
+    publish: false
     artifact-type: jar


### PR DESCRIPTION
This currently breaks our snapshot builds as the renameSnapshotArtifacts task is not defined for tooling/glean-gradle-plugin.

/cc @mdboom 