### PR TITLE
Fix #5603 - Implement notification for when the migration is complete.

### DIFF
--- a/components/support/migration/src/main/res/values/strings.xml
+++ b/components/support/migration/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="mozac_support_migration_ongoing_notification_title">Update in progress</string>
     <!-- Text of the notification shown while we upgrade Fennec to Fenix. -->
     <string name="mozac_support_migration_ongoing_notification_text">Firefox will be ready in a moment…</string>
+    <!-- Title of the notification shown the upgrade from Fennec to Fenix is complete. -->
+    <string name="mozac_support_migration_complete_notification_title">Update complete</string>
+    <!-- Text of the notification shown the upgrade from Fennec to Fenix is complete. -->
+    <string name="mozac_support_migration_complete_notification_text">Firefox is updated - and improved!</string>
 </resources>


### PR DESCRIPTION


Currently a notification is being shown for migration progress status, but no notification is being
displayed to the user for when the migration is complete.
In order to properly handle this notification's remove or click action, a broadcast receiver is
required that listens for this specific actions so it can remove the notification's channel.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks
- [x] **Tests**: This PR doesn't include tests as it contains changes for component not yet tested.
- [x] **Changelog**: This PR does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
