### PR TITLE
Closes #5460: Fennec migration: Disable currently unsupported add-ons

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webextension.EnableSource
+import mozilla.components.concept.engine.webextension.WebExtension
+
+/**
+ * Wraps [AddonMigrationResult] in an exception so that it can be returned via [Result.Failure].
+ *
+ * @property failure Wrapped [AddonMigrationResult] indicating exact failure reason.
+ */
+class AddonMigrationException(val failure: AddonMigrationResult.Failure) : Exception(failure.toString())
+
+/**
+ * Result of an add-on migration.
+ */
+sealed class AddonMigrationResult {
+    /**
+     * Success variants of an add-on migration.
+     */
+    sealed class Success : AddonMigrationResult() {
+        /**
+         * No add-ons installed to migrate.
+         */
+        object NoAddons : Success()
+
+        /**
+         * Successfully migrated add-ons.
+         */
+        data class AddonsMigrated(
+            val migratedAddons: List<WebExtension>
+        ) : Success() {
+            override fun toString(): String {
+                return "Successfully migrated ${migratedAddons.size} add-ons."
+            }
+        }
+    }
+
+    /**
+     * Failure variants of an add-on migration.
+     */
+    sealed class Failure : AddonMigrationResult() {
+        /**
+         * Failed to query installed add-ons via the [Engine].
+         */
+        internal data class FailedToQueryInstalledAddons(val throwable: Throwable) : Failure() {
+            override fun toString(): String {
+                return "Failed to query installed add-ons: ${throwable::class}"
+            }
+        }
+
+        /**
+         * Failed to migrate some or all of the installed add-ons.
+         */
+        internal data class FailedToMigrateAddons(
+            val migratedAddons: List<WebExtension>,
+            val failedAddons: Map<WebExtension, Exception>
+        ) : Failure() {
+            override fun toString(): String {
+                return "Failed to migrate ${failedAddons.size} of ${failedAddons.size + migratedAddons.size} add-ons."
+            }
+        }
+    }
+}
+
+/**
+ * Helper for migrating add-ons.
+ */
+internal object AddonMigration {
+
+    /**
+     * Performs a migration of all installed add-ons. The only migration step involved
+     * is to make sure we disable all currently unsupported add-ons.
+     */
+    @SuppressWarnings("TooGenericExceptionCaught")
+    suspend fun migrate(engine: Engine): Result<AddonMigrationResult> {
+        val installedAddons =
+        try {
+            getInstalledAddons(engine)
+        } catch (e: Exception) {
+            return Result.Failure(AddonMigrationException(AddonMigrationResult.Failure.FailedToQueryInstalledAddons(e)))
+        }
+
+        if (installedAddons.isEmpty()) {
+            return Result.Success(AddonMigrationResult.Success.NoAddons)
+        }
+
+        val migratedAddons = mutableListOf<WebExtension>()
+        val failures = mutableMapOf<WebExtension, Exception>()
+        installedAddons.forEach { addon ->
+            try {
+                migratedAddons += migrateAddon(engine, addon)
+            } catch (e: Exception) {
+                failures[addon] = e
+            }
+        }
+
+        return if (failures.isEmpty()) {
+            Result.Success(AddonMigrationResult.Success.AddonsMigrated(migratedAddons))
+        } else {
+            val failure = AddonMigrationResult.Failure.FailedToMigrateAddons(migratedAddons, failures)
+            Result.Failure(AddonMigrationException(failure))
+        }
+    }
+
+    private suspend fun getInstalledAddons(engine: Engine): List<WebExtension> {
+        return CompletableDeferred<List<WebExtension>>().also { result ->
+            withContext(Dispatchers.Main) {
+                engine.listInstalledWebExtensions(
+                    onSuccess = { result.complete(it) },
+                    onError = { result.completeExceptionally(it) }
+                )
+            }
+        }.await()
+    }
+
+    private suspend fun migrateAddon(engine: Engine, addon: WebExtension): WebExtension {
+        // TODO (For final migration): check if addon is supported (against AMO via
+        // AddonCollectionProvider and/or offline whitelist):
+        // https://github.com/mozilla-mobile/fenix/issues/4983
+        // For now let's disable unconditionally, as we don't support any addon yet.
+        return CompletableDeferred<WebExtension>().also { result ->
+            withContext(Dispatchers.Main) {
+                engine.disableWebExtension(
+                    addon,
+                    EnableSource.APP_SUPPORT,
+                    onSuccess = { result.complete(it) },
+                    onError = { result.completeExceptionally(it) }
+                )
+            }
+        }.await()
+    }
+}

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/Exception.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/Exception.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+/**
+ * Returns a unique identifier for this [Throwable]
+ */
+fun Exception.uniqueId(): String {
+    // In extreme cases, VM is allowed to return an empty stacktrace.
+    val topStackFrameString = this.stackTrace.getOrNull(0)?.toString() ?: ""
+    return "${this::class.java.canonicalName} $topStackFrameString"
+}

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
@@ -533,10 +533,7 @@ internal object FennecLoginsMigration {
         try {
             block()
         } catch (e: Exception) {
-            // In extreme cases, VM is allowed to return an empty stacktrace.
-            val topStackFrameString = e.stackTrace.getOrNull(0)?.toString() ?: ""
-            val exceptionKey = "${e::class.java.canonicalName} $topStackFrameString"
-            collector[exceptionKey] = e
+            collector[e.uniqueId()] = e
         }
     }
 }

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationResultsStore.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationResultsStore.kt
@@ -61,6 +61,7 @@ internal class MigrationResultsStore(context: Context) : SharedPreferencesCache<
                 Migration.FxA.javaClass.simpleName -> Migration.FxA
                 Migration.Logins.javaClass.simpleName -> Migration.Logins
                 Migration.Settings.javaClass.simpleName -> Migration.Settings
+                Migration.Addons.javaClass.simpleName -> Migration.Addons
                 else -> throw IllegalStateException("Unrecognized migration type: $migrationName")
             }
             result[migration] = MigrationRun(version = migrationVersion, success = migrationSuccess)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.IllegalArgumentException
+
+@RunWith(AndroidJUnit4::class)
+class AddonMigrationTest {
+
+    @Test
+    fun `No addons installed`() = runBlocking {
+        val engine: Engine = mock()
+        val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
+            callbackCaptor.value.invoke(emptyList())
+        }
+
+        val result = AddonMigration.migrate(engine)
+
+        assertTrue(result is Result.Success)
+        val migrationResult = (result as Result.Success).value
+        assertTrue(migrationResult is AddonMigrationResult.Success.NoAddons)
+    }
+
+    @Test
+    fun `All addons migrated`() = runBlocking {
+        val addon1: WebExtension = mock()
+        val addon2: WebExtension = mock()
+
+        val engine: Engine = mock()
+        val listSuccessCallback = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(listSuccessCallback.capture(), any())).thenAnswer {
+            listSuccessCallback.value.invoke(listOf(addon1, addon2))
+        }
+
+        val addonCaptor = argumentCaptor<WebExtension>()
+        val disableSuccessCallback = argumentCaptor<((WebExtension) -> Unit)>()
+        whenever(engine.disableWebExtension(addonCaptor.capture(), any(), disableSuccessCallback.capture(), any()))
+            .thenAnswer { disableSuccessCallback.value.invoke(addonCaptor.value) }
+
+        val result = AddonMigration.migrate(engine)
+
+        assertTrue(result is Result.Success)
+        val migrationResult = (result as Result.Success).value
+        assertTrue(migrationResult is AddonMigrationResult.Success.AddonsMigrated)
+
+        val migratedAddons = (migrationResult as AddonMigrationResult.Success.AddonsMigrated).migratedAddons
+        assertEquals(listOf(addon1, addon2), migratedAddons)
+    }
+
+    @Test
+    fun `Failure when querying installed addons`() = runBlocking {
+        val engine: Engine = mock()
+        val errorCallback = argumentCaptor<((Throwable) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(any(), errorCallback.capture())).thenAnswer {
+            errorCallback.value.invoke(IllegalArgumentException())
+        }
+
+        val result = AddonMigration.migrate(engine)
+
+        assertTrue(result is Result.Failure)
+        val migrationResult = (result as Result.Failure).throwables.first()
+        assertTrue(migrationResult is AddonMigrationException)
+
+        val failure = (migrationResult as AddonMigrationException).failure
+        assertTrue(failure is AddonMigrationResult.Failure.FailedToQueryInstalledAddons)
+
+        val cause = (failure as AddonMigrationResult.Failure.FailedToQueryInstalledAddons).throwable
+        assertTrue(cause is IllegalArgumentException)
+    }
+
+    @Test
+    fun `Failure when migrating some addons`() = runBlocking {
+        val addon1: WebExtension = mock()
+        val addon2: WebExtension = mock()
+        val addon3: WebExtension = mock()
+
+        val engine: Engine = mock()
+        val listSuccessCallback = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(listSuccessCallback.capture(), any())).thenAnswer {
+            listSuccessCallback.value.invoke(listOf(addon1, addon2, addon3))
+        }
+
+        val addonCaptor = argumentCaptor<WebExtension>()
+        val disableSuccessCallback = argumentCaptor<((WebExtension) -> Unit)>()
+        val disableErrorCallback = argumentCaptor<((Throwable) -> Unit)>()
+        whenever(engine.disableWebExtension(
+            addonCaptor.capture(),
+            any(),
+            disableSuccessCallback.capture(),
+            disableErrorCallback.capture())
+        )
+        .thenAnswer {
+            if (addonCaptor.value == addon2) {
+                disableErrorCallback.value.invoke(IllegalArgumentException())
+            } else {
+                disableSuccessCallback.value.invoke(addonCaptor.value)
+            }
+        }
+
+        val result = AddonMigration.migrate(engine)
+
+        assertTrue(result is Result.Failure)
+        val migrationResult = (result as Result.Failure).throwables.first()
+        assertTrue(migrationResult is AddonMigrationException)
+
+        val failure = (migrationResult as AddonMigrationException).failure
+        assertTrue(failure is AddonMigrationResult.Failure.FailedToMigrateAddons)
+
+        val migratedAddons = (failure as AddonMigrationResult.Failure.FailedToMigrateAddons).migratedAddons
+        val failedAddons = failure.failedAddons
+        assertEquals(listOf(addon1, addon3), migratedAddons)
+        assertEquals(setOf(addon2), failedAddons.keys)
+        assertTrue(failedAddons[addon2] is IllegalArgumentException)
+    }
+}

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/ExceptionTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/ExceptionTest.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.lang.IllegalArgumentException
+
+class ExceptionTest {
+
+    @Test
+    fun uniqueId() {
+        val id = IllegalArgumentException("test").uniqueId()
+        val id2 = IllegalArgumentException("test2").uniqueId()
+        assertNotEquals(id, id2)
+
+        val ids = (0..1).map { IllegalArgumentException("test").uniqueId() }
+        assertEquals(2, ids.size)
+        assertEquals(ids[0], ids[1])
+    }
+}


### PR DESCRIPTION
This is for the first iteration and currently disabling *all* installed addons. Later we want to match against supported addons from our AMO collection and/or an offline whitelist.

Made sure to capture all outcomes in `AddonMigrationResult`s so we can add telemetry/logs, as needed. Let me know if I missed anything :). 