### PR TITLE
Closes #5875: onTitleChange blocking on history storage write

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
@@ -634,7 +633,11 @@ class GeckoEngineSession(
             if (!privateMode) {
                 currentUrl?.let { url ->
                     settings.historyTrackingDelegate?.let { delegate ->
-                        runBlocking {
+                        // NB: There's no guarantee that the title change will be processed by the
+                        // delegate before the session is closed (and the corresponding coroutine
+                        // job is cancelled). Observers will always be notified of the title
+                        // change though.
+                        launch(coroutineContext) {
                             delegate.onTitleChanged(url, title ?: "")
                         }
                     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
@@ -642,7 +641,11 @@ class GeckoEngineSession(
             if (!privateMode) {
                 currentUrl?.let { url ->
                     settings.historyTrackingDelegate?.let { delegate ->
-                        runBlocking {
+                        // NB: There's no guarantee that the title change will be processed by the
+                        // delegate before the session is closed (and the corresponding coroutine
+                        // job is cancelled). Observers will always be notified of the title
+                        // change though.
+                        launch(coroutineContext) {
                             delegate.onTitleChanged(url, title ?: "")
                         }
                     }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.engine.gecko.media.GeckoMediaDelegate
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
@@ -634,7 +633,11 @@ class GeckoEngineSession(
             if (!privateMode) {
                 currentUrl?.let { url ->
                     settings.historyTrackingDelegate?.let { delegate ->
-                        runBlocking {
+                        // NB: There's no guarantee that the title change will be processed by the
+                        // delegate before the session is closed (and the corresponding coroutine
+                        // job is cancelled). Observers will always be notified of the title
+                        // change though.
+                        launch(coroutineContext) {
                             delegate.onTitleChanged(url, title ?: "")
                         }
                     }


### PR DESCRIPTION
Looking through other call-sites, this seems save to move to an IO thread esp., as it writes to storage. We also already have a custom scope in the engine session which I am using here.