### PR TITLE
Consume popup session after rendering in WebExtensionActionPopupFragment

### DIFF
--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/WebExtensionActionPopupActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/WebExtensionActionPopupActivity.kt
@@ -48,13 +48,6 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
             else -> super.onCreateView(parent, name, context, attrs)
         }
 
-    override fun onBackPressed() {
-        components.store.dispatch(
-            WebExtensionAction.UpdatePopupSessionAction(webExtensionId, popupSession = null)
-        )
-        super.onBackPressed()
-    }
-
     /**
      * A fragment to show the web extension action popup with [EngineView].
      */
@@ -76,18 +69,26 @@ class WebExtensionActionPopupActivity : AppCompatActivity() {
             val session = engineSession
             if (session != null) {
                 addonSettingsEngineView.render(session)
+                consumePopupSession()
             } else {
                 consumeFrom(context!!.components.store) { state ->
                     state.extensions[webExtensionId]?.let { extState ->
                         extState.popupSession?.let {
                             if (engineSession == null) {
                                 addonSettingsEngineView.render(it)
+                                consumePopupSession()
                                 engineSession = it
                             }
                         }
                     }
                 }
             }
+        }
+
+        private fun consumePopupSession() {
+            components.store.dispatch(
+                WebExtensionAction.UpdatePopupSessionAction(webExtensionId, popupSession = null)
+            )
         }
 
         companion object {


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
