### PR TITLE
Pasting URL to URL bar without formatting (Android M and higher)

### DIFF
--- a/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -677,6 +677,14 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
         windowFocusChangeListener?.invoke(hasFocus)
     }
 
+    override fun onTextContextMenuItem(id: Int): Boolean {
+        var newId = id
+        if (newId == android.R.id.paste && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            newId = android.R.id.pasteAsPlainText
+        }
+        return super.onTextContextMenuItem(newId)
+    }
+
     @Suppress("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
         return if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M &&


### PR DESCRIPTION
Partial fix for pasting URL to URL bar (works for Android M and higher).

Before change: text is added with rich formatting

After change: text is added without rich formatting

Closes #5512: Strip formatting when pasting text in url bar 
 
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
