### PR TITLE
Closes #5836: Remove unneeded locales from add-ons

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -130,6 +130,21 @@ data class Addon(
      */
     fun isDisabledAsUnsupported() = installedState?.disabledAsUnsupported == true
 
+    /**
+     * Returns a copy of this [Addon] containing only translations (description,
+     * name, summary) of the provided locales. All other translations
+     * will be removed.
+     *
+     * @param locales list of locales to keep.
+     * @return copy of the addon with all other translations removed.
+     */
+    fun filterTranslations(locales: List<String>): Addon {
+        val descriptions = translatableDescription.filterKeys { locales.contains(it) }
+        val names = translatableName.filterKeys { locales.contains(it) }
+        val summaries = translatableSummary.filterKeys { locales.contains(it) }
+        return copy(translatableName = names, translatableDescription = descriptions, translatableSummary = summaries)
+    }
+
     companion object {
         /**
          * A map of permissions to translation string ids.

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -45,12 +45,17 @@ class AddonManager(
             // Make sure extension support is initialized, i.e. the state of all installed extensions is known.
             WebExtensionSupport.awaitInitialization()
 
-            // Get all available/supported addons from provider and add state if installed.
-            val supportedAddons = addonsProvider.getAvailableAddons().map { addon ->
-                installedExtensions[addon.id]?.let {
-                    addon.copy(installedState = it.toInstalledState())
-                } ?: addon
-            }
+            // Get all available/supported addons from provider and add state if
+            // installed. NB: We're keeping only the translations of the default
+            // lang and the en-US fallback.
+            val locales = listOf(Locale.getDefault().language, "en-US")
+            val supportedAddons = addonsProvider.getAvailableAddons()
+                .map { addon -> addon.filterTranslations(locales) }
+                .map { addon ->
+                    installedExtensions[addon.id]?.let {
+                        addon.copy(installedState = it.toInstalledState())
+                    } ?: addon
+                }
 
             val supportedAddonIds = supportedAddons.map { it.id }
 

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -165,6 +165,36 @@ class AddonManagerTest {
     }
 
     @Test
+    fun `getAddons - filters unneeded locales`() = runBlocking {
+        val addon = Addon(
+            id = "addon1",
+            translatableName = mapOf("en-US" to "name", "invalid1" to "Name", "invalid2" to "nombre"),
+            translatableDescription = mapOf("en-US" to "description", "invalid1" to "Beschreibung", "invalid2" to "descripción"),
+            translatableSummary = mapOf("en-US" to "summary", "invalid1" to "Kurzfassung", "invalid2" to "resumen")
+        )
+
+        val store = BrowserStore()
+
+        val engine: Engine = mock()
+        val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
+        whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
+            callbackCaptor.value.invoke(emptyList())
+        }
+
+        val addonsProvider: AddonsProvider = mock()
+        whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenReturn(listOf(addon))
+        WebExtensionSupport.initialize(engine, store)
+
+        val addons = AddonManager(store, mock(), addonsProvider, mock()).getAddons()
+        assertEquals(1, addons[0].translatableName.size)
+        assertTrue(addons[0].translatableName.contains("en-US"))
+        assertEquals(1, addons[0].translatableDescription.size)
+        assertTrue(addons[0].translatableDescription.contains("en-US"))
+        assertEquals(1, addons[0].translatableSummary.size)
+        assertTrue(addons[0].translatableSummary.contains("en-US"))
+    }
+
+    @Test
     fun `updateAddon - when a extension is updated successfully`() {
         val store = spy(
             BrowserStore(

--- a/components/feature/addons/src/test/java/AddonTest.kt
+++ b/components/feature/addons/src/test/java/AddonTest.kt
@@ -111,7 +111,6 @@ class AddonTest {
             permissions = emptyList(),
             createdAt = "",
             updatedAt = ""
-
         )
         assertFalse(addon.isEnabled())
 
@@ -120,5 +119,31 @@ class AddonTest {
 
         val enabledAddon = addon.copy(installedState = Addon.InstalledState("id", "1.0", "", enabled = true))
         assertTrue(enabledAddon.isEnabled())
+    }
+
+    @Test
+    fun `filterTranslations - only keeps specified translations`() {
+        val addon = Addon(
+            id = "id",
+            authors = emptyList(),
+            categories = emptyList(),
+            downloadUrl = "downloadUrl",
+            version = "version",
+            permissions = emptyList(),
+            createdAt = "",
+            updatedAt = "",
+            translatableName = mapOf("en-US" to "name", "de" to "Name", "es" to "nombre"),
+            translatableDescription = mapOf("en-US" to "description", "de" to "Beschreibung", "es" to "descripción"),
+            translatableSummary = mapOf("en-US" to "summary", "de" to "Kurzfassung", "es" to "resumen")
+        )
+
+        val addonEn = addon.filterTranslations(listOf("en-US"))
+        assertEquals(1, addonEn.translatableName.size)
+        assertTrue(addonEn.translatableName.contains("en-US"))
+
+        val addonEs = addon.filterTranslations(listOf("en-US", "es"))
+        assertEquals(2, addonEs.translatableName.size)
+        assertTrue(addonEs.translatableName.contains("en-US"))
+        assertTrue(addonEs.translatableName.contains("es"))
     }
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonDetailsActivity.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.ui.translate
 import org.mozilla.samples.browser.R
 import java.text.DateFormat
 import java.text.SimpleDateFormat

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonSettingsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonSettingsActivity.kt
@@ -16,6 +16,7 @@ import kotlinx.android.synthetic.main.fragment_add_on_settings.*
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.ui.translate
 import org.mozilla.samples.browser.R
 import org.mozilla.samples.browser.ext.components
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/Extensions.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/Extensions.kt
@@ -7,14 +7,6 @@ package org.mozilla.samples.browser.addons
 import java.text.NumberFormat
 import java.util.Locale
 
-/**
- * Try to find the default language on the map otherwise defaults to "en-US".
- */
-internal fun Map<String, String>.translate(): String {
-    val lang = Locale.getDefault().isO3Language
-    return get(lang) ?: getValue("en-US")
-}
-
 internal fun getFormattedAmount(amount: Int): String {
     return NumberFormat.getNumberInstance(Locale.getDefault()).format(amount)
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.ui.translate
 import mozilla.components.feature.addons.ui.translatedName
 import org.mozilla.samples.browser.R
 import org.mozilla.samples.browser.ext.components

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/PermissionsDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/PermissionsDetailsActivity.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.ui.AddonPermissionsAdapter
+import mozilla.components.feature.addons.ui.translate
 import org.mozilla.samples.browser.R
 
 private const val LEARN_MORE_URL =


### PR DESCRIPTION
I've also verified that switching languages still works with this. Our provider still has all languages, with this we just prevent storing them all in the add-on instance which isn't needed and causes problems when serializing (sending the add-on instance to a different fragment).