### PR TITLE
Closes #5783: Deadlock when dispatching actions during lifecycle change

### DIFF
--- a/components/lib/state/src/main/java/mozilla/components/lib/state/Store.kt
+++ b/components/lib/state/src/main/java/mozilla/components/lib/state/Store.kt
@@ -56,13 +56,12 @@ open class Store<S : State, A : Action>(
         scope.cancel()
     }
     private val dispatcherWithExceptionHandler = dispatcher + exceptionHandler
-    private var currentState = initialState
+    @Volatile private var currentState = initialState
 
     /**
      * The current [State].
      */
     val state: S
-        @Synchronized
         get() = currentState
 
     /**
@@ -151,6 +150,11 @@ open class Store<S : State, A : Action>(
             active = false
         }
 
+        /**
+         * Notifies this subscription's observer of a state change.
+         *
+         * @param state the updated state.
+         */
         @Synchronized
         internal fun dispatch(state: S) {
             if (active) {


### PR DESCRIPTION
The fix here is to make sure we can `resume` without a lock on the store. In general, reading the state on the store shouldn't need to be synchronized with actions being processed/dispatched. Reading the last written state is perfectly fine for other components in the system i.e. reading should not block on pending actions being processed.

@pocmo Can you take a look, fix is as discussed :).