### PR TITLE
Closes #6027 Add support for video autoplay permissions

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -452,6 +452,13 @@ class GeckoEngine(
      * See [Engine.settings]
      */
     override val settings: Settings = object : Settings() {
+
+        init {
+            // `autoplayDefault` has been removed from GV nightly, but for now it must be set to
+            // `allowed` in order for site specific autoplay permissions to work.
+            runtime.settings.autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
+        }
+
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }
@@ -538,16 +545,6 @@ class GeckoEngine(
             get() = PreferredColorScheme.from(runtime.settings.preferredColorScheme)
             set(value) { runtime.settings.preferredColorScheme = value.toGeckoValue() }
 
-        override var allowAutoplayMedia: Boolean
-            get() = runtime.settings.autoplayDefault == GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
-            set(value) {
-                runtime.settings.autoplayDefault = if (value) {
-                    GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
-                } else {
-                    GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
-                }
-            }
-
         override var suspendMediaWhenInactive: Boolean
             get() = defaultSettings?.suspendMediaWhenInactive ?: false
             set(value) { defaultSettings?.suspendMediaWhenInactive = value }
@@ -594,7 +591,6 @@ class GeckoEngine(
             this.testingModeEnabled = it.testingModeEnabled
             this.userAgentString = it.userAgentString
             this.preferredColorScheme = it.preferredColorScheme
-            this.allowAutoplayMedia = it.allowAutoplayMedia
             this.suspendMediaWhenInactive = it.suspendMediaWhenInactive
             this.fontInflationEnabled = it.fontInflationEnabled
             this.fontSizeFactor = it.fontSizeFactor

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -17,6 +17,8 @@ import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_MICROPHONE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_OTHER
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_SCREEN
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
@@ -50,7 +52,9 @@ sealed class GeckoPermissionRequest constructor(
         companion object {
             val permissionsMap = mapOf(
                 PERMISSION_DESKTOP_NOTIFICATION to Permission.ContentNotification(),
-                PERMISSION_GEOLOCATION to Permission.ContentGeoLocation()
+                PERMISSION_GEOLOCATION to Permission.ContentGeoLocation(),
+                PERMISSION_AUTOPLAY_AUDIBLE to Permission.ContentAutoPlayAudible(),
+                PERMISSION_AUTOPLAY_INAUDIBLE to Permission.ContentAutoPlayInaudible()
             )
         }
     }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -66,7 +66,9 @@ import org.mozilla.geckoview.WebExtension as GeckoWebExtension
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineTest {
 
-    private val runtime: GeckoRuntime = mock()
+    private val runtime: GeckoRuntime = mock {
+        whenever(settings).thenReturn(mock())
+    }
     private val context: Context = mock()
 
     @Test
@@ -90,7 +92,9 @@ class GeckoEngineTest {
     fun settings() {
         val defaultSettings = DefaultSettings()
         val contentBlockingSettings = ContentBlocking.Settings.Builder().build()
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val runtimeSettings = mock<GeckoRuntimeSettings>()
         whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
         whenever(runtimeSettings.webFontsEnabled).thenReturn(true)
@@ -143,10 +147,6 @@ class GeckoEngineTest {
         assertEquals(PreferredColorScheme.System, engine.settings.preferredColorScheme)
         engine.settings.preferredColorScheme = PreferredColorScheme.Dark
         verify(runtimeSettings).preferredColorScheme = PreferredColorScheme.Dark.toGeckoValue()
-
-        assertTrue(engine.settings.allowAutoplayMedia)
-        engine.settings.allowAutoplayMedia = false
-        verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
 
         assertFalse(engine.settings.suspendMediaWhenInactive)
         engine.settings.suspendMediaWhenInactive = true
@@ -317,13 +317,15 @@ class GeckoEngineTest {
 
     @Test
     fun defaultSettings() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val runtimeSettings = mock<GeckoRuntimeSettings>()
         val contentBlockingSettings = ContentBlocking.Settings.Builder().build()
         whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
         whenever(runtime.settings).thenReturn(runtimeSettings)
         whenever(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
-        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
+        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
         whenever(runtimeSettings.fontInflationEnabled).thenReturn(true)
 
         val engine = GeckoEngine(context,
@@ -338,7 +340,6 @@ class GeckoEngineTest {
                 testingModeEnabled = true,
                 userAgentString = "test-ua",
                 preferredColorScheme = PreferredColorScheme.Light,
-                allowAutoplayMedia = false,
                 suspendMediaWhenInactive = true,
                 forceUserScalableContent = false
             ), runtime)
@@ -349,7 +350,7 @@ class GeckoEngineTest {
         verify(runtimeSettings).fontInflationEnabled = false
         verify(runtimeSettings).fontSizeFactor = 2.0F
         verify(runtimeSettings).remoteDebuggingEnabled = true
-        verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
+        verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
         verify(runtimeSettings).forceUserScalableEnabled = false
 
         val trackingStrictCategories = TrackingProtectionPolicy.strict().trackingCategories.sumBy { it.id }
@@ -366,7 +367,6 @@ class GeckoEngineTest {
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
-        assertFalse(engine.settings.allowAutoplayMedia)
         assertTrue(engine.settings.suspendMediaWhenInactive)
 
         engine.settings.safeBrowsingPolicy = arrayOf(SafeBrowsingPolicy.PHISHING)
@@ -409,7 +409,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install built-in web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
@@ -438,7 +440,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install built-in web extension successfully but do not allow content messaging`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
@@ -468,7 +472,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install external web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -505,7 +511,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install built-in web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onErrorCalled = false
         val expected = IOException()
@@ -528,7 +536,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install external web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -554,7 +564,9 @@ class GeckoEngineTest {
 
     @Test
     fun `uninstall web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
@@ -595,7 +607,9 @@ class GeckoEngineTest {
 
     @Test
     fun `uninstall web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
@@ -633,7 +647,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles opening a new tab`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -669,7 +685,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles closing tab`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -702,7 +720,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles installation`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -723,7 +743,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles install prompt`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -748,7 +770,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles update prompt`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -789,7 +813,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of browser actions from built-in extensions`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -825,7 +851,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of page actions from built-in extensions`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
@@ -861,7 +889,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of browser actions from external extensions`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -902,7 +932,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of page actions from external extensions`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -943,7 +975,9 @@ class GeckoEngineTest {
 
     @Test
     fun `update web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val bundle = GeckoBundle()
@@ -981,7 +1015,9 @@ class GeckoEngineTest {
 
     @Test
     fun `try to update a web extension without a new update available`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val bundle = GeckoBundle()
@@ -1018,7 +1054,9 @@ class GeckoEngineTest {
 
     @Test
     fun `update web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val updateExtensionResult = GeckoResult<GeckoWebExtension>()
@@ -1061,7 +1099,9 @@ class GeckoEngineTest {
         val installedExtensions = listOf<GeckoWebExtension>(installedExtension)
         val installedExtensionResult = GeckoResult<List<GeckoWebExtension>>()
 
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(extensionController.list()).thenReturn(installedExtensionResult)
         whenever(runtime.webExtensionController).thenReturn(extensionController)
@@ -1084,7 +1124,9 @@ class GeckoEngineTest {
     fun `list web extensions failure`() {
         val installedExtensionResult = GeckoResult<List<GeckoWebExtension>>()
 
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(extensionController.list()).thenReturn(installedExtensionResult)
         whenever(runtime.webExtensionController).thenReturn(extensionController)
@@ -1106,7 +1148,9 @@ class GeckoEngineTest {
 
     @Test
     fun `enable web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val bundle = GeckoBundle()
@@ -1145,7 +1189,9 @@ class GeckoEngineTest {
 
     @Test
     fun `enable web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val enableExtensionResult = GeckoResult<GeckoWebExtension>()
@@ -1181,7 +1227,9 @@ class GeckoEngineTest {
 
     @Test
     fun `disable web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val bundle = GeckoBundle()
@@ -1220,7 +1268,9 @@ class GeckoEngineTest {
 
     @Test
     fun `disable web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
 
         val disableExtensionResult = GeckoResult<GeckoWebExtension>()
@@ -1256,7 +1306,9 @@ class GeckoEngineTest {
 
     @Test(expected = RuntimeException::class)
     fun `WHEN GeckoRuntime is shutting down THEN GeckoEngine throws runtime exception`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
 
         GeckoEngine(context, runtime = runtime)
 
@@ -1270,7 +1322,9 @@ class GeckoEngineTest {
 
     @Test
     fun `clear browsing data for all hosts`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var onSuccessCalled = false
@@ -1287,7 +1341,9 @@ class GeckoEngineTest {
 
     @Test
     fun `error handler invoked when clearing browsing data for all hosts fails`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var throwable: Throwable? = null
@@ -1310,7 +1366,9 @@ class GeckoEngineTest {
 
     @Test
     fun `clear browsing data for specified host`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var onSuccessCalled = false
@@ -1318,8 +1376,8 @@ class GeckoEngineTest {
         val result = GeckoResult<Void>()
         whenever(runtime.storageController).thenReturn(storageController)
         whenever(storageController.clearDataFromHost(
-                eq("mozilla.org"),
-                eq(Engine.BrowsingData.all().types.toLong()))
+            eq("mozilla.org"),
+            eq(Engine.BrowsingData.all().types.toLong()))
         ).thenReturn(result)
         result.complete(null)
 
@@ -1330,7 +1388,9 @@ class GeckoEngineTest {
 
     @Test
     fun `error handler invoked when clearing browsing data for specified hosts fails`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var throwable: Throwable? = null
@@ -1340,8 +1400,8 @@ class GeckoEngineTest {
         val result = GeckoResult<Void>()
         whenever(runtime.storageController).thenReturn(storageController)
         whenever(storageController.clearDataFromHost(
-                eq("mozilla.org"),
-                eq(Engine.BrowsingData.all().types.toLong()))
+            eq("mozilla.org"),
+            eq(Engine.BrowsingData.all().types.toLong()))
         ).thenReturn(result)
         result.completeExceptionally(exception)
 
@@ -1356,7 +1416,9 @@ class GeckoEngineTest {
 
     @Test
     fun `test parsing engine version`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         val version = engine.version
 
@@ -1369,7 +1431,9 @@ class GeckoEngineTest {
     @Test
     fun `after init is called the trackingProtectionExceptionStore must be restored`() {
         val mockStore: TrackingProtectionExceptionStorage = mock()
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         GeckoEngine(context, runtime = runtime, trackingProtectionExceptionStore = mockStore)
 
         verify(mockStore).restore()
@@ -1377,7 +1441,9 @@ class GeckoEngineTest {
 
     @Test
     fun `fetch trackers logged successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
@@ -1442,7 +1508,9 @@ class GeckoEngineTest {
 
     @Test
     fun `fetch trackers logged of the level 2 list`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         val mockSession = mock<GeckoEngineSession>()
         val mockGeckoSetting = mock<GeckoRuntimeSettings>()
@@ -1486,7 +1554,9 @@ class GeckoEngineTest {
 
     @Test
     fun `registerWebNotificationDelegate sets delegate`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
 
         engine.registerWebNotificationDelegate(mock())
@@ -1496,7 +1566,9 @@ class GeckoEngineTest {
 
     @Test
     fun `registerWebPushDelegate sets delegate and returns same handler`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val controller: WebPushController = mock()
         val engine = GeckoEngine(context, runtime = runtime)
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -35,6 +35,14 @@ class GeckoPermissionRequestTest {
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.ContentGeoLocation()), request.permissions)
 
+        request = GeckoPermissionRequest.Content(uri, GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE, callback)
+        assertEquals(uri, request.uri)
+        assertEquals(listOf(Permission.ContentAutoPlayAudible()), request.permissions)
+
+        request = GeckoPermissionRequest.Content(uri, GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE, callback)
+        assertEquals(uri, request.uri)
+        assertEquals(listOf(Permission.ContentAutoPlayInaudible()), request.permissions)
+
         request = GeckoPermissionRequest.Content(uri, 1234, callback)
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.Generic("1234", "Gecko permission type = 1234")), request.permissions)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -536,10 +536,6 @@ class GeckoEngine(
             get() = PreferredColorScheme.from(runtime.settings.preferredColorScheme)
             set(value) { runtime.settings.preferredColorScheme = value.toGeckoValue() }
 
-        // TODO this setting was removed in GV. We'll refactor / remove this in
-        // https://github.com/mozilla-mobile/android-components/pull/5953
-        override var allowAutoplayMedia: Boolean = false
-
         override var suspendMediaWhenInactive: Boolean
             get() = defaultSettings?.suspendMediaWhenInactive ?: false
             set(value) { defaultSettings?.suspendMediaWhenInactive = value }
@@ -586,8 +582,6 @@ class GeckoEngine(
             this.testingModeEnabled = it.testingModeEnabled
             this.userAgentString = it.userAgentString
             this.preferredColorScheme = it.preferredColorScheme
-            this.allowAutoplayMedia = it.allowAutoplayMedia
-            this.suspendMediaWhenInactive = it.suspendMediaWhenInactive
             this.fontInflationEnabled = it.fontInflationEnabled
             this.fontSizeFactor = it.fontSizeFactor
             this.forceUserScalableContent = it.forceUserScalableContent

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -17,6 +17,8 @@ import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_MICROPHONE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_OTHER
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_SCREEN
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
@@ -50,7 +52,9 @@ sealed class GeckoPermissionRequest constructor(
         companion object {
             val permissionsMap = mapOf(
                 PERMISSION_DESKTOP_NOTIFICATION to Permission.ContentNotification(),
-                PERMISSION_GEOLOCATION to Permission.ContentGeoLocation()
+                PERMISSION_GEOLOCATION to Permission.ContentGeoLocation(),
+                PERMISSION_AUTOPLAY_AUDIBLE to Permission.ContentAutoPlayAudible(),
+                PERMISSION_AUTOPLAY_INAUDIBLE to Permission.ContentAutoPlayInaudible()
             )
         }
     }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -340,7 +340,6 @@ class GeckoEngineTest {
                 testingModeEnabled = true,
                 userAgentString = "test-ua",
                 preferredColorScheme = PreferredColorScheme.Light,
-                allowAutoplayMedia = false,
                 suspendMediaWhenInactive = true,
                 forceUserScalableContent = false
             ), runtime)
@@ -367,7 +366,6 @@ class GeckoEngineTest {
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
-        assertFalse(engine.settings.allowAutoplayMedia)
         assertTrue(engine.settings.suspendMediaWhenInactive)
 
         engine.settings.safeBrowsingPolicy = arrayOf(SafeBrowsingPolicy.PHISHING)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -35,6 +35,14 @@ class GeckoPermissionRequestTest {
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.ContentGeoLocation()), request.permissions)
 
+        request = GeckoPermissionRequest.Content(uri, GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE, callback)
+        assertEquals(uri, request.uri)
+        assertEquals(listOf(Permission.ContentAutoPlayAudible()), request.permissions)
+
+        request = GeckoPermissionRequest.Content(uri, GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE, callback)
+        assertEquals(uri, request.uri)
+        assertEquals(listOf(Permission.ContentAutoPlayInaudible()), request.permissions)
+
         request = GeckoPermissionRequest.Content(uri, 1234, callback)
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.Generic("1234", "Gecko permission type = 1234")), request.permissions)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -414,6 +414,13 @@ class GeckoEngine(
      * See [Engine.settings]
      */
     override val settings: Settings = object : Settings() {
+
+        init {
+            // `autoplayDefault` has been removed from GV nightly, but for now it must be set to
+            // `allowed` in order for site specific autoplay permissions to work.
+            runtime.settings.autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
+        }
+
         override var javascriptEnabled: Boolean
             get() = runtime.settings.javaScriptEnabled
             set(value) { runtime.settings.javaScriptEnabled = value }
@@ -500,16 +507,6 @@ class GeckoEngine(
             get() = PreferredColorScheme.from(runtime.settings.preferredColorScheme)
             set(value) { runtime.settings.preferredColorScheme = value.toGeckoValue() }
 
-        override var allowAutoplayMedia: Boolean
-            get() = runtime.settings.autoplayDefault == GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
-            set(value) {
-                runtime.settings.autoplayDefault = if (value) {
-                    GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
-                } else {
-                    GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
-                }
-            }
-
         override var suspendMediaWhenInactive: Boolean
             get() = defaultSettings?.suspendMediaWhenInactive ?: false
             set(value) { defaultSettings?.suspendMediaWhenInactive = value }
@@ -556,7 +553,6 @@ class GeckoEngine(
             this.testingModeEnabled = it.testingModeEnabled
             this.userAgentString = it.userAgentString
             this.preferredColorScheme = it.preferredColorScheme
-            this.allowAutoplayMedia = it.allowAutoplayMedia
             this.suspendMediaWhenInactive = it.suspendMediaWhenInactive
             this.fontInflationEnabled = it.fontInflationEnabled
             this.fontSizeFactor = it.fontSizeFactor

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequest.kt
@@ -17,6 +17,8 @@ import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_MICROPHONE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_OTHER
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource.SOURCE_SCREEN
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
@@ -50,7 +52,9 @@ sealed class GeckoPermissionRequest constructor(
         companion object {
             val permissionsMap = mapOf(
                 PERMISSION_DESKTOP_NOTIFICATION to Permission.ContentNotification(),
-                PERMISSION_GEOLOCATION to Permission.ContentGeoLocation()
+                PERMISSION_GEOLOCATION to Permission.ContentGeoLocation(),
+                PERMISSION_AUTOPLAY_AUDIBLE to Permission.ContentAutoPlayAudible(),
+                PERMISSION_AUTOPLAY_INAUDIBLE to Permission.ContentAutoPlayInaudible()
             )
         }
     }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -65,7 +65,9 @@ import org.mozilla.geckoview.WebExtension as GeckoWebExtension
 @RunWith(AndroidJUnit4::class)
 class GeckoEngineTest {
 
-    private val runtime: GeckoRuntime = mock()
+    private val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
     private val context: Context = mock()
 
     @Test
@@ -89,7 +91,9 @@ class GeckoEngineTest {
     fun settings() {
         val defaultSettings = DefaultSettings()
         val contentBlockingSettings = ContentBlocking.Settings.Builder().build()
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val runtimeSettings = mock<GeckoRuntimeSettings>()
         whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
         whenever(runtimeSettings.webFontsEnabled).thenReturn(true)
@@ -142,10 +146,6 @@ class GeckoEngineTest {
         assertEquals(PreferredColorScheme.System, engine.settings.preferredColorScheme)
         engine.settings.preferredColorScheme = PreferredColorScheme.Dark
         verify(runtimeSettings).preferredColorScheme = PreferredColorScheme.Dark.toGeckoValue()
-
-        assertTrue(engine.settings.allowAutoplayMedia)
-        engine.settings.allowAutoplayMedia = false
-        verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
 
         assertFalse(engine.settings.suspendMediaWhenInactive)
         engine.settings.suspendMediaWhenInactive = true
@@ -316,13 +316,15 @@ class GeckoEngineTest {
 
     @Test
     fun defaultSettings() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val runtimeSettings = mock<GeckoRuntimeSettings>()
         val contentBlockingSettings = ContentBlocking.Settings.Builder().build()
         whenever(runtimeSettings.javaScriptEnabled).thenReturn(true)
         whenever(runtime.settings).thenReturn(runtimeSettings)
         whenever(runtimeSettings.contentBlocking).thenReturn(contentBlockingSettings)
-        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
+        whenever(runtimeSettings.autoplayDefault).thenReturn(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
         whenever(runtimeSettings.fontInflationEnabled).thenReturn(true)
 
         val engine = GeckoEngine(context,
@@ -337,7 +339,6 @@ class GeckoEngineTest {
                 testingModeEnabled = true,
                 userAgentString = "test-ua",
                 preferredColorScheme = PreferredColorScheme.Light,
-                allowAutoplayMedia = false,
                 suspendMediaWhenInactive = true,
                 forceUserScalableContent = false
             ), runtime)
@@ -348,7 +349,7 @@ class GeckoEngineTest {
         verify(runtimeSettings).fontInflationEnabled = false
         verify(runtimeSettings).fontSizeFactor = 2.0F
         verify(runtimeSettings).remoteDebuggingEnabled = true
-        verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED
+        verify(runtimeSettings).autoplayDefault = GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED
         verify(runtimeSettings).forceUserScalableEnabled = false
 
         val trackingStrictCategories = TrackingProtectionPolicy.strict().trackingCategories.sumBy { it.id }
@@ -365,7 +366,6 @@ class GeckoEngineTest {
         assertTrue(engine.settings.testingModeEnabled)
         assertEquals("test-ua", engine.settings.userAgentString)
         assertEquals(PreferredColorScheme.Light, engine.settings.preferredColorScheme)
-        assertFalse(engine.settings.allowAutoplayMedia)
         assertTrue(engine.settings.suspendMediaWhenInactive)
 
         engine.settings.safeBrowsingPolicy = arrayOf(SafeBrowsingPolicy.PHISHING)
@@ -408,7 +408,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install built-in web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
@@ -437,7 +439,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install built-in web extension successfully but do not allow content messaging`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
@@ -467,7 +471,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install external web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -504,7 +510,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install built-in web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onErrorCalled = false
         val expected = IOException()
@@ -527,7 +535,9 @@ class GeckoEngineTest {
 
     @Test
     fun `install external web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -553,7 +563,9 @@ class GeckoEngineTest {
 
     @Test
     fun `uninstall web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
@@ -594,7 +606,9 @@ class GeckoEngineTest {
 
     @Test
     fun `uninstall web extension failure`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
@@ -632,9 +646,13 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles opening a new tab`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+        val settings: GeckoRuntimeSettings = mock()
+        whenever(runtime.settings).thenReturn(settings)
 
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
@@ -668,9 +686,13 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles closing tab`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+        val settings: GeckoRuntimeSettings = mock()
+        whenever(runtime.settings).thenReturn(settings)
 
         val webExt = org.mozilla.geckoview.WebExtension("test", runtime.webExtensionController)
         val webExtensionsDelegate: WebExtensionDelegate = mock()
@@ -701,9 +723,13 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles installation`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+        val settings: GeckoRuntimeSettings = mock()
+        whenever(runtime.settings).thenReturn(settings)
 
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
@@ -722,9 +748,13 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate handles install prompt`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+        val settings: GeckoRuntimeSettings = mock()
+        whenever(runtime.settings).thenReturn(settings)
 
         val extension = GeckoWebExtension("test", runtime.webExtensionController)
         val webExtensionsDelegate: WebExtensionDelegate = mock()
@@ -747,9 +777,13 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of browser actions from built-in extensions`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+        val settings: GeckoRuntimeSettings = mock()
+        whenever(runtime.settings).thenReturn(settings)
 
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
@@ -783,9 +817,13 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of page actions from built-in extensions`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+        val settings: GeckoRuntimeSettings = mock()
+        whenever(runtime.settings).thenReturn(settings)
 
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
@@ -819,7 +857,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of browser actions from external extensions`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -860,7 +900,9 @@ class GeckoEngineTest {
 
     @Test
     fun `web extension delegate notified of page actions from external extensions`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extId = "test-webext"
         val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
 
@@ -901,7 +943,9 @@ class GeckoEngineTest {
 
     @Test
     fun `updating a web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
 
@@ -922,7 +966,9 @@ class GeckoEngineTest {
         val installedExtensions = listOf<GeckoWebExtension>(installedExtension)
         val installedExtensionResult = GeckoResult<List<GeckoWebExtension>>()
 
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(extensionController.list()).thenReturn(installedExtensionResult)
         whenever(runtime.webExtensionController).thenReturn(extensionController)
@@ -945,7 +991,9 @@ class GeckoEngineTest {
     fun `list web extensions failure`() {
         val installedExtensionResult = GeckoResult<List<GeckoWebExtension>>()
 
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(extensionController.list()).thenReturn(installedExtensionResult)
         whenever(runtime.webExtensionController).thenReturn(extensionController)
@@ -967,7 +1015,9 @@ class GeckoEngineTest {
 
     @Test
     fun `enable web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
@@ -998,7 +1048,9 @@ class GeckoEngineTest {
 
     @Test
     fun `disable web extension successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
@@ -1029,7 +1081,9 @@ class GeckoEngineTest {
 
     @Test(expected = RuntimeException::class)
     fun `WHEN GeckoRuntime is shutting down THEN GeckoEngine throws runtime exception`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
 
         GeckoEngine(context, runtime = runtime)
 
@@ -1043,7 +1097,9 @@ class GeckoEngineTest {
 
     @Test
     fun `clear browsing data for all hosts`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var onSuccessCalled = false
@@ -1060,7 +1116,9 @@ class GeckoEngineTest {
 
     @Test
     fun `error handler invoked when clearing browsing data for all hosts fails`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var throwable: Throwable? = null
@@ -1083,7 +1141,9 @@ class GeckoEngineTest {
 
     @Test
     fun `clear browsing data for specified host`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var onSuccessCalled = false
@@ -1103,7 +1163,9 @@ class GeckoEngineTest {
 
     @Test
     fun `error handler invoked when clearing browsing data for specified hosts fails`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val storageController: StorageController = mock()
 
         var throwable: Throwable? = null
@@ -1129,7 +1191,9 @@ class GeckoEngineTest {
 
     @Test
     fun `test parsing engine version`() {
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         val version = engine.version
 
@@ -1142,7 +1206,9 @@ class GeckoEngineTest {
     @Test
     fun `after init is called the trackingProtectionExceptionStore must be restored`() {
         val mockStore: TrackingProtectionExceptionStorage = mock()
-        val runtime: GeckoRuntime = mock()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         GeckoEngine(context, runtime = runtime, trackingProtectionExceptionStore = mockStore)
 
         verify(mockStore).restore()
@@ -1150,7 +1216,9 @@ class GeckoEngineTest {
 
     @Test
     fun `fetch trackers logged successfully`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         var onSuccessCalled = false
         var onErrorCalled = false
@@ -1215,7 +1283,9 @@ class GeckoEngineTest {
 
     @Test
     fun `fetch trackers logged of the level 2 list`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
         val mockSession = mock<GeckoEngineSession>()
         val mockGeckoSetting = mock<GeckoRuntimeSettings>()
@@ -1259,7 +1329,9 @@ class GeckoEngineTest {
 
     @Test
     fun `registerWebNotificationDelegate sets delegate`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val engine = GeckoEngine(context, runtime = runtime)
 
         engine.registerWebNotificationDelegate(mock())
@@ -1269,7 +1341,9 @@ class GeckoEngineTest {
 
     @Test
     fun `registerWebPushDelegate sets delegate and returns same handler`() {
-        val runtime = mock<GeckoRuntime>()
+        val runtime = mock<GeckoRuntime> {
+            whenever(settings).thenReturn(mock())
+        }
         val controller: WebPushController = mock()
         val engine = GeckoEngine(context, runtime = runtime)
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt
@@ -16,6 +16,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.MediaSource
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE
+import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION
 
@@ -34,6 +36,14 @@ class GeckoPermissionRequestTest {
         request = GeckoPermissionRequest.Content(uri, PERMISSION_GEOLOCATION, callback)
         assertEquals(uri, request.uri)
         assertEquals(listOf(Permission.ContentGeoLocation()), request.permissions)
+
+        request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_AUDIBLE, callback)
+        assertEquals(uri, request.uri)
+        assertEquals(listOf(Permission.ContentAutoPlayAudible()), request.permissions)
+
+        request = GeckoPermissionRequest.Content(uri, PERMISSION_AUTOPLAY_INAUDIBLE, callback)
+        assertEquals(uri, request.uri)
+        assertEquals(listOf(Permission.ContentAutoPlayInaudible()), request.permissions)
 
         request = GeckoPermissionRequest.Content(uri, 1234, callback)
         assertEquals(uri, request.uri)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -151,11 +151,6 @@ abstract class Settings {
     open var preferredColorScheme: PreferredColorScheme by UnsupportedSetting()
 
     /**
-     * Setting to control whether media is allowed to auto-play on page load.
-     */
-    open var allowAutoplayMedia: Boolean by UnsupportedSetting()
-
-    /**
      * Setting to control whether media should be suspended when the session is inactive.
      */
     open var suspendMediaWhenInactive: Boolean by UnsupportedSetting()
@@ -204,7 +199,6 @@ data class DefaultSettings(
     override var supportMultipleWindows: Boolean = false,
     override var preferredColorScheme: PreferredColorScheme = PreferredColorScheme.System,
     override var testingModeEnabled: Boolean = false,
-    override var allowAutoplayMedia: Boolean = true,
     override var suspendMediaWhenInactive: Boolean = false,
     override var fontInflationEnabled: Boolean? = null,
     override var fontSizeFactor: Float? = null,

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/PermissionRequest.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/permission/PermissionRequest.kt
@@ -57,6 +57,7 @@ interface PermissionRequest {
  * @property id an optional native engine-specific ID of this permission.
  * @property desc an optional description of what this permission type is for.
  */
+@Suppress("UndocumentedPublicClass")
 sealed class Permission {
     abstract val id: String?
     abstract val desc: String?
@@ -71,6 +72,8 @@ sealed class Permission {
     data class ContentVideoCapture(override val id: String? = "", override val desc: String? = "") : Permission()
     data class ContentVideoScreen(override val id: String? = "", override val desc: String? = "") : Permission()
     data class ContentVideoOther(override val id: String? = "", override val desc: String? = "") : Permission()
+    data class ContentAutoPlayAudible(override val id: String? = "", override val desc: String? = "") : Permission()
+    data class ContentAutoPlayInaudible(override val id: String? = "", override val desc: String? = "") : Permission()
 
     data class AppCamera(override val id: String? = "", override val desc: String? = "") : Permission()
     data class AppAudio(override val id: String? = "", override val desc: String? = "") : Permission()

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -71,8 +71,6 @@ class SettingsTest {
             { settings.preferredColorScheme = PreferredColorScheme.System },
             { settings.testingModeEnabled },
             { settings.testingModeEnabled = false },
-            { settings.allowAutoplayMedia },
-            { settings.allowAutoplayMedia = false },
             { settings.suspendMediaWhenInactive },
             { settings.suspendMediaWhenInactive = false },
             { settings.fontInflationEnabled },
@@ -116,7 +114,6 @@ class SettingsTest {
         assertFalse(settings.supportMultipleWindows)
         assertEquals(PreferredColorScheme.System, settings.preferredColorScheme)
         assertFalse(settings.testingModeEnabled)
-        assertTrue(settings.allowAutoplayMedia)
         assertFalse(settings.suspendMediaWhenInactive)
         assertNull(settings.fontInflationEnabled)
         assertNull(settings.fontSizeFactor)
@@ -150,7 +147,6 @@ class SettingsTest {
             supportMultipleWindows = true,
             preferredColorScheme = PreferredColorScheme.Dark,
             testingModeEnabled = true,
-            allowAutoplayMedia = false,
             suspendMediaWhenInactive = true,
             fontInflationEnabled = false,
             fontSizeFactor = 2.0F,
@@ -180,7 +176,6 @@ class SettingsTest {
         assertTrue(defaultSettings.supportMultipleWindows)
         assertEquals(PreferredColorScheme.Dark, defaultSettings.preferredColorScheme)
         assertTrue(defaultSettings.testingModeEnabled)
-        assertFalse(defaultSettings.allowAutoplayMedia)
         assertTrue(defaultSettings.suspendMediaWhenInactive)
         assertFalse(defaultSettings.fontInflationEnabled!!)
         assertEquals(2.0F, defaultSettings.fontSizeFactor)

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SettingsUseCasesTest.kt
@@ -41,16 +41,16 @@ class SettingsUseCasesTest {
 
     @Test
     fun `UpdateSettingUseCase will update all sessions`() {
-        val autoplaySetting = object : UpdateSettingUseCase<Boolean>(settings, sessionManager) {
+        val allowFileAccessSetting = object : UpdateSettingUseCase<Boolean>(settings, sessionManager) {
             override fun update(settings: Settings, value: Boolean) {
-                settings.allowAutoplayMedia = value
+                settings.allowFileAccess = value
             }
         }
 
-        autoplaySetting(true)
-        verify(settings).allowAutoplayMedia = true
-        verify(engineSessionA.settings).allowAutoplayMedia = true
-        verify(engineSessionB.settings).allowAutoplayMedia = true
+        allowFileAccessSetting(true)
+        verify(settings).allowFileAccess = true
+        verify(engineSessionA.settings).allowFileAccess = true
+        verify(engineSessionB.settings).allowFileAccess = true
     }
 
     @Test

--- a/components/feature/sitepermissions/schemas/mozilla.components.feature.sitepermissions.db.SitePermissionsDatabase/2.json
+++ b/components/feature/sitepermissions/schemas/mozilla.components.feature.sitepermissions.db.SitePermissionsDatabase/2.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "279719818fbc84cac905ddf942282eae",
+    "identityHash": "f5350dbda12da0f415e9d09d00c36f49",
     "entities": [
       {
         "tableName": "site_permissions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin` TEXT NOT NULL, `location` INTEGER NOT NULL, `notification` INTEGER NOT NULL, `microphone` INTEGER NOT NULL, `camera` INTEGER NOT NULL, `bluetooth` INTEGER NOT NULL, `local_storage` INTEGER NOT NULL, `saved_at` INTEGER NOT NULL, PRIMARY KEY(`origin`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin` TEXT NOT NULL, `location` INTEGER NOT NULL, `notification` INTEGER NOT NULL, `microphone` INTEGER NOT NULL, `camera` INTEGER NOT NULL, `bluetooth` INTEGER NOT NULL, `local_storage` INTEGER NOT NULL, `autoplay_audible` INTEGER NOT NULL, `autoplay_inaudible` INTEGER NOT NULL, `saved_at` INTEGER NOT NULL, PRIMARY KEY(`origin`))",
         "fields": [
           {
             "fieldPath": "origin",
@@ -51,6 +51,18 @@
             "notNull": true
           },
           {
+            "fieldPath": "autoplayAudible",
+            "columnName": "autoplay_audible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoplayInaudible",
+            "columnName": "autoplay_inaudible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
             "fieldPath": "savedAt",
             "columnName": "saved_at",
             "affinity": "INTEGER",
@@ -67,9 +79,10 @@
         "foreignKeys": []
       }
     ],
+    "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"279719818fbc84cac905ddf942282eae\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f5350dbda12da0f415e9d09d00c36f49')"
     ]
   }
 }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissions.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissions.kt
@@ -21,6 +21,8 @@ data class SitePermissions(
     val camera: Status = NO_DECISION,
     val bluetooth: Status = NO_DECISION,
     val localStorage: Status = NO_DECISION,
+    val autoplayAudible: Status = NO_DECISION,
+    val autoplayInaudible: Status = NO_DECISION,
     val savedAt: Long
 ) : Parcelable {
     enum class Status(
@@ -49,6 +51,8 @@ data class SitePermissions(
             Permission.LOCAL_STORAGE -> localStorage
             Permission.NOTIFICATION -> notification
             Permission.LOCATION -> location
+            Permission.AUTOPLAY_AUDIBLE -> autoplayAudible
+            Permission.AUTOPLAY_INAUDIBLE -> autoplayInaudible
         }
     }
 }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -26,6 +26,8 @@ import mozilla.components.browser.session.runWithSessionIdOrSelected
 import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.concept.engine.permission.Permission.ContentAudioCapture
 import mozilla.components.concept.engine.permission.Permission.ContentAudioMicrophone
+import mozilla.components.concept.engine.permission.Permission.ContentAutoPlayAudible
+import mozilla.components.concept.engine.permission.Permission.ContentAutoPlayInaudible
 import mozilla.components.concept.engine.permission.Permission.ContentGeoLocation
 import mozilla.components.concept.engine.permission.Permission.ContentNotification
 import mozilla.components.concept.engine.permission.Permission.ContentVideoCamera
@@ -229,7 +231,8 @@ class SitePermissionsFeature(
             storage.findSitePermissionsBy(request.host)
         }
 
-        val prompt = if (shouldApplyRules(permissionFromStorage)) {
+        val prompt = if (shouldApplyRules(permissionFromStorage) ||
+            request.isForAutoplay()) {
             handleRuledFlow(request, session)
         } else {
             handleNoRuledFlow(permissionFromStorage, request, session)
@@ -267,15 +270,28 @@ class SitePermissionsFeature(
         permissionRequest: PermissionRequest,
         session: Session
     ): SitePermissionsDialogFragment? {
-        val action = requireNotNull(sitePermissionsRules).getActionFrom(permissionRequest)
-        return when (action) {
-            SitePermissionsRules.Action.BLOCKED -> {
-                permissionRequest.reject()
-                session.contentPermissionRequest.consume { true }
-                null
-            }
-            SitePermissionsRules.Action.ASK_TO_ALLOW -> {
-                createPrompt(permissionRequest, session)
+        // For now we only support autoplay via sitePermissionsRules until we add support for
+        // autoplay for specific sites see Fenix issue  #8603
+        return if (permissionRequest.isForAutoplay() && sitePermissionsRules == null) {
+            permissionRequest.reject()
+            session.contentPermissionRequest.consume { true }
+            null
+        } else {
+            val action = requireNotNull(sitePermissionsRules).getActionFrom(permissionRequest)
+            when (action) {
+                SitePermissionsRules.Action.ALLOWED -> {
+                    permissionRequest.grant()
+                    session.contentPermissionRequest.consume { true }
+                    null
+                }
+                SitePermissionsRules.Action.BLOCKED -> {
+                    permissionRequest.reject()
+                    session.contentPermissionRequest.consume { true }
+                    null
+                }
+                SitePermissionsRules.Action.ASK_TO_ALLOW -> {
+                    createPrompt(permissionRequest, session)
+                }
             }
         }
     }
@@ -318,6 +334,9 @@ class SitePermissionsFeature(
         return sitePermissions
     }
 
+    private fun PermissionRequest.isForAutoplay() =
+        this.permissions.any { it is ContentAutoPlayInaudible || it is ContentAutoPlayAudible }
+
     private fun updateSitePermissionsStatus(
         status: SitePermissions.Status,
         permission: Permission,
@@ -335,6 +354,12 @@ class SitePermissionsFeature(
             }
             is ContentVideoCamera, is ContentVideoCapture -> {
                 sitePermissions.copy(camera = status)
+            }
+            is ContentAutoPlayAudible -> {
+                sitePermissions.copy(autoplayAudible = status)
+            }
+            is ContentAutoPlayInaudible -> {
+                sitePermissions.copy(autoplayInaudible = status)
             }
             else ->
                 throw InvalidParameterException("$permission is not a valid permission.")
@@ -572,7 +597,8 @@ private fun Permission.isSupported(): Boolean {
         is ContentGeoLocation,
         is ContentNotification,
         is ContentAudioCapture, is ContentAudioMicrophone,
-        is ContentVideoCamera, is ContentVideoCapture -> true
+        is ContentVideoCamera, is ContentVideoCapture,
+        is ContentAutoPlayAudible, is ContentAutoPlayInaudible -> true
         else -> false
     }
 }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsRules.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsRules.kt
@@ -12,18 +12,50 @@ import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BL
 /**
  * Indicate how site permissions must behave by permission category.
  */
-data class SitePermissionsRules(
+data class SitePermissionsRules internal constructor(
     val camera: Action,
     val location: Action,
     val notification: Action,
-    val microphone: Action
+    val microphone: Action,
+    val autoplayAudible: Action,
+    val autoplayInaudible: Action
 ) {
+
+    constructor(
+        camera: Action,
+        location: Action,
+        notification: Action,
+        microphone: Action,
+        autoplayAudible: AutoplayAction,
+        autoplayInaudible: AutoplayAction
+    ) : this(
+        camera = camera,
+        location = location,
+        notification = notification,
+        microphone = microphone,
+        autoplayAudible = autoplayAudible.toAction(),
+        autoplayInaudible = autoplayInaudible.toAction()
+    )
+
     enum class Action {
-        BLOCKED, ASK_TO_ALLOW;
+        ALLOWED, BLOCKED, ASK_TO_ALLOW;
 
         fun toStatus(): SitePermissions.Status = when (this) {
+            ALLOWED -> SitePermissions.Status.ALLOWED
             BLOCKED -> SitePermissions.Status.BLOCKED
             ASK_TO_ALLOW -> SitePermissions.Status.NO_DECISION
+        }
+    }
+
+    /**
+     * Autoplay requests will never prompt the user
+     */
+    enum class AutoplayAction {
+        ALLOWED, BLOCKED;
+
+        internal fun toAction(): Action = when (this) {
+            ALLOWED -> Action.ALLOWED
+            BLOCKED -> Action.BLOCKED
         }
     }
 
@@ -48,6 +80,12 @@ data class SitePermissionsRules(
             }
             is Permission.ContentVideoCamera, is Permission.ContentVideoCapture -> {
                 camera
+            }
+            is Permission.ContentAutoPlayAudible -> {
+                autoplayAudible
+            }
+            is Permission.ContentAutoPlayInaudible -> {
+                autoplayInaudible
             }
             else -> ASK_TO_ALLOW
         }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsStorage.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsStorage.kt
@@ -15,6 +15,8 @@ import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permiss
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.LOCATION
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.MICROPHONE
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.NOTIFICATION
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.AUTOPLAY_AUDIBLE
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.AUTOPLAY_INAUDIBLE
 import mozilla.components.feature.sitepermissions.db.SitePermissionsDatabase
 import mozilla.components.feature.sitepermissions.db.toSitePermissionsEntity
 
@@ -101,6 +103,8 @@ class SitePermissionsStorage(
                 map.putIfAllowed(LOCAL_STORAGE, localStorage, permission)
                 map.putIfAllowed(NOTIFICATION, notification, permission)
                 map.putIfAllowed(LOCATION, location, permission)
+                map.putIfAllowed(AUTOPLAY_AUDIBLE, autoplayAudible, permission)
+                map.putIfAllowed(AUTOPLAY_INAUDIBLE, autoplayInaudible, permission)
             }
         }
         return map
@@ -151,6 +155,7 @@ class SitePermissionsStorage(
     }
 
     enum class Permission {
-        MICROPHONE, BLUETOOTH, CAMERA, LOCAL_STORAGE, NOTIFICATION, LOCATION
+        MICROPHONE, BLUETOOTH, CAMERA, LOCAL_STORAGE, NOTIFICATION, LOCATION, AUTOPLAY_AUDIBLE,
+        AUTOPLAY_INAUDIBLE
     }
 }

--- a/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/db/SitePermissionsEntity.kt
+++ b/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/db/SitePermissionsEntity.kt
@@ -37,6 +37,12 @@ internal data class SitePermissionsEntity(
     @ColumnInfo(name = "local_storage")
     var localStorage: SitePermissions.Status,
 
+    @ColumnInfo(name = "autoplay_audible")
+    var autoplayAudible: SitePermissions.Status,
+
+    @ColumnInfo(name = "autoplay_inaudible")
+    var autoplayInaudible: SitePermissions.Status,
+
     @ColumnInfo(name = "saved_at")
     var savedAt: Long
 ) {
@@ -50,6 +56,8 @@ internal data class SitePermissionsEntity(
             camera,
             bluetooth,
             localStorage,
+            autoplayAudible,
+            autoplayInaudible,
             savedAt
         )
     }
@@ -64,6 +72,8 @@ internal fun SitePermissions.toSitePermissionsEntity(): SitePermissionsEntity {
         camera,
         bluetooth,
         localStorage,
+        autoplayAudible,
+        autoplayInaudible,
         savedAt
     )
 }

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsRulesTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsRulesTest.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.permission.Permission
 import mozilla.components.concept.engine.permission.Permission.ContentAudioCapture
 import mozilla.components.concept.engine.permission.Permission.ContentGeoLocation
 import mozilla.components.concept.engine.permission.Permission.ContentNotification
@@ -58,7 +59,9 @@ class SitePermissionsRulesTest {
             camera = ASK_TO_ALLOW,
             location = BLOCKED,
             notification = ASK_TO_ALLOW,
-            microphone = BLOCKED
+            microphone = BLOCKED,
+            autoplayAudible = ASK_TO_ALLOW,
+            autoplayInaudible = BLOCKED
         )
 
         val mockRequest: PermissionRequest = mock()
@@ -79,6 +82,14 @@ class SitePermissionsRulesTest {
         action = rules.getActionFrom(mockRequest)
         assertEquals(action, rules.camera)
 
+        doReturn(listOf(Permission.ContentAutoPlayAudible())).`when`(mockRequest).permissions
+        action = rules.getActionFrom(mockRequest)
+        assertEquals(action, rules.autoplayAudible)
+
+        doReturn(listOf(Permission.ContentAutoPlayInaudible())).`when`(mockRequest).permissions
+        action = rules.getActionFrom(mockRequest)
+        assertEquals(action, rules.autoplayInaudible)
+
         doReturn(listOf(Generic("", ""))).`when`(mockRequest).permissions
         action = rules.getActionFrom(mockRequest)
         assertEquals(action, rules.camera)
@@ -90,7 +101,9 @@ class SitePermissionsRulesTest {
             camera = ASK_TO_ALLOW,
             location = BLOCKED,
             notification = ASK_TO_ALLOW,
-            microphone = BLOCKED
+            microphone = BLOCKED,
+            autoplayInaudible = ASK_TO_ALLOW,
+            autoplayAudible = ASK_TO_ALLOW
         )
 
         val mockRequest: PermissionRequest = mock()
@@ -103,7 +116,9 @@ class SitePermissionsRulesTest {
             camera = ASK_TO_ALLOW,
             location = BLOCKED,
             notification = ASK_TO_ALLOW,
-            microphone = ASK_TO_ALLOW
+            microphone = ASK_TO_ALLOW,
+            autoplayInaudible = BLOCKED,
+            autoplayAudible = BLOCKED
         )
 
         action = rules.getActionFrom(mockRequest)

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsStorageTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsStorageTest.kt
@@ -18,6 +18,8 @@ import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permiss
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.LOCATION
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.MICROPHONE
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.NOTIFICATION
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.AUTOPLAY_AUDIBLE
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage.Permission.AUTOPLAY_INAUDIBLE
 import mozilla.components.feature.sitepermissions.db.SitePermissionsDao
 import mozilla.components.feature.sitepermissions.db.SitePermissionsDatabase
 import mozilla.components.feature.sitepermissions.db.SitePermissionsEntity
@@ -84,6 +86,8 @@ class SitePermissionsStorageTest {
         assertFalse(LOCATION in map)
         assertFalse(NOTIFICATION in map)
         assertFalse(CAMERA in map)
+        assertFalse(AUTOPLAY_AUDIBLE in map)
+        assertFalse(AUTOPLAY_INAUDIBLE in map)
         assertEquals(2, map[BLUETOOTH]?.size)
         assertEquals(2, map[MICROPHONE]?.size)
     }
@@ -142,6 +146,8 @@ class SitePermissionsStorageTest {
                 microphone = ALLOWED,
                 camera = BLOCKED,
                 bluetooth = ALLOWED,
+                autoplayAudible = BLOCKED,
+                autoplayInaudible = NO_DECISION,
                 savedAt = 0
             ),
             SitePermissionsEntity(
@@ -152,6 +158,8 @@ class SitePermissionsStorageTest {
                 microphone = ALLOWED,
                 camera = BLOCKED,
                 bluetooth = ALLOWED,
+                autoplayAudible = BLOCKED,
+                autoplayInaudible = NO_DECISION,
                 savedAt = 0
             )
         )

--- a/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/db/SitePermissionEntityTest.kt
+++ b/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/db/SitePermissionEntityTest.kt
@@ -23,6 +23,8 @@ class SitePermissionEntityTest {
             microphone = NO_DECISION,
             camera = NO_DECISION,
             bluetooth = ALLOWED,
+            autoplayInaudible = BLOCKED,
+            autoplayAudible = NO_DECISION,
             savedAt = 0
         )
 
@@ -36,6 +38,8 @@ class SitePermissionEntityTest {
             assertEquals(microphone, domainClass.microphone)
             assertEquals(camera, domainClass.camera)
             assertEquals(bluetooth, domainClass.bluetooth)
+            assertEquals(autoplayAudible, domainClass.autoplayAudible)
+            assertEquals(autoplayInaudible, domainClass.autoplayInaudible)
             assertEquals(savedAt, domainClass.savedAt)
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,14 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: `alwaysAllowedSchemes` is removed as a parameter for `AppLinksInterceptor`.
   * Added `engineSupportedSchemes` as a parameter for `AppLinksInterceptor`.  This allows the caller to specify which protocol is supported by the engine.
     * Using this information, app links can decide if a protocol should be launched in a third party app or not regardless of user preference.
+    
+* **feature-sitepermissions**
+  * ⚠️ **This is a breaking change**: add parameters `autoplayAudible` and `autoplayInaudible` to `SitePermissionsRules`.
+    * This allows autoplay settings to be controlled for specific sites, rather than globally.
+  
+* **concept-engine**
+  * ⚠️ **This is a breaking change**: remove deprecated GeckoView setting `allowAutoplayMedia`
+    * This should now be controlled for individual sites via `SitePermissionsRules`
 
 # 33.0.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -25,6 +25,7 @@ import mozilla.components.feature.session.CoordinateScrollingFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
+import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
@@ -163,7 +164,15 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler {
                 context = requireContext(),
                 sessionManager = components.sessionManager,
                 sessionId = sessionId,
-                fragmentManager = requireFragmentManager()
+                fragmentManager = requireFragmentManager(),
+                sitePermissionsRules = SitePermissionsRules(
+                    autoplayAudible = SitePermissionsRules.AutoplayAction.ALLOWED,
+                    autoplayInaudible = SitePermissionsRules.AutoplayAction.ALLOWED,
+                    camera = SitePermissionsRules.Action.ASK_TO_ALLOW,
+                    location = SitePermissionsRules.Action.ASK_TO_ALLOW,
+                    notification = SitePermissionsRules.Action.ASK_TO_ALLOW,
+                    microphone = SitePermissionsRules.Action.ASK_TO_ALLOW
+                )
             ) { permissions ->
                 requestPermissions(permissions, REQUEST_CODE_APP_PERMISSIONS)
             },


### PR DESCRIPTION
For Fenix#8411: fix crash in SitePermissionsFeature#updateSitePermissionsStatus

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

@Amejia481 I've spent a few hours trying to reproduce this crash without any luck.  Hopefully this fixes the crash (and enables https://github.com/mozilla-mobile/fenix/issues/5636), but at the very least it looks unlikely to break anything.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
I don't think this one needs a changelog entry?  Happy to add one if I'm wrong.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
