### PR TITLE
Closes #5175: Allow Socorro to distinguish between fatal and non-fatal crashes

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/Crash.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/Crash.kt
@@ -31,6 +31,7 @@ sealed class Crash {
      * A crash caused by an uncaught exception.
      *
      * @property throwable The [Throwable] that caused the crash.
+     * @property breadcrumbs List of breadcrumbs to send with the crash report.
      */
     data class UncaughtExceptionCrash(
         val throwable: Throwable,
@@ -61,6 +62,7 @@ sealed class Crash {
      * @property isFatal Whether or not the crash was fatal or not: If true, the main application process was affected
      *                   by the crash. If false, only an internal process used by Gecko has crashed and the application
      *                   may be able to recover.
+     * @property breadcrumbs List of breadcrumbs to send with the crash report.
      */
     data class NativeCodeCrash(
         val minidumpPath: String?,

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/CrashReporterService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/CrashReporterService.kt
@@ -7,6 +7,8 @@ package mozilla.components.lib.crash.service
 import mozilla.components.lib.crash.Crash
 
 internal const val INFO_PREFIX = "[INFO]"
+internal const val FATAL_PREFIX = "[FATAL]"
+internal const val NONFATAL_PREFIX = "[NONFATAL]"
 
 /**
  * Interface to be implemented by external services that accept crash reports.

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt
@@ -34,13 +34,13 @@ class MozillaSocorroServiceTest {
             testContext,
             "Test App"
         ))
-        doNothing().`when`(service).sendReport(any(), any(), any(), anyBoolean())
+        doNothing().`when`(service).sendReport(any(), any(), any(), anyBoolean(), anyBoolean())
 
         val crash = Crash.NativeCodeCrash("", true, "", false, arrayListOf())
         service.report(crash)
 
         verify(service).report(crash)
-        verify(service).sendReport(null, crash.minidumpPath, crash.extrasPath, false)
+        verify(service).sendReport(null, crash.minidumpPath, crash.extrasPath, false, false)
     }
 
     @Test
@@ -49,13 +49,13 @@ class MozillaSocorroServiceTest {
             testContext,
             "Test App"
         ))
-        doNothing().`when`(service).sendReport(any(), any(), any(), anyBoolean())
+        doNothing().`when`(service).sendReport(any(), any(), any(), anyBoolean(), anyBoolean())
 
         val crash = Crash.UncaughtExceptionCrash(RuntimeException("Test"), arrayListOf())
         service.report(crash)
 
         verify(service).report(crash)
-        verify(service).sendReport(crash.throwable, null, null, false)
+        verify(service).sendReport(crash.throwable, null, null, true, false)
     }
 
     @Test
@@ -64,13 +64,13 @@ class MozillaSocorroServiceTest {
                 testContext,
                 "Test App"
         ))
-        doNothing().`when`(service).sendReport(any(), any(), any(), anyBoolean())
+        doNothing().`when`(service).sendReport(any(), any(), any(), anyBoolean(), anyBoolean())
 
         val throwable = RuntimeException("Test")
         service.report(throwable)
 
         verify(service).report(throwable)
-        verify(service).sendReport(throwable, null, null, true)
+        verify(service).sendReport(throwable, null, null, false, true)
     }
 
     @Test
@@ -96,7 +96,7 @@ class MozillaSocorroServiceTest {
         val bufferedReader = BufferedReader(reader)
         var request = bufferedReader.readText()
 
-        assert(request.contains("name=JavaStackTrace\r\n\r\njava.lang.RuntimeException: Test"))
+        assert(request.contains("name=JavaStackTrace\r\n\r\n$FATAL_PREFIX java.lang.RuntimeException: Test"))
         assert(request.contains("name=Android_ProcessName\r\n\r\nmozilla.components.lib.crash.test"))
         assert(request.contains("name=ProductID\r\n\r\n{aa3c5121-dab2-40e2-81ca-7ea25febc110}"))
         assert(request.contains("name=Vendor\r\n\r\nMozilla"))
@@ -106,7 +106,7 @@ class MozillaSocorroServiceTest {
         assertFalse(request.contains("name=Notes\r\n\r\n$CAUGHT_EXCEPTION_NOTE"))
 
         verify(service).report(crash)
-        verify(service).sendReport(crash.throwable, null, null, false)
+        verify(service).sendReport(crash.throwable, null, null, true, false)
     }
 
     @Test
@@ -141,7 +141,7 @@ class MozillaSocorroServiceTest {
         assert(request.contains("name=Notes\r\n\r\n$CAUGHT_EXCEPTION_NOTE"))
 
         verify(service).report(throwable)
-        verify(service).sendReport(throwable, null, null, true)
+        verify(service).sendReport(throwable, null, null, false, true)
     }
 
     @Test
@@ -182,7 +182,7 @@ class MozillaSocorroServiceTest {
         assert(request.contains("name=Notes\r\n\r\n$CAUGHT_EXCEPTION_NOTE"))
 
         verify(service).report(throwable)
-        verify(service).sendReport(throwable, null, null, true)
+        verify(service).sendReport(throwable, null, null, false, true)
     }
 
     @Test
@@ -224,7 +224,7 @@ class MozillaSocorroServiceTest {
         assert(request.contains("name=Notes\r\n\r\n$CAUGHT_EXCEPTION_NOTE"))
 
         verify(service).report(throwable)
-        verify(service).sendReport(throwable, null, null, true)
+        verify(service).sendReport(throwable, null, null, false, true)
     }
 
     @Test
@@ -245,7 +245,7 @@ class MozillaSocorroServiceTest {
 
         mockWebServer.shutdown()
         verify(service).report(crash)
-        verify(service).sendReport(crash.throwable, null, null, false)
+        verify(service).sendReport(crash.throwable, null, null, true, false)
     }
 
     @Test
@@ -265,7 +265,7 @@ class MozillaSocorroServiceTest {
         mockWebServer.shutdown()
 
         verify(service).report(crash)
-        verify(service).sendReport(null, crash.minidumpPath, crash.extrasPath, false)
+        verify(service).sendReport(null, crash.minidumpPath, crash.extrasPath, false, false)
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
