### PR TITLE
Fixes #5725 - Set manifest scope to be not-null

### DIFF
--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -14,10 +14,10 @@ import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
 import mozilla.components.concept.engine.EngineSession.SafeBrowsingPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.Tracker
@@ -292,10 +292,12 @@ class GeckoEngineSessionTest {
         val json = JSONObject().apply {
             put("name", "Minimal")
             put("start_url", "/")
+            put("scope", "/")
         }
         val manifest = WebAppManifest(
             name = "Minimal",
-            startUrl = "/"
+            startUrl = "/",
+            scope = "/"
         )
 
         captureDelegates()

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -14,10 +14,10 @@ import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
 import mozilla.components.concept.engine.EngineSession.SafeBrowsingPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.Tracker
@@ -292,10 +292,12 @@ class GeckoEngineSessionTest {
         val json = JSONObject().apply {
             put("name", "Minimal")
             put("start_url", "/")
+            put("scope", "/")
         }
         val manifest = WebAppManifest(
             name = "Minimal",
-            startUrl = "/"
+            startUrl = "/",
+            scope = "/"
         )
 
         captureDelegates()

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -14,10 +14,10 @@ import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
-import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
 import mozilla.components.concept.engine.EngineSession.SafeBrowsingPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.Tracker
@@ -292,10 +292,12 @@ class GeckoEngineSessionTest {
         val json = JSONObject().apply {
             put("name", "Minimal")
             put("start_url", "/")
+            put("scope", "/")
         }
         val manifest = WebAppManifest(
             name = "Minimal",
-            startUrl = "/"
+            startUrl = "/",
+            scope = "/"
         )
 
         captureDelegates()

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -350,6 +350,7 @@ class SessionTest {
             name = "HackerWeb",
             description = "A simply readable Hacker News app.",
             startUrl = ".",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(
                 WebAppManifest.Icon(

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -39,6 +39,12 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class EngineObserverTest {
 
+    private val mozillaManifest = WebAppManifest(
+        name = "Mozilla",
+        startUrl = "https://www.mozilla.org",
+        scope = "https://www.mozilla.org/hello/"
+    )
+
     @Test
     fun engineSessionObserver() {
         val session = Session("")
@@ -256,12 +262,11 @@ class EngineObserverTest {
     @Test
     fun engineObserverClearsWebAppManifestIfNewPageStartsLoading() {
         val session = Session("https://www.mozilla.org")
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
 
         val observer = EngineObserver(session)
-        observer.onWebAppManifestLoaded(manifest)
+        observer.onWebAppManifestLoaded(mozillaManifest)
 
-        assertEquals(manifest, session.webAppManifest)
+        assertEquals(mozillaManifest, session.webAppManifest)
 
         observer.onLocationChange("https://getpocket.com")
 
@@ -271,34 +276,28 @@ class EngineObserverTest {
     @Test
     fun engineObserverDoesNotClearWebAppManifestIfNewPageInStartUrlScope() {
         val session = Session("https://www.mozilla.org")
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://www.mozilla.org")
 
         val observer = EngineObserver(session)
-        observer.onWebAppManifestLoaded(manifest)
+        observer.onWebAppManifestLoaded(mozillaManifest)
 
-        assertEquals(manifest, session.webAppManifest)
+        assertEquals(mozillaManifest, session.webAppManifest)
 
         observer.onLocationChange("https://www.mozilla.org/hello.html")
 
-        assertEquals(manifest, session.webAppManifest)
+        assertEquals(mozillaManifest, session.webAppManifest)
     }
 
     @Test
     fun engineObserverDoesNotClearWebAppManifestIfNewPageInScope() {
         val session = Session("https://www.mozilla.org/hello/page1.html")
-        val manifest = WebAppManifest(
-            name = "Mozilla",
-            startUrl = "https://www.mozilla.org",
-            scope = "https://www.mozilla.org/hello/"
-        )
 
         val observer = EngineObserver(session)
-        observer.onWebAppManifestLoaded(manifest)
+        observer.onWebAppManifestLoaded(mozillaManifest)
 
-        assertEquals(manifest, session.webAppManifest)
+        assertEquals(mozillaManifest, session.webAppManifest)
 
         observer.onLocationChange("https://www.mozilla.org/hello/page2.html")
-        assertEquals(manifest, session.webAppManifest)
+        assertEquals(mozillaManifest, session.webAppManifest)
 
         observer.onLocationChange("https://www.mozilla.org/hello.html")
         assertNull(session.webAppManifest)
@@ -375,7 +374,8 @@ class EngineObserverTest {
         val observer = EngineObserver(session)
         val manifest = WebAppManifest(
             name = "Minimal",
-            startUrl = "/"
+            startUrl = "/",
+            scope = "/"
         )
 
         observer.onWebAppManifestLoaded(manifest)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifest.kt
@@ -49,6 +49,7 @@ import mozilla.components.concept.engine.manifest.WebAppManifest.ExternalApplica
 data class WebAppManifest(
     val name: String,
     val startUrl: String,
+    val scope: String,
     val shortName: String? = null,
     val display: DisplayMode = DisplayMode.BROWSER,
     @ColorInt val backgroundColor: Int? = null,
@@ -57,7 +58,6 @@ data class WebAppManifest(
     val dir: TextDirection = TextDirection.AUTO,
     val lang: String? = null,
     val orientation: Orientation = Orientation.ANY,
-    val scope: String? = null,
     @ColorInt val themeColor: Int? = null,
     val relatedApplications: List<ExternalApplicationResource> = emptyList(),
     val preferRelatedApplications: Boolean = false,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
@@ -44,6 +44,16 @@ class WebAppManifestParser {
     /**
      * Parses the provided JSON and returns a [WebAppManifest] (wrapped in [Result.Success] if parsing was successful.
      * Otherwise [Result.Failure].
+     *
+     * Gecko performs some initial parsing on the Web App Manifest, so the [JSONObject] we work with
+     * does not match what was originally provided by the website. Gecko:
+     * - Changes relative URLs to be absolute
+     * - Changes some space-separated strings into arrays (purpose, sizes)
+     * - Changes colors to follow Android format (#AARRGGBB)
+     * - Removes invalid enum values (ie display: halfscreen)
+     * - Ensures display, dir, start_url, and scope always have a value
+     * - Trims most strings (name, short_name, ...)
+     * See See https://searchfox.org/mozilla-central/source/dom/manifest/ManifestProcessor.jsm
      */
     fun parse(json: JSONObject): Result {
         return try {
@@ -59,7 +69,7 @@ class WebAppManifestParser {
                 backgroundColor = parseColor(json.tryGetString("background_color")),
                 description = json.tryGetString("description"),
                 icons = parseIcons(json),
-                scope = json.tryGetString("scope"),
+                scope = json.getString("scope"),
                 themeColor = parseColor(json.tryGetString("theme_color")),
                 dir = parseTextDirection(json),
                 lang = json.tryGetString("lang"),

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/manifest/WebAppManifestParserTest.kt
@@ -46,7 +46,7 @@ class WebAppManifestParserTest {
         assertEquals(WebAppManifest.TextDirection.AUTO, manifest.dir)
         assertNull(manifest.lang)
         assertEquals(WebAppManifest.Orientation.ANY, manifest.orientation)
-        assertNull(manifest.scope)
+        assertEquals(manifest.startUrl, manifest.scope)
         assertNull(manifest.themeColor)
 
         assertEquals(6, manifest.icons.size)
@@ -194,7 +194,7 @@ class WebAppManifestParserTest {
         assertEquals(WebAppManifest.TextDirection.AUTO, manifest.dir)
         assertNull(manifest.lang)
         assertEquals(WebAppManifest.Orientation.ANY, manifest.orientation)
-        assertNull(manifest.scope)
+        assertEquals(manifest.startUrl, manifest.scope)
         assertNull(manifest.themeColor)
 
         assertEquals(0, manifest.icons.size)
@@ -217,7 +217,7 @@ class WebAppManifestParserTest {
         assertEquals(WebAppManifest.TextDirection.AUTO, manifest.dir)
         assertNull(manifest.lang)
         assertEquals(WebAppManifest.Orientation.ANY, manifest.orientation)
-        assertNull(manifest.scope)
+        assertEquals(manifest.startUrl, manifest.scope)
         assertNull(manifest.themeColor)
 
         assertEquals(0, manifest.icons.size)
@@ -315,7 +315,7 @@ class WebAppManifestParserTest {
         assertEquals(Color.WHITE, manifest.backgroundColor)
         assertEquals(WebAppManifest.TextDirection.AUTO, manifest.dir)
         assertEquals(WebAppManifest.Orientation.ANY, manifest.orientation)
-        assertNull(manifest.scope)
+        assertEquals(manifest.startUrl, manifest.scope)
         assertEquals(rgb(247, 143, 33), manifest.themeColor)
 
         assertEquals(1, manifest.icons.size)
@@ -551,11 +551,16 @@ class WebAppManifestParserTest {
 
     @Test
     fun `Serializing minimal manifest`() {
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
+        val manifest = WebAppManifest(
+            name = "Mozilla",
+            startUrl = "https://mozilla.org",
+            scope = "/"
+        )
         val json = WebAppManifestParser().serialize(manifest)
 
         assertEquals("Mozilla", json.getString("name"))
         assertEquals("https://mozilla.org", json.getString("start_url"))
+        assertEquals("/", json.getString("scope"))
     }
 
     @Test

--- a/components/concept/engine/src/test/resources/manifests/example_mdn.json
+++ b/components/concept/engine/src/test/resources/manifests/example_mdn.json
@@ -2,6 +2,7 @@
   "name": "HackerWeb",
   "short_name": "HackerWeb",
   "start_url": ".",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "description": "A simply readable Hacker News app.",

--- a/components/concept/engine/src/test/resources/manifests/minimal.json
+++ b/components/concept/engine/src/test/resources/manifests/minimal.json
@@ -1,4 +1,5 @@
 {
   "name": "Minimal",
-  "start_url": "/"
+  "start_url": "/",
+  "scope": "/"
 }

--- a/components/concept/engine/src/test/resources/manifests/minimal_share_target.json
+++ b/components/concept/engine/src/test/resources/manifests/minimal_share_target.json
@@ -1,6 +1,7 @@
 {
   "name": "Minimal",
   "start_url": "/",
+  "scope": "/",
   "share_target": {
     "action": "/share-target",
     "params": {

--- a/components/concept/engine/src/test/resources/manifests/minimal_short_name.json
+++ b/components/concept/engine/src/test/resources/manifests/minimal_short_name.json
@@ -1,4 +1,5 @@
 {
   "short_name": "Minimal with Short Name",
-  "start_url": "/"
+  "start_url": "/",
+  "scope": "/"
 }

--- a/components/concept/engine/src/test/resources/manifests/squoosh.json
+++ b/components/concept/engine/src/test/resources/manifests/squoosh.json
@@ -2,6 +2,7 @@
   "name": "Squoosh",
   "short_name": "Squoosh",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "orientation": "any",
   "background_color": "#ffffff",

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/WebAppManifest.kt
@@ -74,7 +74,7 @@ fun WebAppManifest.toCustomTabConfig(): CustomTabConfig {
 fun WebAppManifest.getTrustedScope(): Uri? {
     return when (display) {
         WebAppManifest.DisplayMode.FULLSCREEN,
-        WebAppManifest.DisplayMode.STANDALONE -> (scope ?: startUrl).toUri()
+        WebAppManifest.DisplayMode.STANDALONE -> scope.toUri()
 
         WebAppManifest.DisplayMode.MINIMAL_UI,
         WebAppManifest.DisplayMode.BROWSER -> null

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt
@@ -17,8 +17,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
@@ -30,6 +30,13 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class ManifestStorageTest {
+
+    private val firefoxManifest = WebAppManifest(
+        name = "Firefox",
+        startUrl = "https://firefox.com",
+        scope = "/"
+    )
+
     @Test
     fun `load returns null if entry does not exist`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
@@ -42,7 +49,11 @@ class ManifestStorageTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
+        val manifest = WebAppManifest(
+            name = "Mozilla",
+            startUrl = "https://mozilla.org",
+            scope = "/"
+        )
         whenever(dao.getManifest("https://mozilla.org"))
             .thenReturn(ManifestEntity(manifest))
 
@@ -53,9 +64,8 @@ class ManifestStorageTest {
     fun `save saves the manifest as JSON`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
-        val manifest = WebAppManifest(name = "Firefox", startUrl = "https://firefox.com")
 
-        storage.saveManifest(manifest)
+        storage.saveManifest(firefoxManifest)
         verify(dao).insertManifest(any())
         Unit
     }
@@ -64,16 +74,15 @@ class ManifestStorageTest {
     fun `update replaces the manifest as JSON`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
-        val manifest = WebAppManifest(name = "Firefox", startUrl = "https://firefox.com")
         val existing = ManifestEntity(
-            manifest = manifest,
+            manifest = firefoxManifest,
             createdAt = 0,
             updatedAt = 0
         )
 
         `when`(dao.getManifest("https://firefox.com")).thenReturn(existing)
 
-        storage.updateManifest(manifest)
+        storage.updateManifest(firefoxManifest)
         verify(dao).updateManifest(any())
         Unit
     }
@@ -82,11 +91,10 @@ class ManifestStorageTest {
     fun `update does not replace non-existed manifest`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
-        val manifest = WebAppManifest(name = "Firefox", startUrl = "https://firefox.com")
 
         `when`(dao.getManifest("https://firefox.com")).thenReturn(null)
 
-        storage.updateManifest(manifest)
+        storage.updateManifest(firefoxManifest)
         verify(dao, never()).updateManifest(any())
         Unit
     }
@@ -122,7 +130,7 @@ class ManifestStorageTest {
     fun `updateManifestUsedAt updates usedAt to current timestamp`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
+        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org", scope = "/")
         val entity = ManifestEntity(manifest, usedAt = 0)
 
         val entityCaptor = ArgumentCaptor.forClass(ManifestEntity::class.java)

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppLauncherActivityTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppLauncherActivityTest.kt
@@ -22,16 +22,18 @@ import org.mockito.Mockito.verify
 @RunWith(AndroidJUnit4::class)
 class WebAppLauncherActivityTest {
 
+    private val baseManifest = WebAppManifest(
+        name = "Test",
+        startUrl = "https://www.mozilla.org",
+        scope = "https://www.mozilla.org/"
+    )
+
     @Test
     fun `DisplayMode-Browser launches browser`() {
         val activity = spy(WebAppLauncherActivity())
         doNothing().`when`(activity).launchBrowser(any())
 
-        val manifest = WebAppManifest(
-            name = "Test",
-            startUrl = "https://www.mozilla.org",
-            display = WebAppManifest.DisplayMode.BROWSER
-        )
+        val manifest = baseManifest.copy(display = WebAppManifest.DisplayMode.BROWSER)
 
         activity.routeManifest(manifest.startUrl.toUri(), manifest)
 
@@ -43,11 +45,7 @@ class WebAppLauncherActivityTest {
         val activity = spy(WebAppLauncherActivity())
         doNothing().`when`(activity).launchWebAppShell("https://www.mozilla.org".toUri())
 
-        val manifest = WebAppManifest(
-            name = "Test",
-            startUrl = "https://www.mozilla.org",
-            display = WebAppManifest.DisplayMode.MINIMAL_UI
-        )
+        val manifest = baseManifest.copy(display = WebAppManifest.DisplayMode.MINIMAL_UI)
 
         activity.routeManifest(manifest.startUrl.toUri(), manifest)
 
@@ -59,11 +57,7 @@ class WebAppLauncherActivityTest {
         val activity = spy(WebAppLauncherActivity())
         doNothing().`when`(activity).launchWebAppShell("https://www.mozilla.org".toUri())
 
-        val manifest = WebAppManifest(
-            name = "Test",
-            startUrl = "https://www.mozilla.org",
-            display = WebAppManifest.DisplayMode.FULLSCREEN
-        )
+        val manifest = baseManifest.copy(display = WebAppManifest.DisplayMode.FULLSCREEN)
 
         activity.routeManifest(manifest.startUrl.toUri(), manifest)
 
@@ -75,11 +69,7 @@ class WebAppLauncherActivityTest {
         val activity = spy(WebAppLauncherActivity())
         doNothing().`when`(activity).launchWebAppShell("https://www.mozilla.org".toUri())
 
-        val manifest = WebAppManifest(
-            name = "Test",
-            startUrl = "https://www.mozilla.org",
-            display = WebAppManifest.DisplayMode.STANDALONE
-        )
+        val manifest = baseManifest.copy(display = WebAppManifest.DisplayMode.STANDALONE)
 
         activity.routeManifest(manifest.startUrl.toUri(), manifest)
 
@@ -92,11 +82,7 @@ class WebAppLauncherActivityTest {
         doReturn("test").`when`(activity).packageName
         doNothing().`when`(activity).startActivity(any())
 
-        val manifest = WebAppManifest(
-            name = "Test",
-            startUrl = "https://www.mozilla.org",
-            display = WebAppManifest.DisplayMode.BROWSER
-        )
+        val manifest = baseManifest.copy(display = WebAppManifest.DisplayMode.BROWSER)
 
         activity.launchBrowser(manifest.startUrl.toUri())
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
@@ -76,6 +76,7 @@ class WebAppShortcutManagerTest {
         val manifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://example.com",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(WebAppManifest.Icon(
                 src = "https://example.com/icon.png",
@@ -102,6 +103,7 @@ class WebAppShortcutManagerTest {
         val manifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://example.com",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = emptyList() // no icons
         )
@@ -121,6 +123,7 @@ class WebAppShortcutManagerTest {
         val manifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://example.com",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(WebAppManifest.Icon(
                 src = "https://example.com/icon.png",
@@ -159,6 +162,7 @@ class WebAppShortcutManagerTest {
         session.webAppManifest = WebAppManifest(
             name = "Mozilla",
             shortName = "Moz",
+            scope = "/",
             startUrl = "https://mozilla.org"
         )
         val shortcut = manager.buildBasicShortcut(context, session)
@@ -171,7 +175,7 @@ class WebAppShortcutManagerTest {
         setSdkInt(Build.VERSION_CODES.O)
         val session = Session("https://mozilla.org")
         session.title = "Internet for people, not profit — Mozilla"
-        session.webAppManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
+        session.webAppManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org", scope = "/")
         val shortcut = manager.buildBasicShortcut(context, session)
 
         assertEquals("Mozilla", shortcut.shortLabel)
@@ -202,7 +206,7 @@ class WebAppShortcutManagerTest {
 
     @Test
     fun `updateShortcuts no-op`() = runBlockingTest {
-        val manifests = listOf(WebAppManifest(name = "Demo", startUrl = "https://example.com"))
+        val manifests = listOf(WebAppManifest(name = "Demo", startUrl = "https://example.com", scope = "/"))
         doReturn(null).`when`(manager).buildWebAppShortcut(context, manifests[0])
 
         manager.updateShortcuts(context, manifests)
@@ -217,7 +221,7 @@ class WebAppShortcutManagerTest {
     @Test
     fun `updateShortcuts updates list of existing shortcuts`() = runBlockingTest {
         setSdkInt(Build.VERSION_CODES.N_MR1)
-        val manifests = listOf(WebAppManifest(name = "Demo", startUrl = "https://example.com"))
+        val manifests = listOf(WebAppManifest(name = "Demo", startUrl = "https://example.com", scope = "/"))
         val shortcutCompat: ShortcutInfoCompat = mock()
         val shortcut: ShortcutInfo = mock()
         doReturn(shortcutCompat).`when`(manager).buildWebAppShortcut(context, manifests[0])
@@ -229,7 +233,7 @@ class WebAppShortcutManagerTest {
 
     @Test
     fun `buildWebAppShortcut builds shortcut and saves manifest`() = runBlockingTest {
-        val manifest = WebAppManifest(name = "Demo", startUrl = "https://example.com")
+        val manifest = WebAppManifest(name = "Demo", startUrl = "https://example.com", scope = "/")
         doReturn(mock<IconCompat>()).`when`(manager).buildIconFromManifest(manifest)
 
         val shortcut = manager.buildWebAppShortcut(context, manifest)!!
@@ -246,7 +250,7 @@ class WebAppShortcutManagerTest {
 
     @Test
     fun `buildWebAppShortcut builds shortcut with short name`() = runBlockingTest {
-        val manifest = WebAppManifest(name = "Demo Demo", shortName = "DD", startUrl = "https://example.com")
+        val manifest = WebAppManifest(name = "Demo Demo", shortName = "DD", startUrl = "https://example.com", scope = "/")
         doReturn(mock<IconCompat>()).`when`(manager).buildIconFromManifest(manifest)
 
         val shortcut = manager.buildWebAppShortcut(context, manifest)!!

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt
@@ -14,9 +14,9 @@ import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
@@ -43,6 +43,7 @@ class WebAppUseCasesTest {
         val manifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://example.com",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(WebAppManifest.Icon(
                     src = "https://example.com/icon.png",
@@ -70,6 +71,7 @@ class WebAppUseCasesTest {
         val manifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://example.com",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE,
             icons = listOf(WebAppManifest.Icon(
                 src = "https://example.com/icon.png",

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
@@ -13,16 +13,19 @@ import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.verify
 
 class ActivityKtTest {
+
+    private val baseManifest = WebAppManifest(
+        name = "Test Manifest",
+        startUrl = "/",
+        scope = "/"
+    )
+
     @Test
     fun `applyOrientation calls setRequestedOrientation for every value`() {
         WebAppManifest.Orientation.values().forEach { orientation ->
             val activity: Activity = mock()
             activity.applyOrientation(
-                WebAppManifest(
-                    name = "Test Manifest",
-                    startUrl = "/",
-                    orientation = orientation
-                )
+                baseManifest.copy(orientation = orientation)
             )
             verify(activity).requestedOrientation = anyInt()
         }
@@ -32,28 +35,19 @@ class ActivityKtTest {
     fun `applyOrientation applies common orientations`() {
         run {
             val activity: Activity = mock()
-            activity.applyOrientation(WebAppManifest(
-                name = "Test Manifest",
-                startUrl = "/",
-                orientation = WebAppManifest.Orientation.ANY))
+            activity.applyOrientation(baseManifest.copy(orientation = WebAppManifest.Orientation.ANY))
             verify(activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
         }
 
         run {
             val activity: Activity = mock()
-            activity.applyOrientation(WebAppManifest(
-                name = "Test Manifest",
-                startUrl = "/",
-                orientation = WebAppManifest.Orientation.PORTRAIT))
+            activity.applyOrientation(baseManifest.copy(orientation = WebAppManifest.Orientation.PORTRAIT))
             verify(activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
         }
 
         run {
             val activity: Activity = mock()
-            activity.applyOrientation(WebAppManifest(
-                name = "Test Manifest",
-                startUrl = "/",
-                orientation = WebAppManifest.Orientation.LANDSCAPE))
+            activity.applyOrientation(baseManifest.copy(orientation = WebAppManifest.Orientation.LANDSCAPE))
             verify(activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
         }
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/SessionKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/SessionKtTest.kt
@@ -17,6 +17,7 @@ class SessionKtTest {
     private val demoManifest = WebAppManifest(
         name = "Demo",
         startUrl = "https://mozilla.com",
+        scope = "/",
         display = WebAppManifest.DisplayMode.STANDALONE
     )
     private val demoIcon = WebAppManifest.Icon(src = "https://mozilla.com/example.png")

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/WebAppManifestKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/WebAppManifestKtTest.kt
@@ -20,14 +20,15 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class WebAppManifestKtTest {
 
-    private val demoManifest = WebAppManifest(name = "Demo", startUrl = "https://mozilla.com")
+    private val demoManifest = WebAppManifest(name = "Demo", startUrl = "https://mozilla.com", scope = "/")
     private val demoIcon = WebAppManifest.Icon(src = "https://mozilla.com/example.png")
 
     @Test
     fun `should use name as label`() {
         val taskDescription = WebAppManifest(
             name = "Demo",
-            startUrl = "https://example.com"
+            startUrl = "https://example.com",
+            scope = "/"
         ).toTaskDescription(null)
         assertEquals("Demo", taskDescription.label)
         assertNull(taskDescription.icon)
@@ -39,6 +40,7 @@ class WebAppManifestKtTest {
         val taskDescription = WebAppManifest(
             name = "My App",
             startUrl = "https://example.com",
+            scope = "/",
             themeColor = rgb(255, 0, 255)
         ).toTaskDescription(null)
         assertEquals("My App", taskDescription.label)
@@ -51,6 +53,7 @@ class WebAppManifestKtTest {
         val config = WebAppManifest(
             name = "My App",
             startUrl = "https://example.com",
+            scope = "/",
             themeColor = rgb(255, 0, 255),
             backgroundColor = rgb(230, 230, 230)
         ).toCustomTabConfig()
@@ -72,13 +75,6 @@ class WebAppManifestKtTest {
             display = WebAppManifest.DisplayMode.STANDALONE
         ).getTrustedScope()
         assertEquals("https://example.com/".toUri(), scope)
-
-        val fallbackToStartUrl = WebAppManifest(
-            name = "My App",
-            startUrl = "https://example.com/pwa",
-            display = WebAppManifest.DisplayMode.STANDALONE
-        ).getTrustedScope()
-        assertEquals("https://example.com/pwa".toUri(), fallbackToStartUrl)
     }
 
     @Test
@@ -94,6 +90,7 @@ class WebAppManifestKtTest {
         val fallbackToStartUrl = WebAppManifest(
             name = "My App",
             startUrl = "https://example.com/pwa",
+            scope = "https://example.com/",
             display = WebAppManifest.DisplayMode.MINIMAL_UI
         ).getTrustedScope()
         assertNull(fallbackToStartUrl)

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/ManifestUpdateFeatureTest.kt
@@ -34,6 +34,11 @@ class ManifestUpdateFeatureTest {
     @Mock private lateinit var shortcutManager: WebAppShortcutManager
     @Mock private lateinit var storage: ManifestStorage
     private val sessionId = "external-app-session-id"
+    private val baseManifest = WebAppManifest(
+        name = "Mozilla",
+        startUrl = "https://mozilla.org",
+        scope = "https://mozilla.org/"
+    )
 
     @Before
     fun setup() {
@@ -43,8 +48,7 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `start and stop controls session observer`() {
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, manifest)
+        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest)
 
         feature.start()
         verify(session).register(feature)
@@ -55,9 +59,8 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `start and stop handle null session`() {
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
         `when`(sessionManager.findSessionById(sessionId)).thenReturn(null)
-        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, manifest)
+        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest)
 
         feature.start()
         verify(session, never()).register(feature)
@@ -68,12 +71,11 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `updateStoredManifest is called when the manifest changes`() = runBlockingTest {
-        val initialManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, initialManifest))
+        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest))
         doReturn(Unit).`when`(feature).updateStoredManifest(any())
         feature.start()
 
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org", shortName = "Moz")
+        val manifest = baseManifest.copy(shortName = "Moz")
         feature.onWebAppManifestChanged(session, manifest)
 
         verify(feature).updateStoredManifest(manifest)
@@ -81,19 +83,17 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `updateStoredManifest is not called when the manifest is the same`() = runBlockingTest {
-        val initialManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, initialManifest))
+        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest))
         feature.start()
 
-        feature.onWebAppManifestChanged(session, initialManifest)
+        feature.onWebAppManifestChanged(session, baseManifest)
 
-        verify(feature, never()).updateStoredManifest(initialManifest)
+        verify(feature, never()).updateStoredManifest(baseManifest)
     }
 
     @Test
     fun `updateStoredManifest is not called when the manifest is null`() = runBlockingTest {
-        val initialManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, initialManifest))
+        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest))
         feature.start()
 
         feature.onWebAppManifestChanged(session, null)
@@ -103,11 +103,10 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `updateStoredManifest is not called when the manifest has a different start URL`() = runBlockingTest {
-        val initialManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, initialManifest))
+        val feature = spy(ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest))
         feature.start()
 
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://netscape.com")
+        val manifest = baseManifest.copy(startUrl = "https://netscape.com", scope = "https://netscape.com")
         feature.onWebAppManifestChanged(session, manifest)
 
         verify(feature, never()).updateStoredManifest(manifest)
@@ -115,10 +114,9 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `updateStoredManifest updates storage and shortcut`() = runBlockingTest {
-        val initialManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, initialManifest)
+        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest)
 
-        val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org", shortName = "Moz")
+        val manifest = baseManifest.copy(shortName = "Moz")
         feature.updateStoredManifest(manifest)
 
         verify(storage).updateManifest(manifest)
@@ -127,11 +125,10 @@ class ManifestUpdateFeatureTest {
 
     @Test
     fun `start updates last web app usage`() = runBlockingTest {
-        val initialManifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org", scope = "https://mozilla.org")
-        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, initialManifest)
+        val feature = ManifestUpdateFeature(testContext, sessionManager, shortcutManager, storage, sessionId, baseManifest)
 
         feature.start()
 
-        verify(storage).updateManifestUsedAt(initialManifest)
+        verify(storage).updateManifestUsedAt(baseManifest)
     }
 }

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppActivityFeatureTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/feature/WebAppActivityFeatureTest.kt
@@ -47,6 +47,7 @@ class WebAppActivityFeatureTest {
         val basicManifest = WebAppManifest(
             name = "Demo",
             startUrl = "https://mozilla.com",
+            scope = "/",
             display = WebAppManifest.DisplayMode.STANDALONE
         )
         WebAppActivityFeature(activity, icons, basicManifest).onResume()
@@ -64,6 +65,7 @@ class WebAppActivityFeatureTest {
         val manifest = WebAppManifest(
             name = "Test Manifest",
             startUrl = "/",
+            scope = "/",
             orientation = WebAppManifest.Orientation.LANDSCAPE
         )
 
@@ -77,7 +79,8 @@ class WebAppActivityFeatureTest {
     fun `sets task description`() {
         val manifest = WebAppManifest(
             name = "Test Manifest",
-            startUrl = "/"
+            startUrl = "/",
+            scope = "/"
         )
         val icon = Icon(mock(), source = Icon.Source.GENERATOR)
         `when`(icons.loadIcon(any())).thenReturn(CompletableDeferred(icon))

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
@@ -65,7 +65,8 @@ class WebAppIntentProcessorTest {
 
         val manifest = WebAppManifest(
             name = "Test Manifest",
-            startUrl = "https://mozilla.com"
+            startUrl = "https://mozilla.com",
+            scope = "https://mozilla.com/"
         )
         `when`(storage.loadManifest("https://mozilla.com")).thenReturn(manifest)
 
@@ -85,7 +86,8 @@ class WebAppIntentProcessorTest {
 
         val manifest = WebAppManifest(
             name = "Test Manifest",
-            startUrl = "https://mozilla.com"
+            startUrl = "https://mozilla.com",
+            scope = "https://mozilla.com/"
         )
         `when`(storage.loadManifest("https://mozilla.com")).thenReturn(manifest)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ permalink: /changelog/
   * Added ability load all manifests that apply to a certain url.
   * Added ability to track if an PWA is actively used.
 
+* **concept-engine**
+  * ⚠️ **This is a breaking change**: `WebAppManifest.scope` is now not nullable.
+
 # 28.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v27.0.0...v28.0.0)
@@ -108,7 +111,7 @@ permalink: /changelog/
   * `PromptFeature` now accepts a false by default `isSaveLoginEnabled` lambda to be invoked before showing prompts. If true, users
     will be prompted to save their information after logging in to a website.
   * Prompts will now be closed automatically when pages have mostly loaded
-  
+
 * **service-sync-logins**
   * Added `GeckoLoginStorageDelegate`. This can be attached to a GeckoEngine, where it will be used
   to save user login credentials.


### PR DESCRIPTION
Gecko always provides us with a scope, so it doesn't need to be nullable. I've set it to default to start URL for tests, which is close to what the spec specifies.

Additionally added comments about what changes Gecko performs.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
