### PR TITLE
Fix for #5605 - Set content intent for the migration notifications

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
@@ -6,6 +6,7 @@ package mozilla.components.support.migration
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -21,8 +22,8 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.migration.state.MigrationAction
 import mozilla.components.support.migration.state.MigrationStore
 
-private const val NOTIFICATION_TAG = "mozac.support.migration.notification"
 private const val NOTIFICATION_CHANNEL_ID = "mozac.support.migration.generic"
+private const val NOTIFICATION_TAG = "mozac.support.migration.notification"
 
 private const val TEMPORARY_NOTIFICATION_CHANNEL_NAME = "Migration"
 
@@ -35,6 +36,7 @@ private const val TEMPORARY_NOTIFICATION_CHANNEL_NAME = "Migration"
 abstract class AbstractMigrationService : Service() {
     protected abstract val migrator: FennecMigrator
     protected abstract val store: MigrationStore
+    protected abstract val migrationActivity: Class<out AbstractMigrationProgressActivity>
 
     private val logger = Logger("MigrationService")
     private val scope = MainScope()
@@ -111,6 +113,8 @@ abstract class AbstractMigrationService : Service() {
                 .setSmallIcon(R.drawable.mozac_support_migration_notification_icon)
                 .setContentTitle(getString(titleRes))
                 .setContentText(getString(contentRes))
+                .setContentIntent(PendingIntent.getActivity(this, 0,
+                        Intent(this, migrationActivity), 0))
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setCategory(NotificationCompat.CATEGORY_PROGRESS)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
@@ -550,7 +550,6 @@ class FennecMigrator private constructor(
         runBlocking {
             store.dispatch(MigrationAction.Started).join()
         }
-
         ContextCompat.startForegroundService(context, Intent(context, service))
     }
 


### PR DESCRIPTION
When the user taps on the migration notifications they do nothing because they do not have any content intent set. 
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks
- [x] **Tests**: This PR doesn't include tests as it contains changes for component not yet tested.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.