### PR TITLE
Issue #5509: Provide state in completed migration UI callback

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationProgressActivity.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationProgressActivity.kt
@@ -14,6 +14,9 @@ import mozilla.components.support.migration.state.MigrationStore
 
 /**
  * An activity that notifies on migration progress. Should be used in tandem with [MigrationIntentProcessor].
+ *
+ * Implementation notes: this abstraction exists to ensure that migration apps do not allow the user to
+ * invoke [AppCompatActivity.onBackPressed].
  */
 abstract class AbstractMigrationProgressActivity : AppCompatActivity(), MigrationStateListener {
 
@@ -53,7 +56,7 @@ interface MigrationStateListener {
     /**
      * Invoked when the migration is complete.
      */
-    fun onMigrationCompleted()
+    fun onMigrationCompleted(results: MigrationResults)
 }
 
 internal class MigrationObserver(
@@ -65,10 +68,12 @@ internal class MigrationObserver(
     fun start() {
         scope = store.flowScoped { flow ->
             flow.collect { state ->
+                val results = state.results.orEmpty()
+
                 if (state.progress == MigrationProgress.MIGRATING) {
-                    listener.onMigrationStateChanged(state.progress, state.results.orEmpty())
+                    listener.onMigrationStateChanged(state.progress, results)
                 } else {
-                    listener.onMigrationCompleted()
+                    listener.onMigrationCompleted(results)
                 }
             }
         }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationObserverTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationObserverTest.kt
@@ -41,7 +41,7 @@ class MigrationObserverTest {
 
         observer.start()
 
-        verify(listener).onMigrationCompleted()
+        verify(listener).onMigrationCompleted(any())
 
         store.dispatch(MigrationAction.Started).joinBlocking()
         testDispatcher.advanceUntilIdle()


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

A minor fix to provide the finished state to the callback for apps to consume.

Not adding a changelog since this API was introduced in the same version.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
