### PR TITLE
For issue mozilla-mobile/fenix#8150: Fix crash while trying to fetch add-on icon with networks failures.

### DIFF
--- a/components/feature/addons/build.gradle
+++ b/components/feature/addons/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.androidx_work_testing
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
@@ -4,20 +4,42 @@
 
 package mozilla.components.feature.addons.amo.mozilla.components.feature.addons.ui
 
+import android.widget.ImageView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
+import mozilla.components.feature.addons.amo.AddonCollectionProvider
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter.NotYetSupportedSection
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter.Section
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import java.io.IOException
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class AddonsManagerAdapterTest {
+
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val scope = TestCoroutineScope(testDispatcher)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
     @Test
     fun `createListWithSections() `() {
         val adapter = AddonsManagerAdapter(mock(), mock(), emptyList())
@@ -52,5 +74,25 @@ class AddonsManagerAdapterTest {
             R.string.mozac_feature_addons_unsupported_section,
             (itemsWithSections[4] as NotYetSupportedSection).title
         )
+    }
+
+    @Test
+    fun `handle errors while fetching the add-on icon() `() {
+        val addon = mock<Addon>()
+        val mockedImageView = spy(ImageView(testContext))
+        val mockedCollectionProvider = mock<AddonCollectionProvider>()
+        val adapter = AddonsManagerAdapter(mockedCollectionProvider, mock(), emptyList())
+
+        runBlocking {
+            whenever(mockedCollectionProvider.getAddonIconBitmap(addon)).then {
+                throw IOException("Request failed")
+            }
+            try {
+                adapter.fetchIcon(addon, mockedImageView, scope).join()
+                verify(mockedImageView).setColorFilter(anyInt())
+            } catch (e: IOException) {
+                fail("The exception must be handle in the adapter")
+            }
+        }
     }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
