### PR TITLE
For Fenix#7517: Update menu container style to use 16dp padding

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -8,8 +8,7 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="@dimen/mozac_browser_menu_item_toolbar_height"
-    android:paddingEnd="16dp"
-    android:paddingStart="16dp"
+    style="@style/Mozac.Browser.Menu.Item.Container"
     android:gravity="center_vertical">
 
     <ImageView

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -11,8 +11,8 @@
     <!--Menu Item -->
     <dimen name="mozac_browser_menu_item_text_size">16sp</dimen>
     <dimen name="mozac_browser_menu_item_container_layout_height">48dp</dimen>
-    <dimen name="mozac_browser_menu_item_container_padding_start">24dp</dimen>
-    <dimen name="mozac_browser_menu_item_container_padding_end">24dp</dimen>
+    <dimen name="mozac_browser_menu_item_container_padding_start">16dp</dimen>
+    <dimen name="mozac_browser_menu_item_container_padding_end">16dp</dimen>
     <!--Menu Item -->
 
     <!--BrowserMenuDivider -->


### PR DESCRIPTION
Also allow `mozac_browser_menu_web_extension` to use `@style/Mozac.Browser.Menu.Item.Container`.