### PR TITLE
Closes #5436: Lazy inflate ReaderViewControlsBar

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenter.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenter.kt
@@ -20,6 +20,7 @@ internal class ReaderViewControlsPresenter(
      */
     fun show() {
         view.apply {
+            tryInflate()
             setColorScheme(config.colorScheme)
             setFont(config.fontType)
             setFontSize(config.fontSize)

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/view/ReaderViewControlsView.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/view/ReaderViewControlsView.kt
@@ -45,6 +45,15 @@ interface ReaderViewControlsView {
      */
     fun asView(): View = (this as View)
 
+    /**
+     * Tries to inflate the view if needed.
+     *
+     * See: https://github.com/mozilla-mobile/android-components/issues/5491
+     *
+     * @return true if the inflation was completed, false if the view was already inflated.
+     */
+    fun tryInflate(): Boolean
+
     interface Listener {
         fun onFontChanged(font: FontType)
         fun onFontSizeIncreased(): Int

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenterTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/internal/ReaderViewControlsPresenterTest.kt
@@ -29,6 +29,7 @@ class ReaderViewControlsPresenterTest {
 
         presenter.show()
 
+        verify(view).tryInflate()
         verify(view).setColorScheme(any())
         verify(view).setFontSize(5)
         verify(view).setFont(any())

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/view/ReaderViewControlsBarTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/view/ReaderViewControlsBarTest.kt
@@ -17,6 +17,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -35,6 +36,9 @@ class ReaderViewControlsBarTest {
     @Test
     fun `font options are set`() {
         val bar = ReaderViewControlsBar(appCompatContext)
+
+        bar.showControls()
+
         val serifButton = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_font_serif)
         val sansSerifButton = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_font_sans_serif)
 
@@ -54,6 +58,8 @@ class ReaderViewControlsBarTest {
     @Test
     fun `font size buttons are enabled or disabled`() {
         val bar = ReaderViewControlsBar(appCompatContext)
+
+        bar.showControls()
 
         val sizeDecreaseButton = bar.findViewById<AppCompatButton>(R.id.mozac_feature_readerview_font_size_decrease)
         val sizeIncreaseButton = bar.findViewById<AppCompatButton>(R.id.mozac_feature_readerview_font_size_increase)
@@ -87,6 +93,9 @@ class ReaderViewControlsBarTest {
     @Test
     fun `color scheme is set`() {
         val bar = ReaderViewControlsBar(appCompatContext)
+
+        bar.showControls()
+
         val colorOptionDark = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_color_dark)
         val colorOptionSepia = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_color_sepia)
         val colorOptionLight = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_color_light)
@@ -113,6 +122,7 @@ class ReaderViewControlsBarTest {
     @Test
     fun `showControls updates visibility and requests focus`() {
         val bar = spy(ReaderViewControlsBar(appCompatContext))
+        doNothing().`when`(bar).inflateIfNeeded() // Robolectric has issues with late inflation of merge elements
 
         bar.showControls()
 
@@ -149,6 +159,8 @@ class ReaderViewControlsBarTest {
         val bar = ReaderViewControlsBar(appCompatContext)
         val listener: ReaderViewControlsView.Listener = mock()
 
+        bar.showControls()
+
         assertNull(bar.listener)
 
         bar.listener = listener
@@ -163,6 +175,8 @@ class ReaderViewControlsBarTest {
         val bar = ReaderViewControlsBar(appCompatContext)
         val listener: ReaderViewControlsView.Listener = mock()
 
+        bar.showControls()
+
         assertNull(bar.listener)
 
         bar.listener = listener
@@ -176,6 +190,8 @@ class ReaderViewControlsBarTest {
     fun `listener is invoked when clicking a color scheme`() {
         val bar = ReaderViewControlsBar(appCompatContext)
         val listener: ReaderViewControlsView.Listener = mock()
+
+        bar.showControls()
 
         assertNull(bar.listener)
 

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/view/ReaderViewControlsBarTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/view/ReaderViewControlsBarTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -36,8 +35,7 @@ class ReaderViewControlsBarTest {
     @Test
     fun `font options are set`() {
         val bar = ReaderViewControlsBar(appCompatContext)
-
-        bar.showControls()
+        bar.tryInflate()
 
         val serifButton = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_font_serif)
         val sansSerifButton = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_font_sans_serif)
@@ -58,8 +56,7 @@ class ReaderViewControlsBarTest {
     @Test
     fun `font size buttons are enabled or disabled`() {
         val bar = ReaderViewControlsBar(appCompatContext)
-
-        bar.showControls()
+        bar.tryInflate()
 
         val sizeDecreaseButton = bar.findViewById<AppCompatButton>(R.id.mozac_feature_readerview_font_size_decrease)
         val sizeIncreaseButton = bar.findViewById<AppCompatButton>(R.id.mozac_feature_readerview_font_size_increase)
@@ -93,8 +90,7 @@ class ReaderViewControlsBarTest {
     @Test
     fun `color scheme is set`() {
         val bar = ReaderViewControlsBar(appCompatContext)
-
-        bar.showControls()
+        bar.tryInflate()
 
         val colorOptionDark = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_color_dark)
         val colorOptionSepia = bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_color_sepia)
@@ -122,7 +118,6 @@ class ReaderViewControlsBarTest {
     @Test
     fun `showControls updates visibility and requests focus`() {
         val bar = spy(ReaderViewControlsBar(appCompatContext))
-        doNothing().`when`(bar).inflateIfNeeded() // Robolectric has issues with late inflation of merge elements
 
         bar.showControls()
 
@@ -159,11 +154,10 @@ class ReaderViewControlsBarTest {
         val bar = ReaderViewControlsBar(appCompatContext)
         val listener: ReaderViewControlsView.Listener = mock()
 
-        bar.showControls()
-
         assertNull(bar.listener)
 
         bar.listener = listener
+        bar.tryInflate()
 
         bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_font_sans_serif).performClick()
 
@@ -175,11 +169,10 @@ class ReaderViewControlsBarTest {
         val bar = ReaderViewControlsBar(appCompatContext)
         val listener: ReaderViewControlsView.Listener = mock()
 
-        bar.showControls()
-
         assertNull(bar.listener)
 
         bar.listener = listener
+        bar.tryInflate()
 
         bar.findViewById<AppCompatButton>(R.id.mozac_feature_readerview_font_size_increase).performClick()
 
@@ -191,14 +184,21 @@ class ReaderViewControlsBarTest {
         val bar = ReaderViewControlsBar(appCompatContext)
         val listener: ReaderViewControlsView.Listener = mock()
 
-        bar.showControls()
-
         assertNull(bar.listener)
 
         bar.listener = listener
+        bar.tryInflate()
 
         bar.findViewById<AppCompatRadioButton>(R.id.mozac_feature_readerview_color_sepia).performClick()
 
         verify(listener).onColorSchemeChanged(ReaderViewFeature.ColorScheme.SEPIA)
+    }
+
+    @Test
+    fun `tryInflate is only successfully once`() {
+        val bar = ReaderViewControlsBar(appCompatContext)
+
+        assertTrue(bar.tryInflate())
+        assertFalse(bar.tryInflate())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -76,9 +76,6 @@ permalink: /changelog/
 
 * **browser-menu**
   * Added `BrowserMenuHighlightableSwitch` to represent a highlightable item with a toggle switch.
-  
-* **feature-readerview**
-  * ReaderViewControlsBar now inflates lazily, only when asked to be shown.
 
 * **lib-crash**
   * Now supports performing action after submitting crash report.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -76,6 +76,9 @@ permalink: /changelog/
 
 * **browser-menu**
   * Added `BrowserMenuHighlightableSwitch` to represent a highlightable item with a toggle switch.
+  
+* **feature-readerview**
+  * ReaderViewControlsBar now inflates lazily, only when asked to be shown.
 
 * **lib-crash**
   * Now supports performing action after submitting crash report.


### PR DESCRIPTION

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Building off https://github.com/mozilla-mobile/android-components/pull/5438, we're adding conditional inflation to the ReaderViewControlsBar with some ideas that Colin and I worked on offline.

I'm currently running into unrelated build issues with testing this in Fenix to assert the gains expected, but the basis of the change is largely the same so the code.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
