### PR TITLE
Don't show the add-ons permission dialog if installation is in progress

### DIFF
--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
@@ -121,6 +121,10 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
     }
 
     private fun showPermissionDialog(addon: Addon) {
+        if (isInstallationInProgress) {
+            return
+        }
+
         val dialog = PermissionsDialogFragment.newInstance(
             addon = addon,
             onPositiveButtonClicked = onPositiveButtonClicked
@@ -133,12 +137,17 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
 
     private val onPositiveButtonClicked: ((Addon) -> Unit) = { addon ->
         addonProgressOverlay.visibility = View.VISIBLE
+        isInstallationInProgress = true
+
         requireContext().components.addonManager.installAddon(
             addon,
             onSuccess = {
                 Toast.makeText(
                     requireContext(),
-                    getString(R.string.mozac_feature_addons_successfully_installed, it.translatedName),
+                    getString(
+                        R.string.mozac_feature_addons_successfully_installed,
+                        it.translatedName
+                    ),
                     Toast.LENGTH_SHORT
                 ).show()
 
@@ -147,18 +156,28 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
                 }
 
                 addonProgressOverlay.visibility = View.GONE
+                isInstallationInProgress = false
             },
             onError = { _, _ ->
                 Toast.makeText(
                     requireContext(),
-                    getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName),
+                    getString(
+                        R.string.mozac_feature_addons_failed_to_install,
+                        addon.translatedName
+                    ),
                     Toast.LENGTH_SHORT
                 ).show()
 
                 addonProgressOverlay.visibility = View.GONE
+                isInstallationInProgress = false
             }
         )
     }
+
+    /**
+     * Whether or not an add-on installation is in progress.
+     */
+    private var isInstallationInProgress = false
 
     companion object {
         private const val PERMISSIONS_DIALOG_FRAGMENT_TAG = "ADDONS_PERMISSIONS_DIALOG_FRAGMENT"


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/fenix/issues/8167
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
