### PR TITLE
Issue #5460: Exclude built-in extensions from addon migration

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
@@ -94,7 +94,7 @@ internal object AddonMigration {
 
         val migratedAddons = mutableListOf<WebExtension>()
         val failures = mutableMapOf<WebExtension, Exception>()
-        installedAddons.forEach { addon ->
+        installedAddons.filter { !it.isBuiltIn() }.forEach { addon ->
             try {
                 migratedAddons += migrateAddon(engine, addon)
             } catch (e: Exception) {

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
@@ -39,12 +39,19 @@ class AddonMigrationTest {
     @Test
     fun `All addons migrated`() = runBlocking {
         val addon1: WebExtension = mock()
+        whenever(addon1.isBuiltIn()).thenReturn(false)
+
         val addon2: WebExtension = mock()
+        whenever(addon2.isBuiltIn()).thenReturn(false)
+
+        // Built-in add-ons (browser-icons, readerview) do not need to and shouldn't be migrated.
+        val addon3: WebExtension = mock()
+        whenever(addon3.isBuiltIn()).thenReturn(true)
 
         val engine: Engine = mock()
         val listSuccessCallback = argumentCaptor<((List<WebExtension>) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(listSuccessCallback.capture(), any())).thenAnswer {
-            listSuccessCallback.value.invoke(listOf(addon1, addon2))
+            listSuccessCallback.value.invoke(listOf(addon1, addon2, addon3))
         }
 
         val addonCaptor = argumentCaptor<WebExtension>()


### PR DESCRIPTION
There's **no** bug here currently, as built-in extensions are not being returned by `listInstalled` anyway. That's because they are not yet using the new install API, and are registered on every startup instead.

However, if we ever switch to the new API and persist those extensions as well, then this would be a footgun and we could by mistake migrate/disable them.