### PR TITLE
Provide full menu item count to accessibility services.

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -13,6 +13,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
+import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.PopupWindow
 import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -56,6 +57,13 @@ class BrowserMenu internal constructor(
             }
             adapter = this@BrowserMenu.adapter
         }
+
+        menuList?.setAccessibilityDelegate(object : View.AccessibilityDelegate() {
+            override fun onInitializeAccessibilityNodeInfo(host: View?, info: AccessibilityNodeInfo?) {
+                super.onInitializeAccessibilityNodeInfo(host, info)
+                info?.collectionInfo = AccessibilityNodeInfo.CollectionInfo.obtain(adapter.interactiveCount, 0, false)
+            }
+        })
 
         return PopupWindow(
             view,

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuAdapter.kt
@@ -20,6 +20,7 @@ internal class BrowserMenuAdapter(
     var menu: BrowserMenu? = null
 
     internal val visibleItems = items.filter { it.visible() }
+    internal val interactiveCount = visibleItems.sumBy { it.interactiveCount() }
     private val inflater = LayoutInflater.from(context)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
@@ -17,6 +17,13 @@ interface BrowserMenuItem {
     val visible: () -> Boolean
 
     /**
+     * Lambda expression that returns the number of interactive elements in this menu item.
+     * For example, a simple item will have 1, divider will have 0, and a composite
+     * item, like a tool bar, will have several.
+     */
+    val interactiveCount: () -> Int get() = { 1 }
+
+    /**
      * Returns the layout resource ID of the layout to be inflated for showing a menu item of this
      * type.
      */

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuDivider.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuDivider.kt
@@ -15,6 +15,8 @@ import mozilla.components.browser.menu.R
 class BrowserMenuDivider : BrowserMenuItem {
     override var visible: () -> Boolean = { true }
 
+    override val interactiveCount: () -> Int = { 0 }
+
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_divider
 
     override fun bind(menu: BrowserMenu, view: View) = Unit

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -24,6 +24,8 @@ class BrowserMenuItemToolbar(
 ) : BrowserMenuItem {
     override var visible: () -> Boolean = { true }
 
+    override val interactiveCount: () -> Int = { items.size }
+
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_toolbar
 
     override fun bind(menu: BrowserMenu, view: View) {

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_divider.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_divider.xml
@@ -4,4 +4,5 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <View xmlns:android="http://schemas.android.com/apk/res/android"
       style="@style/Mozac.Browser.Menu.Item.Divider.Horizontal"
-      android:importantForAccessibility="no"/>
+      android:importantForAccessibility="no"
+      android:clickable="false"/>

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt
@@ -25,11 +25,11 @@ class BrowserMenuAdapterTest {
     @Test
     fun `items that return false from the visible lambda will be filtered out`() {
         val items = listOf(
-            createMenuItem(1) { true },
-            createMenuItem(2) { true },
-            createMenuItem(3) { false },
-            createMenuItem(4) { false },
-            createMenuItem(5) { true })
+            createMenuItem(1, { true }),
+            createMenuItem(2, { true }),
+            createMenuItem(3, { false }),
+            createMenuItem(4, { false }),
+            createMenuItem(5, { true }))
 
         val adapter = BrowserMenuAdapter(testContext, items)
 
@@ -107,6 +107,19 @@ class BrowserMenuAdapterTest {
         verify(item2, never()).invalidate(view)
     }
 
+    @Test
+    fun `total interactive item count is given provided adapter`() {
+        val items = listOf(
+                createMenuItem(1, { true }, { 1 }),
+                createMenuItem(2, { true }, { 0 }),
+                createMenuItem(3, { false }, { 10 }),
+                createMenuItem(4, { true }, { 5 }))
+
+        val adapter = BrowserMenuAdapter(testContext, items)
+
+        assertEquals(6, adapter.interactiveCount)
+    }
+
     private fun List<BrowserMenuItem>.assertTrueForOne(predicate: (BrowserMenuItem) -> Boolean) {
         for (item in this) {
             if (predicate(item)) {
@@ -126,10 +139,13 @@ class BrowserMenuAdapterTest {
 
     private fun createMenuItem(
         layout: Int = 0,
-        visible: () -> Boolean = { true }
+        visible: () -> Boolean = { true },
+        interactiveCount: () -> Int = { 1 }
     ): BrowserMenuItem {
         return object : BrowserMenuItem {
             override val visible = visible
+
+            override val interactiveCount = interactiveCount
 
             override fun getLayoutResource() = layout
 


### PR DESCRIPTION
We need to count buttons inside of toolbar items, and ignore dividers.

This fixes mozilla-mobile/fenix#2143


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
