### PR TITLE
Closes #5588: WebExtensionToolbarFeature may display stale actions

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -232,6 +232,16 @@ class BrowserToolbar @JvmOverloads constructor(
     }
 
     /**
+     * Removes a previously added action (see [addBrowserAction]). If the provided
+     * action was never added, this method has no effect.
+     *
+     * @param action the action to remove.
+     */
+    override fun removeBrowserAction(action: Toolbar.Action) {
+        display.removeBrowserAction(action)
+    }
+
+    /**
      * Adds an action to be displayed on the right side of the URL in display mode.
      *
      * Related:

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -543,6 +543,16 @@ class DisplayToolbar internal constructor(
     }
 
     /**
+     * Removes a previously added action (see [addBrowserAction]). If the provided
+     * action was never added, this method has no effect.
+     *
+     * @param action the action to remove.
+     */
+    internal fun removeBrowserAction(action: Toolbar.Action) {
+        views.browserActions.removeAction(action)
+    }
+
+    /**
      * Adds an action to be displayed on the right side of the URL in display mode.
      *
      * Related:

--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/internal/ActionContainer.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/internal/ActionContainer.kt
@@ -54,6 +54,13 @@ internal class ActionContainer @JvmOverloads constructor(
         actions.add(wrapper)
     }
 
+    fun removeAction(action: Toolbar.Action) {
+        actions.find { it.actual == action }?.let {
+            actions.remove(it)
+            removeView(it.view)
+        }
+    }
+
     fun invalidateActions() {
         TransitionManager.beginDelayedTransition(this)
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -331,6 +331,22 @@ class BrowserToolbarTest {
     }
 
     @Test
+    fun `remove browser action will be forwarded to display toolbar`() {
+        val toolbar = BrowserToolbar(testContext)
+        val display: DisplayToolbar = mock()
+
+        toolbar.display = display
+
+        val action = BrowserToolbar.Button(mock(), "Hello") {
+            // Do nothing
+        }
+
+        toolbar.removeBrowserAction(action)
+
+        verify(display).removeBrowserAction(action)
+    }
+
+    @Test
     fun `add page action will be forwarded to display toolbar`() {
         val toolbar = BrowserToolbar(testContext)
 

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -268,6 +268,23 @@ class DisplayToolbarTest {
     }
 
     @Test
+    fun `browser action can be removed`() {
+        val contentDescription = "to-be-removed"
+
+        val (_, displayToolbar) = createDisplayToolbar()
+
+        val action = BrowserToolbar.Button(mock(), contentDescription) {}
+        // Removing action which was never added has no effect
+        displayToolbar.removeBrowserAction(action)
+
+        displayToolbar.addBrowserAction(action)
+        assertEquals(1, displayToolbar.views.browserActions.childCount)
+
+        displayToolbar.removeBrowserAction(action)
+        assertEquals(0, displayToolbar.views.browserActions.childCount)
+    }
+
+    @Test
     fun `page actions will be added as view to the toolbar`() {
         val (_, displayToolbar) = createDisplayToolbar()
 

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -101,6 +101,14 @@ interface Toolbar {
     fun addBrowserAction(action: Action)
 
     /**
+     * Removes a previously added action (see [addBrowserAction]). If the the provided
+     * actions was never added, this method has no effect.
+     *
+     * @param action the action to remove.
+     */
+    fun removeBrowserAction(action: Action)
+
+    /**
      * Declare that the actions (navigation actions, browser actions, page actions) have changed and
      * should be updated if needed.
      */

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -70,6 +70,10 @@ class ToolbarAutocompleteFeatureTest {
             fail()
         }
 
+        override fun removeBrowserAction(action: Toolbar.Action) {
+            fail()
+        }
+
         override fun addPageAction(action: Toolbar.Action) {
             fail()
         }

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -56,6 +56,10 @@ class ToolbarInteractorTest {
             fail()
         }
 
+        override fun removeBrowserAction(action: Toolbar.Action) {
+            fail()
+        }
+
         override fun addPageAction(action: Toolbar.Action) {
             fail()
         }


### PR DESCRIPTION
This makes sure we remove stale browser actions (from uninstalled extensions) from the toolbar. Reason we don't always see this bug is that when switching from the `AddonsFragment` (where we uninstall) back to the `BrowserFragment` we usually get a new view and toolbar and we'd only add the actions of existing extensions. However, when the view and toolbar are re-used we'd see this problem (easily reproducible in an emulator).