### PR TITLE
Closes #5583: Use Firefox logo in migration notification.

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
@@ -24,7 +24,6 @@ private const val NOTIFICATION_TAG = "mozac.support.migration.notification"
 private const val NOTIFICATION_CHANNEL_ID = "mozac.support.migration.generic"
 
 private const val TEMPORARY_NOTIFICATION_CHANNEL_NAME = "Migration"
-private val temporaryNotificationIcon = R.drawable.mozac_lib_crash_notification
 
 /**
  * Abstract implementation of a background service running a configured [FennecMigrator].
@@ -81,7 +80,7 @@ abstract class AbstractMigrationService : Service() {
         val channel = ensureChannelExists()
 
         val builder = NotificationCompat.Builder(this, channel)
-            .setSmallIcon(temporaryNotificationIcon)
+            .setSmallIcon(R.drawable.mozac_support_migration_notification_icon)
             .setContentTitle(getString(R.string.mozac_support_migration_ongoing_notification_title))
             .setContentText(getString(R.string.mozac_support_migration_ongoing_notification_text))
             .setPriority(NotificationCompat.PRIORITY_LOW)

--- a/components/support/migration/src/main/res/drawable/mozac_support_migration_notification_icon.xml
+++ b/components/support/migration/src/main/res/drawable/mozac_support_migration_notification_icon.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="32"
+        android:viewportHeight="32">
+    <path android:fillColor="@android:color/white"
+          android:pathData="M30 10.4a8.5 8.5 0 0 0-3-3.8c0.7 1.4 1.2 3 1.4 4.6-1.7-4.2-4.5-6-6.9-9.6-0.1-0.2-0.6-1-0.7-1.5a10.9 10.9 0 0 0-5.2 7.5c-1 0-2 0.3-3 0.7-0.2 0.1-0.3 0.3-0.2 0.5 0 0.2 0.2 0.3 0.4 0.3 0.3 0 1.2-0.7 3.2-0.8 4 0 6 2.8 6.6 3.9-1-0.8-2.3-1-3.6-1A6.2 6.2 0 0 1 16.1 23c-4.8 0-6.6-3.5-6.9-5.6-0.2-2.1 0.7-2.6 5-2.6 0.8-0.3 1.4-0.9 1.8-1.6 0-0.2-2.6-1.2-3.6-2.2l-1-1-0.4-0.3A6.8 6.8 0 0 1 11 6c-1.4 0.7-2.7 1.6-3.7 2.8-0.6-0.8-0.5-3.2-0.5-3.8-0.2 0.1-5.7 3.2-5.7 11.2a15 15 0 0 0 15 15c7.4 0 14-6 14.9-13.4 0.2-2.1-0.1-5-1-7.4z"/>
+</vector>


### PR DESCRIPTION
Replacing the temporary logo... :)