### PR TITLE
L10n fixes for SSL bypass

### DIFF
--- a/components/browser/errorpages/build.gradle
+++ b/components/browser/errorpages/build.gradle
@@ -33,6 +33,8 @@ android {
 dependencies {
     implementation Dependencies.androidx_annotation
 
+    implementation project(':support-ktx')
+
     implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')

--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.errorpages
 import android.content.Context
 import androidx.annotation.RawRes
 import androidx.annotation.StringRes
+import mozilla.components.support.ktx.android.content.appName
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -51,7 +52,7 @@ object ErrorPages {
                             context.getString(R.string.mozac_browser_errorpages_security_bad_cert_advanced))
                     .replace("%badCertTechInfo%",
                             context.getString(R.string.mozac_browser_errorpages_security_bad_cert_techInfo,
-                                    uri.toString()))
+                                    context.appName, uri.toString()))
                     .replace("%badCertGoBack%",
                             context.getString(R.string.mozac_browser_errorpages_security_bad_cert_back))
                     .replace("%badCertAcceptTemporary%",

--- a/components/browser/errorpages/src/main/res/values/strings.xml
+++ b/components/browser/errorpages/src/main/res/values/strings.xml
@@ -41,16 +41,16 @@
 
     <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website has an invalid SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_advanced">Advanced…</string>
-    <!-- The advanced certificate information shown when a website sends has an invalid SSL certificate. The %1$s will be replaced by the website URL. It's only shown when a website has an invalid SSL certificate. -->
+    <!-- The advanced certificate information shown when a website sends has an invalid SSL certificate. The %1$s will be replaced by the app name and %2$s will be replaced by website URL. It's only shown when a website has an invalid SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_techInfo"><![CDATA[
         <label>Someone could be trying to impersonate the site and you should not continue.</label>
         <br><br>
-        <label>Websites prove their identity via certificates. Firefox does not trust <b>%1$s</b> because its certificate issuer is unknown, the certificate is self-signed, or the server is not sending the correct intermediate certificates.</label>
+        <label>Websites prove their identity via certificates. %1$s does not trust <b>%2$s</b> because its certificate issuer is unknown, the certificate is self-signed, or the server is not sending the correct intermediate certificates.</label>
     ]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_cert_back">Go Back (Recommended)</string>
     <!-- The text shown inside the advanced options button used to bypass the invalid SSL certificate. It's only shown if the user has expanded the advanced options. -->
-    <string name="mozac_browser_errorpages_security_bad_cert_accept_temporary">Accept the Risk and Continue</string>0
+    <string name="mozac_browser_errorpages_security_bad_cert_accept_temporary">Accept the Risk and Continue</string>
 
     <!-- The document title and heading of the error page shown when the user's network connection is interrupted while connecting to a website. -->
     <string name="mozac_browser_errorpages_net_interrupt_title">The connection was interrupted</string>

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -68,7 +68,8 @@ class ErrorPagesTest {
             assertFalse(errorPage.contains("%badCertGoBack%"))
             assertFalse(errorPage.contains("%badCertAcceptTemporary%"))
             verify(context, times(7)).getString(anyInt())
-            verify(context, times(2)).getString(anyInt(), nullable(String::class.java))
+            verify(context, times(1)).getString(anyInt(), nullable(String::class.java))
+            verify(context, times(1)).getString(anyInt(), nullable(String::class.java), nullable(String::class.java))
         } else {
             verify(context, times(4)).getString(anyInt())
             verify(context, times(1)).getString(anyInt(), nullable(String::class.java))


### PR DESCRIPTION
This PR addresses issues reported here: https://github.com/mozilla-l10n/android-l10n/pull/150
- Avoid hardcoding **Firefox** in string resources
- Removed extra character in the **strings.xml** file

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
