### PR TITLE
Use glean gradle plugin for internal a-c uses

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val mozilla_appservices = "0.47.0"
 
-    const val mozilla_glean = "23.0.0"
+    const val mozilla_glean = "23.0.1"
 
     const val material = "1.0.0"
     const val nearby = "17.0.0"

--- a/components/browser/engine-gecko-beta/build.gradle
+++ b/components/browser/engine-gecko-beta/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -69,6 +81,6 @@ dependencies {
     androidTestImplementation project(':tooling-fetch-tests')
 }
 
-apply from: '../../../components/service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/browser/engine-gecko-nightly/build.gradle
+++ b/components/browser/engine-gecko-nightly/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -69,6 +81,6 @@ dependencies {
     androidTestImplementation project(':tooling-fetch-tests')
 }
 
-apply from: '../../../components/service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/browser/engine-gecko/build.gradle
+++ b/components/browser/engine-gecko/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -68,6 +80,6 @@ dependencies {
     androidTestImplementation project(':tooling-fetch-tests')
 }
 
-apply from: '../../../components/service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -59,6 +71,6 @@ dependencies {
 }
 
 ext.gleanGenerateMarkdownDocs = true
-apply from: '../../../components/service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/components/service/glean/scripts/sdk_generator.gradle
+++ b/components/service/glean/scripts/sdk_generator.gradle
@@ -34,6 +34,11 @@ logger.warning("The Glean sdk_generator.gradle script is deprecated. Use the Gle
 // so that it will be shared between all libraries that use Glean.  This is
 // important because it is approximately 300MB in installed size.
 
+///////////////////////////////////////////////////////////////////////////
+// NOTE: SINCE THIS FILE HAS BEEN DEPRECATED, THIS VERSION SHOULD NO LONGER BE
+// UPDATED. THE CANONICAL SOURCE FOR THE glean_parser VERSION IS IN THE
+// glean-gradle-plugin IN https://github.com/mozilla/glean
+///////////////////////////////////////////////////////////////////////////
 String GLEAN_PARSER_VERSION = "1.15.3"
 // The version of Miniconda is explicitly specified.
 // Miniconda3-4.5.12 is known to not work on Windows.

--- a/components/support/sync-telemetry/build.gradle
+++ b/components/support/sync-telemetry/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -48,4 +60,4 @@ apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
 
 ext.gleanGenerateMarkdownDocs = true
-apply from: '../../service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,7 @@ permalink: /changelog/
     * `browser-engine-gecko-nightly`: GeckoView 74.0
 
 * **service-glean**
-  * Glean was updated to v23.0.0:
+  * Glean was updated to v23.0.1:
     * The Glean Gradle Plugin correctly triggers docs and API updates when registry files
       change, without requiring them to be deleted.
     * `parseISOTimeString` has been made 4x faster. This had an impact on Glean
@@ -30,6 +30,8 @@ permalink: /changelog/
       * The public method `PingType.send()` (in all platforms) have been deprecated
         and renamed to `PingType.submit()`.
     * Rename `deletion_request` ping to `deletion-request` ping after glean_parser update
+    * BUGFIX: The Glean Gradle plugin will now work if an app or library doesn't
+      have a metrics.yaml or pings.yaml file.
 
 # 27.0.0
 

--- a/samples/glean/build.gradle
+++ b/samples/glean/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -57,4 +69,4 @@ dependencies {
     androidTestImplementation Dependencies.testing_mockwebserver
 }
 
-apply from: '../../components/service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/samples/glean/samples-glean-library/build.gradle
+++ b/samples/glean/samples-glean-library/build.gradle
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -31,5 +43,5 @@ dependencies {
     implementation project(':service-glean')
 }
 
-apply from: '../../../components/service/glean/scripts/sdk_generator.gradle'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 


### PR DESCRIPTION
This uses the Glean Gradle plugin for all uses internal to android-components.

This is a separate issue than using the Glean Gradle plugin for users external to android-components, which is currently blocked by #5476.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
