### PR TITLE
Closes #4779 - Fix `ExperimentsDebugActivity` command to change server

### DIFF
--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentsUpdater.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/ExperimentsUpdater.kt
@@ -42,7 +42,7 @@ internal class ExperimentsUpdater(
     private val experiments: ExperimentsInternalAPI
 ) {
     private val logger: Logger = Logger(LOG_TAG)
-    private lateinit var config: Configuration
+    internal lateinit var config: Configuration
 
     internal lateinit var source: KintoExperimentSource
 
@@ -119,7 +119,7 @@ internal class ExperimentsUpdater(
     @Synchronized
     internal fun updateExperiments(): Boolean {
         return try {
-            val serverExperiments = getExperimentSource(config).getExperiments(experiments.experimentsResult)
+            val serverExperiments = source.getExperiments(experiments.experimentsResult)
             logger.info("Experiments update from server: $serverExperiments")
             experiments.onExperimentsUpdated(serverExperiments)
             true

--- a/components/service/experiments/src/main/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivity.kt
+++ b/components/service/experiments/src/main/java/mozilla/components/service/experiments/debug/ExperimentsDebugActivity.kt
@@ -98,6 +98,8 @@ class ExperimentsDebugActivity : Activity() {
                 logger.info("Changing Kinto instance to ${config.kintoEndpoint}")
                 // Update the default config
                 Experiments.configuration = config
+                // Also update the updater's copy of the config
+                Experiments.updater.config = config
                 // Reset the source to use the new endpoint
                 Experiments.updater.source = Experiments.updater.getExperimentSource(config)
             }


### PR DESCRIPTION
This fixes the issue of not being able to change the Kinto endpoint using the `adb` command.  

The issue was due to the fact that the source was being updated, but then subsequently not being used for the update because the `ExperimentUpdater` was building a new `ExperimentSource` using the old config rather than using the updated one.