### PR TITLE
For Fenix#4151: fixes crashes when too many tabs have been opened

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -323,6 +323,24 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.requestClose]
+     */
+    override fun requestClose(reason: RequestCloseReason) {
+        close()
+    }
+
+    /**
+     * See [EngineSession.ensureOpen].
+     */
+    override fun ensureOpen(sessionState: EngineSessionState?) {
+        if (!geckoSession.isOpen) {
+            job = Job()
+            geckoSession.open(runtime)
+            if (sessionState != null) restoreState(sessionState)
+        }
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     @Suppress("ComplexMethod")

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -330,6 +330,24 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.requestClose]
+     */
+    override fun requestClose(reason: RequestCloseReason) {
+        close()
+    }
+
+    /**
+     * See [EngineSession.ensureOpen].
+     */
+    override fun ensureOpen(sessionState: EngineSessionState?) {
+        if (!geckoSession.isOpen) {
+            job = Job()
+            geckoSession.open(runtime)
+            if (sessionState != null) restoreState(sessionState)
+        }
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     @Suppress("ComplexMethod")

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -323,6 +323,24 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.requestClose]
+     */
+    override fun requestClose(reason: RequestCloseReason) {
+        close()
+    }
+
+    /**
+     * See [EngineSession.ensureOpen].
+     */
+    override fun ensureOpen(sessionState: EngineSessionState?) {
+        if (!geckoSession.isOpen) {
+            job = Job()
+            geckoSession.open(runtime)
+            if (sessionState != null) restoreState(sessionState)
+        }
+    }
+
+    /**
      * NavigationDelegate implementation for forwarding callbacks to observers of the session.
      */
     @Suppress("ComplexMethod")

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -170,6 +170,22 @@ class SystemEngineSession(
     }
 
     /**
+     * See [EngineSession.requestClose]
+     */
+    override fun requestClose(reason: RequestCloseReason) {
+        // Noop. This object cannot be reopened, and so will not be closed until it is no longer
+        // needed. See [close]
+    }
+
+    /**
+     * See [EngineSession.ensureOpen].
+     */
+    override fun ensureOpen(sessionState: EngineSessionState?) {
+        // Noop. This object cannot be reopened, and so will not be closed until it is no longer
+        // needed. See [close]
+    }
+
+    /**
      * See [EngineSession.clearData]
      */
     @Suppress("TooGenericExceptionCaught")

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/LegacySessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/LegacySessionManagerTest.kt
@@ -1,0 +1,156 @@
+package mozilla.components.browser.session
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class LegacySessionManagerTest {
+
+    private lateinit var manager: LegacySessionManager
+
+    private val session1 = Session("https://www.mozilla.org")
+    private val session2 = Session("https://www.wikipedia.org")
+    private val session3 = Session("https://www.duckduckgo.com")
+    private val allSessions = listOf(session1, session2, session3)
+    private val engineSessionMock1 = mock<EngineSession>()
+    private val engineSessionMock2 = mock<EngineSession>()
+    private val engineSessionMock3 = mock<EngineSession>()
+    private val allEngineSessions = listOf(engineSessionMock1, engineSessionMock2, engineSessionMock3)
+
+    @Test
+    fun `the most recently added session should always be at the front of openSessions`() {
+        manager = TestLegacySessionManager(6)
+        manager.add(allSessions)
+
+        // The first added session is always selected
+        assertEquals(1, manager.openSessions.size)
+
+        manager.select(session1)
+        assertEquals(session1.id, manager.openSessions.peekFirst())
+
+        manager.select(session2)
+        assertEquals(session2.id, manager.openSessions.peekFirst())
+
+        manager.select(session3)
+        assertEquals(session3.id, manager.openSessions.peekFirst())
+
+        manager.select(session1)
+        assertEquals(session1.id, manager.openSessions.peekFirst())
+    }
+
+    @Test
+    fun `when sessions are selected multiple times they should only exist once in openSessions`() {
+        manager = TestLegacySessionManager(6)
+        manager.add(allSessions)
+
+        listOf(session1, session2, session3, session1, session2, session3, session2).forEach {
+            manager.select(it)
+        }
+
+        assertEquals(3, manager.openSessions.size)
+        assertEquals(listOf(session2.id, session3.id, session1.id), manager.openSessions.toList())
+    }
+
+    @Test
+    fun `onLowMemory should trim openSessions to only the selected session`() {
+        manager = TestLegacySessionManager(6)
+        manager.add(allSessions)
+        allSessions.forEach { manager.select(it) }
+
+        assertEquals(3, manager.openSessions.size)
+        assertEquals(session3, manager.selectedSession)
+
+        manager.onLowMemory()
+
+        assertEquals(1, manager.openSessions.size)
+        assertEquals(listOf(session3.id), manager.openSessions.toList())
+        assertEquals(session3, manager.selectedSession)
+    }
+
+    @Test
+    fun `when open sessions are trimmed by a call to select, at least maxOpenSessions should remain`() {
+        manager = TestLegacySessionManager(2)
+        manager.add(allSessions)
+        allSessions.forEach { manager.select(it) }
+        assertEquals(manager.maxOpenSessions, manager.openSessions.size)
+
+        manager.select(session2)
+        assertEquals(manager.maxOpenSessions, manager.openSessions.size)
+
+        manager.select(session1)
+        assertEquals(manager.maxOpenSessions, manager.openSessions.size)
+
+        manager.select(session3)
+        assertEquals(manager.maxOpenSessions, manager.openSessions.size)
+
+        manager.select(session2)
+        assertEquals(manager.maxOpenSessions, manager.openSessions.size)
+    }
+
+    @Test
+    fun `when open sessions are trimmed by a call to select, the LRU value should be trimmed`() {
+        manager = TestLegacySessionManager(2)
+        manager.add(allSessions)
+        allSessions.forEach { manager.select(it) }
+        assertEquals(listOf(session3.id, session2.id), manager.openSessions.toList())
+
+        manager.select(session2)
+        assertEquals(listOf(session2.id, session3.id), manager.openSessions.toList())
+
+        manager.select(session1)
+        assertEquals(listOf(session1.id, session2.id), manager.openSessions.toList())
+
+        manager.select(session3)
+        assertEquals(listOf(session3.id, session1.id), manager.openSessions.toList())
+
+        manager.select(session2)
+        assertEquals(listOf(session2.id, session3.id), manager.openSessions.toList())
+    }
+
+    @Test
+    fun `engineSessions should be disabled as sessions are removed from openSessions`() {
+        manager = TestLegacySessionManager(2)
+
+        allSessions.zip(allEngineSessions)
+            .forEach { (session, engineSession) ->
+                manager.add(session = session, engineSession = engineSession, selected = true)
+            }
+
+        assertEquals(listOf(session3.id, session2.id), manager.openSessions.toList())
+        verifySessionsClosed(1, engineSessionMock1)
+        verifySessionsClosed(0, engineSessionMock2, engineSessionMock3)
+
+        manager.onLowMemory()
+
+        assertEquals(listOf(session3.id), manager.openSessions.toList())
+        verifySessionsClosed(1, engineSessionMock1, engineSessionMock2)
+        verifySessionsClosed(0, engineSessionMock3)
+
+        manager.select(session1)
+
+        assertEquals(listOf(session1.id, session3.id), manager.openSessions.toList())
+        verifySessionsClosed(1, engineSessionMock1, engineSessionMock2)
+        verifySessionsClosed(0, engineSessionMock3)
+
+        manager.select(session2)
+
+        assertEquals(listOf(session2.id, session1.id), manager.openSessions.toList())
+        verifySessionsClosed(1, engineSessionMock1, engineSessionMock2, engineSessionMock3)
+    }
+}
+
+/**
+ * Allows changing [maxOpenSessions] to make tests less verbose.
+ */
+private class TestLegacySessionManager(override val maxOpenSessions: Int) :
+    LegacySessionManager(mock(), SessionManager.EngineSessionLinker(null))
+
+private fun verifySessionsClosed(times: Int, vararg sessions: EngineSession) {
+    sessions.forEach {
+        verify(it, times(times)).requestClose(any())
+    }
+}

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -75,6 +75,8 @@ class EngineObserverTest {
                 notifyObservers { onLoadingStateChange(true) }
                 notifyObservers { onNavigationStateChange(true, true) }
             }
+            override fun requestClose(reason: RequestCloseReason) {}
+            override fun ensureOpen(sessionState: EngineSessionState?) {}
         }
         engineSession.register(EngineObserver(session))
 
@@ -118,6 +120,8 @@ class EngineObserverTest {
                     notifyObservers { onSecurityChange(false) }
                 }
             }
+            override fun requestClose(reason: RequestCloseReason) {}
+            override fun ensureOpen(sessionState: EngineSessionState?) {}
         }
         engineSession.register(EngineObserver(session))
 
@@ -156,6 +160,8 @@ class EngineObserverTest {
             override fun clearFindMatches() {}
             override fun exitFullScreenMode() {}
             override fun recoverFromCrash(): Boolean { return false }
+            override fun requestClose(reason: RequestCloseReason) {}
+            override fun ensureOpen(sessionState: EngineSessionState?) {}
         }
         val observer = EngineObserver(session)
         engineSession.register(observer)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -391,6 +391,13 @@ abstract class EngineSession(
     }
 
     /**
+     * Indicates why [requestClose] was called.
+     */
+    enum class RequestCloseReason {
+        LowMemory
+    }
+
+    /**
      * Loads the given URL.
      *
      * @param url the url to load.
@@ -536,4 +543,19 @@ abstract class EngineSession(
      */
     @CallSuper
     open fun close() = delegate.unregisterObservers()
+
+    /**
+     * Request that the session be closed. This may be ignored by the session.
+     *
+     * @param [reason] why this window should be closed.
+     */
+    abstract fun requestClose(reason: RequestCloseReason)
+
+    /**
+     * Open a closed session. This will ready it so that it can be viewed by a user.
+     *
+     * @param [sessionState] saved state that should be restored. If null, the session will reopen
+     * to about:blank
+     */
+    abstract fun ensureOpen(sessionState: EngineSessionState?)
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,12 @@ permalink: /changelog/
     * The version of `glean_parser` has been upgraded to 1.17.3
     * Collections performed before initialization (preinit tasks) are now dispatched off
       the main thread during initialization.
+      
+* **browser-session**
+  * Basic memory management added to `SessionManager`
+    * Whenever `SessionManager#onLowMemory` is called, all `EngineSessions` except for the currently selected one will be closed to save memory.
+    * Whenever a new session is selected, if the max number of open sessions is already open, the LRU one will be closed.
+    * Closed `EngineSessions` have their state stored, and will be reloaded when they are reopened.
 
 # 31.0.0
 


### PR DESCRIPTION
For Fenix#4151: fixes crashes when too many tabs have been opened

Adds 2 new behaviors:
1) when SessionManager#onLowMemory is called, all sessions except for the currently selected one will be closed to save memory.
2) whenever a new session is selected, if the max number of open sessions is already open, the LRU one will be closed.

All closed sessions have their state stored, and will be reloaded (pretty quickly, actually) when they are reopened.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
