### PR TITLE
Closes #5946: HttpIconLoad$toIconLoaderResult can throw an IOException

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/HttpIconLoader.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/loader/HttpIconLoader.kt
@@ -49,18 +49,17 @@ class HttpIconLoader(
             redirect = Request.Redirect.FOLLOW,
             useCaches = true)
 
-        val response = try {
-            httpClient.fetch(downloadRequest)
+        return try {
+            val response = httpClient.fetch(downloadRequest)
+            if (response.isSuccess) {
+                response.toIconLoaderResult()
+            } else {
+                failureCache.rememberFailure(resource.url)
+                IconLoader.Result.NoResult
+            }
         } catch (e: IOException) {
             logger.debug("IOException while trying to download icon resource", e)
             return IconLoader.Result.NoResult
-        }
-
-        return if (response.isSuccess) {
-            response.toIconLoaderResult()
-        } else {
-            failureCache.rememberFailure(resource.url)
-            IconLoader.Result.NoResult
         }
     }
 


### PR DESCRIPTION
This patch for #5946 (which is a relatively high crasher) simply pulls `response.toIconLoaderResult` into the existing try/catch so that an IOException originating from `Response.body.readBytes()` will be caught too and be turned into a `IconLoader.Result.NoResult` result.

> I think I have a decent test but I don't know mockito well enough to understand if this is correct. 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
