### PR TITLE
Fix publishing local artifacts of `tooling-glean-gradle`

### DIFF
--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -25,6 +25,11 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
+static def getLocalPublicationTimestamp() {
+    def date = new Date()
+    return date.format('yyyyMMddHHmmss')
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -25,6 +25,7 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
+// Must match the implementation in publish.gradle
 static def getLocalPublicationTimestamp() {
     def date = new Date()
     return date.format('yyyyMMddHHmmss')

--- a/publish.gradle
+++ b/publish.gradle
@@ -8,6 +8,7 @@ def libVcsUrl = properties.libVcsUrl
 def libLicense = properties.libLicense
 def libLicenseUrl = properties.libLicenseUrl
 
+// Must match the implementation in components/tooling/glean-gradle-plugin/build.gradle
 static def getLocalPublicationTimestamp() {
     def date = new Date()
     return date.format('yyyyMMddHHmmss')


### PR DESCRIPTION
Fixes this issue when publishing local builds:

```
FAILURE: Build failed with an exception.* Where:
Build file '/Users/tublitzed/GIT/android-components/components/tooling/glean-gradle-plugin/build.gradle' line: 38* What went wrong:
A problem occurred evaluating project ':tooling-glean-gradle'.
> Could not find method getLocalPublicationTimestamp() for arguments [] on object of type org.gradle.api.publish.maven.internal.publication.DefaultMavenPom.
```

Thanks @Baron-Severin for the solution!

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
