### PR TITLE
Closes #5627: Catch RecordNotFoundError exception in Push

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import mozilla.appservices.push.CommunicationError
 import mozilla.appservices.push.CommunicationServerError
+import mozilla.appservices.push.RecordNotFoundError
 import mozilla.appservices.push.SubscriptionResponse
 import mozilla.components.concept.push.Bus
 import mozilla.components.concept.push.EncryptedPushMessage
@@ -358,7 +359,7 @@ internal fun CoroutineScope.launchAndTry(
         try {
             block()
         } catch (e: RustPushError) {
-            if (e !is CommunicationServerError && e !is CommunicationError) {
+            if (e !is CommunicationServerError && e !is CommunicationError && e !is RecordNotFoundError) {
                 throw e
             }
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
@@ -11,6 +11,7 @@ import mozilla.appservices.push.CommunicationError
 import mozilla.appservices.push.CommunicationServerError
 import mozilla.appservices.push.CryptoError
 import mozilla.appservices.push.KeyInfo
+import mozilla.appservices.push.RecordNotFoundError
 import mozilla.appservices.push.SubscriptionInfo
 import mozilla.appservices.push.SubscriptionResponse
 import org.junit.Assert.assertEquals
@@ -61,6 +62,11 @@ class AutoPushFeatureKtTest {
 
         CoroutineScope(coroutineContext).launchAndTry(
             { throw CommunicationError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw RecordNotFoundError("should not fail test") },
             { assert(true) }
         )
     }


### PR DESCRIPTION
This is the a-c fix for
https://github.com/mozilla/application-services/issues/2282.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
