### PR TITLE
Clean up web extension action menu popup 

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -29,6 +29,7 @@
         android:textAlignment="viewStart"
         android:paddingEnd="16dp"
         android:paddingStart="16dp"
+        android:clickable="false"
         tools:ignore="RtlCompat"
         tools:text="uBlock Origin" />
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -33,6 +33,7 @@ class WebExtensionBrowserMenuBuilderTest {
             "id" to WebExtensionState(
                 "id",
                 "url",
+                "name",
                 true,
                 browserAction = browserAction,
                 pageAction = pageAction
@@ -81,6 +82,7 @@ class WebExtensionBrowserMenuBuilderTest {
             "id" to WebExtensionState(
                 "id",
                 "url",
+                "name",
                 true,
                 browserAction = browserAction,
                 pageAction = pageAction

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt
@@ -59,6 +59,7 @@ class WebExtensionBrowserMenuTest {
             "browser_action" to WebExtensionState(
                 "browser_action",
                 "url",
+                "name",
                 true,
                 browserAction = browserAction,
                 pageAction = pageAction
@@ -94,6 +95,7 @@ class WebExtensionBrowserMenuTest {
             "id" to WebExtensionState(
                 "id",
                 "url",
+                "name",
                 true,
                 browserAction = defaultBrowserAction,
                 pageAction = defaultPageAction
@@ -116,6 +118,7 @@ class WebExtensionBrowserMenuTest {
             "id2" to WebExtensionState(
                 "id2",
                 "url",
+                "name",
                 true,
                 browserAction = anotherBrowserAction,
                 pageAction = anotherPageAction
@@ -146,6 +149,7 @@ class WebExtensionBrowserMenuTest {
             "id" to WebExtensionState(
                 "id",
                 "url",
+                "name",
                 true,
                 browserAction = defaultBrowserAction,
                 pageAction = defaultPageAction
@@ -155,6 +159,7 @@ class WebExtensionBrowserMenuTest {
             "id" to WebExtensionState(
                 "id",
                 "url",
+                "name",
                 true,
                 browserAction = overriddenBrowserAction,
                 pageAction = overriddenPageAction
@@ -198,6 +203,7 @@ class WebExtensionBrowserMenuTest {
             "enabled" to WebExtensionState(
                 "enabled",
                 "url",
+                "name",
                 true,
                 browserAction = enabledBrowserAction,
                 pageAction = enabledPageAction
@@ -205,6 +211,7 @@ class WebExtensionBrowserMenuTest {
             "disabled" to WebExtensionState(
                 "disabled",
                 "url",
+                "name",
                 false,
                 browserAction = disabledBrowserAction,
                 pageAction = disabledPageAction

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/WebExtensionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/WebExtensionState.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionPageAction
  * @property id The unique identifier for this web extension.
  * @property url The url pointing to a resources path for locating the extension
  * within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ * @property name The name of this web extension.
  * @property enabled Whether or not this web extension is enabled, defaults to true.
  * @property browserAction The browser action state of this extension.
  * @property pageAction The page action state of this extension.
@@ -24,6 +25,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionPageAction
 data class WebExtensionState(
     val id: String,
     val url: String? = null,
+    val name: String? = null,
     val enabled: Boolean = true,
     val browserAction: WebExtensionBrowserAction? = null,
     val pageAction: WebExtensionPageAction? = null,

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
@@ -137,6 +137,7 @@ class WebExtensionActionTest {
                 "extensionId" to WebExtensionState(
                     "extensionId",
                     "url",
+                    "name",
                     true,
                     mockedBrowserAction1
                 )
@@ -218,6 +219,7 @@ class WebExtensionActionTest {
                 "extensionId" to WebExtensionState(
                     "extensionId",
                     "url",
+                    "name",
                     true,
                     mockedPageAction1
                 )

--- a/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
+++ b/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt
@@ -53,10 +53,10 @@ class WebExtensionToolbarFeatureTest {
             WebExtensionBrowserAction("overridden_browser_action_title", false, mock(), "", 0, 0) {}
         val toolbar: Toolbar = mock()
         val extensions: Map<String, WebExtensionState> = mapOf(
-            "id" to WebExtensionState("id", "url", true, browserAction = defaultBrowserAction, pageAction = defaultPageAction)
+            "id" to WebExtensionState("id", "url", "name", true, browserAction = defaultBrowserAction, pageAction = defaultPageAction)
         )
         val overriddenExtensions: Map<String, WebExtensionState> = mapOf(
-            "id" to WebExtensionState("id", "url", true, browserAction = overriddenBrowserAction, pageAction = overriddenPageAction)
+            "id" to WebExtensionState("id", "url", "name", true, browserAction = overriddenBrowserAction, pageAction = overriddenPageAction)
         )
         val store = spy(
             BrowserStore(
@@ -99,6 +99,7 @@ class WebExtensionToolbarFeatureTest {
             "enabled" to WebExtensionState(
                 "enabled",
                 "url",
+                "name",
                 true,
                 browserAction = enabledAction,
                 pageAction = enablePageAction
@@ -106,6 +107,7 @@ class WebExtensionToolbarFeatureTest {
             "disabled" to WebExtensionState(
                 "disabled",
                 "url",
+                "name",
                 false,
                 browserAction = disabledAction,
                 pageAction = disablePageAction

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -365,7 +365,7 @@ class WebExtensionSupportTest {
         )))
 
         val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
-        WebExtensionSupport.initialize(engine, store)
+        WebExtensionSupport.initialize(engine, store, openPopupInTab = true)
         verify(engine).registerWebExtensionDelegate(delegateCaptor.capture())
 
         // Toggling should open tab
@@ -417,13 +417,9 @@ class WebExtensionSupportTest {
 
         val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
 
-        var webExtensionId = ""
         WebExtensionSupport.initialize(
             engine,
-            store,
-            onActionPopupToggleOverride = {
-                webExtensionId = it.id
-            }
+            store
         )
         verify(engine).registerWebExtensionDelegate(delegateCaptor.capture())
 
@@ -432,18 +428,8 @@ class WebExtensionSupportTest {
         val actionCaptor = argumentCaptor<mozilla.components.browser.state.action.BrowserAction>()
         verify(store, times(1)).dispatch(actionCaptor.capture())
 
-        store.waitUntilIdle()
         val value = actionCaptor.value
         assertNotNull((value as WebExtensionAction.UpdatePopupSessionAction).popupSession)
-        assertNotNull(store.state.extensions[webExtensionId]?.popupSession)
-
-        // Update store to clear popupSession reference
-        store.dispatch(
-            WebExtensionAction.UpdatePopupSessionAction(webExtensionId, popupSession = null)
-        ).joinBlocking()
-
-        store.waitUntilIdle()
-        assertNull(store.state.extensions[webExtensionId]?.popupSession)
     }
 
     @Test

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -6,23 +6,32 @@ package org.mozilla.samples.browser
 
 import android.content.ComponentCallbacks2
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
 import mozilla.components.feature.intent.ext.getSessionId
 import mozilla.components.browser.tabstray.BrowserTabsTray
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.UserInteractionHandler
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import mozilla.components.support.utils.SafeIntent
+import org.mozilla.samples.browser.addons.WebExtensionActionPopupActivity
 import org.mozilla.samples.browser.ext.components
 
 /**
  * Activity that holds the [BrowserFragment].
  */
 open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
+    private var webExtScope: CoroutineScope? = null
 
     /**
      * Returns a new instance of [BrowserFragment] to display.
@@ -41,6 +50,17 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
                 commit()
             }
         }
+    }
+
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    override fun onStart() {
+        super.onStart()
+        webExtScope = observeWebExtensionPopups()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        webExtScope?.cancel()
     }
 
     override fun onDestroy() {
@@ -69,5 +89,26 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
     override fun onTrimMemory(level: Int) {
         components.sessionManager.onLowMemory()
         components.icons.onLowMemory()
+    }
+
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    private fun observeWebExtensionPopups(): CoroutineScope {
+        return components.store.flowScoped { flow ->
+            flow.ifChanged { it.extensions }
+                .map { it.extensions.filterValues { extension -> extension.popupSession != null } }
+                .ifChanged()
+                .collect { extensionStates ->
+                    if (extensionStates.values.isNotEmpty()) {
+                        // We currently limit to one active popup session at a time
+                        val webExtensionState = extensionStates.values.first()
+
+                        val intent = Intent(this, WebExtensionActionPopupActivity::class.java)
+                        intent.putExtra("web_extension_id", webExtensionState.id)
+                        intent.putExtra("web_extension_name", webExtensionState.name)
+                        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                        startActivity(intent)
+                    }
+                }
+        }
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -5,7 +5,6 @@
 package org.mozilla.samples.browser
 
 import android.app.Application
-import android.content.Intent
 import mozilla.components.browser.session.Session
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.service.glean.Glean
@@ -16,7 +15,6 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.webextensions.WebExtensionSupport
-import org.mozilla.samples.browser.addons.WebExtensionActionPopupActivity
 
 class SampleApplication : Application() {
     val components by lazy { Components(this) }
@@ -61,17 +59,7 @@ class SampleApplication : Application() {
                         val selected = components.sessionManager.findSessionById(sessionId)
                         selected?.let { components.tabsUseCases.selectTab(it) }
                 },
-                onUpdatePermissionRequest = components.addonUpdater::onUpdatePermissionRequest,
-                onActionPopupToggleOverride = {
-                    webExtension ->
-                        val intent = Intent(this, WebExtensionActionPopupActivity::class.java)
-                        intent.putExtra("web_extension_id", webExtension.id)
-                        webExtension.getMetadata()?.let {
-                            intent.putExtra("web_extension_name", it.name)
-                        }
-                        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                        startActivity(intent)
-                }
+                onUpdatePermissionRequest = components.addonUpdater::onUpdatePermissionRequest
             )
         } catch (e: UnsupportedOperationException) {
             // Web extension support is only available for engine gecko


### PR DESCRIPTION
- Remove onActionPopupToggleOverride and add openPopupInTab flag.
- Add store flow to observe for `extension.popUpSession` change when it's not null in sample browser.
- Fix web extension menu item label view being clickable; only the container should be.

This cleans up and makes it easier for Fenix integration as well as easier to deprecate `WebExtensionSupport` class later down the road when browser store refactor is complete.