### PR TITLE
Bump a-s dependency to 0.48.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.48.1"
+    const val mozilla_appservices = "0.48.2"
 
     const val mozilla_glean = "23.0.1"
 


### PR DESCRIPTION
Changelog: https://github.com/mozilla/application-services/releases/tag/v0.48.2

Fixes a crash in Fenix Nightly 

@grigoryk @csadilek r?