### PR TITLE
For Fenix#8367: Update add-on item rating_bar to be more accessible

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -98,6 +98,7 @@ class AddonsManagerAdapter(
         val titleView = view.findViewById<TextView>(R.id.add_on_name)
         val summaryView = view.findViewById<TextView>(R.id.add_on_description)
         val ratingView = view.findViewById<RatingBar>(R.id.rating)
+        val ratingAccessibleView = view.findViewById<TextView>(R.id.rating_accessibility)
         val userCountView = view.findViewById<TextView>(R.id.users_count)
         val addButton = view.findViewById<ImageView>(R.id.add_button)
         return AddonViewHolder(
@@ -106,6 +107,7 @@ class AddonsManagerAdapter(
             titleView,
             summaryView,
             ratingView,
+            ratingAccessibleView,
             userCountView,
             addButton
         )
@@ -165,9 +167,14 @@ class AddonsManagerAdapter(
         addon.rating?.let {
             val userCount = context.getString(R.string.mozac_feature_addons_user_rating_count)
             val ratingContentDescription =
-                context.getString(R.string.mozac_feature_addons_rating_content_description)
-            holder.ratingView.contentDescription =
-                String.format(ratingContentDescription, it.average)
+                String.format(
+                    context.getString(R.string.mozac_feature_addons_rating_content_description),
+                    it.average
+                )
+            holder.ratingView.contentDescription = ratingContentDescription
+            // Android RatingBar is not very accessibility-friendly, we will use non visible TextView
+            // for contentDescription for the TalkBack feature
+            holder.ratingAccessibleView.text = ratingContentDescription
             holder.ratingView.rating = it.average
             holder.userCountView.text = String.format(userCount, getFormattedAmount(it.reviews))
         }

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
@@ -40,6 +40,7 @@ sealed class CustomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val titleView: TextView,
         val summaryView: TextView,
         val ratingView: RatingBar,
+        val ratingAccessibleView: TextView,
         val userCountView: TextView,
         val addButton: ImageView
     ) : CustomViewHolder(view)

--- a/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
+++ b/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
@@ -76,7 +76,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="20dp"
                     android:isIndicator="true"
+                    android:importantForAccessibility="no"
                     android:numStars="5" />
+
+            <TextView
+                android:id="@+id/rating_accessibility"
+                android:layout_width="0dp"
+                android:layout_height="0dp" />
 
             <TextView
                     android:id="@+id/users_count"


### PR DESCRIPTION
Appears to be related to an issue with Android `RatingBar` (and its parent `ProgressBar` ).