### PR TITLE
Closes #3960 Support for bypassing SSL certificates

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -28,7 +28,12 @@ object ErrorPages {
             it.readText()
         }
 
-        return context.resources.openRawResource(htmlResource)
+        val showSSLAdvanced: Boolean = when (errorType) {
+            ErrorType.ERROR_SECURITY_SSL, ErrorType.ERROR_SECURITY_BAD_CERT -> true
+            else -> false
+        }
+
+        var htmlPage = context.resources.openRawResource(htmlResource)
             .bufferedReader()
             .use { it.readText() }
             .replace("%pageTitle%", context.getString(R.string.mozac_browser_errorpages_page_title))
@@ -38,6 +43,23 @@ object ErrorPages {
             .replace("%messageLong%", context.getString(errorType.messageRes, uri))
             .replace("<ul>", "<ul role=\"presentation\">")
             .replace("%css%", css)
+
+        htmlPage.apply {
+            if (showSSLAdvanced) {
+                htmlPage = replace("%showSSL%", "true")
+                    .replace("%badCertAdvanced%",
+                            context.getString(R.string.mozac_browser_errorpages_security_bad_cert_advanced))
+                    .replace("%badCertTechInfo%",
+                            context.getString(R.string.mozac_browser_errorpages_security_bad_cert_techInfo,
+                                    uri.toString()))
+                    .replace("%badCertGoBack%",
+                            context.getString(R.string.mozac_browser_errorpages_security_bad_cert_back))
+                    .replace("%badCertAcceptTemporary%",
+                            context.getString(R.string.mozac_browser_errorpages_security_bad_cert_accept_temporary))
+            }
+        }
+
+        return htmlPage
     }
 }
 

--- a/components/browser/errorpages/src/main/res/raw/error_pages.html
+++ b/components/browser/errorpages/src/main/res/raw/error_pages.html
@@ -10,6 +10,41 @@
         <meta name="viewport" content="width=device-width; user-scalable=false;" />
         <title>%pageTitle%</title>
         <style>%css%</style>
+        <script type="text/javascript">
+            var showSSL = %showSSL%
+            var advancedVisible = false;
+            function toggleAdvanced() {
+                if (advancedVisible) {
+                    document.getElementById('badCertAdvancedPanel').style.display='none';
+
+                } else {
+                    document.getElementById('badCertAdvancedPanel').style.display='block';
+                }
+
+                advancedVisible = !advancedVisible;
+            }
+            function acceptAndContinue(temporary) {
+                document.addCertException(temporary).then(() => {
+                        location.reload();
+                    },
+                    err => {
+                        console.error("Unexpected error: " + err)
+                    }
+                );
+            }
+            document.addEventListener("DOMContentLoaded", function() {
+                if (typeof document.addCertException === "undefined") {
+                    document.getElementById('advancedButton').style.display='none';
+
+                } else {
+                    if (showSSL) {
+                        document.getElementById('advancedButton').style.display='block';
+                    } else {
+                        document.getElementById('advancedButton').style.display='none';
+                    }
+                }
+            }, false);
+        </script>
     </head>
 
     <body id="errorPage" dir="auto">
@@ -26,7 +61,7 @@
 
                 <!-- Short Description -->
                 <div id="errorShortDesc">
-                   %messageLong%
+                    %messageLong%
                 </div>
 
             </div>
@@ -34,6 +69,22 @@
             <!-- Retry Button -->
             <button id="errorTryAgain" onclick="window.location.reload()">%button%</button>
 
+            <!-- Advanced Button -->
+            <button id="advancedButton" class="buttonSecondary" onclick="toggleAdvanced()" style="display: none;">%badCertAdvanced%</button>
+
+            <div id="advancedPanelContainer">
+                <div id="badCertAdvancedPanel" class="advanced-panel" style="display: none;">
+                    <p id="badCertTechnicalInfo">
+                        %badCertTechInfo%
+                    </p>
+                    <div id="advancedPanelButtonContainer" class="button-container">
+                        <button id="advancedPanelReturnButton" onClick="window.history.back()" class="button">%badCertGoBack%</button>
+                    </div>
+                    <div id="advancedPanelButtonContainer" class="button-container">
+                        <button id="button" class="buttonSecondary" onClick="acceptAndContinue(true)">%badCertAcceptTemporary%</button>
+                    </div>
+                </div>
+            </div>
         </div>
     </body>
 </html>

--- a/components/browser/errorpages/src/main/res/raw/error_style.css
+++ b/components/browser/errorpages/src/main/res/raw/error_style.css
@@ -73,6 +73,21 @@ button {
   margin: var(--moz-vertical-spacing) 0 0;
 }
 
+.buttonSecondary{
+  /* Force buttons to display: block here to try and enforce collapsing margins */
+  display: block;
+  width: 100%;
+  border: none;
+  padding: 1rem;
+  font-family: sans-serif;
+  background-color: rgba(249, 249, 250, 0.1);
+  color: #FFFFFF;
+  font-weight: 300;
+  border-radius: 2px;
+  background-image: none;
+  margin: var(--moz-vertical-spacing) 0 0;
+}
+
 #errorPageContainer {
   /* If the page is greater than 550px center the content.
    * This number should be kept in sync with the media query for tablets below */
@@ -101,4 +116,42 @@ button {
       min-height: calc(100% - 64px);
     }
   }
+}
+
+#advancedPanelButtonContainer {
+  background-color: rgba(128, 128, 147, 0.1);
+  display: flex;
+  justify-content: center;
+  padding: 0.5em;
+}
+
+#advancedPanelContainer {
+  width: 100%;
+  left: 0;
+}
+
+.advanced-panel {
+  display: none;
+  background-color: #202023;
+  border: 1px solid rgba(249, 249, 250, 0.2);
+  margin: 48px auto;
+  min-width: 13em;
+  max-width: 52em;
+}
+
+.button-container {
+  display: flex;
+  flex-flow: row;
+}
+
+.button-container > button {
+  flex: 1 0 50%;
+  text-align: center;
+  margin: 0em 0.1em 0em 0.1em;
+}
+
+#badCertTechnicalInfo {
+  margin: 0em 1em 1em;
+  overflow: auto;
+  white-space: pre-line;
 }

--- a/components/browser/errorpages/src/main/res/values/strings.xml
+++ b/components/browser/errorpages/src/main/res/values/strings.xml
@@ -39,6 +39,19 @@
       </ul>
     ]]></string>
 
+    <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website has an invalid SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_advanced">Advanced…</string>
+    <!-- The advanced certificate information shown when a website sends has an invalid SSL certificate. It's only shown when a website has an invalid SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_techInfo"><![CDATA[
+        <label>Someone could be trying to impersonate the site and you should not continue.</label>
+        <br><br>
+        <label>Websites prove their identity via certificates. Firefox does not trust <b>%1$s</b> because its certificate issuer is unknown, the certificate is self-signed, or the server is not sending the correct intermediate certificates.</label>
+    ]]></string>
+    <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_back">Go Back (Recommended)</string>
+    <!-- The text shown inside the advanced options button used to bypass the invalid SSL certificate. It's only shown if the user has expanded the advanced options. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_accept_temporary">Accept the Risk and Continue</string>0
+
     <!-- The document title and heading of the error page shown when the user's network connection is interrupted while connecting to a website. -->
     <string name="mozac_browser_errorpages_net_interrupt_title">The connection was interrupted</string>
     <!-- The error message shown when the user's network connection is interrupted while connecting to a website. -->

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -61,7 +61,17 @@ class ErrorPagesTest {
         assertFalse(errorPage.contains("%messageLong%"))
         assertFalse(errorPage.contains("%css%"))
 
-        verify(context, times(4)).getString(anyInt())
-        verify(context, times(1)).getString(anyInt(), nullable(String::class.java))
+        if (errorType == ErrorType.ERROR_SECURITY_SSL || errorType == ErrorType.ERROR_SECURITY_BAD_CERT) {
+            assertFalse(errorPage.contains("%showSSL%"))
+            assertFalse(errorPage.contains("%badCertAdvanced%"))
+            assertFalse(errorPage.contains("%badCertTechInfo%"))
+            assertFalse(errorPage.contains("%badCertGoBack%"))
+            assertFalse(errorPage.contains("%badCertAcceptTemporary%"))
+            verify(context, times(7)).getString(anyInt())
+            verify(context, times(2)).getString(anyInt(), nullable(String::class.java))
+        } else {
+            verify(context, times(4)).getString(anyInt())
+            verify(context, times(1)).getString(anyInt(), nullable(String::class.java))
+        }
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -81,6 +81,9 @@ permalink: /changelog/
   val id = NotificationIds.getNextIdForTag(context, "mozac.my.feature")
   ```
 
+* **browser-errorpages**
+  * Added support for bypassing invalid SSL certification.
+
 # 26.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v25.0.0...v26.0.0)


### PR DESCRIPTION
This PR adds support for bypassing SSL certificates. Only temporary bypass is supported by GV right now.

Closes #3960.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
