### PR TITLE
Always use web app manifest if possible

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -36,7 +36,7 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.pwa.WebAppLauncherActivity.Companion.ACTION_PWA_LAUNCHER
 import mozilla.components.feature.pwa.ext.installableManifest
-import mozilla.components.feature.pwa.ext.isInstallable
+import mozilla.components.feature.pwa.ext.hasLargeIcons
 
 private val pwaIconMemoryCache = IconMemoryCache()
 
@@ -126,7 +126,7 @@ class WebAppShortcutManager(
             .setShortLabel(shortLabel.ifBlank { fallbackLabel })
             .setIntent(shortcutIntent)
 
-        val icon = if (manifest != null && manifest.isInstallable()) {
+        val icon = if (manifest != null && manifest.hasLargeIcons()) {
             buildIconFromManifest(manifest)
         } else {
             session.icon?.let { IconCompat.createWithBitmap(it) }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Session.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Session.kt
@@ -6,9 +6,6 @@ package mozilla.components.feature.pwa.ext
 
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.manifest.WebAppManifest
-import mozilla.components.concept.engine.manifest.WebAppManifest.Icon.Purpose
-
-private const val MIN_INSTALLABLE_ICON_SIZE = 192
 
 /**
  * Checks if the current session represents an installable web app.
@@ -20,14 +17,6 @@ private const val MIN_INSTALLABLE_ICON_SIZE = 192
  * - The icons array in the manifest contains an icon of at least 192x192
  */
 fun Session.installableManifest(): WebAppManifest? {
-    if (!securityInfo.secure) return null
     val manifest = webAppManifest ?: return null
-
-    val installable = manifest.icons.any { icon ->
-        (Purpose.ANY in icon.purpose || Purpose.MASKABLE in icon.purpose) &&
-            icon.sizes.any { size ->
-                size.minLength >= MIN_INSTALLABLE_ICON_SIZE
-            }
-    }
-    return if (installable) manifest else null
+    return if (securityInfo.secure && manifest.isInstallable()) manifest else null
 }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Session.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Session.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.pwa.ext
 
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.concept.engine.manifest.WebAppManifest.DisplayMode.BROWSER
 
 /**
  * Checks if the current session represents an installable web app.
@@ -14,9 +15,14 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
  * Websites are installable if:
  * - The site is served over HTTPS
  * - The site has a valid manifest with a name or short_name
+ * - The manifest display mode is standalone, fullscreen, or minimal-ui
  * - The icons array in the manifest contains an icon of at least 192x192
  */
 fun Session.installableManifest(): WebAppManifest? {
     val manifest = webAppManifest ?: return null
-    return if (securityInfo.secure && manifest.isInstallable()) manifest else null
+    return if (securityInfo.secure && manifest.display != BROWSER && manifest.hasLargeIcons()) {
+        manifest
+    } else {
+        null
+    }
 }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -14,7 +14,20 @@ import androidx.core.net.toUri
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.concept.engine.manifest.WebAppManifest.Icon.Purpose
 import mozilla.components.support.utils.ColorUtils.isDark
+
+private const val MIN_INSTALLABLE_ICON_SIZE = 192
+
+/**
+ * Checks if the web app manifest can be used to create a shortcut icon.
+ */
+fun WebAppManifest.isInstallable() = icons.any { icon ->
+    (Purpose.ANY in icon.purpose || Purpose.MASKABLE in icon.purpose) &&
+        icon.sizes.any { size ->
+            size.minLength >= MIN_INSTALLABLE_ICON_SIZE
+        }
+}
 
 /**
  * Creates a [TaskDescription] for the activity manager based on the manifest.

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -21,8 +21,11 @@ private const val MIN_INSTALLABLE_ICON_SIZE = 192
 
 /**
  * Checks if the web app manifest can be used to create a shortcut icon.
+ *
+ * Websites have an installable icon if the manifest contains an icon of at least 192x192.
+ * @see [installableManifest]
  */
-fun WebAppManifest.isInstallable() = icons.any { icon ->
+fun WebAppManifest.hasLargeIcons() = icons.any { icon ->
     (Purpose.ANY in icon.purpose || Purpose.MASKABLE in icon.purpose) &&
         icon.sizes.any { size ->
             size.minLength >= MIN_INSTALLABLE_ICON_SIZE

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
@@ -168,7 +168,18 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `buildBasicShortcut uses session title as label by default`() = runBlockingTest {
+    fun `buildBasicShortcut uses manifest name as label by default`() = runBlockingTest {
+        setSdkInt(Build.VERSION_CODES.O)
+        val session = Session("https://mozilla.org")
+        session.title = "Internet for people, not profit — Mozilla"
+        session.webAppManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
+        val shortcut = manager.buildBasicShortcut(context, session)
+
+        assertEquals("Mozilla", shortcut.shortLabel)
+    }
+
+    @Test
+    fun `buildBasicShortcut uses session title as label if there is no manifest`() = runBlockingTest {
         setSdkInt(Build.VERSION_CODES.O)
         val expectedTitle = "Internet for people, not profit — Mozilla"
         val session = Session("https://mozilla.org")

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
@@ -36,12 +36,13 @@ class WebAppUseCasesTest {
     @Test
     fun `isInstallable returns true if currentSession has a manifest`() {
         val manifest = WebAppManifest(
-                name = "Demo",
-                startUrl = "https://example.com",
-                icons = listOf(WebAppManifest.Icon(
-                        src = "https://example.com/icon.png",
-                        sizes = listOf(Size(192, 192))
-                ))
+            name = "Demo",
+            startUrl = "https://example.com",
+            display = WebAppManifest.DisplayMode.STANDALONE,
+            icons = listOf(WebAppManifest.Icon(
+                    src = "https://example.com/icon.png",
+                    sizes = listOf(Size(192, 192))
+            ))
         )
 
         val session: Session = mock()
@@ -64,6 +65,7 @@ class WebAppUseCasesTest {
         val manifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://example.com",
+            display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(WebAppManifest.Icon(
                 src = "https://example.com/icon.png",
                 sizes = listOf(Size(192, 192))

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/SessionKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/SessionKtTest.kt
@@ -14,7 +14,11 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SessionKtTest {
-    private val demoManifest = WebAppManifest(name = "Demo", startUrl = "https://mozilla.com")
+    private val demoManifest = WebAppManifest(
+        name = "Demo",
+        startUrl = "https://mozilla.com",
+        display = WebAppManifest.DisplayMode.STANDALONE
+    )
     private val demoIcon = WebAppManifest.Icon(src = "https://mozilla.com/example.png")
 
     @Test

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/WebAppManifestKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/WebAppManifestKtTest.kt
@@ -8,8 +8,10 @@ import android.graphics.Color
 import android.graphics.Color.rgb
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.manifest.Size
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,6 +19,9 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class WebAppManifestKtTest {
+
+    private val demoManifest = WebAppManifest(name = "Demo", startUrl = "https://mozilla.com")
+    private val demoIcon = WebAppManifest.Icon(src = "https://mozilla.com/example.png")
 
     @Test
     fun `should use name as label`() {
@@ -92,5 +97,64 @@ class WebAppManifestKtTest {
             display = WebAppManifest.DisplayMode.MINIMAL_UI
         ).getTrustedScope()
         assertNull(fallbackToStartUrl)
+    }
+
+    @Test
+    fun `web app must have an icon to be installable`() {
+        val noIconManifest = demoManifest
+        assertFalse(noIconManifest.hasLargeIcons())
+
+        val noSizeIconManifest = demoManifest.copy(icons = listOf(demoIcon))
+        assertFalse(noSizeIconManifest.hasLargeIcons())
+
+        val onlyBadgeIconManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(
+                sizes = listOf(Size(512, 512)),
+                purpose = setOf(WebAppManifest.Icon.Purpose.BADGE)
+            )
+        ))
+        assertFalse(onlyBadgeIconManifest.hasLargeIcons())
+    }
+
+    @Test
+    fun `web app must have 192x192 icons to be installable`() {
+        val smallIconManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(sizes = listOf(Size(32, 32)))
+        ))
+        assertFalse(smallIconManifest.hasLargeIcons())
+
+        val weirdSizeManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(sizes = listOf(Size(50, 200)))
+        ))
+        assertFalse(weirdSizeManifest.hasLargeIcons())
+
+        val largeIconManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(sizes = listOf(Size(192, 192)))
+        ))
+        assertTrue(largeIconManifest.hasLargeIcons())
+
+        val multiSizeIconManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(sizes = listOf(Size(16, 16), Size(512, 512)))
+        ))
+        assertTrue(multiSizeIconManifest.hasLargeIcons())
+
+        val multiIconManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(sizes = listOf(Size(191, 193))),
+            demoIcon.copy(sizes = listOf(Size(512, 512))),
+            demoIcon.copy(
+                sizes = listOf(Size(192, 192)),
+                purpose = setOf(WebAppManifest.Icon.Purpose.BADGE)
+            )
+        ))
+        assertTrue(multiIconManifest.hasLargeIcons())
+
+        val onlyBadgeManifest = demoManifest.copy(icons = listOf(
+            demoIcon.copy(sizes = listOf(Size(191, 191))),
+            demoIcon.copy(
+                sizes = listOf(Size(192, 192)),
+                purpose = setOf(WebAppManifest.Icon.Purpose.BADGE)
+            )
+        ))
+        assertFalse(onlyBadgeManifest.hasLargeIcons())
     }
 }


### PR DESCRIPTION
Good for sites like Wikipedia that supply a web app manifest that we can take icons from, but should not be opened standalone.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
