### PR TITLE
For #5373 - Add menu candidate class

### DIFF
--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -29,6 +29,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
     implementation project(':concept-engine')
+    implementation project(':browser-menu2')
     implementation project(':browser-state')
     implementation project(':support-base')
     implementation project(':support-ktx')

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
@@ -4,7 +4,9 @@
 
 package mozilla.components.browser.menu
 
+import android.content.Context
 import android.view.View
+import mozilla.components.browser.menu2.candidate.MenuCandidate
 
 /**
  * Interface to be implemented by menu items to be shown in the browser menu.
@@ -38,4 +40,9 @@ interface BrowserMenuItem {
      * Called by the browser menu to update the displayed data of this item using the passed view.
      */
     fun invalidate(view: View) = Unit
+
+    /**
+     * Converts the menu item into a menu candidate.
+     */
+    fun asCandidate(context: Context): MenuCandidate? = null
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCategory.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCategory.kt
@@ -4,13 +4,20 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.graphics.Typeface
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
+import mozilla.components.browser.menu2.candidate.TextAlignment
+import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.browser.menu2.candidate.TypefaceStyle
 
 /**
  * A browser menu item displaying styleable text, usable for menu categories
@@ -26,8 +33,8 @@ class BrowserMenuCategory(
     private val textSize: Float = NO_ID.toFloat(),
     @ColorRes
     private val textColorResource: Int = NO_ID,
-    private val textStyle: Int = Typeface.BOLD,
-    private val textAlignment: Int = View.TEXT_ALIGNMENT_VIEW_START
+    @TypefaceStyle private val textStyle: Int = Typeface.BOLD,
+    @TextAlignment private val textAlignment: Int = View.TEXT_ALIGNMENT_VIEW_START
 ) : BrowserMenuItem {
     override var visible: () -> Boolean = { true }
 
@@ -48,4 +55,15 @@ class BrowserMenuCategory(
         textView.setTypeface(textView.typeface, textStyle)
         textView.textAlignment = textAlignment
     }
+
+    override fun asCandidate(context: Context) = DecorativeTextMenuCandidate(
+        label,
+        textStyle = TextStyle(
+            size = if (textSize == NO_ID.toFloat()) null else textSize,
+            color = if (textColorResource == NO_ID) null else getColor(context, textColorResource),
+            textStyle = textStyle,
+            textAlignment = textAlignment
+        ),
+        containerStyle = ContainerStyle(isVisible = visible())
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCheckbox.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCheckbox.kt
@@ -4,7 +4,9 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
 
 /**
  * A simple browser menu checkbox.
@@ -19,4 +21,8 @@ class BrowserMenuCheckbox(
     listener: (Boolean) -> Unit
 ) : BrowserMenuCompoundButton(label, initialState, listener) {
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_checkbox
+
+    override fun asCandidate(context: Context) = super.asCandidate(context).copy(
+        end = CompoundMenuCandidate.ButtonType.CHECKBOX
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButton.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButton.kt
@@ -4,11 +4,14 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import android.widget.CompoundButton
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.browser.menu2.candidate.ContainerStyle
 import java.lang.reflect.Modifier.PRIVATE
 
 /**
@@ -37,4 +40,12 @@ abstract class BrowserMenuCompoundButton(
             }
         }
     }
+
+    override fun asCandidate(context: Context) = CompoundMenuCandidate(
+        label,
+        isChecked = initialState(),
+        end = CompoundMenuCandidate.ButtonType.CHECKBOX,
+        containerStyle = ContainerStyle(isVisible = visible()),
+        onCheckedChange = listener
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuDivider.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuDivider.kt
@@ -4,10 +4,13 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DividerMenuCandidate
 
 /**
  * A browser menu item to display a horizontal divider.
@@ -20,4 +23,8 @@ class BrowserMenuDivider : BrowserMenuItem {
     override fun getLayoutResource() = R.layout.mozac_browser_menu_item_divider
 
     override fun bind(menu: BrowserMenu, view: View) = Unit
+
+    override fun asCandidate(context: Context) = DividerMenuCandidate(
+        containerStyle = ContainerStyle(isVisible = visible())
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.content.res.ColorStateList
 import android.view.View
 import android.widget.TextView
@@ -14,6 +15,10 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.HighlightableMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.browser.menu2.candidate.HighPriorityHighlightEffect
+import mozilla.components.browser.menu2.candidate.LowPriorityHighlightEffect
+import mozilla.components.browser.menu2.candidate.TextMenuCandidate
 
 @Suppress("Deprecation")
 private val defaultHighlight = BrowserMenuHighlightableItem.Highlight(0, 0, 0, 0)
@@ -136,6 +141,32 @@ class BrowserMenuHighlightableItem(
             endImageView.setImageDrawable(null)
             endImageView.visibility = View.GONE
             notificationDotView.visibility = View.GONE
+        }
+    }
+
+    override fun asCandidate(context: Context): TextMenuCandidate {
+        val base = super.asCandidate(context)
+        if (!isHighlighted()) return base
+
+        @Suppress("Deprecation")
+        return when (highlight) {
+            is BrowserMenuHighlight.HighPriority -> base.copy(
+                text = highlight.label ?: label,
+                end = if (highlight.endImageResource == NO_ID) null else DrawableMenuIcon(
+                    context,
+                    highlight.endImageResource
+                ),
+                effect = HighPriorityHighlightEffect(
+                    backgroundTint = highlight.backgroundTint
+                )
+            )
+            is BrowserMenuHighlight.LowPriority -> base.copy(
+                text = highlight.label ?: label,
+                start = (base.start as? DrawableMenuIcon)?.copy(
+                    effect = LowPriorityHighlightEffect(notificationTint = highlight.notificationTint)
+                )
+            )
+            is BrowserMenuHighlight.ClassicHighlight -> base
         }
     }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitch.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.content.res.ColorStateList
 import android.view.View
 import androidx.annotation.ColorRes
@@ -15,6 +16,9 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.HighlightableMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.browser.menu2.candidate.LowPriorityHighlightEffect
 
 /**
  * A browser menu switch that can show a highlighted icon.
@@ -72,5 +76,19 @@ class BrowserMenuHighlightableSwitch(
 
         notificationDotView.isVisible = isHighlighted
         switch.text = if (isHighlighted) highlight.label ?: label else label
+    }
+
+    override fun asCandidate(context: Context): CompoundMenuCandidate {
+        val base = super.asCandidate(context)
+        return if (isHighlighted()) {
+            base.copy(
+                text = highlight.label ?: label,
+                start = (base.start as? DrawableMenuIcon)?.copy(
+                    effect = LowPriorityHighlightEffect(notificationTint = highlight.notificationTint)
+                )
+            )
+        } else {
+            base
+        }
     }
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import android.widget.Switch
 import androidx.annotation.DrawableRes
@@ -11,6 +12,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.AppCompatImageView
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
 import java.lang.reflect.Modifier
 
 /**
@@ -40,4 +43,9 @@ class BrowserMenuImageSwitch(
         val imageView = view.findViewById<AppCompatImageView>(R.id.image)
         imageView.setImageResource(imageResource)
     }
+
+    override fun asCandidate(context: Context) = super.asCandidate(context).copy(
+        start = DrawableMenuIcon(context, imageResource),
+        end = CompoundMenuCandidate.ButtonType.SWITCH
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -11,9 +12,14 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.browser.menu2.candidate.TextMenuCandidate
+import mozilla.components.browser.menu2.candidate.TextStyle
 
 internal const val NO_ID = -1
 
@@ -77,4 +83,18 @@ open class BrowserMenuImageText(
             setTintResource(iconTintColorResource)
         }
     }
+
+    override fun asCandidate(context: Context) = TextMenuCandidate(
+        label,
+        start = DrawableMenuIcon(
+            context,
+            resource = imageResource,
+            tint = if (iconTintColorResource == NO_ID) null else getColor(context, iconTintColorResource)
+        ),
+        textStyle = TextStyle(
+            color = if (textColorResource == NO_ID) null else getColor(context, textColorResource)
+        ),
+        containerStyle = ContainerStyle(isVisible = visible()),
+        onClick = listener
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -11,9 +12,14 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.browser.menu2.candidate.RowMenuCandidate
+import mozilla.components.browser.menu2.candidate.SmallMenuCandidate
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 
 /**
@@ -58,6 +64,11 @@ class BrowserMenuItemToolbar(
         }
     }
 
+    override fun asCandidate(context: Context) = RowMenuCandidate(
+        items = items.map { it.asCandidate(context) },
+        containerStyle = ContainerStyle(isVisible = visible())
+    )
+
     /**
      * A button to be shown in a toolbar inside the browser menu.
      *
@@ -86,6 +97,17 @@ class BrowserMenuItemToolbar(
         internal open fun invalidate(view: ImageView) {
             view.isEnabled = isEnabled()
         }
+
+        internal open fun asCandidate(context: Context) = SmallMenuCandidate(
+            contentDescription,
+            icon = DrawableMenuIcon(
+                context,
+                resource = imageResource,
+                tint = if (iconTintColorResource == NO_ID) null else getColor(context, iconTintColorResource)
+            ),
+            containerStyle = ContainerStyle(isEnabled = isEnabled()),
+            onClick = listener
+        )
     }
 
     /**
@@ -139,6 +161,25 @@ class BrowserMenuItemToolbar(
             if (isInPrimaryState() != wasInPrimaryState) {
                 bind(view)
             }
+        }
+
+        override fun asCandidate(context: Context): SmallMenuCandidate = if (isInPrimaryState()) {
+            super.asCandidate(context)
+        } else {
+            SmallMenuCandidate(
+                secondaryContentDescription,
+                icon = DrawableMenuIcon(
+                    context,
+                    resource = secondaryImageResource,
+                    tint = if (secondaryImageTintResource == NO_ID) {
+                        null
+                    } else {
+                        getColor(context, secondaryImageTintResource)
+                    }
+                ),
+                containerStyle = ContainerStyle(isEnabled = !disableInSecondaryState),
+                onClick = listener
+            )
         }
     }
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuSwitch.kt
@@ -4,7 +4,9 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
 
 /**
  * A simple browser menu switch.
@@ -19,4 +21,8 @@ class BrowserMenuSwitch(
     listener: (Boolean) -> Unit
 ) : BrowserMenuCompoundButton(label, initialState, listener) {
     override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_switch
+
+    override fun asCandidate(context: Context) = super.asCandidate(context).copy(
+        end = CompoundMenuCandidate.ButtonType.SWITCH
+    )
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItem.kt
@@ -4,12 +4,19 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
+import mozilla.components.browser.menu2.candidate.MenuCandidate
+import mozilla.components.browser.menu2.candidate.TextMenuCandidate
+import mozilla.components.browser.menu2.candidate.TextStyle
 
 /**
  * A simple browser menu item displaying text.
@@ -48,6 +55,28 @@ class SimpleBrowserMenuItem(
         } else {
             // Remove the ripple effect
             textView.background = null
+        }
+    }
+
+    override fun asCandidate(context: Context): MenuCandidate {
+        val textStyle = TextStyle(
+            size = if (textSize == NO_ID.toFloat()) null else textSize,
+            color = if (textColorResource == NO_ID) null else getColor(context, textColorResource)
+        )
+        val containerStyle = ContainerStyle(isVisible = visible())
+        return if (listener != null) {
+            TextMenuCandidate(
+                label,
+                textStyle = textStyle,
+                containerStyle = containerStyle,
+                onClick = listener
+            )
+        } else {
+            DecorativeTextMenuCandidate(
+                label,
+                textStyle = textStyle,
+                containerStyle = containerStyle
+            )
         }
     }
 }

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_checkbox.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_checkbox.xml
@@ -8,7 +8,7 @@
     android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
     android:button="@null"
     android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
-    android:drawablePadding="12dp"
+    android:drawablePadding="@dimen/mozac_browser_menu_checkbox_padding"
     android:gravity="center_vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp" />

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -14,8 +14,8 @@
 
     <ImageView
         android:id="@+id/action_image"
-        android:layout_width="24dp"
-        android:layout_height="27dp"
+        android:layout_width="@dimen/mozac_browser_menu_item_web_extension_icon_width"
+        android:layout_height="@dimen/mozac_browser_menu_item_web_extension_icon_height"
         android:layout_gravity="center"
         android:importantForAccessibility="no"
         android:src="@drawable/mozac_browser_menu_notification_icon"/>

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -22,6 +22,7 @@
     <!--BrowserMenuHighlightableItem -->
     <dimen name="mozac_browser_menu_highlightable_notification_translate_x">4dp</dimen>
     <dimen name="mozac_browser_menu_highlightable_notification_translate_y">-4dp</dimen>
+    <dimen name="mozac_browser_menu_highlightable_notification_dot_size">8dp</dimen>
     <!--BrowserMenuHighlightableItem -->
 
     <!-- BrowserMenuCategory -->
@@ -30,6 +31,15 @@
     <dimen name="mozac_browser_menu_category_padding_start">24dp</dimen>
     <dimen name="mozac_browser_menu_category_padding_end">24dp</dimen>
     <!-- BrowserMenuCategory -->
+
+    <!--BrowserMenuCheckbox -->
+    <dimen name="mozac_browser_menu_checkbox_padding">12dp</dimen>
+    <!--BrowserMenuCheckbox -->
+
+    <!--WebExtensionBrowserMenuItem -->
+    <dimen name="mozac_browser_menu_item_web_extension_icon_width">24dp</dimen>
+    <dimen name="mozac_browser_menu_item_web_extension_icon_height">27dp</dimen>
+    <!--WebExtensionBrowserMenuItem -->
 
     <!--BrowserMenuImageText-->
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt
@@ -9,8 +9,10 @@ import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
-import org.junit.Assert.assertEquals
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
+import mozilla.components.browser.menu2.candidate.TextStyle
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,6 +78,69 @@ class BrowserMenuCategoryTest {
         val textView = view.findViewById<TextView>(R.id.category_text)
 
         assertEquals(View.TEXT_ALIGNMENT_VIEW_END, textView.textAlignment)
+    }
+
+    @Test
+    fun `menu category can be converted to candidate`() {
+        assertEquals(
+            DecorativeTextMenuCandidate(
+                label,
+                textStyle = TextStyle(
+                    textStyle = Typeface.BOLD,
+                    textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                )
+            ),
+            BrowserMenuCategory(label).asCandidate(context)
+        )
+
+        assertEquals(
+            DecorativeTextMenuCandidate(
+                label,
+                textStyle = TextStyle(
+                    size = 12f,
+                    textStyle = Typeface.BOLD,
+                    textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                )
+            ),
+            BrowserMenuCategory(label, 12f).asCandidate(context)
+        )
+
+        assertEquals(
+            DecorativeTextMenuCandidate(
+                label,
+                textStyle = TextStyle(
+                    color = ContextCompat.getColor(context, android.R.color.holo_red_dark),
+                    textStyle = Typeface.BOLD,
+                    textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                )
+            ),
+            BrowserMenuCategory(
+                label,
+                textColorResource = android.R.color.holo_red_dark
+            ).asCandidate(context)
+        )
+
+        assertEquals(
+            DecorativeTextMenuCandidate(
+                label,
+                textStyle = TextStyle(
+                    textStyle = Typeface.ITALIC,
+                    textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                )
+            ),
+            BrowserMenuCategory(label, textStyle = Typeface.ITALIC).asCandidate(context)
+        )
+
+        assertEquals(
+            DecorativeTextMenuCandidate(
+                label,
+                textStyle = TextStyle(
+                    textStyle = Typeface.BOLD,
+                    textAlignment = View.TEXT_ALIGNMENT_VIEW_END
+                )
+            ),
+            BrowserMenuCategory(label, textAlignment = View.TEXT_ALIGNMENT_VIEW_END).asCandidate(context)
+        )
     }
 
     private fun inflate(browserMenuCategory: BrowserMenuCategory): View {

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCheckboxTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCheckboxTest.kt
@@ -5,6 +5,8 @@
 package mozilla.components.browser.menu.item
 
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -14,5 +16,23 @@ class BrowserMenuCheckboxTest {
     fun `browser checkbox uses correct layout`() {
         val item = BrowserMenuCheckbox("Hello") {}
         assertEquals(R.layout.mozac_browser_menu_item_checkbox, item.getLayoutResource())
+    }
+
+    @Test
+    fun `checkbox can be converted to candidate with correct end type`() {
+        val listener = { _: Boolean -> }
+
+        assertEquals(
+            CompoundMenuCandidate(
+                "Hello",
+                isChecked = false,
+                end = CompoundMenuCandidate.ButtonType.CHECKBOX,
+                onCheckedChange = listener
+            ),
+            BrowserMenuCheckbox(
+                "Hello",
+                listener = listener
+            ).asCandidate(mock())
+        )
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -10,7 +10,9 @@ import android.widget.CheckBox
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -78,6 +80,38 @@ class BrowserMenuCompoundButtonTest {
     fun `hitting default methods`() {
         val item = SimpleTestBrowserCompoundButton("") {}
         item.invalidate(mock(View::class.java))
+    }
+
+    @Test
+    fun `menu compound button can be converted to candidate`() {
+        val listener = { _: Boolean -> }
+
+        assertEquals(
+            CompoundMenuCandidate(
+                "Hello",
+                isChecked = false,
+                end = CompoundMenuCandidate.ButtonType.CHECKBOX,
+                onCheckedChange = listener
+            ),
+            SimpleTestBrowserCompoundButton(
+                "Hello",
+                listener = listener
+            ).asCandidate(testContext)
+        )
+
+        assertEquals(
+            CompoundMenuCandidate(
+                "Hello",
+                isChecked = true,
+                end = CompoundMenuCandidate.ButtonType.CHECKBOX,
+                onCheckedChange = listener
+            ),
+            SimpleTestBrowserCompoundButton(
+                "Hello",
+                initialState = { true },
+                listener = listener
+            ).asCandidate(testContext)
+        )
     }
 
     class SimpleTestBrowserCompoundButton(

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuDividerTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuDividerTest.kt
@@ -4,13 +4,13 @@
 
 package mozilla.components.browser.menu.item
 
-import android.view.View
-import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DividerMenuCandidate
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.mockito.Mockito.mock
 
 class BrowserMenuDividerTest {
 
@@ -24,7 +24,24 @@ class BrowserMenuDividerTest {
     fun `hitting default methods`() {
         val item = BrowserMenuDivider()
         assertTrue(item.visible())
-        item.bind(mock(BrowserMenu::class.java), mock(View::class.java))
-        item.invalidate(mock(View::class.java))
+        item.bind(mock(), mock())
+        item.invalidate(mock())
+    }
+
+    @Test
+    fun `menu divider can be converted to candidate`() {
+        assertEquals(
+            DividerMenuCandidate(),
+            BrowserMenuDivider().asCandidate(mock())
+        )
+
+        assertEquals(
+            DividerMenuCandidate(
+                containerStyle = ContainerStyle(isVisible = true)
+            ),
+            BrowserMenuDivider().apply {
+                visible = { true }
+            }.asCandidate(mock())
+        )
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitchTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitchTest.kt
@@ -4,11 +4,17 @@
 
 package mozilla.components.browser.menu.item
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class BrowserMenuImageSwitchTest {
     private lateinit var menuItem: BrowserMenuImageSwitch
     private val label = "test"
@@ -32,5 +38,23 @@ class BrowserMenuImageSwitchTest {
     @Test
     fun `menu item  has correct icon`() {
         assertEquals(icon, menuItem.imageResource)
+    }
+
+    @Test
+    fun `menu switch can be converted to candidate`() {
+        val listener = { _: Boolean -> }
+
+        assertEquals(
+            CompoundMenuCandidate(
+                label,
+                isChecked = false,
+                start = DrawableMenuIcon(null),
+                end = CompoundMenuCandidate.ButtonType.SWITCH,
+                onCheckedChange = listener
+            ),
+            BrowserMenuImageSwitch(icon, label, listener = listener).asCandidate(testContext).run {
+                copy(start = (start as DrawableMenuIcon?)?.copy(drawable = null))
+            }
+        )
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
@@ -9,10 +9,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.content.ContextCompat.getColor
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.browser.menu2.candidate.TextMenuCandidate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -76,6 +79,45 @@ class BrowserMenuImageTextTest {
         val imageView = view.findViewById<AppCompatImageView>(R.id.image)
 
         assertNull(imageView.imageTintList)
+    }
+
+    @Test
+    fun `menu image text item can be converted to candidate`() {
+        val listener = {}
+
+        assertEquals(
+            TextMenuCandidate(
+                "label",
+                start = DrawableMenuIcon(null),
+                onClick = listener
+            ),
+            BrowserMenuImageText(
+                "label",
+                android.R.drawable.ic_menu_report_image,
+                listener = listener
+            ).asCandidate(context).run {
+                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
+            }
+        )
+
+        assertEquals(
+            TextMenuCandidate(
+                "label",
+                start = DrawableMenuIcon(
+                    null,
+                    tint = getColor(context, android.R.color.black)
+                ),
+                onClick = listener
+            ),
+            BrowserMenuImageText(
+                "label",
+                android.R.drawable.ic_menu_report_image,
+                android.R.color.black,
+                listener = listener
+            ).asCandidate(context).run {
+                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
+            }
+        )
     }
 
     private fun inflate(item: BrowserMenuImageText): View {

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -9,9 +9,14 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.content.ContextCompat.getColor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.browser.menu2.candidate.RowMenuCandidate
+import mozilla.components.browser.menu2.candidate.SmallMenuCandidate
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -290,5 +295,101 @@ class BrowserMenuItemToolbarTest {
 
         assertTrue(callbackInvoked)
         verify(menu).dismiss()
+    }
+
+    @Test
+    fun `toolbar can be converted to candidate`() {
+        val listener = {}
+
+        assertEquals(
+            RowMenuCandidate(emptyList()),
+            BrowserMenuItemToolbar(emptyList()).asCandidate(testContext)
+        )
+
+        var isEnabled = false
+        var isInPrimaryState = true
+        val toolbarWithTwoState = BrowserMenuItemToolbar(listOf(
+            BrowserMenuItemToolbar.Button(
+                R.drawable.abc_ic_ab_back_material,
+                "Button01",
+                isEnabled = { isEnabled },
+                listener = listener
+            ),
+            BrowserMenuItemToolbar.Button(
+                R.drawable.abc_ic_ab_back_material,
+                "Button02",
+                iconTintColorResource = R.color.accent_material_light,
+                listener = listener
+            ),
+            BrowserMenuItemToolbar.TwoStateButton(
+                primaryImageResource = R.drawable.abc_ic_go_search_api_material,
+                primaryContentDescription = "TwoStatePrimary",
+                secondaryImageResource = R.drawable.abc_ic_clear_material,
+                secondaryContentDescription = "TwoStateSecondary",
+                isInPrimaryState = { isInPrimaryState },
+                listener = listener
+            )
+        ))
+
+        assertEquals(
+            RowMenuCandidate(listOf(
+                SmallMenuCandidate(
+                    "Button01",
+                    icon = DrawableMenuIcon(null),
+                    containerStyle = ContainerStyle(isEnabled = false),
+                    onClick = listener
+                ),
+                SmallMenuCandidate(
+                    "Button02",
+                    icon = DrawableMenuIcon(
+                        null,
+                        tint = getColor(testContext, R.color.accent_material_light)
+                    ),
+                    onClick = listener
+                ),
+                SmallMenuCandidate(
+                    "TwoStatePrimary",
+                    icon = DrawableMenuIcon(null),
+                    onClick = listener
+                )
+            )),
+            toolbarWithTwoState.asCandidate(testContext).run {
+                copy(items = items.map {
+                    it.copy(icon = it.icon.copy(drawable = null))
+                })
+            }
+        )
+
+        isEnabled = true
+        isInPrimaryState = false
+
+        assertEquals(
+            RowMenuCandidate(listOf(
+                SmallMenuCandidate(
+                    "Button01",
+                    icon = DrawableMenuIcon(null),
+                    containerStyle = ContainerStyle(isEnabled = true),
+                    onClick = listener
+                ),
+                SmallMenuCandidate(
+                    "Button02",
+                    icon = DrawableMenuIcon(
+                        null,
+                        tint = getColor(testContext, R.color.accent_material_light)
+                    ),
+                    onClick = listener
+                ),
+                SmallMenuCandidate(
+                    "TwoStateSecondary",
+                    icon = DrawableMenuIcon(null),
+                    onClick = listener
+                )
+            )),
+            toolbarWithTwoState.asCandidate(testContext).run {
+                copy(items = items.map {
+                    it.copy(icon = it.icon.copy(drawable = null))
+                })
+            }
+        )
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuSwitchTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuSwitchTest.kt
@@ -5,14 +5,34 @@
 package mozilla.components.browser.menu.item
 
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class BrowserMenuSwitchTest {
 
     @Test
-    fun `browser checkbox uses correct layout`() {
+    fun `browser switch uses correct layout`() {
         val item = BrowserMenuSwitch("Hello") {}
         assertEquals(R.layout.mozac_browser_menu_item_switch, item.getLayoutResource())
+    }
+
+    @Test
+    fun `switch can be converted to candidate with correct end type`() {
+        val listener = { _: Boolean -> }
+
+        assertEquals(
+            CompoundMenuCandidate(
+                "Hello",
+                isChecked = false,
+                end = CompoundMenuCandidate.ButtonType.SWITCH,
+                onCheckedChange = listener
+            ),
+            BrowserMenuSwitch(
+                "Hello",
+                listener = listener
+            ).asCandidate(mock())
+        )
     }
 }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
@@ -7,9 +7,13 @@ package mozilla.components.browser.menu.item
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
+import androidx.core.content.ContextCompat.getColor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
+import mozilla.components.browser.menu2.candidate.TextMenuCandidate
+import mozilla.components.browser.menu2.candidate.TextStyle
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -76,6 +80,37 @@ class SimpleBrowserMenuItemTest {
         assertEquals(textView.text, "Powered by Mozilla")
         assertEquals(textView.textSize, 10f)
         assertEquals(textView.currentTextColor, testContext.getColor(android.R.color.holo_green_dark))
+    }
+
+    @Test
+    fun `simple menu item can be converted to candidate`() {
+        val listener = {}
+
+        assertEquals(
+            TextMenuCandidate(
+                "Hello",
+                onClick = listener
+            ),
+            SimpleBrowserMenuItem(
+                "Hello",
+                listener = listener
+            ).asCandidate(testContext)
+        )
+
+        assertEquals(
+            DecorativeTextMenuCandidate(
+                "Powered by Mozilla",
+                textStyle = TextStyle(
+                    size = 10f,
+                    color = getColor(testContext, android.R.color.holo_green_dark)
+                )
+            ),
+            SimpleBrowserMenuItem(
+                "Powered by Mozilla",
+                10f,
+                android.R.color.holo_green_dark
+            ).asCandidate(testContext)
+        )
     }
 
     private fun inflate(item: SimpleBrowserMenuItem): View {

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -28,6 +28,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.notNull
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -99,7 +100,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(badgeView)
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.findViewById<View>(R.id.container)).thenReturn(container)
-        whenever(view.context).thenReturn(mock())
+        whenever(view.context).thenReturn(testContext)
 
         val browserAction = Action(
             title = "title",
@@ -137,7 +138,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(badgeView)
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.findViewById<View>(R.id.container)).thenReturn(container)
-        whenever(view.context).thenReturn(mock())
+        whenever(view.context).thenReturn(testContext)
 
         val browserAction = Action(
                 title = "title",
@@ -152,7 +153,7 @@ class WebExtensionBrowserMenuItemTest {
         action.bind(mock(), view)
         testDispatcher.advanceUntilIdle()
 
-        verify(imageView).setImageResource(R.drawable.mozac_ic_web_extension_default_icon)
+        verify(imageView).setImageDrawable(notNull())
     }
 
     @Test

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/ContainerStyle.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/ContainerStyle.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.candidate
+
+/**
+ * Describes styling for the menu option container.
+ *
+ * @property isVisible When false, the option will not be displayed.
+ * @property isEnabled When false, the option will be greyed out and disabled.
+ */
+data class ContainerStyle(
+    val isVisible: Boolean = true,
+    val isEnabled: Boolean = true
+)

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/MenuCandidate.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/MenuCandidate.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.candidate
+
+/**
+ * Menu option data classes to be shown in the browser menu.
+ */
+sealed class MenuCandidate {
+    abstract val containerStyle: ContainerStyle
+}
+
+/**
+ * Interactive menu option that displays some text.
+ *
+ * @property text Text to display.
+ * @property start Icon to display before the text.
+ * @property end Icon to display after the text.
+ * @property textStyle Styling to apply to the text.
+ * @property containerStyle Styling to apply to the container.
+ * @property effect Effects to apply to the option.
+ * @property onClick Click listener called when this menu option is clicked.
+ */
+data class TextMenuCandidate(
+    val text: String,
+    val start: MenuIcon? = null,
+    val end: MenuIcon? = null,
+    val textStyle: TextStyle = TextStyle(),
+    override val containerStyle: ContainerStyle = ContainerStyle(),
+    val effect: MenuCandidateEffect? = null,
+    val onClick: () -> Unit = {}
+) : MenuCandidate()
+
+/**
+ * Menu option that displays static text.
+ *
+ * @property text Text to display.
+ * @property height Custom height for the menu option.
+ * @property textStyle Styling to apply to the text.
+ * @property containerStyle Styling to apply to the container.
+ */
+data class DecorativeTextMenuCandidate(
+    val text: String,
+    val height: Int? = null,
+    val textStyle: TextStyle = TextStyle(),
+    override val containerStyle: ContainerStyle = ContainerStyle()
+) : MenuCandidate()
+
+/**
+ * Menu option that shows a switch or checkbox.
+ *
+ * @property text Text to display.
+ * @property start Icon to display before the text.
+ * @property end Compound button to display after the text.
+ * @property textStyle Styling to apply to the text.
+ * @property containerStyle Styling to apply to the container.
+ * @property effect Effects to apply to the option.
+ * @property onCheckedChange Listener called when this menu option is checked or unchecked.
+ */
+data class CompoundMenuCandidate(
+    val text: String,
+    val isChecked: Boolean,
+    val start: MenuIcon? = null,
+    val end: ButtonType,
+    val textStyle: TextStyle = TextStyle(),
+    override val containerStyle: ContainerStyle = ContainerStyle(),
+    val effect: MenuCandidateEffect? = null,
+    val onCheckedChange: (Boolean) -> Unit
+) : MenuCandidate() {
+
+    /**
+     * Compound button types to display with the compound menu option.
+     */
+    enum class ButtonType {
+        CHECKBOX,
+        SWITCH
+    }
+}
+
+/**
+ * Displays a row of small menu options.
+ *
+ * @property items Small menu options to display.
+ * @property containerStyle Styling to apply to the container.
+ */
+data class RowMenuCandidate(
+    val items: List<SmallMenuCandidate>,
+    override val containerStyle: ContainerStyle = ContainerStyle()
+) : MenuCandidate()
+
+/**
+ * Menu option to display a horizontal divider.
+ *
+ * @property containerStyle Styling to apply to the divider.
+ */
+data class DividerMenuCandidate(
+    override val containerStyle: ContainerStyle = ContainerStyle()
+) : MenuCandidate()

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/MenuEffect.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/MenuEffect.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.candidate
+
+import androidx.annotation.ColorInt
+
+/**
+ * Describes an effect for the menu.
+ * Effects can also alter the button to open the menu.
+ */
+sealed class MenuEffect
+
+/**
+ * Describes an effect for a menu candidate and its container.
+ * Effects can also alter the button that opens the menu.
+ */
+sealed class MenuCandidateEffect : MenuEffect()
+
+/**
+ * Describes an effect for a menu icon.
+ * Effects can also alter the button that opens the menu.
+ */
+sealed class MenuIconEffect : MenuEffect()
+
+/**
+ * Displays a notification dot.
+ * Used for highlighting new features to the user, such as what's new or a recommended feature.
+ *
+ * @property notificationTint Tint for the notification dot displayed on the icon and menu button.
+ */
+data class LowPriorityHighlightEffect(
+    @ColorInt val notificationTint: Int
+) : MenuIconEffect()
+
+/**
+ * Changes the background of the menu item.
+ * Used for errors that require user attention, like sync errors.
+ *
+ * @property backgroundTint Tint for the menu item background color.
+ * Also used to highlight the menu button.
+ */
+data class HighPriorityHighlightEffect(
+    @ColorInt val backgroundTint: Int
+) : MenuCandidateEffect()

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/MenuIcon.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/MenuIcon.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.candidate
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
+
+/**
+ * Menu option data classes to be shown alongside menu options
+ */
+sealed class MenuIcon
+
+/**
+ * Menu icon that displays a drawable.
+ *
+ * @property drawable Drawable icon to display.
+ * @property tint Tint to apply to the drawable.
+ * @property effect Effects to apply to the icon.
+ */
+data class DrawableMenuIcon(
+    override val drawable: Drawable?,
+    @ColorInt override val tint: Int? = null,
+    val effect: MenuIconEffect? = null
+) : MenuIcon(), MenuIconWithDrawable {
+
+    constructor(
+        context: Context,
+        @DrawableRes resource: Int,
+        @ColorInt tint: Int? = null,
+        effect: MenuIconEffect? = null
+    ) : this(AppCompatResources.getDrawable(context, resource), tint, effect)
+}
+
+/**
+ * Menu icon that displays an image button.
+ *
+ * @property drawable Drawable icon to display.
+ * @property tint Tint to apply to the drawable.
+ * @property onClick Click listener called when this menu option is clicked.
+ */
+data class DrawableButtonMenuIcon(
+    override val drawable: Drawable?,
+    @ColorInt override val tint: Int? = null,
+    val onClick: () -> Unit = {}
+) : MenuIcon(), MenuIconWithDrawable {
+
+    constructor(
+        context: Context,
+        @DrawableRes resource: Int,
+        @ColorInt tint: Int? = null,
+        onClick: () -> Unit = {}
+    ) : this(AppCompatResources.getDrawable(context, resource), tint, onClick)
+}
+
+/**
+ * Menu icon to display additional text at the end of a menu option.
+ *
+ * @property text Text to display.
+ * @property backgroundTint Color to show behind text.
+ * @property textStyle Styling to apply to the text.
+ */
+data class TextMenuIcon(
+    val text: String,
+    @ColorInt val backgroundTint: Int? = null,
+    val textStyle: TextStyle = TextStyle()
+) : MenuIcon()
+
+internal interface MenuIconWithDrawable {
+    val drawable: Drawable?
+    @get:ColorInt val tint: Int?
+}

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/SmallMenuCandidate.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/SmallMenuCandidate.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.candidate
+
+/**
+ * Small icon button menu option. Can only be used with [RowMenuCandidate].
+ *
+ * @property contentDescription Description of the icon.
+ * @property icon Icon to display.
+ * @property containerStyle Styling to apply to the container.
+ * @property onClick Click listener called when this menu option is clicked.
+ */
+data class SmallMenuCandidate(
+    val contentDescription: String,
+    val icon: DrawableMenuIcon,
+    val containerStyle: ContainerStyle = ContainerStyle(),
+    val onClick: () -> Unit = {}
+)

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/TextStyle.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/candidate/TextStyle.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.candidate
+
+import android.graphics.Typeface
+import android.view.View
+import androidx.annotation.ColorInt
+import androidx.annotation.Dimension
+import androidx.annotation.IntDef
+
+/**
+ * Describes styling for text inside a menu option.
+ *
+ * @param size: The size of the text.
+ * @param color: The color to apply to the text.
+ */
+data class TextStyle(
+    @Dimension(unit = Dimension.PX) val size: Float? = null,
+    @ColorInt val color: Int? = null,
+    @TypefaceStyle val textStyle: Int = Typeface.NORMAL,
+    @TextAlignment val textAlignment: Int = View.TEXT_ALIGNMENT_INHERIT
+)
+
+/**
+ * Enum for [Typeface] values.
+ */
+@IntDef(value = [Typeface.NORMAL, Typeface.BOLD, Typeface.ITALIC, Typeface.BOLD_ITALIC])
+annotation class TypefaceStyle
+
+/**
+ * Enum for text alignment values.
+ */
+@IntDef(value = [
+    View.TEXT_ALIGNMENT_GRAVITY,
+    View.TEXT_ALIGNMENT_INHERIT,
+    View.TEXT_ALIGNMENT_CENTER,
+    View.TEXT_ALIGNMENT_TEXT_START,
+    View.TEXT_ALIGNMENT_TEXT_END,
+    View.TEXT_ALIGNMENT_VIEW_START,
+    View.TEXT_ALIGNMENT_VIEW_END
+])
+annotation class TextAlignment


### PR DESCRIPTION
Spun out of #5496

This is part of a new browser-menu v2 API, designed to work with lib-state.

This introduces a new API using immutable data classes to represent options. Stateful functionality like the two-state button is replaced with swapping out data classes and submitting a new list of options.

This PR *only* includes the data classes, plus some helpers to migrate from the old style to the new style. It does not affect the existing menus, which continue to work just fine.

See #5496 for an example of rendering code.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
