### PR TITLE
Bug 1608153 - .taskcluster.yml: Do not trigger a new build when a Git…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -92,11 +92,16 @@ tasks:
                   then: ${event.action}
                   else: 'UNDEFINED'
 
+              releaseAction:
+                  $if: 'tasks_for == "github-release"'
+                  then: ${event.action}
+                  else: 'UNDEFINED'
           in:
               $if: >
-                tasks_for in ["github-release", "action", "cron"]
-                || tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "edited", "synchronize"]
-                || tasks_for == "github-push" && head_branch[:10] != "refs/tags/" && head_branch != "staging.tmp" && head_branch != "trying.tmp"
+                tasks_for in ["action", "cron"]
+                || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "edited", "synchronize"])
+                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/" && head_branch != "staging.tmp" && head_branch != "trying.tmp")
+                || (tasks_for == "github-release" && releaseAction == "published")
               then:
                   $let:
                       level:


### PR DESCRIPTION
…Hub release is edited

This makes `.taskcluster.yml` similar to what we have on Fenix: https://github.com/mozilla-mobile/fenix/blob/eb2eed1c9c027884ddfa2e8b7eb2d25aea5e8239/.taskcluster.yml#L104

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
