### PR TITLE
Closes #5175: Allow Socorro to distinguish between fatal and non-fatal crashes

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/Crash.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/Crash.kt
@@ -31,6 +31,7 @@ sealed class Crash {
      * A crash caused by an uncaught exception.
      *
      * @property throwable The [Throwable] that caused the crash.
+     * @property breadcrumbs List of breadcrumbs to send with the crash report.
      */
     data class UncaughtExceptionCrash(
         val throwable: Throwable,
@@ -61,6 +62,7 @@ sealed class Crash {
      * @property isFatal Whether or not the crash was fatal or not: If true, the main application process was affected
      *                   by the crash. If false, only an internal process used by Gecko has crashed and the application
      *                   may be able to recover.
+     * @property breadcrumbs List of breadcrumbs to send with the crash report.
      */
     data class NativeCodeCrash(
         val minidumpPath: String?,

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
@@ -36,6 +36,12 @@ import kotlin.random.Random
 private const val MOZILLA_PRODUCT_ID = "{eeb82917-e434-4870-8148-5c03d4caa81b}"
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal const val FATAL_CRASH_NOTE = "This is a fatal crash"
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal const val NONFATAL_CRASH_NOTE = "This is a non-fatal crash"
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal const val CAUGHT_EXCEPTION_NOTE = "This is a caught exception, not a real crash"
 
 /**
@@ -61,15 +67,15 @@ class MozillaSocorroService(
     private val startTime = System.currentTimeMillis()
 
     override fun report(crash: Crash.UncaughtExceptionCrash) {
-        sendReport(crash.throwable, null, null, false)
+        sendReport(crash.throwable, null, null, isFatal = true, isCaughtException = false)
     }
 
     override fun report(crash: Crash.NativeCodeCrash) {
-        sendReport(null, crash.minidumpPath, crash.extrasPath, false)
+        sendReport(null, crash.minidumpPath, crash.extrasPath, isFatal = crash.isFatal, isCaughtException = false)
     }
 
     override fun report(throwable: Throwable) {
-        sendReport(throwable, null, null, true)
+        sendReport(throwable, null, null, isFatal = false, isCaughtException = true)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -77,6 +83,7 @@ class MozillaSocorroService(
         throwable: Throwable?,
         miniDumpFilePath: String?,
         extrasFilePath: String?,
+        isFatal: Boolean,
         isCaughtException: Boolean
     ) {
         val url = URL(serverUrl)
@@ -91,7 +98,7 @@ class MozillaSocorroService(
             conn.setRequestProperty("Content-Encoding", "gzip")
 
             sendCrashData(conn.outputStream, boundary, throwable, miniDumpFilePath, extrasFilePath,
-                    isCaughtException)
+                    isFatal, isCaughtException)
 
             BufferedReader(InputStreamReader(conn.inputStream)).use {
                 val response = StringBuffer()
@@ -110,13 +117,14 @@ class MozillaSocorroService(
         }
     }
 
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "LongMethod")
     private fun sendCrashData(
         os: OutputStream,
         boundary: String,
         throwable: Throwable?,
         miniDumpFilePath: String?,
         extrasFilePath: String?,
+        isFatal: Boolean,
         isCaughtException: Boolean
     ) {
         val nameSet = mutableSetOf<String>()
@@ -147,8 +155,10 @@ class MozillaSocorroService(
             minidumpFile.delete()
         }
 
-        if (isCaughtException) {
-            sendPart(gzipOs, boundary, "Notes", CAUGHT_EXCEPTION_NOTE, nameSet)
+        when {
+            isFatal -> sendPart(gzipOs, boundary, "Notes", FATAL_CRASH_NOTE, nameSet)
+            isCaughtException -> sendPart(gzipOs, boundary, "Notes", CAUGHT_EXCEPTION_NOTE, nameSet)
+            else -> sendPart(gzipOs, boundary, "Notes", NONFATAL_CRASH_NOTE, nameSet)
         }
 
         sendPackageInstallTime(gzipOs, boundary, nameSet)
@@ -328,7 +338,10 @@ class MozillaSocorroService(
         return resultMap
     }
 
-    private fun getExceptionStackTrace(throwable: Throwable, isCaughtException: Boolean): String {
+    private fun getExceptionStackTrace(
+        throwable: Throwable,
+        isCaughtException: Boolean
+    ): String {
         val stringWriter = StringWriter()
         val printWriter = PrintWriter(stringWriter)
         throwable.printStackTrace(printWriter)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
