### PR TITLE
For mozilla-mobile/fenix#5881 - Avoid tippy top pwa icons

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -25,7 +25,6 @@ import mozilla.components.browser.icons.loader.DataUriIconLoader
 import mozilla.components.browser.icons.loader.HttpIconLoader
 import mozilla.components.browser.icons.loader.MemoryIconLoader
 import mozilla.components.browser.icons.preparer.MemoryIconPreparer
-import mozilla.components.browser.icons.preparer.TippyTopIconPreparer
 import mozilla.components.browser.icons.processor.AdaptiveIconProcessor
 import mozilla.components.browser.icons.processor.ColorProcessor
 import mozilla.components.browser.icons.processor.MemoryIconProcessor
@@ -35,8 +34,8 @@ import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.pwa.WebAppLauncherActivity.Companion.ACTION_PWA_LAUNCHER
-import mozilla.components.feature.pwa.ext.installableManifest
 import mozilla.components.feature.pwa.ext.hasLargeIcons
+import mozilla.components.feature.pwa.ext.installableManifest
 
 private val pwaIconMemoryCache = IconMemoryCache()
 
@@ -244,7 +243,6 @@ private fun webAppIcons(
     httpClient = httpClient,
     generator = DefaultIconGenerator(cornerRadiusDimen = null),
     preparers = listOf(
-        TippyTopIconPreparer(context.assets),
         MemoryIconPreparer(pwaIconMemoryCache)
     ),
     loaders = listOf(


### PR DESCRIPTION
The tippy top icons aren't suitable as PWA launcher icons, and override the icons provided in the manifest. As PWAs use a separate icon processor, lets just remove TippyTop there.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
