### PR TITLE
Closes #5432: Add API to query unsupported addons

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.Port
@@ -240,6 +241,7 @@ class GeckoWebExtension(
                 version = it.version,
                 permissions = it.permissions.toList(),
                 hostPermissions = it.origins.toList(),
+                disabledFlags = DisabledFlags.select(0),
                 optionsPageUrl = null, // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
                 openOptionsPageInTab = null // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
             )

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor
@@ -338,6 +339,9 @@ class GeckoWebExtensionTest {
         assertEquals("https://developer1.dev", metadata.developerUrl)
         assertEquals("https://mozilla.org", metadata.homePageUrl)
         assertEquals("myextension", metadata.name)
+        assertFalse(metadata.disabledFlags.contains(DisabledFlags.USER))
+        assertFalse(metadata.disabledFlags.contains(DisabledFlags.BLOCKLIST))
+        assertFalse(metadata.disabledFlags.contains(DisabledFlags.APP_SUPPORT))
         assertNull(metadata.optionsPageUrl)
         assertNull(metadata.openOptionsPageInTab)
     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.Port
@@ -240,6 +241,7 @@ class GeckoWebExtension(
                 version = it.version,
                 permissions = it.permissions.toList(),
                 hostPermissions = it.origins.toList(),
+                disabledFlags = DisabledFlags.select(it.disabledFlags),
                 optionsPageUrl = null, // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
                 openOptionsPageInTab = null // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
             )

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor
@@ -321,7 +322,7 @@ class GeckoWebExtensionTest {
         metaDataBundle.putString("name", "myextension")
         metaDataBundle.putString("optionsPageUrl", "")
         metaDataBundle.putBoolean("openOptionsPageInTab", false)
-        metaDataBundle.putStringArray("disabledFlags", emptyArray())
+        metaDataBundle.putStringArray("disabledFlags", arrayOf("userDisabled"))
         val bundle = GeckoBundle()
         bundle.putString("webExtensionId", "id")
         bundle.putString("locationURI", "uri")
@@ -339,6 +340,9 @@ class GeckoWebExtensionTest {
         assertEquals("https://developer1.dev", metadata.developerUrl)
         assertEquals("https://mozilla.org", metadata.homePageUrl)
         assertEquals("myextension", metadata.name)
+        assertTrue(metadata.disabledFlags.contains(DisabledFlags.USER))
+        assertFalse(metadata.disabledFlags.contains(DisabledFlags.BLOCKLIST))
+        assertFalse(metadata.disabledFlags.contains(DisabledFlags.APP_SUPPORT))
         assertNull(metadata.optionsPageUrl)
         assertNull(metadata.openOptionsPageInTab)
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -301,11 +301,16 @@ data class Metadata(
      * Whether or not the options page should be opened in a new tab:
      * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui#syntax
      */
-    val openOptionsPageInTab: Boolean?
+    val openOptionsPageInTab: Boolean?,
+
+    /**
+     * Describes the reason (or reasons) why an extension is disabled.
+     */
+    val disabledFlags: DisabledFlags
 )
 
 /**
- * Provides additional information about why an extension was enabled or disabled.
+ * Provides additional information about why an extension is being enabled or disabled.
  */
 @Suppress("MagicNumber")
 enum class EnableSource(val id: Int) {
@@ -319,4 +324,29 @@ enum class EnableSource(val id: Int) {
      * on available support.
      */
     APP_SUPPORT(1 shl 1),
+}
+
+/**
+ * Flags to check for different reasons why an extension is disabled.
+ */
+class DisabledFlags internal constructor(val value: Int) {
+    companion object {
+        const val USER: Int = 1 shl 1
+        const val BLOCKLIST: Int = 1 shl 2
+        const val APP_SUPPORT: Int = 1 shl 3
+
+        /**
+         * Selects a combination of flags.
+         *
+         * @param flags the flags to select.
+         */
+        fun select(vararg flags: Int) = DisabledFlags(flags.sum())
+    }
+
+    /**
+     * Checks if the provided flag is set.
+     *
+     * @param flag the flag to check.
+     */
+    fun contains(flag: Int) = (value and flag) != 0
 }

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -96,7 +96,8 @@ data class Addon(
         val version: String,
         val optionsPageUrl: String,
         val enabled: Boolean = false,
-        val supported: Boolean = true
+        val supported: Boolean = true,
+        val disabledAsUnsupported: Boolean = false
     ) : Parcelable
 
     /**
@@ -120,6 +121,14 @@ data class Addon(
      * Returns whether or not this [Addon] is currently supported by the browser.
      */
     fun isSupported() = installedState?.supported == true
+
+    /**
+     * Returns whether or not this [Addon] is currently disabled because it is not
+     * supported. This is based on the installed extension state in the engine. An
+     * addon can be disabled as unsupported and later become supported, so
+     * both [isSupported] and [isDisabledAsUnsupported] can be true.
+     */
+    fun isDisabledAsUnsupported() = installedState?.disabledAsUnsupported == true
 
     companion object {
         /**

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.addons
 
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.AddonUpdater.Status
@@ -43,6 +44,7 @@ class AddonManager(
             // Make sure extension support is initialized, i.e. the state of all installed extensions is known.
             WebExtensionSupport.awaitInitialization()
 
+            // Get all available/supported addons from provider and add state if installed.
             val supportedAddons = addonsProvider.getAvailableAddons().map { addon ->
                 installedExtensions[addon.id]?.let {
                     addon.copy(installedState = it.toInstalledState())
@@ -218,4 +220,10 @@ private fun WebExtension.toInstalledState() =
     // TODO Add optionsUrl
     // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1598792
     // TODO https://bugzilla.mozilla.org/show_bug.cgi?id=1597793
-    Addon.InstalledState(id, getMetadata()?.version ?: "", "https://mozilla.org", isEnabled())
+    Addon.InstalledState(
+        id = id,
+        version = getMetadata()?.version ?: "",
+        optionsPageUrl = "https://mozilla.org",
+        enabled = isEnabled(),
+        disabledAsUnsupported = getMetadata()?.disabledFlags?.contains(DisabledFlags.APP_SUPPORT) == true
+    )


### PR DESCRIPTION
This just brings in the flag/state so we know why an extension was disabled when we're querying it from GV. This is the only part that wasn't available in your original PR @psymoon. With this we can later add UI to indicate that the extension is installed but disabled because it wasn't supported, or we could write code to automatically enable these addons.

Let's talk more about it later...