### PR TITLE
Issue #4470: Wire up API for page action support

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -26,8 +26,8 @@ import mozilla.components.concept.engine.content.blocking.TrackingProtectionExce
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.utils.EngineVersion
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
@@ -65,12 +65,16 @@ class GeckoEngine(
 
     private var webExtensionDelegate: WebExtensionDelegate? = null
     private val webExtensionActionHandler = object : ActionHandler {
-        override fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: BrowserAction) {
+        override fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: Action) {
             webExtensionDelegate?.onBrowserActionDefined(extension, action)
         }
 
-        override fun onToggleBrowserActionPopup(extension: WebExtension, action: BrowserAction): EngineSession? {
-            return webExtensionDelegate?.onToggleBrowserActionPopup(extension, GeckoEngineSession(runtime), action)
+        override fun onPageAction(extension: WebExtension, session: EngineSession?, action: Action) {
+            webExtensionDelegate?.onPageActionDefined(extension, action)
+        }
+
+        override fun onToggleActionPopup(extension: WebExtension, action: Action): EngineSession? {
+            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime), action)
         }
     }
 

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -9,7 +9,7 @@ import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Metadata
@@ -179,14 +179,23 @@ class GeckoWebExtension(
                 session: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                actionHandler.onBrowserAction(this@GeckoWebExtension, null, action.toBrowserAction())
+                actionHandler.onBrowserAction(this@GeckoWebExtension, null, action.convert())
+            }
+
+            override fun onPageAction(
+                ext: GeckoNativeWebExtension,
+                // Session will always be null here for the global default delegate
+                session: GeckoSession?,
+                action: GeckoNativeWebExtensionAction
+            ) {
+                actionHandler.onPageAction(this@GeckoWebExtension, null, action.convert())
             }
 
             override fun onTogglePopup(
                 ext: GeckoNativeWebExtension,
                 action: GeckoNativeWebExtensionAction
             ): GeckoResult<GeckoSession>? {
-                val session = actionHandler.onToggleBrowserActionPopup(this@GeckoWebExtension, action.toBrowserAction())
+                val session = actionHandler.onToggleActionPopup(this@GeckoWebExtension, action.convert())
                 return session?.let { GeckoResult.fromValue((session as GeckoEngineSession).geckoSession) }
             }
         }
@@ -211,7 +220,15 @@ class GeckoWebExtension(
                 geckoSession: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                actionHandler.onBrowserAction(this@GeckoWebExtension, session, action.toBrowserAction())
+                actionHandler.onBrowserAction(this@GeckoWebExtension, session, action.convert())
+            }
+
+            override fun onPageAction(
+                ext: GeckoNativeWebExtension,
+                geckoSession: GeckoSession?,
+                action: GeckoNativeWebExtensionAction
+            ) {
+                actionHandler.onPageAction(this@GeckoWebExtension, session, action.convert())
             }
         }
 
@@ -283,14 +300,14 @@ private fun createWebExtensionFlags(allowContentMessaging: Boolean): Long {
     }
 }
 
-private fun GeckoNativeWebExtensionAction.toBrowserAction(): BrowserAction {
+private fun GeckoNativeWebExtensionAction.convert(): Action {
     val loadIcon: (suspend (Int) -> Bitmap?)? = icon?.let {
         { size -> icon?.get(size)?.await() }
     }
 
     val onClick = { click() }
 
-    return BrowserAction(
+    return Action(
         title,
         enabled,
         loadIcon,

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -18,8 +18,8 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.support.test.any
@@ -771,14 +771,50 @@ class GeckoEngineTest {
         val actionHandlerCaptor = argumentCaptor<ActionHandler>()
         verify(extension).registerActionHandler(actionHandlerCaptor.capture())
 
-        val browserAction: BrowserAction = mock()
+        val browserAction: Action = mock()
         actionHandlerCaptor.value.onBrowserAction(extension, null, browserAction)
         verify(webExtensionsDelegate).onBrowserActionDefined(eq(extension), eq(browserAction))
-        assertNull(actionHandlerCaptor.value.onToggleBrowserActionPopup(extension, browserAction))
-        verify(webExtensionsDelegate).onToggleBrowserActionPopup(eq(extension), any(), eq(browserAction))
+        assertNull(actionHandlerCaptor.value.onToggleActionPopup(extension, browserAction))
+        verify(webExtensionsDelegate).onToggleActionPopup(eq(extension), any(), eq(browserAction))
 
-        whenever(webExtensionsDelegate.onToggleBrowserActionPopup(any(), any(), any())).thenReturn(mock())
-        assertNotNull(actionHandlerCaptor.value.onToggleBrowserActionPopup(extension, browserAction))
+        whenever(webExtensionsDelegate.onToggleActionPopup(any(), any(), any())).thenReturn(mock())
+        assertNotNull(actionHandlerCaptor.value.onToggleActionPopup(extension, browserAction))
+    }
+
+    @Test
+    fun `web extension delegate notified of page actions from built-in extensions`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val result = GeckoResult<Void>()
+        whenever(runtime.registerWebExtension(any())).thenReturn(result)
+
+        val extension = spy(mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
+            "test-webext",
+            "resource://android/assets/extensions/test",
+            runtime.webExtensionController,
+            true,
+            true
+        ))
+        engine.installWebExtension(extension)
+        result.complete(null)
+
+        val actionHandlerCaptor = argumentCaptor<ActionHandler>()
+        verify(extension).registerActionHandler(actionHandlerCaptor.capture())
+
+        val pageAction: Action = mock()
+        actionHandlerCaptor.value.onPageAction(extension, null, pageAction)
+        verify(webExtensionsDelegate).onPageActionDefined(eq(extension), eq(pageAction))
+        assertNull(actionHandlerCaptor.value.onToggleActionPopup(extension, pageAction))
+        verify(webExtensionsDelegate).onToggleActionPopup(eq(extension), any(), eq(pageAction))
+
+        whenever(webExtensionsDelegate.onToggleActionPopup(any(), any(), any())).thenReturn(mock())
+        assertNotNull(actionHandlerCaptor.value.onToggleActionPopup(extension, pageAction))
     }
 
     @Test
@@ -814,12 +850,53 @@ class GeckoEngineTest {
         actionDelegateCaptor.value.onBrowserAction(extension, null, browserAction)
 
         val extensionCaptor = argumentCaptor<WebExtension>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val actionCaptor = argumentCaptor<Action>()
         verify(webExtensionsDelegate).onBrowserActionDefined(extensionCaptor.capture(), actionCaptor.capture())
         assertEquals(extId, extensionCaptor.value.id)
 
         actionCaptor.value.onClick()
         verify(browserAction).click()
+    }
+
+    @Test
+    fun `web extension delegate notified of page actions from external extensions`() {
+        val runtime = mock<GeckoRuntime>()
+        val extId = "test-webext"
+        val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
+
+        val extensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(extensionController)
+
+        val engine = GeckoEngine(context, runtime = runtime)
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val result = GeckoResult<GeckoWebExtension>()
+        whenever(extensionController.install(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl)
+        val extension = spy(
+            GeckoWebExtension(
+                extUrl,
+                extId,
+                org.mozilla.geckoview.WebExtension.Flags.NONE,
+                runtime.webExtensionController
+            )
+        )
+        result.complete(extension)
+
+        val actionDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.ActionDelegate>()
+        verify(extension).setActionDelegate(actionDelegateCaptor.capture())
+
+        val pageAction: org.mozilla.geckoview.WebExtension.Action = mock()
+        actionDelegateCaptor.value.onPageAction(extension, null, pageAction)
+
+        val extensionCaptor = argumentCaptor<WebExtension>()
+        val actionCaptor = argumentCaptor<Action>()
+        verify(webExtensionsDelegate).onPageActionDefined(extensionCaptor.capture(), actionCaptor.capture())
+        assertEquals(extId, extensionCaptor.value.id)
+
+        actionCaptor.value.onClick()
+        verify(pageAction).click()
     }
 
     @Test

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,11 +6,12 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
+import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -221,8 +222,10 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val browserActionCaptor = argumentCaptor<Action>()
+        val pageActionCaptor = argumentCaptor<Action>()
         val nativeBrowserAction: WebExtension.Action = mock()
+        val nativePageAction: WebExtension.Action = mock()
 
         // Verify actions will not be acted on when not supported
         val extensionWithActions = GeckoWebExtension(
@@ -250,17 +253,23 @@ class GeckoWebExtensionTest {
 
         // Verify that browser actions are forwarded to the handler
         actionDelegateCaptor.value.onBrowserAction(nativeGeckoWebExt, null, nativeBrowserAction)
-        verify(actionHandler).onBrowserAction(eq(extension), eq(null), actionCaptor.capture())
+        verify(actionHandler).onBrowserAction(eq(extension), eq(null), browserActionCaptor.capture())
+
+        // Verify that page actions are forwarded to the handler
+        actionDelegateCaptor.value.onPageAction(nativeGeckoWebExt, null, nativePageAction)
+        verify(actionHandler).onPageAction(eq(extension), eq(null), pageActionCaptor.capture())
 
         // Verify that toggle popup is forwarded to the handler
         actionDelegateCaptor.value.onTogglePopup(nativeGeckoWebExt, nativeBrowserAction)
-        verify(actionHandler).onToggleBrowserActionPopup(eq(extension), actionCaptor.capture())
+        verify(actionHandler).onToggleActionPopup(eq(extension), any())
 
         // We don't have access to the native WebExtension.Action fields and
         // can't mock them either, but we can verify that we've linked
         // the actions by simulating a click.
-        actionCaptor.value.onClick()
+        browserActionCaptor.value.onClick()
         verify(nativeBrowserAction).click()
+        pageActionCaptor.value.onClick()
+        verify(nativePageAction).click()
     }
 
     @Test
@@ -273,8 +282,10 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val browserActionCaptor = argumentCaptor<Action>()
+        val pageActionCaptor = argumentCaptor<Action>()
         val nativeBrowserAction: WebExtension.Action = mock()
+        val nativePageAction: WebExtension.Action = mock()
 
         // Create extension and register action handler for session
         val extension = GeckoWebExtension(
@@ -293,13 +304,19 @@ class GeckoWebExtensionTest {
 
         // Verify that browser actions are forwarded to the handler
         actionDelegateCaptor.value.onBrowserAction(nativeGeckoWebExt, null, nativeBrowserAction)
-        verify(actionHandler).onBrowserAction(eq(extension), eq(session), actionCaptor.capture())
+        verify(actionHandler).onBrowserAction(eq(extension), eq(session), browserActionCaptor.capture())
+
+        // Verify that page actions are forwarded to the handler
+        actionDelegateCaptor.value.onPageAction(nativeGeckoWebExt, null, nativePageAction)
+        verify(actionHandler).onPageAction(eq(extension), eq(session), pageActionCaptor.capture())
 
         // We don't have access to the native WebExtension.Action fields and
         // can't mock them either, but we can verify that we've linked
         // the actions by simulating a click.
-        actionCaptor.value.onClick()
+        browserActionCaptor.value.onClick()
         verify(nativeBrowserAction).click()
+        pageActionCaptor.value.onClick()
+        verify(nativePageAction).click()
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -27,7 +27,7 @@ import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
@@ -65,12 +65,16 @@ class GeckoEngine(
 
     private var webExtensionDelegate: WebExtensionDelegate? = null
     private val webExtensionActionHandler = object : ActionHandler {
-        override fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: BrowserAction) {
+        override fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: Action) {
             webExtensionDelegate?.onBrowserActionDefined(extension, action)
         }
 
-        override fun onToggleBrowserActionPopup(extension: WebExtension, action: BrowserAction): EngineSession? {
-            return webExtensionDelegate?.onToggleBrowserActionPopup(extension, GeckoEngineSession(runtime), action)
+        override fun onPageAction(extension: WebExtension, session: EngineSession?, action: Action) {
+            webExtensionDelegate?.onPageActionDefined(extension, action)
+        }
+
+        override fun onToggleActionPopup(extension: WebExtension, action: Action): EngineSession? {
+            return webExtensionDelegate?.onToggleActionPopup(extension, GeckoEngineSession(runtime), action)
         }
     }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -8,8 +8,8 @@ import android.graphics.Bitmap
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
 import mozilla.components.browser.engine.gecko.await
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Metadata
@@ -179,14 +179,23 @@ class GeckoWebExtension(
                 session: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                actionHandler.onBrowserAction(this@GeckoWebExtension, null, action.toBrowserAction())
+                actionHandler.onBrowserAction(this@GeckoWebExtension, null, action.convert())
+            }
+
+            override fun onPageAction(
+                ext: GeckoNativeWebExtension,
+                // Session will always be null here for the global default delegate
+                session: GeckoSession?,
+                action: GeckoNativeWebExtensionAction
+            ) {
+                actionHandler.onPageAction(this@GeckoWebExtension, null, action.convert())
             }
 
             override fun onTogglePopup(
                 ext: GeckoNativeWebExtension,
                 action: GeckoNativeWebExtensionAction
             ): GeckoResult<GeckoSession>? {
-                val session = actionHandler.onToggleBrowserActionPopup(this@GeckoWebExtension, action.toBrowserAction())
+                val session = actionHandler.onToggleActionPopup(this@GeckoWebExtension, action.convert())
                 return session?.let { GeckoResult.fromValue((session as GeckoEngineSession).geckoSession) }
             }
         }
@@ -211,7 +220,15 @@ class GeckoWebExtension(
                 geckoSession: GeckoSession?,
                 action: GeckoNativeWebExtensionAction
             ) {
-                actionHandler.onBrowserAction(this@GeckoWebExtension, session, action.toBrowserAction())
+                actionHandler.onBrowserAction(this@GeckoWebExtension, session, action.convert())
+            }
+
+            override fun onPageAction(
+                ext: GeckoNativeWebExtension,
+                geckoSession: GeckoSession?,
+                action: GeckoNativeWebExtensionAction
+            ) {
+                actionHandler.onPageAction(this@GeckoWebExtension, session, action.convert())
             }
         }
 
@@ -282,14 +299,14 @@ private fun createWebExtensionFlags(allowContentMessaging: Boolean): Long {
     }
 }
 
-private fun GeckoNativeWebExtensionAction.toBrowserAction(): BrowserAction {
+private fun GeckoNativeWebExtensionAction.convert(): Action {
     val loadIcon: (suspend (Int) -> Bitmap?)? = icon?.let {
         { size -> icon?.get(size)?.await() }
     }
 
     val onClick = { click() }
 
-    return BrowserAction(
+    return Action(
         title,
         enabled,
         loadIcon,

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,11 +6,12 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
+import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -221,8 +222,10 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val browserActionCaptor = argumentCaptor<Action>()
+        val pageActionCaptor = argumentCaptor<Action>()
         val nativeBrowserAction: WebExtension.Action = mock()
+        val nativePageAction: WebExtension.Action = mock()
 
         // Verify actions will not be acted on when not supported
         val extensionWithActions = GeckoWebExtension(
@@ -250,17 +253,23 @@ class GeckoWebExtensionTest {
 
         // Verify that browser actions are forwarded to the handler
         actionDelegateCaptor.value.onBrowserAction(nativeGeckoWebExt, null, nativeBrowserAction)
-        verify(actionHandler).onBrowserAction(eq(extension), eq(null), actionCaptor.capture())
+        verify(actionHandler).onBrowserAction(eq(extension), eq(null), browserActionCaptor.capture())
+
+        // Verify that page actions are forwarded to the handler
+        actionDelegateCaptor.value.onPageAction(nativeGeckoWebExt, null, nativePageAction)
+        verify(actionHandler).onPageAction(eq(extension), eq(null), pageActionCaptor.capture())
 
         // Verify that toggle popup is forwarded to the handler
         actionDelegateCaptor.value.onTogglePopup(nativeGeckoWebExt, nativeBrowserAction)
-        verify(actionHandler).onToggleBrowserActionPopup(eq(extension), actionCaptor.capture())
+        verify(actionHandler).onToggleActionPopup(eq(extension), any())
 
         // We don't have access to the native WebExtension.Action fields and
         // can't mock them either, but we can verify that we've linked
         // the actions by simulating a click.
-        actionCaptor.value.onClick()
+        browserActionCaptor.value.onClick()
         verify(nativeBrowserAction).click()
+        pageActionCaptor.value.onClick()
+        verify(nativePageAction).click()
     }
 
     @Test
@@ -273,8 +282,10 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val browserActionCaptor = argumentCaptor<Action>()
+        val pageActionCaptor = argumentCaptor<Action>()
         val nativeBrowserAction: WebExtension.Action = mock()
+        val nativePageAction: WebExtension.Action = mock()
 
         // Create extension and register action handler for session
         val extension = GeckoWebExtension(
@@ -293,13 +304,19 @@ class GeckoWebExtensionTest {
 
         // Verify that browser actions are forwarded to the handler
         actionDelegateCaptor.value.onBrowserAction(nativeGeckoWebExt, null, nativeBrowserAction)
-        verify(actionHandler).onBrowserAction(eq(extension), eq(session), actionCaptor.capture())
+        verify(actionHandler).onBrowserAction(eq(extension), eq(session), browserActionCaptor.capture())
+
+        // Verify that page actions are forwarded to the handler
+        actionDelegateCaptor.value.onPageAction(nativeGeckoWebExt, null, nativePageAction)
+        verify(actionHandler).onPageAction(eq(extension), eq(session), pageActionCaptor.capture())
 
         // We don't have access to the native WebExtension.Action fields and
         // can't mock them either, but we can verify that we've linked
         // the actions by simulating a click.
-        actionCaptor.value.onClick()
+        browserActionCaptor.value.onClick()
         verify(nativeBrowserAction).click()
+        pageActionCaptor.value.onClick()
+        verify(nativePageAction).click()
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -26,8 +26,8 @@ import mozilla.components.concept.engine.content.blocking.TrackingProtectionExce
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.utils.EngineVersion
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -168,16 +168,16 @@ class GeckoEngine(
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1599897
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1582185
             ext.registerActionHandler(object : ActionHandler {
-                override fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: BrowserAction) {
+                override fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: Action) {
                     webExtensionDelegate?.onBrowserActionDefined(extension, action)
                 }
 
-                override fun onToggleBrowserActionPopup(
+                override fun onToggleActionPopup(
                     extension: WebExtension,
-                    action: BrowserAction
+                    action: Action
                 ): EngineSession? {
                     val session = GeckoEngineSession(runtime)
-                    return webExtensionDelegate?.onToggleBrowserActionPopup(extension, session, action)
+                    return webExtensionDelegate?.onToggleActionPopup(extension, session, action)
                 }
             })
         }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -18,8 +18,8 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.support.test.any
@@ -592,14 +592,14 @@ class GeckoEngineTest {
         val actionHandlerCaptor = argumentCaptor<ActionHandler>()
         verify(extension).registerActionHandler(actionHandlerCaptor.capture())
 
-        val browserAction: BrowserAction = mock()
+        val browserAction: Action = mock()
         actionHandlerCaptor.value.onBrowserAction(extension, null, browserAction)
         verify(webExtensionsDelegate).onBrowserActionDefined(eq(extension), eq(browserAction))
-        assertNull(actionHandlerCaptor.value.onToggleBrowserActionPopup(extension, browserAction))
-        verify(webExtensionsDelegate).onToggleBrowserActionPopup(eq(extension), any(), eq(browserAction))
+        assertNull(actionHandlerCaptor.value.onToggleActionPopup(extension, browserAction))
+        verify(webExtensionsDelegate).onToggleActionPopup(eq(extension), any(), eq(browserAction))
 
-        whenever(webExtensionsDelegate.onToggleBrowserActionPopup(any(), any(), any())).thenReturn(mock())
-        assertNotNull(actionHandlerCaptor.value.onToggleBrowserActionPopup(extension, browserAction))
+        whenever(webExtensionsDelegate.onToggleActionPopup(any(), any(), any())).thenReturn(mock())
+        assertNotNull(actionHandlerCaptor.value.onToggleActionPopup(extension, browserAction))
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -6,8 +6,8 @@ package mozilla.components.browser.engine.gecko.webextension
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.support.test.argumentCaptor
@@ -207,7 +207,7 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val actionCaptor = argumentCaptor<Action>()
         val nativeBrowserAction: WebExtension.Action = mock()
 
         // Verify actions will not be acted on when not supported
@@ -238,7 +238,7 @@ class GeckoWebExtensionTest {
 
         // Verify that toggle popup is forwarded to the handler
         actionDelegateCaptor.value.onTogglePopup(nativeGeckoWebExt, nativeBrowserAction)
-        verify(actionHandler).onToggleBrowserActionPopup(eq(extension), actionCaptor.capture())
+        verify(actionHandler).onToggleActionPopup(eq(extension), actionCaptor.capture())
 
         // We don't have access to the native WebExtension.Action fields and
         // can't mock them either, but we can verify that we've linked
@@ -256,7 +256,7 @@ class GeckoWebExtensionTest {
         val nativeGeckoWebExt: WebExtension = mock()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
-        val actionCaptor = argumentCaptor<BrowserAction>()
+        val actionCaptor = argumentCaptor<Action>()
         val nativeBrowserAction: WebExtension.Action = mock()
 
         // Create extension and register action handler for session

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenu.kt
@@ -14,14 +14,11 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 
-typealias WebExtensionBrowserAction = BrowserAction
-
 /**
- * A popup menu for [WebExtensionBrowserAction] menu items.
+ * A [BrowserMenu] capable of displaying browser and page actions from web extensions.
  */
 class WebExtensionBrowserMenu internal constructor(
     adapter: BrowserMenuAdapter,

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu.WebExtensionBrowserAction
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.support.base.log.Log
 
 /**

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.menu.item.WebExtensionBrowserMenuItem
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
@@ -19,7 +19,8 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.Action
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
@@ -158,7 +159,7 @@ class WebExtensionBrowserMenuTest {
     fun `browser actions can be overridden per tab`() {
         webExtensionBrowserActions.clear()
         val loadIcon: (suspend (Int) -> Bitmap?)? = { mock() }
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = loadIcon,
             enabled = true,
@@ -167,7 +168,7 @@ class WebExtensionBrowserMenuTest {
             badgeBackgroundColor = Color.BLUE
         ) {}
 
-        val browserActionOverride = BrowserAction(
+        val browserActionOverride = Action(
             title = "updatedTitle",
             loadIcon = null,
             enabled = false,

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -14,7 +14,7 @@ import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.R
 import mozilla.components.browser.menu.WebExtensionBrowserMenu
-import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -60,7 +60,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { icon },
             enabled = false,
@@ -88,7 +88,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { icon },
             enabled = true,
@@ -123,7 +123,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
                 title = "title",
                 loadIcon = { throw IllegalArgumentException() },
                 enabled = true,
@@ -153,7 +153,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { icon },
             enabled = true,
@@ -189,7 +189,7 @@ class WebExtensionBrowserMenuItemTest {
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { icon },
             enabled = true,
@@ -207,7 +207,7 @@ class WebExtensionBrowserMenuItemTest {
         verify(labelView).setText("title")
         verify(badgeView).setText("badgeText")
 
-        val browserActionOverride = BrowserAction(
+        val browserActionOverride = Action(
                 title = "override",
                 loadIcon = { icon },
                 enabled = true,

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -22,10 +22,11 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
+import mozilla.components.concept.engine.webextension.WebExtensionPageAction
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.lib.state.Action
 
-typealias WebExtensionBrowserAction = mozilla.components.concept.engine.webextension.BrowserAction
 /**
  * [Action] implementation related to [BrowserState].
  */
@@ -283,9 +284,9 @@ sealed class WebExtensionAction : BrowserAction() {
         WebExtensionAction()
 
     /**
-     * Update the given [updatedExtension] in the [BrowserState.extensions].
+     * Updates the given [updatedExtension] in the [BrowserState.extensions].
      */
-    data class UpdateWebExtension(val updatedExtension: WebExtensionState) : WebExtensionAction()
+    data class UpdateWebExtensionAction(val updatedExtension: WebExtensionState) : WebExtensionAction()
 
     /**
      * Updates a browser action of a given [extensionId].
@@ -296,21 +297,39 @@ sealed class WebExtensionAction : BrowserAction() {
     ) : WebExtensionAction()
 
     /**
-     * Keeps track of the last session used to display the [BrowserAction] popup.
+     * Updates a page action of a given [extensionId].
      */
-    data class UpdateBrowserActionPopupSession(
+    data class UpdatePageAction(
+        val extensionId: String,
+        val pageAction: WebExtensionPageAction
+    ) : WebExtensionAction()
+
+    /**
+     * Keeps track of the last session used to display an extension action popup.
+     */
+    data class UpdatePopupSessionAction(
         val extensionId: String,
         val popupSessionId: String
     ) : WebExtensionAction()
 
     /**
-     * Updates a browser action that belongs to the given [sessionId] and [extensionId] on the
+     * Updates a tab-specific browser action that belongs to the given [sessionId] and [extensionId] on the
      * [TabSessionState.extensionState].
      */
     data class UpdateTabBrowserAction(
         val sessionId: String,
         val extensionId: String,
         val browserAction: WebExtensionBrowserAction
+    ) : WebExtensionAction()
+
+    /**
+     * Updates a page action that belongs to the given [sessionId] and [extensionId] on the
+     * [TabSessionState.extensionState].
+     */
+    data class UpdateTabPageAction(
+        val sessionId: String,
+        val extensionId: String,
+        val pageAction: WebExtensionPageAction
     ) : WebExtensionAction()
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
@@ -42,7 +42,12 @@ internal object WebExtensionReducer {
                     it.copy(browserAction = action.browserAction)
                 }
             }
-            is WebExtensionAction.UpdateBrowserActionPopupSession -> {
+            is WebExtensionAction.UpdatePageAction -> {
+                state.updateWebExtensionState(action.extensionId) {
+                    it.copy(pageAction = action.pageAction)
+                }
+            }
+            is WebExtensionAction.UpdatePopupSessionAction -> {
                 state.updateWebExtensionState(action.extensionId) {
                     it.copy(browserActionPopupSession = action.popupSessionId)
                 }
@@ -52,7 +57,12 @@ internal object WebExtensionReducer {
                     it.copy(browserAction = action.browserAction)
                 }
             }
-            is WebExtensionAction.UpdateWebExtension -> {
+            is WebExtensionAction.UpdateTabPageAction -> {
+                state.updateWebExtensionTabState(action.sessionId, action.extensionId) {
+                    it.copy(pageAction = action.pageAction)
+                }
+            }
+            is WebExtensionAction.UpdateWebExtensionAction -> {
                 state.updateWebExtensionState(action.updatedExtension.id) { action.updatedExtension }
             }
         }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/WebExtensionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/WebExtensionState.kt
@@ -4,7 +4,8 @@
 
 package mozilla.components.browser.state.state
 
-typealias WebExtensionBrowserAction = mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
+import mozilla.components.concept.engine.webextension.WebExtensionPageAction
 
 /**
  * Value type that represents the state of a web extension.
@@ -13,7 +14,8 @@ typealias WebExtensionBrowserAction = mozilla.components.concept.engine.webexten
  * @property url The url pointing to a resources path for locating the extension
  * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
  * @property enabled Whether or not this web extension is enabled, defaults to true.
- * @property browserAction A list browser action that this web extension has.
+ * @property browserAction The browser action state of this extension.
+ * @property pageAction The page action state of this extension.
  * @property browserActionPopupSession The ID of the session displaying
  * the browser action popup.
  */
@@ -22,5 +24,6 @@ data class WebExtensionState(
     val url: String? = null,
     val enabled: Boolean = true,
     val browserAction: WebExtensionBrowserAction? = null,
+    val pageAction: WebExtensionPageAction? = null,
     val browserActionPopupSession: String? = null
 )

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/Action.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/Action.kt
@@ -7,7 +7,7 @@ package mozilla.components.concept.engine.webextension
 import android.graphics.Bitmap
 
 /**
- * Value type that represents the state of a browser action within a [WebExtension].
+ * Value type that represents the state of a browser or page action within a [WebExtension].
  *
  * @property title The title of the browser action to be visible in the user interface.
  * @property enabled Indicates if the browser action should be enabled or disabled.
@@ -17,7 +17,7 @@ import android.graphics.Bitmap
  * @property badgeBackgroundColor The browser action's badge background color.
  * @property onClick A callback to be executed when this browser action is clicked.
  */
-data class BrowserAction(
+data class Action(
     val title: String?,
     val enabled: Boolean?,
     val loadIcon: (suspend (Int) -> Bitmap?)?,
@@ -27,13 +27,15 @@ data class BrowserAction(
     val onClick: () -> Unit
 ) {
     /**
-     * Returns a copy of this [BrowserAction] with the provided overrides applied e.g. for tab-specific overrides.
+     * Returns a copy of this [Action] with the provided override applied e.g. for tab-specific overrides.
      *
      * @param override the action to use for overriding properties. Note that only the provided
-     * (non-null) properties of the override will be applied, all other properties will remain unchanged.
+     * (non-null) properties of the override will be applied, all other properties will remain
+     * unchanged. An extension can send a tab-specific action and only include the properties
+     * it wants to override for the tab.
      */
-    fun copyWithOverride(override: BrowserAction) =
-        BrowserAction(
+    fun copyWithOverride(override: Action) =
+        Action(
             title = override.title ?: title,
             enabled = override.enabled ?: enabled,
             badgeText = override.badgeText ?: badgeText,
@@ -43,3 +45,6 @@ data class BrowserAction(
             onClick = override.onClick
         )
 }
+
+typealias WebExtensionBrowserAction = Action
+typealias WebExtensionPageAction = Action

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -149,19 +149,29 @@ interface ActionHandler {
      * @param extension the extension that defined the browser action.
      * @param session the [EngineSession] if this action is to be updated for a
      * specific session, or null if this is to set a new default value.
-     * @param action the [BrowserAction]
+     * @param action the browser action as [Action].
      */
-    fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: BrowserAction) = Unit
+    fun onBrowserAction(extension: WebExtension, session: EngineSession?, action: Action) = Unit
 
     /**
-     * Invoked when a browser action wants to toggle a popup view.
+     * Invoked when a page action is defined or updated.
      *
      * @param extension the extension that defined the browser action.
-     * @param action the [BrowserAction]
+     * @param session the [EngineSession] if this action is to be updated for a
+     * specific session, or null if this is to set a new default value.
+     * @param action the [Action]
+     */
+    fun onPageAction(extension: WebExtension, session: EngineSession?, action: Action) = Unit
+
+    /**
+     * Invoked when a browser or page action wants to toggle a popup view.
+     *
+     * @param extension the extension that defined the browser or page action.
+     * @param action the action as [Action].
      * @return the [EngineSession] that was used for displaying the popup,
      * or null if the popup was closed.
      */
-    fun onToggleBrowserActionPopup(extension: WebExtension, action: BrowserAction): EngineSession? = null
+    fun onToggleActionPopup(extension: WebExtension, action: Action): EngineSession? = null
 }
 
 /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.EngineSession
  * extensions e.g. an extension was installed, or an extension wants to open
  * a new tab.
  */
+@Suppress("TooManyFunctions")
 interface WebExtensionDelegate {
 
     /**
@@ -64,27 +65,37 @@ interface WebExtensionDelegate {
 
     /**
      * Invoked when a web extension defines a browser action. To listen for session-specific
-     * overrides of [BrowserAction]s and other action-specific events (e.g. opening a popup)
+     * overrides of [Action]s and other action-specific events (e.g. opening a popup)
      * see [WebExtension.registerActionHandler].
      *
      * @param webExtension The [WebExtension] defining the browser action.
-     * @param action the defined [BrowserAction].
+     * @param action the defined browser [Action].
      */
-    fun onBrowserActionDefined(webExtension: WebExtension, action: BrowserAction) = Unit
+    fun onBrowserActionDefined(webExtension: WebExtension, action: Action) = Unit
 
     /**
-     * Invoked when a browser action wants to toggle a popup view.
+     * Invoked when a web extension defines a page action. To listen for session-specific
+     * overrides of [Action]s and other action-specific events (e.g. opening a popup)
+     * see [WebExtension.registerActionHandler].
+     *
+     * @param webExtension The [WebExtension] defining the browser action.
+     * @param action the defined page [Action].
+     */
+    fun onPageActionDefined(webExtension: WebExtension, action: Action) = Unit
+
+    /**
+     * Invoked when a browser or page action wants to toggle a popup view.
      *
      * @param webExtension The [WebExtension] that wants to display the popup.
      * @param engineSession The [EngineSession] to use for displaying the popup.
-     * @param action the [BrowserAction] that defines the popup.
+     * @param action the [Action] that defines the popup.
      * @return the [EngineSession] used to display the popup, or null if no popup
      * was displayed.
      */
-    fun onToggleBrowserActionPopup(
+    fun onToggleActionPopup(
         webExtension: WebExtension,
         engineSession: EngineSession,
-        action: BrowserAction
+        action: Action
     ): EngineSession? = null
 
     /**

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -188,7 +188,7 @@ class AddonManagerTest {
         }
 
         val actionHandlerCaptor = argumentCaptor<ActionHandler>()
-        val actionCaptor = argumentCaptor<WebExtensionAction.UpdateWebExtension>()
+        val actionCaptor = argumentCaptor<WebExtensionAction.UpdateWebExtensionAction>()
 
         // Verifying we returned the right status
         verify(engine).updateWebExtension(any(), onSuccessCaptor.capture(), any())

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarAction.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarAction.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.base.log.Log

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
@@ -17,13 +17,10 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.webextension.BrowserAction
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
-
-typealias WebExtensionBrowserAction = BrowserAction
 
 /**
  * Web extension toolbar implementation that updates the toolbar whenever the state of web

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
@@ -16,7 +16,8 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.Action
+import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -32,8 +33,6 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-
-typealias WebExtensionBrowserAction = BrowserAction
 
 class WebExtensionToolbarFeatureTest {
     private val testDispatcher = TestCoroutineDispatcher()
@@ -110,7 +109,7 @@ class WebExtensionToolbarFeatureTest {
         val webExtToolbarFeature = getWebExtensionToolbarFeature()
 
         val loadIcon: (suspend (Int) -> Bitmap?)? = { mock() }
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = loadIcon,
             enabled = true,
@@ -119,7 +118,7 @@ class WebExtensionToolbarFeatureTest {
             badgeBackgroundColor = Color.BLUE
         ) {}
 
-        val browserActionOverride = BrowserAction(
+        val browserActionOverride = Action(
             title = "updatedTitle",
             loadIcon = null,
             enabled = false,
@@ -168,7 +167,7 @@ class WebExtensionToolbarFeatureTest {
     fun `stale browser actions are remove when feature is restarted`() {
         val browserExtensions = HashMap<String, WebExtensionState>()
         val loadIcon: (suspend (Int) -> Bitmap?)? = { mock() }
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = loadIcon,
             enabled = true,

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
@@ -14,7 +14,7 @@ import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import mozilla.components.concept.engine.webextension.BrowserAction
+import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.ext.joinBlocking
@@ -50,7 +50,7 @@ class WebExtensionToolbarTest {
         whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(textView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { icon },
             enabled = true,
@@ -84,7 +84,7 @@ class WebExtensionToolbarTest {
         whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(textView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { throw IllegalArgumentException() },
             enabled = true,
@@ -105,7 +105,7 @@ class WebExtensionToolbarTest {
     fun createView() {
         var listenerWasClicked = false
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = { mock() },
             enabled = false,
@@ -143,7 +143,7 @@ class WebExtensionToolbarTest {
         whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(textView)
         whenever(view.context).thenReturn(mock())
 
-        val browserAction = BrowserAction(
+        val browserAction = Action(
             title = "title",
             loadIcon = @Suppress("UNREACHABLE_CODE") {
                 while (true) { delay(10) }


### PR DESCRIPTION
Part 1: Bring in the engine and store API and wire it up.

Part 2 will be to add the action to our UIs (toolbar and browser menu) which we'll do separately.