### PR TITLE
Navigate to home screen after PWA is installed

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -4,9 +4,14 @@
 
 package mozilla.components.feature.pwa
 
+import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_MAIN
+import android.content.Intent.CATEGORY_HOME
 import android.content.Intent.FLAG_ACTIVITY_NEW_DOCUMENT
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.pm.ShortcutManager
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
@@ -81,7 +86,14 @@ class WebAppShortcutManager(
             }
 
             if (shortcut != null) {
-                ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+                val intent = Intent(ACTION_MAIN).apply {
+                    addCategory(CATEGORY_HOME)
+                    flags = FLAG_ACTIVITY_NEW_TASK
+                }
+                val pendingIntent = PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT)
+                val intentSender = pendingIntent.intentSender
+
+                ShortcutManagerCompat.requestPinShortcut(context, shortcut, intentSender)
             }
         }
     }


### PR DESCRIPTION
Pulled this logic [from Fennec](https://searchfox.org/mozilla-esr68/source/mobile/android/base/java/org/mozilla/gecko/util/ShortcutUtils.java#79).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
