### PR TITLE
Closes #5433: Add UX flow for unsupported add-ons

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -34,10 +34,10 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class Addon(
     val id: String,
-    val authors: List<Author>,
-    val categories: List<String>,
-    val downloadUrl: String,
-    val version: String,
+    val authors: List<Author> = emptyList(),
+    val categories: List<String> = emptyList(),
+    val downloadUrl: String = "",
+    val version: String = "",
     val permissions: List<String> = emptyList(),
     val translatableName: Map<String, String> = emptyMap(),
     val translatableDescription: Map<String, String> = emptyMap(),
@@ -45,8 +45,8 @@ data class Addon(
     val iconUrl: String = "",
     val siteUrl: String = "",
     val rating: Rating? = null,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: String = "",
+    val updatedAt: String = "",
     val installedState: InstalledState? = null
 ) : Parcelable {
     /**
@@ -85,6 +85,8 @@ data class Addon(
      * @property version The installed version.
      * @property enabled Indicates if this [Addon] is enabled to interact with web content or not,
      * defaults to false.
+     * @property supported Indicates if this [Addon] is supported by the browser or not, defaults
+     * to true.
      * @property optionsPageUrl the URL of the page displaying the
      * options page (options_ui in the extension's manifest).
      */
@@ -93,7 +95,8 @@ data class Addon(
         val id: String,
         val version: String,
         val optionsPageUrl: String,
-        val enabled: Boolean = false
+        val enabled: Boolean = false,
+        val supported: Boolean = true
     ) : Parcelable
 
     /**
@@ -112,6 +115,11 @@ data class Addon(
      * Returns whether or not this [Addon] is currently enabled.
      */
     fun isEnabled() = installedState?.enabled == true
+
+    /**
+     * Returns whether or not this [Addon] is currently supported by the browser.
+     */
+    fun isSupported() = installedState?.supported == true
 
     companion object {
         /**

--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <string name="mozac_feature_addons_installed_section">Installed</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) addons, this string indicates the recommended section. -->
     <string name="mozac_feature_addons_recommended_section">Recommended</string>
+    <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) addons, this string indicates the not yet supported section. -->
+    <string name="mozac_feature_addons_unsupported_section">Not yet supported</string>
     <!-- Displays a page with all the details of an addon. -->
     <string name="mozac_feature_addons_details">Details</string>
     <!-- Displays a page with all the permissions of an addon. -->
@@ -105,6 +107,8 @@
     <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d new permissions are required</string>
     <!-- Name of the "notification channel" used for displaying a notification for updating an addon. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_updater_notification_channel">Addon updates</string>
+    <!-- This is the caption for not yet supported screen caption -->
+    <string name="mozac_feature_addons_not_yet_supported_caption">Firefox add-on technology is modernizing. These add-ons use frameworks that are not compatible with Firefox 75 &amp; beyond.</string>
     <!-- This is the caption for the addon installation progress overlay -->
     <string name="mozac_add_on_install_progress_caption">Downloading and verifying add-on&#8230;</string>
 

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -68,6 +68,11 @@
             android:label="@string/mozac_feature_addons_addons"
             android:theme="@style/Theme.AppCompat.Light" />
 
+        <activity
+            android:name=".addons.NotYetSupportedAddonActivity"
+            android:label="@string/mozac_feature_addons_addons"
+            android:theme="@style/Theme.AppCompat.Light" />
+
         <activity android:name=".IntentReceiverActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/NotYetSupportedAddonActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/NotYetSupportedAddonActivity.kt
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.samples.browser.addons
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.feature.addons.Addon
+import org.mozilla.samples.browser.R
+import org.mozilla.samples.browser.ext.components
+
+/**
+ * Activity for managing unsupported add-ons.
+ */
+class NotYetSupportedAddonActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val addons = requireNotNull(intent.getParcelableArrayListExtra<Addon>("add_ons"))
+
+        supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.container, NotYetSupportedAddonFragment.create(addons))
+                .commit()
+    }
+
+    /**
+     * Fragment for managing add-ons that are not yet supported by the browser.
+     */
+    class NotYetSupportedAddonFragment : Fragment() {
+        private lateinit var addons: List<Addon>
+
+        override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+            addons = requireNotNull(arguments?.getParcelableArrayList("add_ons"))
+            return inflater.inflate(R.layout.fragment_not_yet_supported_addons, container, false)
+        }
+
+        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+            super.onViewCreated(view, savedInstanceState)
+
+            val recyclerView: RecyclerView = view.findViewById(R.id.unsupported_add_ons_list)
+            recyclerView.layoutManager = LinearLayoutManager(requireContext())
+            recyclerView.adapter = UnsupportedAddonsAdapter(addons)
+        }
+
+        companion object {
+            /**
+             * Create an [NotYetSupportedAddonFragment] with add_ons as a required parameter.
+             */
+            fun create(addons: ArrayList<Addon>) = NotYetSupportedAddonFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelableArrayList("add_ons", addons)
+                }
+            }
+        }
+    }
+
+    /**
+     * An adapter for displaying unsupported add-on items.
+     */
+    class UnsupportedAddonsAdapter(
+        private val addons: List<Addon>
+    ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+        override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+            holder as UnsupportedAddonViewHolder
+            val context = holder.itemView.context
+            val addon = addons[position]
+
+            holder.titleView.text =
+                if (addon.translatableName.isNotEmpty()) {
+                    addon.translatableName.translate()
+                } else {
+                    addon.id
+                }
+
+            holder.removeButton.setOnClickListener {
+                context.components.addonManager.uninstallAddon(addon,
+                    onSuccess = {
+                        Toast.makeText(context, "Successfully removed add-on", Toast.LENGTH_SHORT).show()
+                    },
+                    onError = { _, _ ->
+                        Toast.makeText(context, "Failed to remove add-on", Toast.LENGTH_SHORT).show()
+                    })
+            }
+        }
+
+        override fun getItemCount(): Int {
+            return addons.size
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+            val context = parent.context
+            val inflater = LayoutInflater.from(context)
+            val view = inflater.inflate(R.layout.add_ons_unsupported_item, parent, false)
+
+            val iconView = view.findViewById<ImageView>(R.id.add_on_icon)
+            val titleView = view.findViewById<TextView>(R.id.add_on_name)
+            val removeButton = view.findViewById<ImageButton>(R.id.add_on_remove_button)
+
+            return UnsupportedAddonViewHolder(view, iconView, titleView, removeButton)
+        }
+
+        /**
+         * A view holder for displaying unsupported add-on items.
+         */
+        class UnsupportedAddonViewHolder(
+            view: View,
+            val iconView: ImageView,
+            val titleView: TextView,
+            val removeButton: ImageButton
+        ) : RecyclerView.ViewHolder(view)
+    }
+}

--- a/samples/browser/src/main/res/layout/add_ons_unsupported_item.xml
+++ b/samples/browser/src/main/res/layout/add_ons_unsupported_item.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/add_on_icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@drawable/mozac_ic_extensions"
+        android:importantForAccessibility="no"
+        android:scaleType="fitCenter" />
+
+    <TextView
+        android:id="@+id/add_on_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="16sp"
+        tools:text="uBlock Origin" />
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_weight="1" />
+
+    <ImageButton
+        android:id="@+id/add_on_remove_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:tint="@android:color/darker_gray"
+        android:contentDescription="@string/mozac_feature_addons_remove"
+        android:src="@drawable/mozac_ic_delete" />
+
+
+</LinearLayout>

--- a/samples/browser/src/main/res/layout/addons_section_unsupported_section_item.xml
+++ b/samples/browser/src/main/res/layout/addons_section_unsupported_section_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/unsupported_add_on_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/photonGrey30" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:textSize="18sp"
+        tools:text="Not yet supported" />
+
+</LinearLayout>
+

--- a/samples/browser/src/main/res/layout/fragment_not_yet_supported_addons.xml
+++ b/samples/browser/src/main/res/layout/fragment_not_yet_supported_addons.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:text="@string/mozac_feature_addons_not_yet_supported_caption" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/photonGrey30" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/unsupported_add_ons_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".BrowserActivity"/>
+
+</LinearLayout>


### PR DESCRIPTION
This also has partial implementation for allowing `AddonManager.getAddons()` to include unsupported extensions (https://github.com/mozilla-mobile/android-components/issues/5432)


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
