### PR TITLE
Add Enabled and Disabled strings for add-ons settings

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -240,7 +240,7 @@ class AddonsManagerAdapter(
 
         // Add installed section and addons if available
         if (installedAddons.isNotEmpty()) {
-            itemsWithSections.add(Section(R.string.mozac_feature_addons_installed_section))
+            itemsWithSections.add(Section(R.string.mozac_feature_addons_enabled))
             itemsWithSections.addAll(installedAddons)
         }
 

--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -69,6 +69,10 @@
     <string name="mozac_feature_addons_settings_on">On</string>
     <!-- Indicates the add-on is disabled. -->
     <string name="mozac_feature_addons_settings_off">Off</string>
+    <!-- Indicates the add-on is enabled. -->
+    <string name="mozac_feature_addons_enabled">Enabled</string>
+    <!-- Indicates the add-on is disabled. -->
+    <string name="mozac_feature_addons_disabled">Disabled</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the installed section. -->
     <string name="mozac_feature_addons_installed_section">Installed</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the recommended section. -->

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
@@ -66,7 +66,7 @@ class AddonsManagerAdapterTest {
 
         assertEquals(7, itemsWithSections.size)
         assertEquals(
-            R.string.mozac_feature_addons_installed_section,
+            R.string.mozac_feature_addons_enabled,
             (itemsWithSections[0] as Section).title
         )
         assertEquals(installedAddon, itemsWithSections[1])

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
@@ -144,9 +144,9 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
 
     private fun Switch.setState(checked: Boolean) {
         val text = if (checked) {
-            R.string.mozac_feature_addons_settings_on
+            R.string.mozac_feature_addons_enabled
         } else {
-            R.string.mozac_feature_addons_settings_off
+            R.string.mozac_feature_addons_disabled
         }
         setText(text)
         isChecked = checked


### PR DESCRIPTION
In the new mockup for the add-on settings, it uses the strings "Enabled" and "Disabled" instead of "On" and "Off".

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
