### PR TITLE
Issue #5886: Automatically cancel 'migration completed' notification after user clicks it.

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
@@ -104,7 +104,9 @@ abstract class AbstractMigrationService : Service() {
         val channel: String = NOTIFICATION_CHANNEL_ID
         val titleRes: Int = R.string.mozac_support_migration_complete_notification_title
         val contentRes: Int = R.string.mozac_support_migration_complete_notification_text
-        val builder = getNotificationBuilder(titleRes, contentRes, channel)
+        val builder = getNotificationBuilder(titleRes, contentRes, channel).apply {
+            setAutoCancel(true)
+        }
 
         NotificationManagerCompat.from(this).notify(
             NOTIFICATION_TAG,


### PR DESCRIPTION
Follow-up patch for #5886.