### PR TITLE
Issue #5673: Make URL detection better

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
@@ -312,31 +312,11 @@ class WebURLFinder {
             WORD_BOUNDARY +
             ")")
 
-        private const val autolinkWebUrlPattern = "\\w+(://[/]*|:|\\.)\\w+\\S*"
+        // Taken from mozilla.components.support.utils.URLStringUtils. See documentation
+        // there for a complete description.
+        private const val autolinkWebUrlPattern = "(\\w+-)*\\w+(://[/]*|:|\\.)(\\w+-)*\\w+([\\S&&[^\\w-]]\\S*)?"
 
         private val autolinkWebUrl by lazy {
-            // Be lenient about what is potentially a URL in a text string. Anything that contains
-            // a :, ://, or . and has no internal spaces is potentially a URL.
-            //
-            // Use java.util.regex because it is always unicode aware on Android.
-            // https://developer.android.com/reference/java/util/regex/Pattern.html
-            //
-            // Use both the \w+ and \S* after the punctuation because they seem to match slightly
-            // different things. The \S matches any non-whitespace character (e.g., '~') and \w
-            // matches only word characters. In other words, the regex is requiring that there be a
-            // non-symbol character somewhere after the ., : or :// and before any other character
-            // or the end of the string. For example, match
-            // mozilla.com/~userdir
-            // and not
-            // mozilla./~ or mozilla:/
-            // Without the [/]* after the :// in the alternation of the characters required to be a
-            // valid URL,
-            // file:///home/user/myfile.html
-            // is considered a search term; it is clearly a URL.
-            //
-            // This is almost identical to the regular expression known as URLStringUtils.isURLLenient
-            // but does not have the (padding and the) anchoring at either end because this regular
-            // expression is used to find multiple matches in a single string.
             Pattern.compile(autolinkWebUrlPattern, 0)
         }
 

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
@@ -84,20 +84,35 @@ class URLStringUtilsTest {
         assertTrue(isURLLike("file://////////////home//user/myfile.html"))
         assertTrue(isURLLike("file://C:\\Users\\user\\myfile.html"))
         assertTrue(isURLLike("http://192.168.255.255"))
-
         assertTrue(isURLLike("link.unknown"))
-
         // Per https://bugs.chromium.org/p/chromium/issues/detail?id=31405, ICANN will accept
         // purely numeric gTLDs.
         assertTrue(isURLLike("3.14.2019"))
+        assertTrue(isURLLike("3-four.14.2019"))
         assertTrue(isURLLike(" cnn.com "))
         assertTrue(isURLLike(" cnn.com"))
         assertTrue(isURLLike("cnn.com "))
         assertTrue(isURLLike("mozilla.com/~userdir"))
-
+        assertTrue(isURLLike("my-domain.com"))
         assertTrue(isURLLike("http://faß.de//"))
         assertTrue(isURLLike("cnn.cơḿ"))
         assertTrue(isURLLike("cnn.çơḿ"))
+
+        // Examples from the code comments:
+        assertTrue(isURLLike("c-c.com"))
+        assertTrue(isURLLike("c-c-c-c.c-c-c"))
+        assertTrue(isURLLike("c-http://c.com"))
+        assertTrue(isURLLike("about-mozilla:mozilla"))
+        assertTrue(isURLLike("c-http.d-x"))
+        assertTrue(isURLLike("www.c.-"))
+        assertTrue(isURLLike("3-3.3"))
+        assertTrue(isURLLike("www.c-c.-"))
+
+        assertFalse(isURLLike(" -://x.com "))
+        assertFalse(isURLLike("  -x.com"))
+        assertFalse(isURLLike("http://www-.com"))
+        assertFalse(isURLLike("www.c-c-  "))
+        assertFalse(isURLLike("3-3 "))
     }
 
     @Test
@@ -113,15 +128,36 @@ class URLStringUtilsTest {
         assertFalse(isSearchTerm("file://////////////home//user/myfile.html"))
         assertFalse(isSearchTerm("file://C:\\Users\\user\\myfile.html"))
         assertFalse(isSearchTerm("http://192.168.255.255"))
+        assertFalse(isSearchTerm("link.unknown"))
         // Per https://bugs.chromium.org/p/chromium/issues/detail?id=31405, ICANN will accept
         // purely numeric gTLDs.
         assertFalse(isSearchTerm("3.14.2019"))
+        assertFalse(isSearchTerm("3-four.14.2019"))
         assertFalse(isSearchTerm(" cnn.com "))
         assertFalse(isSearchTerm(" cnn.com"))
         assertFalse(isSearchTerm("cnn.com "))
+        assertFalse(isSearchTerm("my-domain.com"))
+        assertFalse(isSearchTerm("camp-firefox.de"))
+        assertFalse(isSearchTerm("http://my-domain.com"))
         assertFalse(isSearchTerm("mozilla.com/~userdir"))
         assertFalse(isSearchTerm("http://faß.de//"))
         assertFalse(isSearchTerm("cnn.cơḿ"))
         assertFalse(isSearchTerm("cnn.çơḿ"))
+
+        // Examples from the code comments:
+        assertFalse(isSearchTerm("c-c.com"))
+        assertFalse(isSearchTerm("c-c-c-c.c-c-c"))
+        assertFalse(isSearchTerm("c-http://c.com"))
+        assertFalse(isSearchTerm("about-mozilla:mozilla"))
+        assertFalse(isSearchTerm("c-http.d-x"))
+        assertFalse(isSearchTerm("www.c.-"))
+        assertFalse(isSearchTerm("3-3.3"))
+        assertFalse(isSearchTerm("www.c-c.-"))
+
+        assertTrue(isSearchTerm(" -://x.com "))
+        assertTrue(isSearchTerm("  -x.com"))
+        assertTrue(isSearchTerm("http://www-.com"))
+        assertTrue(isSearchTerm("www.c-c-  "))
+        assertTrue(isSearchTerm("3-3 "))
     }
 }

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/WebURLFinderTest.java
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/WebURLFinderTest.java
@@ -48,11 +48,16 @@ public class WebURLFinderTest {
         assertEquals("http://t-example:8080/appversion-1.0.0/f/action.xhtml", find("test.com http://t-example:8080/appversion-1.0.0/f/action.xhtml"));
         assertEquals("http://t-example:8080/appversion-1.0.0/f/action.xhtml", find("http://t-example:8080/appversion-1.0.0/f/action.xhtml"));
         assertEquals("http://ß.de/", find("http://ß.de/ çnn.çơḿ"));
+        assertEquals("htt-p://ß.de/", find("çnn.çơḿ htt-p://ß.de/"));
     }
 
     @Test
     public void testNoScheme() {
         assertEquals("noscheme.com", find("noscheme.com example.com"));
+        assertEquals("noscheme.com", find("-noscheme.com example.com"));
+        assertEquals("n-oscheme.com", find("n-oscheme.com example.com"));
+        assertEquals("n-oscheme.com", find("----------n-oscheme.com "));
+        assertEquals("n-oscheme.ç", find("----------n-oscheme.ç-----------------------"));
     }
 
     @Test


### PR DESCRIPTION
The lenient URL method was apparently not lenient after all.
It did not detect that camp-firefox.de was a valid URL. This
change to the regular expression fixes that. See related Fenix
issue #7800.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
