### PR TITLE
Refactor to decouple WebExtensions from the engine architecture

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -31,6 +31,7 @@ import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
@@ -59,7 +60,7 @@ class GeckoEngine(
     executorProvider: () -> GeckoWebExecutor = { GeckoWebExecutor(runtime) },
     override val trackingProtectionExceptionStore: TrackingProtectionExceptionStorage =
         TrackingProtectionExceptionFileStorage(context, runtime)
-) : Engine {
+) : Engine, WebExtensionRuntime {
     private val executor by lazy { executorProvider.invoke() }
     private val localeUpdater = LocaleSettingUpdater(context, runtime)
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -26,11 +26,12 @@ import mozilla.components.concept.engine.content.blocking.TrackingProtectionExce
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.utils.EngineVersion
-import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.Action
+import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
@@ -59,7 +60,7 @@ class GeckoEngine(
     executorProvider: () -> GeckoWebExecutor = { GeckoWebExecutor(runtime) },
     override val trackingProtectionExceptionStore: TrackingProtectionExceptionStorage =
         TrackingProtectionExceptionFileStorage(context, runtime)
-) : Engine {
+) : Engine, WebExtensionRuntime {
     private val executor by lazy { executorProvider.invoke() }
     private val localeUpdater = LocaleSettingUpdater(context, runtime)
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -30,6 +30,7 @@ import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
@@ -58,7 +59,7 @@ class GeckoEngine(
     executorProvider: () -> GeckoWebExecutor = { GeckoWebExecutor(runtime) },
     override val trackingProtectionExceptionStore: TrackingProtectionExceptionStorage =
         TrackingProtectionExceptionFileStorage(context, runtime)
-) : Engine {
+) : Engine, WebExtensionRuntime {
     private val executor by lazy { executorProvider.invoke() }
     private val localeUpdater = LocaleSettingUpdater(context, runtime)
     private var webExtensionDelegate: WebExtensionDelegate? = null

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -10,9 +10,7 @@ import androidx.annotation.MainThread
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.utils.EngineVersion
-import mozilla.components.concept.engine.webextension.EnableSource
-import mozilla.components.concept.engine.webextension.WebExtension
-import mozilla.components.concept.engine.webextension.WebExtensionDelegate
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
@@ -23,7 +21,7 @@ import java.lang.UnsupportedOperationException
  * Entry point for interacting with the engine implementation.
  */
 @Suppress("TooManyFunctions")
-interface Engine {
+interface Engine : WebExtensionRuntime {
 
     /**
      * Describes a combination of browsing data types stored by the engine.
@@ -112,128 +110,6 @@ interface Engine {
      * Not all [Engine] implementations may actually implement this.
      */
     fun speculativeConnect(url: String)
-
-    /**
-     * Installs the provided extension in this engine.
-     *
-     * @param id the unique ID of the extension.
-     * @param url the url pointing to either a resources path for locating the extension
-     * within the APK file (e.g. resource://android/assets/extensions/my_web_ext) or to a
-     * local (e.g. resource://android/assets/extensions/my_web_ext.xpi) or remote
-     * (e.g. https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi) XPI file.
-     * @param allowContentMessaging whether or not the web extension is allowed
-     * to send messages from content scripts, defaults to true.
-     * @param supportActions whether or not browser and page actions are handled when
-     * received from the web extension, defaults to false.
-     * @param onSuccess (optional) callback invoked if the extension was installed successfully,
-     * providing access to the [WebExtension] object for bi-directional messaging.
-     * @param onError (optional) callback invoked if there was an error installing the extension.
-     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
-     * have web extension support.
-     */
-    @Suppress("LongParameterList")
-    fun installWebExtension(
-        id: String,
-        url: String,
-        allowContentMessaging: Boolean = true,
-        supportActions: Boolean = false,
-        onSuccess: ((WebExtension) -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
-
-    /**
-     * Updates the provided [extension] if a new version is available.
-     *
-     * @param extension the extension to be updated.
-     * @param onSuccess (optional) callback invoked if the extension was updated successfully,
-     * providing access to the [WebExtension] object for bi-directional messaging, if null is provided
-     * that means that the [WebExtension] hasn't been change since the last update.
-     * @param onError (optional) callback invoked if there was an error updating the extension.
-     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
-     * have web extension support.
-     */
-    fun updateWebExtension(
-        extension: WebExtension,
-        onSuccess: ((WebExtension?) -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): Unit = onError(
-        extension.id,
-        UnsupportedOperationException("Web extension support is not available in this engine")
-    )
-
-    /**
-     * Uninstalls the provided extension from this engine.
-     *
-     * @param ext the [WebExtension] to uninstall.
-     * @param onSuccess (optional) callback invoked if the extension was uninstalled successfully.
-     * @param onError (optional) callback invoked if there was an error uninstalling the extension.
-     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
-     * have web extension support.
-     */
-    fun uninstallWebExtension(
-        ext: WebExtension,
-        onSuccess: (() -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): Unit = onError(ext.id, UnsupportedOperationException("Web extension support is not available in this engine"))
-
-    /**
-     * Lists the currently installed web extensions in this engine.
-     *
-     * @param onSuccess callback invoked with the list of of installed [WebExtension]s.
-     * @param onError (optional) callback invoked if there was an error querying
-     * the installed extensions. This callback is invoked with an [UnsupportedOperationException]
-     * in case the engine doesn't have web extension support.
-     */
-    fun listInstalledWebExtensions(
-        onSuccess: ((List<WebExtension>) -> Unit),
-        onError: ((Throwable) -> Unit) = { }
-    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
-
-    /**
-     * Enables the provided [WebExtension]. If the extension is already enabled the [onSuccess]
-     * callback will be invoked, but this method has no effect on the extension.
-     *
-     * @param extension the extension to enable.
-     * @param source [EnableSource] to indicate why the extension is enabled.
-     * @param onSuccess (optional) callback invoked with the enabled [WebExtension]
-     * @param onError (optional) callback invoked if there was an error enabling
-     * the extensions. This callback is invoked with an [UnsupportedOperationException]
-     * in case the engine doesn't have web extension support.
-     */
-    fun enableWebExtension(
-        extension: WebExtension,
-        source: EnableSource = EnableSource.USER,
-        onSuccess: ((WebExtension) -> Unit) = { },
-        onError: ((Throwable) -> Unit) = { }
-    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
-
-    /**
-     * Disables the provided [WebExtension]. If the extension is already disabled the [onSuccess]
-     * callback will be invoked, but this method has no effect on the extension.
-     *
-     * @param extension the extension to disable.
-     * @param source [EnableSource] to indicate why the extension is disabled.
-     * @param onSuccess (optional) callback invoked with the enabled [WebExtension]
-     * @param onError (optional) callback invoked if there was an error disabling
-     * the installed extensions. This callback is invoked with an [UnsupportedOperationException]
-     * in case the engine doesn't have web extension support.
-     */
-    fun disableWebExtension(
-        extension: WebExtension,
-        source: EnableSource = EnableSource.USER,
-        onSuccess: ((WebExtension) -> Unit),
-        onError: ((Throwable) -> Unit) = { }
-    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
-
-    /**
-     * Registers a [WebExtensionDelegate] to be notified of engine events
-     * related to web extensions
-     *
-     * @param webExtensionDelegate callback to be invoked for web extension events.
-     */
-    fun registerWebExtensionDelegate(
-        webExtensionDelegate: WebExtensionDelegate
-    ): Unit = throw UnsupportedOperationException("Web extension support is not available in this engine")
 
     /**
      * Registers a [WebNotificationDelegate] to be notified of engine events

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.webextension
+
+import java.lang.UnsupportedOperationException
+
+/**
+ * Entry point for interacting with the web extensions.
+ */
+interface WebExtensionRuntime {
+
+    /**
+     * Installs the provided extension in this engine.
+     *
+     * @param id the unique ID of the extension.
+     * @param url the url pointing to either a resources path for locating the extension
+     * within the APK file (e.g. resource://android/assets/extensions/my_web_ext) or to a
+     * local (e.g. resource://android/assets/extensions/my_web_ext.xpi) or remote
+     * (e.g. https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi) XPI file.
+     * @param allowContentMessaging whether or not the web extension is allowed
+     * to send messages from content scripts, defaults to true.
+     * @param supportActions whether or not browser and page actions are handled when
+     * received from the web extension, defaults to false.
+     * @param onSuccess (optional) callback invoked if the extension was installed successfully,
+     * providing access to the [WebExtension] object for bi-directional messaging.
+     * @param onError (optional) callback invoked if there was an error installing the extension.
+     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
+     * have web extension support.
+     */
+    @Suppress("LongParameterList")
+    fun installWebExtension(
+        id: String,
+        url: String,
+        allowContentMessaging: Boolean = true,
+        supportActions: Boolean = false,
+        onSuccess: ((WebExtension) -> Unit) = { },
+        onError: ((String, Throwable) -> Unit) = { _, _ -> }
+    ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
+     * Updates the provided [extension] if a new version is available.
+     *
+     * @param extension the extension to be updated.
+     * @param onSuccess (optional) callback invoked if the extension was updated successfully,
+     * providing access to the [WebExtension] object for bi-directional messaging, if null is provided
+     * that means that the [WebExtension] hasn't been change since the last update.
+     * @param onError (optional) callback invoked if there was an error updating the extension.
+     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
+     * have web extension support.
+     */
+    fun updateWebExtension(
+        extension: WebExtension,
+        onSuccess: ((WebExtension?) -> Unit) = { },
+        onError: ((String, Throwable) -> Unit) = { _, _ -> }
+    ): Unit = onError(
+        extension.id,
+        UnsupportedOperationException("Web extension support is not available in this engine")
+    )
+
+    /**
+     * Uninstalls the provided extension from this engine.
+     *
+     * @param ext the [WebExtension] to uninstall.
+     * @param onSuccess (optional) callback invoked if the extension was uninstalled successfully.
+     * @param onError (optional) callback invoked if there was an error uninstalling the extension.
+     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
+     * have web extension support.
+     */
+    fun uninstallWebExtension(
+        ext: WebExtension,
+        onSuccess: (() -> Unit) = { },
+        onError: ((String, Throwable) -> Unit) = { _, _ -> }
+    ): Unit = onError(ext.id, UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
+     * Lists the currently installed web extensions in this engine.
+     *
+     * @param onSuccess callback invoked with the list of of installed [WebExtension]s.
+     * @param onError (optional) callback invoked if there was an error querying
+     * the installed extensions. This callback is invoked with an [UnsupportedOperationException]
+     * in case the engine doesn't have web extension support.
+     */
+    fun listInstalledWebExtensions(
+        onSuccess: ((List<WebExtension>) -> Unit),
+        onError: ((Throwable) -> Unit) = { }
+    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
+     * Enables the provided [WebExtension]. If the extension is already enabled the [onSuccess]
+     * callback will be invoked, but this method has no effect on the extension.
+     *
+     * @param extension the extension to enable.
+     * @param source [EnableSource] to indicate why the extension is enabled.
+     * @param onSuccess (optional) callback invoked with the enabled [WebExtension]
+     * @param onError (optional) callback invoked if there was an error enabling
+     * the extensions. This callback is invoked with an [UnsupportedOperationException]
+     * in case the engine doesn't have web extension support.
+     */
+    fun enableWebExtension(
+        extension: WebExtension,
+        source: EnableSource = EnableSource.USER,
+        onSuccess: ((WebExtension) -> Unit) = { },
+        onError: ((Throwable) -> Unit) = { }
+    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
+     * Disables the provided [WebExtension]. If the extension is already disabled the [onSuccess]
+     * callback will be invoked, but this method has no effect on the extension.
+     *
+     * @param extension the extension to disable.
+     * @param source [EnableSource] to indicate why the extension is disabled.
+     * @param onSuccess (optional) callback invoked with the enabled [WebExtension]
+     * @param onError (optional) callback invoked if there was an error disabling
+     * the installed extensions. This callback is invoked with an [UnsupportedOperationException]
+     * in case the engine doesn't have web extension support.
+     */
+    fun disableWebExtension(
+        extension: WebExtension,
+        source: EnableSource = EnableSource.USER,
+        onSuccess: ((WebExtension) -> Unit),
+        onError: ((Throwable) -> Unit) = { }
+    ): Unit = onError(UnsupportedOperationException("Web extension support is not available in this engine"))
+
+    /**
+     * Registers a [WebExtensionDelegate] to be notified of engine events
+     * related to web extensions
+     *
+     * @param webExtensionDelegate callback to be invoked for web extension events.
+     */
+    fun registerWebExtensionDelegate(
+        webExtensionDelegate: WebExtensionDelegate
+    ): Unit = throw UnsupportedOperationException("Web extension support is not available in this engine")
+}

--- a/components/feature/webcompat/src/main/java/mozilla/components/feature/webcompat/WebCompatFeature.kt
+++ b/components/feature/webcompat/src/main/java/mozilla/components/feature/webcompat/WebCompatFeature.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.webcompat
 
-import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.support.base.log.logger.Logger
 
 /**
@@ -16,8 +16,11 @@ object WebCompatFeature {
     internal const val WEBCOMPAT_EXTENSION_ID = "webcompat@mozilla.com"
     internal const val WEBCOMPAT_EXTENSION_URL = "resource://android/assets/extensions/webcompat/"
 
-    fun install(engine: Engine) {
-        engine.installWebExtension(WEBCOMPAT_EXTENSION_ID, WEBCOMPAT_EXTENSION_URL,
+    /**
+     * Installs the web extension in the runtime through the WebExtensionRuntime install method
+     */
+    fun install(runtime: WebExtensionRuntime) {
+        runtime.installWebExtension(WEBCOMPAT_EXTENSION_ID, WEBCOMPAT_EXTENSION_URL,
             onSuccess = {
                 logger.debug("Installed WebCompat webextension: ${it.id}")
             },

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
@@ -5,10 +5,10 @@
 package mozilla.components.support.webextensions
 
 import androidx.annotation.VisibleForTesting
-import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.MessageHandler
 import mozilla.components.concept.engine.webextension.WebExtension
+import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.support.base.log.logger.Logger
 import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
@@ -29,16 +29,16 @@ class WebExtensionController(
     private var registerBackgroundMessageHandler: (WebExtension) -> Unit? = { }
 
     /**
-     * Makes sure the web extension is installed in the provided engine. If a
+     * Makes sure the web extension is installed in the provided runtime. If a
      * content message handler was registered (see
      * [registerContentMessageHandler]) before install completed, registration
      * will happen upon successful installation.
      *
-     * @param engine the [Engine] the web extension should be installed in.
+     * @param runtime the [WebExtensionRuntime] the web extension should be installed in.
      */
-    fun install(engine: Engine) {
+    fun install(runtime: WebExtensionRuntime) {
         if (!installedExtensions.containsKey(extensionId)) {
-            engine.installWebExtension(extensionId, extensionUrl,
+            runtime.installWebExtension(extensionId, extensionUrl,
                 onSuccess = {
                     logger.debug("Installed extension: ${it.id}")
                     synchronized(this@WebExtensionController) {

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -452,7 +452,7 @@ class WebExtensionSupportTest {
 
         val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
         WebExtensionSupport.initialize(
-            engine = engine,
+            runtime = engine,
             store = store,
             onUpdatePermissionRequest = { _, _, _, _ ->
                 executed = true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ permalink: /changelog/
 * [Dependencies](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Dependencies.kt)
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
+* **WebExtensions refactor**
+  * The Web Extensions related methods have been refactored from `Engine` into a new `WebExtensionRuntime` interface.
+  * The `Engine` interface now implements the `WebExtensionRuntime` interface.
+  * `WebCompatFeature` has been updated to receive a `WebExtensionRuntime` instead of a `Engine` as `install` method parameter.
 
 # 30.0.0
 


### PR DESCRIPTION
Closes #5735 Closes #5736 Closes #5737

The purpose of this task is to expose the `WebExtensions` features in a a more `concept-engine` architecture agnostic way. 

The Web Extensions implementation is coupled to the concept-engine/browser-session architecture. Some projects would prefer to have their own engine/session implementation but still be able to use modules from AC like the Web Extensions features. This is the case for Firefox Reality where we need a very specific engine/session implementation.

WebExtensions shouldn't require much from Engine/Session as at the moment. They just use the runtime and the session from the inner engine implementations and in some cases might require session life cycle related callbacks to register handlers. We sould be able to refactor all the WebExtension realated code out of `Engine` and `EngineSession` and ideally also remove from the WebExtensions any dependency from session life cycle related classes like `SelectionAwareSessionObserver` or `LifecycleAwareFeature`.

I've made a basic refactor proposal based on the reported issues. You can take look at it in this PR.
- Added a new `WebExtensionEngine` interface that provides all the WebExtensions required functionality: `installWebExtension`, `updateWebExtension`, etc. to limit the required code to add support for AC Web Extensions.
- Add a new `WebExtensionEngineSession` interface that provides access to the inner browser session as that's the one thing that Web Extensions require at the moment.
- Make `Engine` and `EngineSession` implement `WebExtensionEngine` and `WebExtensionEngineSession`.
- Updated `FxaWebChannelFeature` so `SessionManager` is an optional parameter and decouple it's implementation from it so they life cycle callbacks can be handled independently.
- Updating the AC codebase to follow the new pattern.

Things not yet covered by this proposal:
- [ ] Completely decouple the extensions from `SessionManager` and `SelectionAwareSessionObserver`.
- [ ] Follow the same pattern for other Web Extension features like `ReaderViewFeature`.
- [ ] Update tests and fix CI issues
- [ ] Refactor all the WebExtensions related code from `concept-engine` into support-webextensions?
- [ ] Probably a bunch of things that I've missed

If this look like a good initial step, I can keep on working on it. Otherwise you can close it and and we can discuss the opened issues to see what would be the right way to go to make AC Web Extensions to work for any GV based project.

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
