### PR TITLE
Issue #5260: Fall back to default icon if action icon fails to load

### DIFF
--- a/components/feature/toolbar/src/main/res/drawable/mozac_ic_web_extension_default_icon.xml
+++ b/components/feature/toolbar/src/main/res/drawable/mozac_ic_web_extension_default_icon.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+            android:fillColor="#FF000000"
+            android:pathData="M6,18c0,0.55 0.45,1 1,1h1v3.5c0,0.83 0.67,1.5 1.5,1.5s1.5,-0.67 1.5,-1.5L11,19h2v3.5c0,0.83 0.67,1.5 1.5,1.5s1.5,-0.67 1.5,-1.5L16,19h1c0.55,0 1,-0.45 1,-1L18,8L6,8v10zM3.5,8C2.67,8 2,8.67 2,9.5v7c0,0.83 0.67,1.5 1.5,1.5S5,17.33 5,16.5v-7C5,8.67 4.33,8 3.5,8zM20.5,8c-0.83,0 -1.5,0.67 -1.5,1.5v7c0,0.83 0.67,1.5 1.5,1.5s1.5,-0.67 1.5,-1.5v-7c0,-0.83 -0.67,-1.5 -1.5,-1.5zM15.53,2.16l1.3,-1.3c0.2,-0.2 0.2,-0.51 0,-0.71 -0.2,-0.2 -0.51,-0.2 -0.71,0l-1.48,1.48C13.85,1.23 12.95,1 12,1c-0.96,0 -1.86,0.23 -2.66,0.63L7.85,0.15c-0.2,-0.2 -0.51,-0.2 -0.71,0 -0.2,0.2 -0.2,0.51 0,0.71l1.31,1.31C6.97,3.26 6,5.01 6,7h12c0,-1.99 -0.97,-3.75 -2.47,-4.84zM10,5L9,5L9,4h1v1zM15,5h-1L14,4h1v1z" />
+</vector>
+

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
@@ -75,6 +75,33 @@ class WebExtensionToolbarTest {
     }
 
     @Test
+    fun fallbackToDefaultIcon() {
+        val imageView: ImageView = mock()
+        val textView: TextView = mock()
+        val view: View = mock()
+
+        whenever(view.findViewById<ImageView>(R.id.action_image)).thenReturn(imageView)
+        whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(textView)
+        whenever(view.context).thenReturn(mock())
+
+        val browserAction = BrowserAction(
+            title = "title",
+            loadIcon = { throw IllegalArgumentException() },
+            enabled = true,
+            badgeText = "badgeText",
+            badgeTextColor = Color.WHITE,
+            badgeBackgroundColor = Color.BLUE
+        ) {}
+
+        val action = WebExtensionToolbarAction(browserAction, iconJobDispatcher = testDispatcher) {}
+        action.bind(view)
+        action.iconJob?.joinBlocking()
+        testDispatcher.advanceUntilIdle()
+
+        verify(imageView).setImageResource(R.drawable.mozac_ic_web_extension_default_icon)
+    }
+
+    @Test
     fun createView() {
         var listenerWasClicked = false
 


### PR DESCRIPTION
GV patch is pending, but this is good to keep anyway in case we ever fail to load the icon.