### PR TITLE
Closes #5677: Catch all known non-fatal push errors

### DIFF
--- a/components/concept/push/src/main/java/mozilla/components/concept/push/PushProcessor.kt
+++ b/components/concept/push/src/main/java/mozilla/components/concept/push/PushProcessor.kt
@@ -95,13 +95,16 @@ data class EncryptedPushMessage(
 /**
  *  Various error types.
  */
-sealed class PushError(open val desc: String) {
-    data class Registration(override val desc: String) : PushError(desc)
-    data class Network(override val desc: String) : PushError(desc)
+sealed class PushError(override val message: String) : Exception() {
+    data class Registration(override val message: String) : PushError(message)
+    data class Network(override val message: String) : PushError(message)
     /**
      * @property cause Original exception from Rust code.
      */
-    data class Rust(val cause: Exception) : PushError(cause.toString())
-    data class MalformedMessage(override val desc: String) : PushError(desc)
-    data class ServiceUnavailable(override val desc: String) : PushError(desc)
+    data class Rust(
+        override val cause: Throwable?,
+        override val message: String = cause?.message.orEmpty()
+    ) : PushError(message)
+    data class MalformedMessage(override val message: String) : PushError(message)
+    data class ServiceUnavailable(override val message: String) : PushError(message)
 }

--- a/components/concept/push/src/test/java/mozilla/components/concept/push/PushErrorTest.kt
+++ b/components/concept/push/src/test/java/mozilla/components/concept/push/PushErrorTest.kt
@@ -6,7 +6,6 @@ package mozilla.components.concept.push
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.lang.IllegalStateException
 
 class PushErrorTest {
     @Test
@@ -14,18 +13,20 @@ class PushErrorTest {
         // This test is mostly to satisfy coverage.
 
         var error: PushError = PushError.MalformedMessage("message")
-        assertEquals("message", error.desc)
+        assertEquals("message", error.message)
 
         error = PushError.Network("network")
-        assertEquals("network", error.desc)
+        assertEquals("network", error.message)
 
         error = PushError.Registration("reg")
-        assertEquals("reg", error.desc)
+        assertEquals("reg", error.message)
 
-        error = PushError.Rust(IllegalStateException("boo"))
-        assertEquals("java.lang.IllegalStateException: boo", error.desc)
+        val exception = IllegalStateException()
+        val rustError = PushError.Rust(exception, "rust")
+        assertEquals("rust", rustError.message)
+        assertEquals(exception, rustError.cause)
 
         error = PushError.ServiceUnavailable("service")
-        assertEquals("service", error.desc)
+        assertEquals("service", error.message)
     }
 }

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
@@ -7,13 +7,20 @@ package mozilla.components.feature.push
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import mozilla.appservices.push.AlreadyRegisteredError
 import mozilla.appservices.push.CommunicationError
 import mozilla.appservices.push.CommunicationServerError
 import mozilla.appservices.push.CryptoError
 import mozilla.appservices.push.KeyInfo
+import mozilla.appservices.push.InternalPanic
+import mozilla.appservices.push.MissingRegistrationTokenError
 import mozilla.appservices.push.RecordNotFoundError
+import mozilla.appservices.push.StorageError
+import mozilla.appservices.push.StorageSqlError
 import mozilla.appservices.push.SubscriptionInfo
 import mozilla.appservices.push.SubscriptionResponse
+import mozilla.appservices.push.TranscodingError
+import mozilla.appservices.push.UrlParseError
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -48,13 +55,18 @@ class AutoPushFeatureKtTest {
         assertEquals(ServiceType.ADM, config2.serviceType)
     }
 
-    @Test(expected = CryptoError::class)
+    @Test(expected = InternalPanic::class)
     fun `launchAndTry throws on unrecoverable Rust exceptions`() = runBlockingTest {
-        CoroutineScope(coroutineContext).launchAndTry({ throw CryptoError("unit test") }, { assert(false) })
+        CoroutineScope(coroutineContext).launchAndTry({ throw InternalPanic("unit test") }, { assert(false) })
     }
 
     @Test
     fun `launchAndTry should NOT throw on recoverable Rust exceptions`() = runBlockingTest {
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw CryptoError("should not fail test") },
+            { assert(true) }
+        )
+
         CoroutineScope(coroutineContext).launchAndTry(
             { throw CommunicationServerError("should not fail test") },
             { assert(true) }
@@ -66,7 +78,37 @@ class AutoPushFeatureKtTest {
         )
 
         CoroutineScope(coroutineContext).launchAndTry(
+            { throw AlreadyRegisteredError() },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw StorageError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw MissingRegistrationTokenError() },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw StorageSqlError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw TranscodingError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
             { throw RecordNotFoundError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw UrlParseError("should not fail test") },
             { assert(true) }
         )
     }

--- a/components/lib/push-amazon/src/test/java/mozilla/components/lib/push/amazon/AbstractAmazonPushServiceTest.kt
+++ b/components/lib/push-amazon/src/test/java/mozilla/components/lib/push/amazon/AbstractAmazonPushServiceTest.kt
@@ -95,7 +95,7 @@ class AbstractAmazonPushServiceTest {
         verify(processor).onError(captor.capture())
 
         assertTrue(captor.value is PushError.Registration)
-        assertTrue(captor.value.desc.contains("registration failed"))
+        assertTrue(captor.value.message.contains("registration failed"))
     }
 
     @Test
@@ -111,7 +111,7 @@ class AbstractAmazonPushServiceTest {
         verify(processor).onError(captor.capture())
 
         assertTrue(captor.value is PushError.MalformedMessage)
-        assertTrue(captor.value.desc.contains("NoSuchElementException"))
+        assertTrue(captor.value.message.contains("NoSuchElementException"))
     }
 
     @Test

--- a/components/lib/push-firebase/src/test/java/mozilla/components/lib/push/firebase/AbstractFirebasePushServiceTest.kt
+++ b/components/lib/push-firebase/src/test/java/mozilla/components/lib/push/firebase/AbstractFirebasePushServiceTest.kt
@@ -88,7 +88,7 @@ class AbstractFirebasePushServiceTest {
         verify(processor).onError(captor.capture())
 
         assertTrue(captor.value is PushError.MalformedMessage)
-        assertTrue(captor.value.desc.contains("NoSuchElementException"))
+        assertTrue(captor.value.message.contains("NoSuchElementException"))
     }
 
     @Test


### PR DESCRIPTION
Previously, we wanted to throw on all unknown push errors so that we
were notified on them. Since this seems to be more common than
originally expected, we should just catch them and in a future version,
we should log them without crashing.

All of these push errors can be considered recoverable except
for InternalPanic.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Spoke offline with @jrconlin, and it's safe to not crash on these errors.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
