### PR TITLE
For Fenix#7506: relax MenuButton visibility for use in Fenix

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/MenuButton.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/MenuButton.kt
@@ -23,7 +23,15 @@ import mozilla.components.browser.toolbar.R
 import mozilla.components.browser.toolbar.facts.emitOpenMenuFact
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 
-internal class MenuButton @JvmOverloads constructor(
+/**
+ * A `three-dot` button used for expanding menus.
+ *
+ * In most use cases, this should not be used directly by consumers. Instead, prefer to let this be
+ * created and managed by a [DisplayToolbar] where possible.
+ *
+ * This should be invalidated whenever its highlightable state may have changed.
+ */
+class MenuButton @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0


### PR DESCRIPTION
For Fenix#7506: relax MenuButton visibility for use in Fenix
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This is in support of https://github.com/mozilla-mobile/fenix/pull/7665

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
Only changes visibility
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
Small, non-breaking change.  Let me know if you think this should be added anyway
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
