### PR TITLE
Closes #4721: Upgrade A-S to 0.48.1; reuse session token during FxA migration

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.46.0"
+    const val mozilla_appservices = "0.47.0"
 
     const val mozilla_glean = "23.0.1"
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.47.0"
+    const val mozilla_appservices = "0.48.1"
 
     const val mozilla_glean = "23.0.1"
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.44.0"
+    const val mozilla_appservices = "0.46.0"
 
     const val mozilla_glean = "23.0.1"
 

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Connection.kt
@@ -10,6 +10,7 @@ import mozilla.appservices.places.PlacesReaderConnection
 import mozilla.appservices.places.PlacesWriterConnection
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.support.sync.telemetry.SyncTelemetry
+import org.json.JSONObject
 import java.io.Closeable
 import java.io.File
 
@@ -40,8 +41,15 @@ internal interface Connection : Closeable {
     fun syncHistory(syncInfo: SyncAuthInfo)
     fun syncBookmarks(syncInfo: SyncAuthInfo)
 
-    fun importVisitsFromFennec(dbPath: String)
-    fun importBookmarksFromFennec(dbPath: String)
+    /**
+     * @return Migration metrics wrapped in a JSON object. See libplaces for schema details.
+     */
+    fun importVisitsFromFennec(dbPath: String): JSONObject
+
+    /**
+     * @return Migration metrics wrapped in a JSON object. See libplaces for schema details.
+     */
+    fun importBookmarksFromFennec(dbPath: String): JSONObject
 }
 
 /**
@@ -94,14 +102,14 @@ internal object RustPlacesConnection : Connection {
         SyncTelemetry.processBookmarksPing(ping)
     }
 
-    override fun importVisitsFromFennec(dbPath: String) {
+    override fun importVisitsFromFennec(dbPath: String): JSONObject {
         check(api != null) { "must call init first" }
-        api!!.importVisitsFromFennec(dbPath)
+        return api!!.importVisitsFromFennec(dbPath)
     }
 
-    override fun importBookmarksFromFennec(dbPath: String) {
+    override fun importBookmarksFromFennec(dbPath: String): JSONObject {
         check(api != null) { "must call init first" }
-        api!!.importBookmarksFromFennec(dbPath)
+        return api!!.importBookmarksFromFennec(dbPath)
     }
 
     override fun close() = synchronized(this) {

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONObject
 
 /**
  * Implementation of the [BookmarksStorage] which is backed by a Rust Places lib via [PlacesApi].
@@ -191,10 +192,11 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * Before running this, first run [PlacesHistoryStorage.importFromFennec] to import history and visits data.
      *
      * @param dbPath Absolute path to Fennec's browser.db file.
+     * @return Migration metrics wrapped in a JSON object. See libplaces for schema details.
      */
     @Throws(PlacesException::class)
-    fun importFromFennec(dbPath: String) {
-        places.importBookmarksFromFennec(dbPath)
+    fun importFromFennec(dbPath: String): JSONObject {
+        return places.importBookmarksFromFennec(dbPath)
     }
 
     /**

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -22,6 +22,7 @@ import mozilla.components.concept.sync.SyncStatus
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.segmentAwareDomainMatch
+import org.json.JSONObject
 
 const val AUTOCOMPLETE_SOURCE_NAME = "placesHistory"
 
@@ -196,10 +197,11 @@ open class PlacesHistoryStorage(context: Context) : PlacesStorage(context), Hist
      * Import history and visits data from Fennec's browser.db file.
      *
      * @param dbPath Absolute path to Fennec's browser.db file.
+     * @return Migration metrics wrapped in a JSON object. See libplaces for schema details.
      */
     @Throws(PlacesException::class)
-    fun importFromFennec(dbPath: String) {
-        places.importVisitsFromFennec(dbPath)
+    fun importFromFennec(dbPath: String): JSONObject {
+        return places.importVisitsFromFennec(dbPath)
     }
 
     /**

--- a/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -509,12 +510,14 @@ class PlacesHistoryStorageTest {
                 return 0L
             }
 
-            override fun importVisitsFromFennec(dbPath: String) {
+            override fun importVisitsFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
-            override fun importBookmarksFromFennec(dbPath: String) {
+            override fun importBookmarksFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
             override fun close() {
@@ -554,12 +557,14 @@ class PlacesHistoryStorageTest {
                 return 0L
             }
 
-            override fun importVisitsFromFennec(dbPath: String) {
+            override fun importVisitsFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
-            override fun importBookmarksFromFennec(dbPath: String) {
+            override fun importBookmarksFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
             override fun close() {
@@ -599,12 +604,14 @@ class PlacesHistoryStorageTest {
                 return 0L
             }
 
-            override fun importVisitsFromFennec(dbPath: String) {
+            override fun importVisitsFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
-            override fun importBookmarksFromFennec(dbPath: String) {
+            override fun importBookmarksFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
             override fun close() {
@@ -648,12 +655,14 @@ class PlacesHistoryStorageTest {
                 return 0L
             }
 
-            override fun importVisitsFromFennec(dbPath: String) {
+            override fun importVisitsFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
-            override fun importBookmarksFromFennec(dbPath: String) {
+            override fun importBookmarksFromFennec(dbPath: String): JSONObject {
                 fail()
+                return JSONObject()
             }
 
             override fun close() {

--- a/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -152,7 +152,8 @@ interface OAuthAccount : AutoCloseable {
     fun registerPersistenceCallback(callback: StatePersistenceCallback)
 
     /**
-     * Attempts to migrate from an existing session token without user input
+     * Attempts to migrate from an existing session token without user input.
+     * Passed-in session token will be reused.
      *
      * @param sessionToken token string to use for login
      * @param kSync sync string for login
@@ -160,6 +161,17 @@ interface OAuthAccount : AutoCloseable {
      * @return Deferred boolean success or failure for the migration event
      */
     fun migrateFromSessionTokenAsync(sessionToken: String, kSync: String, kXCS: String): Deferred<Boolean>
+
+    /**
+     * Attempts to migrate from an existing session token without user input.
+     * New session token will be created.
+     *
+     * @param sessionToken token string to use for login
+     * @param kSync sync string for login
+     * @param kXCS XCS string for login
+     * @return Deferred boolean success or failure for the migration event
+     */
+    fun copyFromSessionTokenAsync(sessionToken: String, kSync: String, kXCS: String): Deferred<Boolean>
 
     /**
      * Returns the device constellation for the current account

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -160,6 +160,12 @@ class FirefoxAccount internal constructor(
         }
     }
 
+    override fun copyFromSessionTokenAsync(sessionToken: String, kSync: String, kXCS: String) = scope.async {
+        handleFxaExceptions(logger, "copyFromSessionToken") {
+            inner.copyFromSessionToken(sessionToken, kSync, kXCS)
+        }
+    }
+
     override fun getTokenServerEndpointURL(): String {
         return inner.getTokenServerEndpointURL()
     }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -624,7 +624,7 @@ open class FxaAccountManager(
                     is Event.SignInShareableAccount -> {
                         account.registerPersistenceCallback(statePersistenceCallback)
 
-                        val migrationResult = account.migrateFromSessionTokenAsync(
+                        val migrationResult = account.copyFromSessionTokenAsync(
                             via.account.authInfo.sessionToken,
                             via.account.authInfo.kSync,
                             via.account.authInfo.kXCS

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -47,12 +47,12 @@ internal sealed class Event {
             return this.javaClass.simpleName
         }
     }
-    data class SignInShareableAccount(val account: ShareableAccount) : Event() {
+    data class SignInShareableAccount(val account: ShareableAccount, val reuseAccount: Boolean) : Event() {
         override fun toString(): String {
             return this.javaClass.simpleName
         }
     }
-    object SignedInShareableAccount : Event()
+    data class SignedInShareableAccount(val reuseAccount: Boolean) : Event()
     object RecoveredFromAuthenticationProblem : Event()
     object FetchProfile : Event()
     object FetchedProfile : Event()

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/AsyncLoginsStorage.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.sync.SyncStatus
 import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.components.concept.sync.LockableStore
 import mozilla.components.support.sync.telemetry.SyncTelemetry
+import org.json.JSONObject
 
 /**
  * This type contains the set of information required to successfully
@@ -285,7 +286,7 @@ interface AsyncLoginsStorage : AutoCloseable {
      * @rejectsWith [LoginsStorageException] If DB isn't empty during an import; also, on unexpected errors
      * (IO failure, rust panics, etc).
      */
-    fun importLoginsAsync(logins: List<ServerPassword>): Deferred<Long>
+    fun importLoginsAsync(logins: List<ServerPassword>): Deferred<JSONObject>
 }
 
 /**
@@ -368,7 +369,7 @@ open class AsyncLoginsStorageAdapter<T : LoginsStorage>(private val wrapped: T) 
         return wrapped.getHandle()
     }
 
-    override fun importLoginsAsync(logins: List<ServerPassword>): Deferred<Long> {
+    override fun importLoginsAsync(logins: List<ServerPassword>): Deferred<JSONObject> {
         return scope.async { wrapped.importLogins(logins.toTypedArray()) }
     }
 

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
@@ -136,7 +136,7 @@ private object AuthenticatedAccountProcessor {
             authInfo = fennecAuthInfo
         )
 
-        if (!accountManager.signInWithShareableAccountAsync(shareableAccount).await()) {
+        if (!accountManager.signInWithShareableAccountAsync(shareableAccount, reuseAccount = true).await()) {
             // What do we do now?
             // We detected an account in a good state, and failed to actually login with it.
             // This could indicate that credentials stored in Fennec are no longer valid, or that we had a

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.sharing.ShareableAccount
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.json.JSONException
@@ -79,7 +80,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any())).thenReturn(CompletableDeferred(true))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(true))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Success) {
             assertEquals(FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount::class, this.value::class)
@@ -87,7 +88,7 @@ class FennecFxaMigrationTest {
             assertEquals("Married", (this.value as FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount).stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture())
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252fsvj8932vj32movj97325hjfksdhfjstrg23yurt267r23", captor.value.authInfo.kSync)
@@ -101,7 +102,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any())).thenReturn(CompletableDeferred(true))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(true))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Success) {
             assertEquals(FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount::class, this.value::class)
@@ -109,7 +110,7 @@ class FennecFxaMigrationTest {
             assertEquals("Cohabiting", (this.value as FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount).stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture())
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252bc4ccc3a239fsdfsdf32fg32wf3w4e3472d41d1a204890", captor.value.authInfo.kSync)
@@ -123,7 +124,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any())).thenReturn(CompletableDeferred(false))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(false))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Failure) {
             val unwrapped = this.throwables.first() as FxaMigrationException
@@ -133,7 +134,7 @@ class FennecFxaMigrationTest {
             assertEquals("Married", (unwrapped.failure as FxaMigrationResult.Failure.FailedToSignIntoAuthenticatedAccount).stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture())
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252fsvj8932vj32movj97325hjfksdhfjstrg23yurt267r23", captor.value.authInfo.kSync)
@@ -147,7 +148,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any())).thenReturn(CompletableDeferred(false))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(false))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Failure) {
             val unwrapped = this.throwables.first() as FxaMigrationException
@@ -157,7 +158,7 @@ class FennecFxaMigrationTest {
             assertEquals("Cohabiting", unwrappedFailure.stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture())
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252bc4ccc3a239fsdfsdf32fg32wf3w4e3472d41d1a204890", captor.value.authInfo.kSync)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -38,6 +38,7 @@ import mozilla.components.service.sync.logins.AsyncLoginsStorageAdapter
 import mozilla.components.service.sync.logins.ServerPassword
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.whenever
+import mozilla.components.support.test.eq
 import org.mockito.Mockito.reset
 import java.lang.IllegalArgumentException
 
@@ -484,7 +485,7 @@ class FennecMigratorTest {
             .setCoroutineContext(this.coroutineContext)
             .build()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any())).thenReturn(CompletableDeferred(true))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(true))
 
         with(migrator.migrateAsync().await()) {
             assertEquals(1, this.size)
@@ -493,7 +494,7 @@ class FennecMigratorTest {
         }
 
         val captor = argumentCaptor<ShareableAccount>()
-        verify(accountManager).signInWithShareableAccountAsync(captor.capture())
+        verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
 
         assertEquals("test@example.com", captor.value.email)
         // This is going to be package name (org.mozilla.firefox) in actual builds.
@@ -521,7 +522,7 @@ class FennecMigratorTest {
             .build()
 
         // For now, we don't treat sign-in failure any different from success. E.g. it's a one-shot attempt.
-        `when`(accountManager.signInWithShareableAccountAsync(any())).thenReturn(CompletableDeferred(false))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(false))
 
         with(migrator.migrateAsync().await()) {
             assertEquals(1, this.size)
@@ -530,7 +531,7 @@ class FennecMigratorTest {
         }
 
         val captor = argumentCaptor<ShareableAccount>()
-        verify(accountManager).signInWithShareableAccountAsync(captor.capture())
+        verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
 
         assertEquals("test@example.com", captor.value.email)
         // This is going to be package name (org.mozilla.firefox) in actual builds.

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -588,13 +588,13 @@ class FennecMigratorTest {
                     timeCreated = 1574735368749,
                     timeLastUsed = 1574735368749,
                     timePasswordChanged = 1574735368749,
-                    usernameField = null,
-                    passwordField = null
+                    usernameField = "",
+                    passwordField = ""
                 ),
                 ServerPassword(
                     id = "{cf7cabe4-ec82-4800-b077-c6d97ffcd63a}",
                     hostname = "https://html.com",
-                    username = null,
+                    username = "",
                     password = "testp",
                     httpRealm = null,
                     formSubmitURL = "https://html.com",
@@ -602,7 +602,7 @@ class FennecMigratorTest {
                     timeCreated = 1574735237274,
                     timeLastUsed = 1574735237274,
                     timePasswordChanged = 1574735237274,
-                    usernameField = null,
+                    usernameField = "",
                     passwordField = "password"
                 )
             ), this)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,10 @@ permalink: /changelog/
   )
   ```
 
+* **service-firefox-accounts**
+  * `signInWithShareableAccountAsync` now takes a `reuseAccount` parameter, allowing consumers
+    to reuse existing session token (and FxA device) associated with the passed-in account.
+
 # 27.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v26.0.0...v27.0.0)


### PR DESCRIPTION
This PR does three things:
- bumps A-S to 0.48.1 which includes necessary APIs. This also exposes migration metrics, as well
- adapts FxAccountManager to be able to re-use existing session token, vs creating a new one
- configures migration code to use the new FxA "reuse account" path

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
