### PR TITLE
Fenix 5236 - Fix search alignment

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.awesomebar.layout
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.ImageView
 import android.widget.TextView
 import mozilla.components.browser.awesomebar.BrowserAwesomeBar
@@ -42,6 +43,10 @@ internal sealed class DefaultSuggestionViewHolder {
             } else {
                 descriptionView.visibility = View.VISIBLE
                 descriptionView.text = suggestion.description
+
+                val titleParams = titleView.layoutParams as MarginLayoutParams
+                titleParams.setMargins(0, 0, 0, 0)
+                titleView.requestLayout()
             }
 
             view.setOnClickListener {

--- a/components/browser/awesomebar/src/main/res/layout/mozac_browser_awesomebar_item_generic.xml
+++ b/components/browser/awesomebar/src/main/res/layout/mozac_browser_awesomebar_item_generic.xml
@@ -29,6 +29,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
+        android:layout_marginTop="-1dp"
         android:ellipsize="end"
         android:lines="1"
         android:textSize="15sp"


### PR DESCRIPTION
Per https://github.com/mozilla-mobile/fenix/issues/5236, we need to move the alignment of the search suggestion title -1dp if there's no description.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
