### PR TITLE
Fixes #5878: Pass URI to high risk error page messages

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -73,7 +73,7 @@ object ErrorPages {
     ): String {
         val title = context.getString(errorType.titleRes)
         val button = context.getString(errorType.refreshButtonRes)
-        val description = context.getString(errorType.messageRes)
+        val description = context.getString(errorType.messageRes, uri)
         val imageName = if (errorType.imageNameRes != null) context.getString(errorType.imageNameRes) + ".svg" else ""
         val badCertAdvanced = context.getString(R.string.mozac_browser_errorpages_security_bad_cert_advanced)
         val badCertTechInfo = context.getString(R.string.mozac_browser_errorpages_security_bad_cert_techInfo,


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
### Before
<img width="350" alt="Screen Shot 2020-02-10 at 1 16 14 PM" src="https://user-images.githubusercontent.com/4400286/74191455-74b9bb80-4c08-11ea-958c-e3f405f81c05.png">

### After
<img width="350" alt="Screen Shot 2020-02-10 at 1 15 31 PM" src="https://user-images.githubusercontent.com/4400286/74191463-784d4280-4c08-11ea-886e-f87f370f2191.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
