### PR TITLE
Closes #5550: Manual GV upgrade to 74.0.20200113093823

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,8 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-
-    const val nightly_version = "74.0.20200110095023"
+    const val nightly_version = "74.0.20200113093823"
 
     /**
      * GeckoView Beta Version.

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -443,7 +443,8 @@ class GeckoEngineSession(
             }
 
             notifyObservers {
-                onSecurityChange(securityInfo.isSecure, securityInfo.host, securityInfo.issuerOrganization)
+                // TODO provide full certificate info: https://github.com/mozilla-mobile/android-components/issues/5557
+                onSecurityChange(securityInfo.isSecure, securityInfo.host, securityInfo.certificate?.issuerDN?.name)
             }
         }
 


### PR DESCRIPTION
Doesn't appear that the issuer is used right now. So, let's unblock this upgrade and file a follow-up to integration the full cert. info?