### PR TITLE
Bump a-s dependency to 0.48.3.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.48.2"
+    const val mozilla_appservices = "0.48.3"
 
     const val mozilla_glean = "24.1.0"
 

--- a/components/browser/storage-sync/build.gradle
+++ b/components/browser/storage-sync/build.gradle
@@ -42,7 +42,12 @@ configurations {
 
 dependencies {
     // These dependencies are part of this module's public API.
-    api Dependencies.mozilla_places
+    api(Dependencies.mozilla_places) {
+        // Use our own version of the Glean dependency,
+        // which might be different from the version declared by A-S.
+        exclude group: 'org.mozilla.components', module: 'service-glean'
+    }
+
     api Dependencies.mozilla_remote_tabs
     api project(':concept-storage')
     api project(':concept-sync')
@@ -67,6 +72,7 @@ dependencies {
     testImplementation Dependencies.testing_mockwebserver
 
     testImplementation Dependencies.mozilla_full_megazord_forUnitTests
+    testImplementation Dependencies.mozilla_glean_forUnitTests
 }
 
 apply from: '../../../publish.gradle'


### PR DESCRIPTION
Changelog: https://github.com/mozilla/application-services/releases/tag/v0.48.3

@grigoryk ⚠️ important migration fixes included 