### PR TITLE
Update the Glean SDK integration test

### DIFF
--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
@@ -20,8 +20,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import mozilla.components.service.glean.testing.GleanTestLocalServer
 import org.json.JSONObject
 import org.junit.Assert.assertFalse
@@ -36,15 +34,10 @@ class BaselinePingTest {
     val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
 
     @get:Rule
-    val gleanRule = GleanTestLocalServer(getPingServerPort())
+    val gleanRule = GleanTestLocalServer(context, getPingServerPort())
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
-
-    @Before
-    fun clearWorkManager() {
-        WorkManagerTestInitHelper.initializeTestWorkManager(context)
-    }
 
     private fun waitForPingContent(
         pingName: String,
@@ -66,34 +59,6 @@ class BaselinePingTest {
         return null
     }
 
-    /**
-     * Sadly, the WorkManager still requires us to manually trigger the upload job.
-     * This function goes through all the active jobs by Glean (there should only be
-     * one!) and triggers them.
-     */
-    private fun triggerEnqueuedUpload() {
-        // The tag is really internal to PingUploadWorker, but we can't do much more
-        // than copy-paste unless we want to increase our API surface.
-        val tag = "mozac_service_glean_ping_upload_worker"
-        val reasonablyHighCITimeoutMs = 5000L
-
-        runBlocking {
-            withTimeout(reasonablyHighCITimeoutMs) {
-                do {
-                    val workInfoList = WorkManager.getInstance(context).getWorkInfosByTag(tag).get()
-                    workInfoList.forEach { workInfo ->
-                        if (workInfo.state === WorkInfo.State.ENQUEUED) {
-                            // Trigger WorkManager using TestDriver
-                            val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
-                            testDriver?.setAllConstraintsMet(workInfo.id)
-                            return@withTimeout
-                        }
-                    }
-                } while (true)
-            }
-        }
-    }
-
     @Test
     fun validateBaselinePing() {
         // Wait for the app to be idle/ready.
@@ -107,10 +72,6 @@ class BaselinePingTest {
 
         // Move it to background.
         device.pressHome()
-
-        // Wait for the upload job to be present and trigger it.
-        Thread.sleep(1000) // FIXME: for some reason, without this, WorkManager won't find the job
-        triggerEnqueuedUpload()
 
         // Validate the received data.
         val baselinePing = waitForPingContent("baseline")!!


### PR DESCRIPTION
This removes the hack to manually make the WorkManager trigger pending pings.

**Note**: this won't work before #5579 is merged

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
