### PR TITLE
Closes #5537: Add IntentProcessor to handle intents when migrating

### DIFF
--- a/components/support/migration/build.gradle
+++ b/components/support/migration/build.gradle
@@ -56,6 +56,12 @@ configurations {
     jnaForTest
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
     implementation project(':concept-engine')
     implementation project(':browser-session')
@@ -69,6 +75,9 @@ dependencies {
     implementation project(':lib-state')
 
     implementation project(':support-ktx')
+    implementation project(':support-utils')
+
+    implementation project(':feature-intent')
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationIntentProcessor.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationIntentProcessor.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import android.content.Intent
+import mozilla.components.feature.intent.processing.IntentProcessor
+import mozilla.components.support.migration.state.MigrationProgress
+import mozilla.components.support.migration.state.MigrationStore
+
+/**
+ * An [IntentProcessor] that checks if we're in a migration state.
+ *
+ * ⚠️ When using this processor, ensure this is the first processor to be invoked if there are multiple.
+ */
+class MigrationIntentProcessor(private val store: MigrationStore) : IntentProcessor {
+
+    /**
+     * Matches itself with all intents in order to ensure processing all of incoming intents.
+     */
+    override fun matches(intent: Intent): Boolean = store.state.progress == MigrationProgress.MIGRATING
+
+    /**
+     * Processes all incoming intents if a migration is in progress.
+     *
+     * If this is true, we should show an instance of AbstractMigrationProgressActivity.
+     */
+    override suspend fun process(intent: Intent): Boolean {
+        return when (store.state.progress) {
+            MigrationProgress.COMPLETED, MigrationProgress.NONE -> false
+            MigrationProgress.MIGRATING -> true
+        }
+    }
+}

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationIntentProcessorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationIntentProcessorTest.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.migration
+
+import android.content.Intent
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.support.migration.state.MigrationAction
+import mozilla.components.support.migration.state.MigrationStore
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MigrationIntentProcessorTest {
+    @Test
+    fun `matches against all view action intents`() = runBlockingTest {
+        val store = MigrationStore()
+        val processor = MigrationIntentProcessor(store)
+        val intent: Intent = mock()
+
+        assertFalse(processor.matches(intent))
+
+        store.dispatch(MigrationAction.Started).joinBlocking()
+
+        assertTrue(processor.matches(intent))
+    }
+
+    @Test
+    fun `process updates intent`() = runBlockingTest {
+        val store = MigrationStore()
+        val processor = MigrationIntentProcessor(store)
+        val intent: Intent = mock()
+
+        assertFalse(processor.process(intent))
+
+        store.dispatch(MigrationAction.Completed).joinBlocking()
+        assertFalse(processor.process(intent))
+
+        store.dispatch(MigrationAction.Started).joinBlocking()
+        assertTrue(processor.process(intent))
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,7 @@ permalink: /changelog/
 * **support-migration**
   * **New Telemetry Notice**
   * Added a 'migration' ping, which contains telemetry data about migration via Glean. It's emitted whenever a migration is executed.
+  * Added `MigrationIntentProcessor` for handling incoming intents when migration is in progress.
 
 # 27.0.0
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Since an app would need to handle what to do when migrating, with our case being to show a blocking UI, we need to delegate that to the app to do since the activity would live in the app.

In https://github.com/mozilla-mobile/android-components/issues/5509, we'll create an `AbstractMigrationProgressActivity` so that we can notify frontend code when the show progress and finished states without the app needing to observe the store directly.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
