### PR TITLE
Closes #5900: IntentReceiverActivity is reused when opening intent from other apps.

### DIFF
--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -78,7 +78,13 @@
             android:label="@string/mozac_feature_addons_addons"
             android:theme="@style/Theme.AppCompat.Light" />
 
-        <activity android:name=".IntentReceiverActivity">
+        <activity
+            android:name=".IntentReceiverActivity"
+            android:relinquishTaskIdentity="true"
+            android:taskAffinity=""
+            android:exported="true"
+            android:excludeFromRecents="true" >
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
@@ -20,6 +20,14 @@ class IntentReceiverActivity : Activity() {
             val intent = intent?.let { Intent(it) } ?: Intent()
             val intentProcessors = components.externalAppIntentProcessors + components.tabIntentProcessor
 
+            // Explicitly remove the new task and clear task flags (Our browser activity is a single
+            // task activity and we never want to start a second task here).
+            intent.flags = intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK.inv()
+            intent.flags = intent.flags and Intent.FLAG_ACTIVITY_CLEAR_TASK.inv()
+
+            // LauncherActivity is started with the "excludeFromRecents" flag (set in manifest). We
+            // do not want to propagate this flag from the launcher activity to the browser.
+            intent.flags = intent.flags and Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS.inv()
             intentProcessors.any { it.process(intent) }
 
             setBrowserActivity(intent)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
