### PR TITLE
Closes #5915: Built-in extensions are disabled by default

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -276,7 +276,7 @@ class GeckoWebExtension(
     }
 
     override fun isEnabled(): Boolean {
-        return nativeExtension.metaData?.enabled == true
+        return nativeExtension.metaData?.enabled ?: true
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -415,7 +415,7 @@ class GeckoWebExtensionTest {
     }
 
     @Test
-    fun `isEnabled depends on native state`() {
+    fun `isEnabled depends on native state and defaults to true if state unknown`() {
         val webExtensionController: WebExtensionController = mock()
 
         val bundle = GeckoBundle()
@@ -423,7 +423,7 @@ class GeckoWebExtensionTest {
         bundle.putString("locationURI", "uri")
         val nativeExtensionWithoutMetadata = MockWebExtension(bundle)
         val webExtension = GeckoWebExtension(nativeExtensionWithoutMetadata, webExtensionController)
-        assertFalse(webExtension.isEnabled())
+        assertTrue(webExtension.isEnabled())
 
         val metaDataBundle = GeckoBundle()
         metaDataBundle.putBoolean("enabled", true)

--- a/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
+++ b/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeature.kt
@@ -58,10 +58,10 @@ class WebExtensionToolbarFeature(
      */
     override fun start() {
         // The feature could start with an existing view and toolbar so
-        // we have to check if any stale actions (from uninstalled
-        // extensions) are being displayed and remove them.
+        // we have to check if any stale actions (from uninstalled or
+        // disabled extensions) are being displayed and remove them.
         webExtensionBrowserActions
-            .filterKeys { !store.state.extensions.containsKey(it) }
+            .filterKeys { !store.state.extensions.containsKey(it) || store.state.extensions[it]?.enabled == false }
             .forEach { (extensionId, action) ->
                 toolbar.removeBrowserAction(action)
                 toolbar.invalidateActions()
@@ -69,7 +69,7 @@ class WebExtensionToolbarFeature(
             }
 
         webExtensionPageActions
-            .filterKeys { !store.state.extensions.containsKey(it) }
+            .filterKeys { !store.state.extensions.containsKey(it) || store.state.extensions[it]?.enabled == false }
             .forEach { (extensionId, action) ->
                 toolbar.removePageAction(action)
                 toolbar.invalidateActions()


### PR DESCRIPTION
Also, make sure we remove actions from disabled extensions from the toolbar. There's no bug here for add-ons or existing built-in extensions (as the current ones don't have browser actions), but let's fix it.