### PR TITLE
Refresh constellation state if not present

### DIFF
--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsFeature.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsFeature.kt
@@ -72,11 +72,15 @@ class SyncedTabsFeature(
     }
 
     /**
-     * List of synced devices.
+     * List of synced devices. If they haven't been fetched yet, we'll do it.
      */
     @VisibleForTesting
-    internal fun syncClients(): List<Device>? {
+    internal suspend fun syncClients(): List<Device>? {
         accountManager.withConstellation { constellation ->
+            constellation.state()?.let {
+                return it.otherDevices
+            }
+            constellation.refreshDevicesAsync().await()
             return constellation.state()?.otherDevices
         }
         return null


### PR DESCRIPTION
Technically the caller of `SyncedTabsFeature.getSyncedTabs` could refresh devices beforehand but it's just easier to do it here.