### PR TITLE
Clean up and document CustomTabsToolbarFeature

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserver.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserver.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.feature
+
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.toolbar.Toolbar
+
+/**
+ * Sets the title of the custom tab toolbar based on the session title and URL.
+ */
+class CustomTabSessionTitleObserver(
+    private val toolbar: Toolbar
+) : Session.Observer {
+    private var receivedTitle = false
+
+    override fun onUrlChanged(session: Session, url: String) {
+        // If we showed a title once in a custom tab then we are going to continue displaying
+        // a title (to avoid the layout bouncing around). However if no title is available then
+        // we just use the URL.
+        if (receivedTitle && session.title.isEmpty()) {
+            toolbar.title = url
+        }
+    }
+
+    override fun onTitleChanged(session: Session, title: String) {
+        if (title.isNotEmpty()) {
+            toolbar.title = title
+            receivedTitle = true
+        } else if (receivedTitle) {
+            // See comment in OnUrlChanged().
+            toolbar.title = session.url
+        }
+    }
+}

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -474,7 +474,7 @@ class CustomTabsToolbarFeatureTest {
         val menuBuilder = toolbar.display.menuBuilder!!
 
         assertEquals(3, menuBuilder.items.size)
-        assertTrue(menuBuilder.items[2] is SimpleBrowserMenuItem)
+        assertTrue(menuBuilder.items[0] is SimpleBrowserMenuItem)
     }
 
     @Test

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.customtabs.feature
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.session.Session
+import mozilla.components.concept.toolbar.AutocompleteDelegate
+import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+@RunWith(AndroidJUnit4::class)
+class CustomTabSessionTitleObserverTest {
+
+    @Test
+    fun `show title only if not empty`() {
+        val toolbar: Toolbar = mock()
+        val session = Mockito.spy(Session("https://mozilla.org"))
+        val observer = CustomTabSessionTitleObserver(toolbar)
+        val title = "Internet for people, not profit - Mozilla"
+
+        observer.onTitleChanged(session, title = "")
+        verify(toolbar, never()).title = ""
+
+        observer.onTitleChanged(session, title = title)
+        verify(toolbar).title = title
+    }
+
+    @Test
+    fun `Will use URL as title if title was shown once and is now empty`() {
+        val toolbar = MockToolbar()
+        val session = Session("https://mozilla.org")
+        session.register(CustomTabSessionTitleObserver(toolbar))
+
+        assertEquals("", toolbar.title)
+
+        session.url = "https://www.mozilla.org/en-US/firefox/"
+        assertEquals("", toolbar.title)
+
+        session.title = "Firefox - Protect your life online with privacy-first products"
+        assertEquals("Firefox - Protect your life online with privacy-first products", toolbar.title)
+
+        session.url = "https://github.com/mozilla-mobile/android-components"
+        assertEquals("Firefox - Protect your life online with privacy-first products", toolbar.title)
+
+        session.title = ""
+        assertEquals("https://github.com/mozilla-mobile/android-components", toolbar.title)
+
+        session.title = "A collection of Android libraries to build browsers or browser-like applications."
+        assertEquals("A collection of Android libraries to build browsers or browser-like applications.", toolbar.title)
+
+        session.title = ""
+        assertEquals("https://github.com/mozilla-mobile/android-components", toolbar.title)
+    }
+
+    private class MockToolbar : Toolbar {
+        override var title: String = ""
+
+        override var url: CharSequence by ThrowProperty()
+        override var private: Boolean by ThrowProperty()
+        override var siteSecure: Toolbar.SiteSecurity by ThrowProperty()
+        override var siteTrackingProtection: Toolbar.SiteTrackingProtection by ThrowProperty()
+        override fun setSearchTerms(searchTerms: String) = Unit
+        override fun displayProgress(progress: Int) = Unit
+        override fun onBackPressed(): Boolean = false
+        override fun onStop() = Unit
+        override fun setOnUrlCommitListener(listener: (String) -> Boolean) = Unit
+        override fun setAutocompleteListener(filter: suspend (String, AutocompleteDelegate) -> Unit) = Unit
+        override fun addBrowserAction(action: Toolbar.Action) = Unit
+        override fun removeBrowserAction(action: Toolbar.Action) = Unit
+        override fun invalidateActions() = Unit
+        override fun addPageAction(action: Toolbar.Action) = Unit
+        override fun addNavigationAction(action: Toolbar.Action) = Unit
+        override fun addEditAction(action: Toolbar.Action) = Unit
+        override fun setOnEditListener(listener: Toolbar.OnEditListener) = Unit
+        override fun displayMode() = Unit
+        override fun editMode() = Unit
+    }
+
+    private class ThrowProperty<T> : ReadWriteProperty<Any, T> {
+        override fun getValue(thisRef: Any, property: KProperty<*>): T =
+            throw UnsupportedOperationException("Cannot get $property")
+
+        override fun setValue(thisRef: Any, property: KProperty<*>, value: T) =
+            throw UnsupportedOperationException("Cannot set $property")
+    }
+}


### PR DESCRIPTION
Doc comments and a bit of cleanup and bugfixing.

- The `CustomTabActionButtonConfig.tint` property now lets the action button be tinted.
- Negative indices are interpreted as 0 rather than max, so it gets the closest valid value.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
