### PR TITLE
Closes #5884 - Let PWA site controls be customized

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/SiteControlsBuilder.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/SiteControlsBuilder.kt
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa.feature
+
+import android.app.PendingIntent
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.content.getSystemService
+import mozilla.components.browser.session.Session
+import mozilla.components.feature.pwa.R
+import mozilla.components.feature.session.SessionUseCases
+
+/**
+ * Callback for [WebAppSiteControlsFeature] that lets the displayed notification be customized.
+ */
+interface SiteControlsBuilder {
+
+    /**
+     * Create the notification to be displayed. Initial values are set in the provided [builder]
+     * and additional actions can be added here. Actions should be represented as [PendingIntent]
+     * that are filtered by [getFilter] and handled in [onReceiveBroadcast].
+     */
+    fun buildNotification(context: Context, builder: NotificationCompat.Builder, channelId: String)
+
+    /**
+     * Return an intent filter that matches the actions specified in [buildNotification].
+     */
+    fun getFilter(): IntentFilter
+
+    /**
+     * Handle actions the user selected in the site controls notification.
+     */
+    fun onReceiveBroadcast(context: Context, session: Session, intent: Intent)
+
+    /**
+     * Default implementation of [SiteControlsBuilder] that copies the URL of the site when tapped.
+     */
+    open class Default : SiteControlsBuilder {
+
+        override fun getFilter() = IntentFilter().apply {
+            addAction(ACTION_COPY)
+        }
+
+        override fun buildNotification(context: Context, builder: NotificationCompat.Builder, channelId: String) {
+            val copyIntent = createPendingIntent(context, ACTION_COPY, 1)
+
+            builder.setContentText(context.getString(R.string.mozac_feature_pwa_site_controls_notification_text))
+            builder.setContentIntent(copyIntent)
+        }
+
+        override fun onReceiveBroadcast(context: Context, session: Session, intent: Intent) {
+            when (intent.action) {
+                ACTION_COPY -> {
+                    context.getSystemService<ClipboardManager>()?.let { clipboardManager ->
+                        clipboardManager.setPrimaryClip(ClipData.newPlainText(session.url, session.url))
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.mozac_feature_pwa_copy_success),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+        }
+
+        protected fun createPendingIntent(context: Context, action: String, requestCode: Int): PendingIntent {
+            val intent = Intent(action)
+            intent.setPackage(context.packageName)
+            return PendingIntent.getBroadcast(context, requestCode, intent, 0)
+        }
+
+        companion object {
+            private const val ACTION_COPY = "mozilla.components.feature.pwa.COPY"
+        }
+    }
+
+    /**
+     * Implementation of [SiteControlsBuilder] that adds a Refresh button and
+     * copies the URL of the site when tapped.
+     */
+    class CopyAndRefresh(
+        private val reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase
+    ) : Default() {
+
+        override fun getFilter() = super.getFilter().apply {
+            addAction(ACTION_REFRESH)
+        }
+
+        override fun buildNotification(context: Context, builder: NotificationCompat.Builder, channelId: String) {
+            super.buildNotification(context, builder, channelId)
+            val refreshAction = NotificationCompat.Action(
+                R.drawable.ic_refresh,
+                context.getString(R.string.mozac_feature_pwa_site_controls_refresh),
+                createPendingIntent(context, ACTION_REFRESH, 2)
+            )
+
+            builder.addAction(refreshAction)
+        }
+
+        override fun onReceiveBroadcast(context: Context, session: Session, intent: Intent) {
+            when (intent.action) {
+                ACTION_REFRESH -> reloadUrlUseCase(session)
+                else -> super.onReceiveBroadcast(context, session, intent)
+            }
+        }
+
+        companion object {
+            private const val ACTION_REFRESH = "mozilla.components.feature.pwa.REFRESH"
+        }
+    }
+}

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppSiteControlsFeatureTest.kt
@@ -27,7 +27,7 @@ class WebAppSiteControlsFeatureTest {
     fun `register receiver on resume`() {
         val context = spy(testContext)
 
-        val feature = WebAppSiteControlsFeature(context, mock(), mock(), "session-id", mock())
+        val feature = WebAppSiteControlsFeature(context, mock(), "session-id", mock())
         feature.onResume()
 
         verify(context).registerReceiver(eq(feature), any())
@@ -39,7 +39,7 @@ class WebAppSiteControlsFeatureTest {
 
         doNothing().`when`(context).unregisterReceiver(any())
 
-        val feature = WebAppSiteControlsFeature(context, mock(), mock(), "session-id", mock())
+        val feature = WebAppSiteControlsFeature(context, mock(), "session-id", mock())
         feature.onPause()
 
         verify(context).unregisterReceiver(feature)


### PR DESCRIPTION
Customize the notification that shows up when a PWA is open with any options.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
