### PR TITLE
Do not identify IPv6 addresses as search terms.

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
@@ -71,7 +71,7 @@ object URLStringUtils {
         // valid URL,
         // file:///home/user/myfile.html
         // is considered a search term; it is clearly a URL.
-        Pattern.compile("^\\s*\\w+(://[/]*|:|\\.)\\w+\\S*\\s*$", flags)
+        Pattern.compile("^\\s*\\w+(://[/]*|:|\\.)\\[?[\\w:]+\\S*\\s*$", flags)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
@@ -204,6 +204,24 @@ class WebURLFinder {
         private const val PORT_NUMBER = "\\:\\d{1,5}"
 
         /**
+         * Regular expression to match IPv6 addresses, with optional zone identifier.
+         *
+         * Taken from:
+         * https://nbviewer.jupyter.org/github/rasbt/python_reference/blob/master/tutorials/useful_regex.ipynb#Ipv6
+         */
+        private const val IPV6_ADDRESS = (
+                "\\[" +
+                        "((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))" +
+                        "|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})|:))" +
+                        "|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})|:))" +
+                        "|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))" +
+                        "|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))" +
+                        "|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))" +
+                        "|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))" +
+                        "|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:)))" +
+                        "(%.+)?\\]")
+
+        /**
          * Valid UCS characters defined in RFC 3987. Excludes space characters.
          */
         private const val UCS_CHAR = "[" +
@@ -261,12 +279,12 @@ class WebURLFinder {
          * Regular expression that matches domain names using either [.STRICT_HOST_NAME] or
          * [.IP_ADDRESS]
          */
-        private const val STRICT_DOMAIN_NAME = ("(?:$STRICT_HOST_NAME|$IP_ADDRESS)")
+        private const val STRICT_DOMAIN_NAME = ("(?:$STRICT_HOST_NAME|$IP_ADDRESS|$IPV6_ADDRESS)")
 
         /**
          * Regular expression that matches domain names without a TLD
          */
-        private const val RELAXED_DOMAIN_NAME = "(?:(?:$IRI_LABEL(?:\\.(?=\\S))?)+|$IP_ADDRESS)"
+        private const val RELAXED_DOMAIN_NAME = "(?:(?:$IRI_LABEL(?:\\.(?=\\S))?)+|$IP_ADDRESS|$IPV6_ADDRESS)"
 
         /**
          * Regular expression to match strings that do not start with a supported protocol. The TLDs

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
@@ -45,6 +45,8 @@ class URLStringUtilsTest {
         assertTrue(isURLLikeStrict("http://mozilla"))
         assertTrue(isURLLikeStrict("http://192.168.255.255"))
         assertTrue(isURLLikeStrict("192.167.255.255"))
+        assertTrue(isURLLikeStrict("http://[fe80::1%eth0]"))
+        assertTrue(isURLLikeStrict("[2001:500:88:200::8]"))
         assertTrue(isURLLikeStrict("about:crashcontent"))
         assertTrue(isURLLikeStrict(" about:crashcontent "))
         assertTrue(isURLLikeStrict("sample:about "))
@@ -84,6 +86,8 @@ class URLStringUtilsTest {
         assertTrue(isURLLike("file://////////////home//user/myfile.html"))
         assertTrue(isURLLike("file://C:\\Users\\user\\myfile.html"))
         assertTrue(isURLLike("http://192.168.255.255"))
+        assertTrue(isURLLike("http://[fe80::1%eth0]"))
+        assertTrue(isURLLike("http://[::1]:8080"))
 
         assertTrue(isURLLike("link.unknown"))
 
@@ -113,6 +117,8 @@ class URLStringUtilsTest {
         assertFalse(isSearchTerm("file://////////////home//user/myfile.html"))
         assertFalse(isSearchTerm("file://C:\\Users\\user\\myfile.html"))
         assertFalse(isSearchTerm("http://192.168.255.255"))
+        assertFalse(isSearchTerm("http://[fe80::1%eth0]"))
+        assertFalse(isSearchTerm("http://[::1]:8080"))
         // Per https://bugs.chromium.org/p/chromium/issues/detail?id=31405, ICANN will accept
         // purely numeric gTLDs.
         assertFalse(isSearchTerm("3.14.2019"))


### PR DESCRIPTION
Currently it is impossible to navigate to IPv6 literals (`[::1]:8080`) on the Android browsers because the addresses are misidentified as search terms. This PR incorporates a new regex adopted from [this notebook](https://nbviewer.jupyter.org/github/rasbt/python_reference/blob/master/tutorials/useful_regex.ipynb#Ipv6) and includes some test cases.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
