### PR TITLE
Closes #5524: Intermittent failure in WebExtensionSupportTest

### DIFF
--- a/components/support/webextensions/build.gradle
+++ b/components/support/webextensions/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
 
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -26,6 +26,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.After
@@ -374,6 +375,8 @@ class WebExtensionSupportTest {
         actionCaptor = argumentCaptor()
         verify(store, times(6)).dispatch(actionCaptor.capture())
         assertEquals(popupSessionId, (actionCaptor.value as TabListAction.SelectTabAction).tabId)
+
+        store.waitUntilIdle()
 
         // Toggling again should close tab
         delegateCaptor.value.onToggleBrowserActionPopup(ext, engineSession, browserAction)


### PR DESCRIPTION
This is another example where we need our new `waitUntilIdle` as a method we're calling dispatches an action that we can't join on in the test. So, we have to wait until the store processed the action. Looked over the other tests in this class as well. This should be the only place that's needed right now.