### PR TITLE
Closes #5692: NotImplementedError: Octet length not supported

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecLoginsMigration.kt
@@ -25,7 +25,7 @@ import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
 @Suppress("MagicNumber")
-fun ByteArray.getEncodingLength(offset: Int): Int {
+internal fun ByteArray.getEncodingLength(offset: Int): Int {
     // First byte indicates type.
     // Second byte is length of the octet string.
     // There are two definite forms of specifying length: short and long.
@@ -56,7 +56,8 @@ fun ByteArray.getEncodingLength(offset: Int): Int {
     return when (numOctets) {
         1 -> this[offset + 2].toInt() and 0xFF
         2 -> (this[offset + 2].toInt() and 0xFF shl 8) or (this[offset + 3].toInt() and 0xFF)
-        3 -> (this[offset + 2].toInt() and 0xFF shl 16) or (this[offset + 3].toInt() and 0xFF shl 8) or (this[offset + 4].toInt() and 0xFF)
+        3 -> (this[offset + 2].toInt() and 0xFF shl 16) or (this[offset + 3].toInt() and 0xFF shl 8) or
+                (this[offset + 4].toInt() and 0xFF)
         else -> throw IllegalStateException("Unsupported number of octets: $numOctets")
     }
 }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecLoginsMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecLoginsMigrationTest.kt
@@ -224,32 +224,32 @@ class FennecLoginsMigrationTest {
     @Test
     fun testGetEncodingLength() {
         // Short form
-        assertEquals(0,   byteArrayOf(0, 0x00.toByte()).getEncodingLength(0))
-        assertEquals(3,   byteArrayOf(0, 0x03.toByte()).getEncodingLength(0))
+        assertEquals(0, byteArrayOf(0, 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3, byteArrayOf(0, 0x03.toByte()).getEncodingLength(0))
         assertEquals(127, byteArrayOf(0, 0x7F.toByte()).getEncodingLength(0))
         // Long form 1 byte
-        assertEquals(0,   byteArrayOf(0, 0x81.toByte(), 0x00.toByte()).getEncodingLength(0))
-        assertEquals(3,   byteArrayOf(0, 0x81.toByte(), 0x03.toByte()).getEncodingLength(0))
+        assertEquals(0, byteArrayOf(0, 0x81.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3, byteArrayOf(0, 0x81.toByte(), 0x03.toByte()).getEncodingLength(0))
         assertEquals(127, byteArrayOf(0, 0x81.toByte(), 0x7F.toByte()).getEncodingLength(0))
         assertEquals(128, byteArrayOf(0, 0x81.toByte(), 0x80.toByte()).getEncodingLength(0))
         assertEquals(255, byteArrayOf(0, 0x81.toByte(), 0xFF.toByte()).getEncodingLength(0))
         // Long form 2 bytes
-        assertEquals(0,     byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0x00.toByte()).getEncodingLength(0))
-        assertEquals(3,     byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0x03.toByte()).getEncodingLength(0))
-        assertEquals(4660,  byteArrayOf(0, 0x82.toByte(), 0x12.toByte(), 0x34.toByte()).getEncodingLength(0))
+        assertEquals(0, byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3, byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0x03.toByte()).getEncodingLength(0))
+        assertEquals(4660, byteArrayOf(0, 0x82.toByte(), 0x12.toByte(), 0x34.toByte()).getEncodingLength(0))
         assertEquals(32896, byteArrayOf(0, 0x82.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
-        assertEquals(255,   byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(255, byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0xFF.toByte()).getEncodingLength(0))
         assertEquals(65280, byteArrayOf(0, 0x82.toByte(), 0xFF.toByte(), 0x00.toByte()).getEncodingLength(0))
-        assertEquals(511,   byteArrayOf(0, 0x82.toByte(), 0x01.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(511, byteArrayOf(0, 0x82.toByte(), 0x01.toByte(), 0xFF.toByte()).getEncodingLength(0))
         assertEquals(32639, byteArrayOf(0, 0x82.toByte(), 0x7F.toByte(), 0x7F.toByte()).getEncodingLength(0))
         // Long form 3 bytes
-        assertEquals(0,        byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()).getEncodingLength(0))
-        assertEquals(3,        byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x03.toByte()).getEncodingLength(0))
-        assertEquals(8421504,  byteArrayOf(0, 0x83.toByte(), 0x80.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
-        assertEquals(32896,    byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
-        assertEquals(128,      byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x80.toByte()).getEncodingLength(0))
-        assertEquals(255,      byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0xFF.toByte()).getEncodingLength(0))
-        assertEquals(65535,    byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0xFF.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(0, byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3, byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x03.toByte()).getEncodingLength(0))
+        assertEquals(8421504, byteArrayOf(0, 0x83.toByte(), 0x80.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(32896, byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(128, byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(255, byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(65535, byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0xFF.toByte(), 0xFF.toByte()).getEncodingLength(0))
         assertEquals(16777215, byteArrayOf(0, 0x83.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()).getEncodingLength(0))
     }
 }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecLoginsMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecLoginsMigrationTest.kt
@@ -220,4 +220,36 @@ class FennecLoginsMigrationTest {
     private fun throwingFunction() {
         throw IllegalArgumentException("where are ma argz!")
     }
+
+    @Test
+    fun testGetEncodingLength() {
+        // Short form
+        assertEquals(0,   byteArrayOf(0, 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3,   byteArrayOf(0, 0x03.toByte()).getEncodingLength(0))
+        assertEquals(127, byteArrayOf(0, 0x7F.toByte()).getEncodingLength(0))
+        // Long form 1 byte
+        assertEquals(0,   byteArrayOf(0, 0x81.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3,   byteArrayOf(0, 0x81.toByte(), 0x03.toByte()).getEncodingLength(0))
+        assertEquals(127, byteArrayOf(0, 0x81.toByte(), 0x7F.toByte()).getEncodingLength(0))
+        assertEquals(128, byteArrayOf(0, 0x81.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(255, byteArrayOf(0, 0x81.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        // Long form 2 bytes
+        assertEquals(0,     byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3,     byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0x03.toByte()).getEncodingLength(0))
+        assertEquals(4660,  byteArrayOf(0, 0x82.toByte(), 0x12.toByte(), 0x34.toByte()).getEncodingLength(0))
+        assertEquals(32896, byteArrayOf(0, 0x82.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(255,   byteArrayOf(0, 0x82.toByte(), 0x00.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(65280, byteArrayOf(0, 0x82.toByte(), 0xFF.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(511,   byteArrayOf(0, 0x82.toByte(), 0x01.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(32639, byteArrayOf(0, 0x82.toByte(), 0x7F.toByte(), 0x7F.toByte()).getEncodingLength(0))
+        // Long form 3 bytes
+        assertEquals(0,        byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()).getEncodingLength(0))
+        assertEquals(3,        byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x03.toByte()).getEncodingLength(0))
+        assertEquals(8421504,  byteArrayOf(0, 0x83.toByte(), 0x80.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(32896,    byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x80.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(128,      byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0x80.toByte()).getEncodingLength(0))
+        assertEquals(255,      byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0x00.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(65535,    byteArrayOf(0, 0x83.toByte(), 0x00.toByte(), 0xFF.toByte(), 0xFF.toByte()).getEncodingLength(0))
+        assertEquals(16777215, byteArrayOf(0, 0x83.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()).getEncodingLength(0))
+    }
 }


### PR DESCRIPTION
This patch for #5692   fixes a integer sign issue when pulling bytes with the high bit set out of a `ByteArray`. I also fixed a bug where 3-byte lengths were not correctly decoded. (Unclear how likely it is that we encounter a login item that is larger than 2^16 though.)

I was not sure how to write a test for the embedded `ByteArray.getEncodingLength` so I actually pulled that extension method out of the `FennecLoginsMigration` class. Let me know if there is an elegant solution for that.

Draft because I'll add a few more test cases with funny numbers.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
