### PR TITLE
Closes 851: Add read timeout when fetching AMO collection

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -24,12 +24,14 @@ import org.json.JSONObject
 import java.io.File
 import java.io.IOException
 import java.util.Date
+import java.util.concurrent.TimeUnit
 
 internal const val API_VERSION = "api/v4"
 internal const val DEFAULT_SERVER_URL = "https://addons.mozilla.org"
 internal const val DEFAULT_COLLECTION_NAME = "7e8d6dc651b54ab385fb8791bf9dac"
 internal const val COLLECTION_FILE_NAME = "mozilla_components_addon_collection_%s.json"
 internal const val MINUTE_IN_MS = 60 * 1000
+internal const val READ_TIMEOUT_IN_SECONDS = 20L
 
 /**
  * Provide access to the collections AMO API.
@@ -74,7 +76,10 @@ class AddonCollectionProvider(
         }
 
         return cachedAddons ?: client.fetch(
-                Request(url = "$serverURL/$API_VERSION/accounts/account/mozilla/collections/$collectionName/addons")
+                Request(
+                    url = "$serverURL/$API_VERSION/accounts/account/mozilla/collections/$collectionName/addons",
+                    readTimeout = Pair(READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+                )
             )
             .use { response ->
                 if (response.isSuccess) {

--- a/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.verify
 import java.io.IOException
 import java.util.Date
 import java.io.InputStream
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class AddonCollectionProviderTest {
@@ -132,7 +133,10 @@ class AddonCollectionProviderTest {
 
             // Authors
             assertTrue(addon.authors.isEmpty())
-            verify(mockedClient).fetch(Request(url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/7e8d6dc651b54ab385fb8791bf9dac/addons"))
+            verify(mockedClient).fetch(Request(
+                url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/7e8d6dc651b54ab385fb8791bf9dac/addons",
+                readTimeout = Pair(READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+            ))
 
             // Ratings
             assertNull(addon.rating)


### PR DESCRIPTION
Tested on the slowest setting in an emulator and this was still good enough. We could be more aggressive, but this seems fine to me.