### PR TITLE
Closes #5463: Notify GV web ext. controller when active session changes

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -314,6 +314,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.markActiveForWebExtensions].
+     */
+    override fun markActiveForWebExtensions(active: Boolean) {
+        runtime.webExtensionController.setTabActive(geckoSession, active)
+    }
+
+    /**
      * See [EngineSession.close].
      */
     override fun close() {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
@@ -287,9 +287,14 @@ class LegacySessionManager(
             this.getEngineSession(it)
         }
         engineSessionLinker.link(session, engineSession, parent)
+
+        if (session == selectedSession) {
+            engineSession.markActiveForWebExtensions(true)
+        }
     }
 
     private fun unlink(session: Session) {
+        getEngineSession(session)?.markActiveForWebExtensions(false)
         engineSessionLinker.unlink(session)
     }
 
@@ -324,6 +329,7 @@ class LegacySessionManager(
         notifyObservers { onSessionRemoved(session) }
 
         if (selectedBeforeRemove != selectedSession && selectedIndex != NO_SELECTION) {
+            getEngineSession(selectedSessionOrThrow)?.markActiveForWebExtensions(true)
             notifyObservers { onSessionSelected(selectedSessionOrThrow) }
         }
     }
@@ -491,8 +497,13 @@ class LegacySessionManager(
             "Value to select is not in list"
         }
 
+        selectedSession?.let {
+            getEngineSession(it)?.markActiveForWebExtensions(false)
+        }
+
         selectedIndex = index
 
+        getEngineSession(session)?.markActiveForWebExtensions(true)
         notifyObservers { onSessionSelected(session) }
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/utils/AllSessionsObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/utils/AllSessionsObserverTest.kt
@@ -20,8 +20,10 @@ class AllSessionsObserverTest {
     fun `Observer will be registered on all already existing Sessions`() {
         val session1: Session = mock()
         `when`(session1.id).thenReturn("1")
+        `when`(session1.engineSessionHolder).thenReturn(mock())
         val session2: Session = mock()
         `when`(session2.id).thenReturn("2")
+        `when`(session2.engineSessionHolder).thenReturn(mock())
 
         val sessionManager = SessionManager(engine = mock()).apply {
             add(session1)
@@ -48,8 +50,10 @@ class AllSessionsObserverTest {
 
         val session1: Session = mock()
         `when`(session1.id).thenReturn("1")
+        `when`(session1.engineSessionHolder).thenReturn(mock())
         val session2: Session = mock()
         `when`(session2.id).thenReturn("2")
+        `when`(session2.engineSessionHolder).thenReturn(mock())
 
         sessionManager.add(session1)
         sessionManager.add(session2)
@@ -61,7 +65,9 @@ class AllSessionsObserverTest {
     @Test
     fun `Observer will be unregistered if Session gets removed`() {
         val session1: Session = spy(Session("https://www.mozilla.org"))
+        `when`(session1.engineSessionHolder).thenReturn(mock())
         val session2: Session = mock()
+        `when`(session2.engineSessionHolder).thenReturn(mock())
 
         val sessionManager = SessionManager(engine = mock()).apply {
             add(session1)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -523,6 +523,14 @@ abstract class EngineSession(
     abstract fun recoverFromCrash(): Boolean
 
     /**
+     * Marks this session active/inactive for web extensions to support
+     * tabs.query({active: true}).
+     *
+     * @param active whether this session should be marked as active or inactive.
+     */
+    open fun markActiveForWebExtensions(active: Boolean) = Unit
+
+    /**
      * Close the session. This may free underlying objects. Call this when you are finished using
      * this session.
      */


### PR DESCRIPTION
With this the uBlock UI is functional in popups.

I think we ultimately should
- Remove support for opening action popups in regular tabs
- Implement this as a side-effect in a middleware when the engine session is linked

@pocmo as discussed, adding this to the session manager, can you take a look as well?

