### PR TITLE
Closes #5815: Update unsupported addons adapter when uninstall occurs

### DIFF
--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/UnsupportedAddonsAdapterTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/UnsupportedAddonsAdapterTest.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.amo.mozilla.components.feature.addons.ui
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonManager
+import mozilla.components.feature.addons.ui.UnsupportedAddonsAdapter
+import mozilla.components.feature.addons.ui.UnsupportedAddonsAdapterDelegate
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class UnsupportedAddonsAdapterTest {
+
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
+    @Test
+    fun `removing successfully notifies the adapter item changed`() {
+        val addonManager: AddonManager = mock()
+        val unsupportedAddonsAdapterDelegate: UnsupportedAddonsAdapterDelegate = mock()
+        val unsupportedAddons = listOf(Addon("id1"), Addon("id2"))
+
+        val adapter = UnsupportedAddonsAdapter(
+            addonManager,
+            unsupportedAddonsAdapterDelegate,
+            unsupportedAddons
+        )
+
+        adapter.removeUninstalledAddonAtPosition(0)
+        testDispatcher.advanceUntilIdle()
+        verify(unsupportedAddonsAdapterDelegate, times(1)).onUninstallSuccess()
+        assertEquals(1, adapter.itemCount)
+
+        adapter.removeUninstalledAddonAtPosition(0)
+        testDispatcher.advanceUntilIdle()
+        verify(unsupportedAddonsAdapterDelegate, times(2)).onUninstallSuccess()
+        assertEquals(0, adapter.itemCount)
+
+        adapter.removeUninstalledAddonAtPosition(0)
+        testDispatcher.advanceUntilIdle()
+        verify(unsupportedAddonsAdapterDelegate, times(2)).onUninstallSuccess()
+    }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/addons/NotYetSupportedAddonActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/addons/NotYetSupportedAddonActivity.kt
@@ -45,6 +45,7 @@ class NotYetSupportedAddonActivity : AppCompatActivity() {
      */
     class NotYetSupportedAddonFragment : Fragment(), UnsupportedAddonsAdapterDelegate {
         private lateinit var addons: List<Addon>
+        private var adapter: UnsupportedAddonsAdapter? = null
 
         override fun onCreateView(
             inflater: LayoutInflater,
@@ -60,12 +61,14 @@ class NotYetSupportedAddonActivity : AppCompatActivity() {
 
             val context = requireContext()
             val recyclerView: RecyclerView = view.findViewById(R.id.unsupported_add_ons_list)
-            recyclerView.layoutManager = LinearLayoutManager(context)
-            recyclerView.adapter = UnsupportedAddonsAdapter(
+            adapter = UnsupportedAddonsAdapter(
                 addonManager = context.components.addonManager,
                 unsupportedAddonsAdapterDelegate = this@NotYetSupportedAddonFragment,
-                unsupportedAddons = addons
+                addons = addons
             )
+
+            recyclerView.layoutManager = LinearLayoutManager(context)
+            recyclerView.adapter = adapter
 
             view.findViewById<View>(R.id.learn_more_label).setOnClickListener {
                 val intent = Intent(Intent.ACTION_VIEW).setData(Uri.parse(LEARN_MORE_URL))
@@ -80,6 +83,9 @@ class NotYetSupportedAddonActivity : AppCompatActivity() {
         override fun onUninstallSuccess() {
             Toast.makeText(context, "Successfully removed add-on", Toast.LENGTH_SHORT)
                 .show()
+            if (adapter?.itemCount == 0) {
+                activity?.onBackPressed()
+            }
         }
 
         companion object {


### PR DESCRIPTION
One concern I have with this approach is if adapter can ever be null (i.e. garbage collected) at the wrong time (when `onUninstallSuccess` is invoked but activity/fragment is being destroyed). I tried testing uninstalling and pressing back quickly a few times and I haven't seen any crashes (perhaps the nullable adapter check is sufficient)