### PR TITLE
Switch to reuseAccount=false for the FxA migration

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
@@ -136,7 +136,7 @@ private object AuthenticatedAccountProcessor {
             authInfo = fennecAuthInfo
         )
 
-        if (!accountManager.signInWithShareableAccountAsync(shareableAccount, reuseAccount = true).await()) {
+        if (!accountManager.signInWithShareableAccountAsync(shareableAccount, reuseAccount = false).await()) {
             // What do we do now?
             // We detected an account in a good state, and failed to actually login with it.
             // This could indicate that credentials stored in Fennec are no longer valid, or that we had a

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
@@ -80,7 +80,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(true))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(false))).thenReturn(CompletableDeferred(true))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Success) {
             assertEquals(FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount::class, this.value::class)
@@ -88,7 +88,7 @@ class FennecFxaMigrationTest {
             assertEquals("Married", (this.value as FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount).stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(false))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252fsvj8932vj32movj97325hjfksdhfjstrg23yurt267r23", captor.value.authInfo.kSync)
@@ -102,7 +102,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(true))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(false))).thenReturn(CompletableDeferred(true))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Success) {
             assertEquals(FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount::class, this.value::class)
@@ -110,7 +110,7 @@ class FennecFxaMigrationTest {
             assertEquals("Cohabiting", (this.value as FxaMigrationResult.Success.SignedInIntoAuthenticatedAccount).stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(false))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252bc4ccc3a239fsdfsdf32fg32wf3w4e3472d41d1a204890", captor.value.authInfo.kSync)
@@ -124,7 +124,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "married-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(false))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(false))).thenReturn(CompletableDeferred(false))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Failure) {
             val unwrapped = this.throwables.first() as FxaMigrationException
@@ -134,7 +134,7 @@ class FennecFxaMigrationTest {
             assertEquals("Married", (unwrapped.failure as FxaMigrationResult.Failure.FailedToSignIntoAuthenticatedAccount).stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(false))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252fsvj8932vj32movj97325hjfksdhfjstrg23yurt267r23", captor.value.authInfo.kSync)
@@ -148,7 +148,7 @@ class FennecFxaMigrationTest {
         val fxaPath = File(getTestPath("fxa"), "cohabiting-v4.json")
         val accountManager: FxaAccountManager = mock()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(false))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(false))).thenReturn(CompletableDeferred(false))
 
         with(FennecFxaMigration.migrate(fxaPath, testContext, accountManager) as Result.Failure) {
             val unwrapped = this.throwables.first() as FxaMigrationException
@@ -158,7 +158,7 @@ class FennecFxaMigrationTest {
             assertEquals("Cohabiting", unwrappedFailure.stateLabel)
 
             val captor = argumentCaptor<ShareableAccount>()
-            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
+            verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(false))
 
             assertEquals("test@example.com", captor.value.email)
             assertEquals("252bc4ccc3a239fsdfsdf32fg32wf3w4e3472d41d1a204890", captor.value.authInfo.kSync)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -485,7 +485,7 @@ class FennecMigratorTest {
             .setCoroutineContext(this.coroutineContext)
             .build()
 
-        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(true))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(false))).thenReturn(CompletableDeferred(true))
 
         with(migrator.migrateAsync().await()) {
             assertEquals(1, this.size)
@@ -494,7 +494,7 @@ class FennecMigratorTest {
         }
 
         val captor = argumentCaptor<ShareableAccount>()
-        verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
+        verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(false))
 
         assertEquals("test@example.com", captor.value.email)
         // This is going to be package name (org.mozilla.firefox) in actual builds.
@@ -522,7 +522,7 @@ class FennecMigratorTest {
             .build()
 
         // For now, we don't treat sign-in failure any different from success. E.g. it's a one-shot attempt.
-        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(true))).thenReturn(CompletableDeferred(false))
+        `when`(accountManager.signInWithShareableAccountAsync(any(), eq(false))).thenReturn(CompletableDeferred(false))
 
         with(migrator.migrateAsync().await()) {
             assertEquals(1, this.size)
@@ -531,7 +531,7 @@ class FennecMigratorTest {
         }
 
         val captor = argumentCaptor<ShareableAccount>()
-        verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(true))
+        verify(accountManager).signInWithShareableAccountAsync(captor.capture(), eq(false))
 
         assertEquals("test@example.com", captor.value.email)
         // This is going to be package name (org.mozilla.firefox) in actual builds.


### PR DESCRIPTION
The other option is what we really want, but it currently doesn't work.

(same as https://github.com/mozilla-mobile/android-components/pull/5571 but w/ tests passing)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
