### PR TITLE
Issue #4500: Integrate GV API to enable/disable web extensions

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -28,6 +28,7 @@ import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -329,6 +330,7 @@ class GeckoEngine(
      */
     override fun enableWebExtension(
         extension: WebExtension,
+        source: EnableSource,
         onSuccess: (WebExtension) -> Unit,
         onError: (Throwable) -> Unit
     ) {
@@ -342,6 +344,7 @@ class GeckoEngine(
      */
     override fun disableWebExtension(
         extension: WebExtension,
+        source: EnableSource,
         onSuccess: (WebExtension) -> Unit,
         onError: (Throwable) -> Unit
     ) {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -28,6 +28,7 @@ import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -329,12 +330,19 @@ class GeckoEngine(
      */
     override fun enableWebExtension(
         extension: WebExtension,
+        source: EnableSource,
         onSuccess: (WebExtension) -> Unit,
         onError: (Throwable) -> Unit
     ) {
-        // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1599585
-        webExtensionDelegate?.onEnabled(extension)
-        onSuccess(extension)
+        runtime.webExtensionController.enable((extension as GeckoWebExtension).nativeExtension, source.id).then({
+            val enabledExtension = GeckoWebExtension(it!!, runtime.webExtensionController)
+            webExtensionDelegate?.onEnabled(enabledExtension)
+            onSuccess(enabledExtension)
+            GeckoResult<Void>()
+        }, { throwable ->
+            onError(throwable)
+            GeckoResult<Void>()
+        })
     }
 
     /**
@@ -342,12 +350,19 @@ class GeckoEngine(
      */
     override fun disableWebExtension(
         extension: WebExtension,
+        source: EnableSource,
         onSuccess: (WebExtension) -> Unit,
         onError: (Throwable) -> Unit
     ) {
-        // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1599585
-        webExtensionDelegate?.onDisabled(extension)
-        onSuccess(extension)
+        runtime.webExtensionController.disable((extension as GeckoWebExtension).nativeExtension, source.id).then({
+            val disabledExtension = GeckoWebExtension(it!!, runtime.webExtensionController)
+            webExtensionDelegate?.onDisabled(disabledExtension)
+            onSuccess(disabledExtension)
+            GeckoResult<Void>()
+        }, { throwable ->
+            onError(throwable)
+            GeckoResult<Void>()
+        })
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -247,8 +247,7 @@ class GeckoWebExtension(
     }
 
     override fun isEnabled(): Boolean {
-        // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1599585
-        return true
+        return nativeExtension.metaData?.enabled == true
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -397,10 +397,25 @@ class GeckoWebExtensionTest {
     @Test
     fun `isEnabled depends on native state`() {
         val webExtensionController: WebExtensionController = mock()
-        val extension = GeckoWebExtension(
-            WebExtension("resource://url", "id", WebExtension.Flags.NONE, webExtensionController),
-            webExtensionController
-        )
-        assertTrue(extension.isEnabled())
+
+        val bundle = GeckoBundle()
+        bundle.putString("webExtensionId", "id")
+        bundle.putString("locationURI", "uri")
+        val nativeExtensionWithoutMetadata = MockWebExtension(bundle)
+        val webExtension = GeckoWebExtension(nativeExtensionWithoutMetadata, webExtensionController)
+        assertFalse(webExtension.isEnabled())
+
+        val metaDataBundle = GeckoBundle()
+        metaDataBundle.putStringArray("disabledFlags", emptyArray())
+        bundle.putBundle("metaData", metaDataBundle)
+        val nativeEnabledWebExtension = MockWebExtension(bundle)
+        val enabledWebExtension = GeckoWebExtension(nativeEnabledWebExtension, webExtensionController)
+        assertTrue(enabledWebExtension.isEnabled())
+
+        metaDataBundle.putStringArray("disabledFlags", arrayOf("userDisabled"))
+        bundle.putBundle("metaData", metaDataBundle)
+        val nativeDisabledWebExtnesion = MockWebExtension(bundle)
+        val disabledWebExtension = GeckoWebExtension(nativeDisabledWebExtnesion, webExtensionController)
+        assertFalse(disabledWebExtension.isEnabled())
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -10,6 +10,7 @@ import androidx.annotation.MainThread
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.utils.EngineVersion
+import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -192,6 +193,8 @@ interface Engine {
      * Enables the provided [WebExtension]. If the extension is already enabled the [onSuccess]
      * callback will be invoked, but this method has no effect on the extension.
      *
+     * @param extension the extension to enable.
+     * @param source [EnableSource] to indicate why the extension is enabled.
      * @param onSuccess (optional) callback invoked with the enabled [WebExtension]
      * @param onError (optional) callback invoked if there was an error enabling
      * the extensions. This callback is invoked with an [UnsupportedOperationException]
@@ -199,6 +202,7 @@ interface Engine {
      */
     fun enableWebExtension(
         extension: WebExtension,
+        source: EnableSource = EnableSource.USER,
         onSuccess: ((WebExtension) -> Unit) = { },
         onError: ((Throwable) -> Unit) = { }
     ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
@@ -207,6 +211,8 @@ interface Engine {
      * Disables the provided [WebExtension]. If the extension is already disabled the [onSuccess]
      * callback will be invoked, but this method has no effect on the extension.
      *
+     * @param extension the extension to disable.
+     * @param source [EnableSource] to indicate why the extension is disabled.
      * @param onSuccess (optional) callback invoked with the enabled [WebExtension]
      * @param onError (optional) callback invoked if there was an error disabling
      * the installed extensions. This callback is invoked with an [UnsupportedOperationException]
@@ -214,6 +220,7 @@ interface Engine {
      */
     fun disableWebExtension(
         extension: WebExtension,
+        source: EnableSource = EnableSource.USER,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((Throwable) -> Unit) = { }
     ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -303,3 +303,20 @@ data class Metadata(
      */
     val openOptionsPageInTab: Boolean?
 )
+
+/**
+ * Provides additional information about why an extension was enabled or disabled.
+ */
+@Suppress("MagicNumber")
+enum class EnableSource(val id: Int) {
+    /**
+     * The extension is enabled or disabled by the user.
+     */
+    USER(1),
+
+    /**
+     * The extension is enabled or disabled by the application based
+     * on available support.
+     */
+    APP_SUPPORT(1 shl 1),
+}

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -403,7 +403,7 @@ class AddonManagerTest {
             enabledAddon = it
         })
 
-        verify(engine).enableWebExtension(eq(extension), onSuccessCaptor.capture(), any())
+        verify(engine).enableWebExtension(eq(extension), any(), onSuccessCaptor.capture(), any())
         onSuccessCaptor.value.invoke(extension)
         assertNotNull(enabledAddon)
         assertEquals(addon.id, enabledAddon!!.id)
@@ -430,7 +430,7 @@ class AddonManagerTest {
 
         // Extension is not installed so we're invoking the error callback and never the engine
         manager.enableAddon(addon, onError = errorCallback)
-        verify(engine, never()).enableWebExtension(any(), any(), onErrorCaptor.capture())
+        verify(engine, never()).enableWebExtension(any(), any(), any(), onErrorCaptor.capture())
         assertNotNull(throwable!!)
         assertEquals("Addon is not installed", throwable!!.localizedMessage)
 
@@ -439,12 +439,12 @@ class AddonManagerTest {
         whenever(extension.id).thenReturn("ext1")
         WebExtensionSupport.installedExtensions[addon.id] = extension
         manager.enableAddon(addon, onError = errorCallback)
-        verify(engine, never()).enableWebExtension(any(), any(), onErrorCaptor.capture())
+        verify(engine, never()).enableWebExtension(any(), any(), any(), onErrorCaptor.capture())
 
         // Make sure engine error is forwarded to caller
         val installedAddon = addon.copy(installedState = Addon.InstalledState(addon.id, "1.0", "", true))
         manager.enableAddon(installedAddon, onError = errorCallback)
-        verify(engine).enableWebExtension(eq(extension), any(), onErrorCaptor.capture())
+        verify(engine).enableWebExtension(eq(extension), any(), any(), onErrorCaptor.capture())
         onErrorCaptor.value.invoke(IllegalStateException("test"))
         assertNotNull(throwable!!)
         assertEquals("test", throwable!!.localizedMessage)
@@ -476,7 +476,7 @@ class AddonManagerTest {
             disabledAddon = it
         })
 
-        verify(engine).disableWebExtension(eq(extension), onSuccessCaptor.capture(), any())
+        verify(engine).disableWebExtension(eq(extension), any(), onSuccessCaptor.capture(), any())
         onSuccessCaptor.value.invoke(extension)
         assertNotNull(disabledAddon)
         assertEquals(addon.id, disabledAddon!!.id)
@@ -503,7 +503,7 @@ class AddonManagerTest {
 
         // Extension is not installed so we're invoking the error callback and never the engine
         manager.disableAddon(addon, onError = errorCallback)
-        verify(engine, never()).disableWebExtension(any(), any(), onErrorCaptor.capture())
+        verify(engine, never()).disableWebExtension(any(), any(), any(), onErrorCaptor.capture())
         assertNotNull(throwable!!)
         assertEquals("Addon is not installed", throwable!!.localizedMessage)
 
@@ -512,12 +512,12 @@ class AddonManagerTest {
         whenever(extension.id).thenReturn("ext1")
         WebExtensionSupport.installedExtensions[addon.id] = extension
         manager.disableAddon(addon, onError = errorCallback)
-        verify(engine, never()).disableWebExtension(any(), any(), onErrorCaptor.capture())
+        verify(engine, never()).disableWebExtension(any(), any(), any(), onErrorCaptor.capture())
 
         // Make sure engine error is forwarded to caller
         val installedAddon = addon.copy(installedState = Addon.InstalledState(addon.id, "1.0", "", true))
         manager.disableAddon(installedAddon, onError = errorCallback)
-        verify(engine).disableWebExtension(eq(extension), any(), onErrorCaptor.capture())
+        verify(engine).disableWebExtension(eq(extension), any(), any(), onErrorCaptor.capture())
         onErrorCaptor.value.invoke(IllegalStateException("test"))
         assertNotNull(throwable!!)
         assertEquals("test", throwable!!.localizedMessage)

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
@@ -73,7 +73,7 @@ class WebExtensionToolbarFeature(
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun renderWebExtensionActions(state: BrowserState, tab: SessionState? = null) {
         val extensions = state.extensions.values.toList()
-        extensions.forEach { extension ->
+        extensions.filter { it.enabled }.forEach { extension ->
             extension.browserAction?.let { browserAction ->
                 // Add the global browser action if it doesn't exist
                 val toolbarAction = webExtensionBrowserActions.getOrPut(extension.id) {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
@@ -50,27 +50,10 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
         switch.setState(addon.isEnabled())
         switch.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
-                this.components.addonManager.disableAddon(
-                    addon,
-                    onSuccess = {
-                        Toast.makeText(
-                            this,
-                            "Successfully disabled ${addon.translatableName.translate()}",
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    },
-                    onError = {
-                        Toast.makeText(
-                            this,
-                            "Failed to disable ${addon.translatableName.translate()}",
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                )
-            } else {
                 this.components.addonManager.enableAddon(
                     addon,
                     onSuccess = {
+                        switch.setState(true)
                         Toast.makeText(
                             this,
                             "Successfully enabled ${addon.translatableName.translate()}",
@@ -81,6 +64,25 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
                         Toast.makeText(
                             this,
                             "Failed to enable ${addon.translatableName.translate()}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                )
+            } else {
+                this.components.addonManager.disableAddon(
+                    addon,
+                    onSuccess = {
+                        switch.setState(false)
+                        Toast.makeText(
+                            this,
+                            "Successfully disabled ${addon.translatableName.translate()}",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    onError = {
+                        Toast.makeText(
+                            this,
+                            "Failed to disable ${addon.translatableName.translate()}",
                             Toast.LENGTH_SHORT
                         ).show()
                     }


### PR DESCRIPTION
With this we can enable/disable extensions. Had to add a fix to the `WebExtensionToolbar` to not show disabled extensions, and a fix in our sample browser that had the isChecked condition inverted.