### PR TITLE
No issue: Adds callback for app to control showing logins prompt

### DIFF
--- a/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt
+++ b/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt
@@ -33,7 +33,27 @@ class GeckoLoginStorageDelegateTest {
         loginsStorage = mockLoginsStorage()
         keystore = SecureAbove22Preferences(testContext, "name")
         scope = TestCoroutineScope()
-        delegate = GeckoLoginStorageDelegate(loginsStorage, keystore, scope)
+        delegate = GeckoLoginStorageDelegate(loginsStorage, keystore, { false }, scope)
+    }
+
+    @Test
+    @Config(sdk = [21])
+    fun `WHEN passed false for shouldAutofill onLoginsFetch returns early`() {
+        scope.launch {
+            delegate.onLoginFetch("login")
+            verify(loginsStorage, times(0)).touch(any()).await()
+        }
+    }
+
+    @Test
+    @Config(sdk = [21])
+    fun `WHEN passed true for shouldAutofill onLoginsFetch does not return early`() {
+        delegate = GeckoLoginStorageDelegate(loginsStorage, keystore, { true }, scope)
+
+        scope.launch {
+            delegate.onLoginFetch("login")
+            verify(loginsStorage, times(1)).touch(any()).await()
+        }
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,10 +52,14 @@ permalink: /changelog/
 * **feature-prompts**
   * `PromptFeature` may now optionally accept a `LoginValidationDelegate`. If present, it users 
   will be prompted to save their information after logging in to a website.
+  * `PromptFeature` now accepts a false by default `isSaveLoginEnabled` lambda to be invoked before showing prompts. If true, users
+    will be prompted to save their information after logging in to a website.
   
 * **service-sync-logins**
   * Added `GeckoLoginStorageDelegate`. This can be attached to a GeckoEngine, where it will be used 
   to save user login credentials.
+  * `GeckoLoginStorageDelegate` now accepts a false by default `isAutofillEnabled` lambda to be invoked before fetching logins. If false,
+   logins will not be fetched to autofill.
 
 * **service-firefox-accounts**
   * `signInWithShareableAccountAsync` now takes a `reuseAccount` parameter, allowing consumers


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This is needed so that we don't have to recreate the gecko runtime every time a user changes the "save logins" setting.
We also need to be able to control whether or not we are autofilling via a Fenix setting.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
