### PR TITLE
Fixed `ContextMenuFeature` and `DownloadsFeature` not working for non-selected normal tab

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
@@ -64,6 +64,21 @@ fun BrowserState.findCustomTabOrSelectedTab(customTabId: String? = null): Sessio
 }
 
 /**
+ * Finds and returns the tab with the given id or the selected tab if no id was provided (null). Returns null
+ * if no matching tab could be found or if no selected tab exists.
+ *
+ * @param tabId An optional ID of a tab. If not provided or null then the selected tab will be returned.
+ * @return The custom tab with the provided ID or the selected tav if no id was provided.
+ */
+fun BrowserState.findTabOrCustomTabOrSelectedTab(tabId: String? = null): SessionState? {
+    return if (tabId != null) {
+        findTabOrCustomTab(tabId)
+    } else {
+        selectedTab
+    }
+}
+
+/**
  * List of private tabs.
  */
 val BrowserState.privateTabs: List<TabSessionState>

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
@@ -103,6 +103,24 @@ class SelectorsKtTest {
     }
 
     @Test
+    fun `findTabOrCustomTabOrSelectedTab extension function`() {
+        val tab = createTab("https://www.firefox.com")
+        val otherTab = createTab("https://getpocket.com")
+        val customTab = createCustomTab("https://www.mozilla.org")
+
+        val state = BrowserState(
+                tabs = listOf(tab, otherTab),
+                customTabs = listOf(customTab),
+                selectedTabId = tab.id)
+
+        assertEquals(tab, state.findTabOrCustomTabOrSelectedTab())
+        assertEquals(tab, state.findTabOrCustomTabOrSelectedTab(null))
+        assertEquals(tab, state.findTabOrCustomTabOrSelectedTab(tab.id))
+        assertEquals(otherTab, state.findTabOrCustomTabOrSelectedTab(otherTab.id))
+        assertEquals(customTab, state.findTabOrCustomTabOrSelectedTab(customTab.id))
+    }
+
+    @Test
     fun `privateTabs and normalTabs extension properties`() {
         val tab1 = createTab("https://www.firefox.com")
         val tab2 = createTab("https://www.mozilla.org")

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import mozilla.components.browser.session.Session
-import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
 import mozilla.components.browser.state.selector.findTabOrCustomTab
+import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineView
@@ -41,8 +41,8 @@ internal const val FRAGMENT_TAG = "mozac_feature_contextmenu_dialog"
  * menu. If a context menu item was selected by the user the feature will invoke the [ContextMenuCandidate.action]
  * method of the related candidate.
  * @property engineView The [EngineView]] this feature component should show context menus for.
- * @param customTabId Optional id of a custom tab. Instead of showing context menus for the currently
- * selected tab this feature will show only context menus for this custom tab if an id is provided.
+ * @param tabId Optional id of a tab. Instead of showing context menus for the currently selected tab this feature will
+ * show only context menus for this tab if an id is provided.
  */
 class ContextMenuFeature(
     private val fragmentManager: FragmentManager,
@@ -50,7 +50,7 @@ class ContextMenuFeature(
     private val candidates: List<ContextMenuCandidate>,
     private val engineView: EngineView,
     private val useCases: ContextMenuUseCases,
-    private val customTabId: String? = null
+    private val tabId: String? = null
 ) : LifecycleAwareFeature {
     private var scope: CoroutineScope? = null
 
@@ -59,7 +59,7 @@ class ContextMenuFeature(
      */
     override fun start() {
         scope = store.flowScoped { flow ->
-            flow.map { state -> state.findCustomTabOrSelectedTab(customTabId) }
+            flow.map { state -> state.findTabOrCustomTabOrSelectedTab(tabId) }
                 .ifChanged { it?.content?.hitResult }
                 .collect { state ->
                     val hitResult = state?.content?.hitResult

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
+import mozilla.components.browser.state.selector.findTabOrCustomTabOrSelectedTab
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore
@@ -59,7 +60,7 @@ class DownloadsFeature(
     override var onNeedToRequestPermissions: OnNeedToRequestPermissions = { },
     onDownloadStopped: onDownloadStopped = noop,
     private val downloadManager: DownloadManager = AndroidDownloadManager(applicationContext),
-    private val customTabId: String? = null,
+    private val tabId: String? = null,
     private val fragmentManager: FragmentManager? = null,
     private val promptsStyling: PromptsStyling? = null,
     @VisibleForTesting(otherwise = PRIVATE)
@@ -89,7 +90,7 @@ class DownloadsFeature(
         }
 
         scope = store.flowScoped { flow ->
-            flow.mapNotNull { state -> state.findCustomTabOrSelectedTab(customTabId) }
+            flow.mapNotNull { state -> state.findTabOrCustomTabOrSelectedTab(tabId) }
                 .ifChanged { it.content.download }
                 .collect { state ->
                     val download = state.content.download
@@ -205,7 +206,7 @@ class DownloadsFeature(
     }
 
     private fun withActiveDownload(block: (Pair<SessionState, DownloadState>) -> Unit) {
-        val state = store.state.findCustomTabOrSelectedTab(customTabId) ?: return
+        val state = store.state.findCustomTabOrSelectedTab(tabId) ?: return
         val download = state.content.download ?: return
         block(Pair(state, download))
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -115,6 +115,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                     requireContext().applicationContext,
                     DownloadService::class
                 ),
+                tabId = sessionId,
                 onNeedToRequestPermissions = { permissions ->
                     requestPermissions(permissions, REQUEST_CODE_DOWNLOAD_PERMISSIONS)
                 }),

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -142,7 +142,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
             store = components.store,
             candidates = contextMenuCandidates,
             engineView = layout.engineView,
-            useCases = components.contextMenuUseCases)
+            useCases = components.contextMenuUseCases,
+            tabId = sessionId)
 
         promptFeature.set(
             feature = PromptFeature(


### PR DESCRIPTION
- Added `BrowserState.findTabOrCustomTabOrSelectedTab` extension method.
- Fixed `ContextMenuFeature` not working for non-selected normal tab.
- Fixed `DownloadsFeature` not working for non-selected normal tab

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
