### PR TITLE
Add nightly releases to compete snapshots - part 1 (building) bors r=JohanLorenzo,pocmo

### DIFF
--- a/automation/taskcluster/rename_artifacts.py
+++ b/automation/taskcluster/rename_artifacts.py
@@ -18,7 +18,6 @@ import sys
 
 ARTIFACT_EXTENSIONS = ('.aar', '.pom', '-sources.jar', '.jar')
 HASH_EXTENSIONS = ('', '.sha1', '.md5')
-# TODO: to replace here with mozilla-version sanity check and parsing
 MAVEN_VERSION_REGEX = re.compile(r"(?P<major_number>\d+)\.(?P<minor_number>\d+)\.(?P<patch_number>\d+)", re.VERBOSE)
 
 
@@ -26,7 +25,7 @@ def _extract_and_check_version(archive_filename, pattern):
     """Function to check if a version-based regex matches a given filename"""
     match = pattern.search(archive_filename)
     try:
-        version = match.group()
+        _ = match.group()
     except AttributeError:
         raise Exception(
             'File "{}" present in archive has invalid version. '
@@ -35,13 +34,13 @@ def _extract_and_check_version(archive_filename, pattern):
             )
         )
 
-    return version
+    return match.groupdict()
 
 
 def _extract_version(files):
     """Function to find and ensure that a single version has been used
     across a component's related files"""
-    identifiers = {_extract_and_check_version(file_, MAVEN_VERSION_REGEX)
+    identifiers = {frozenset(_extract_and_check_version(file_, MAVEN_VERSION_REGEX).items())
         for file_ in files}
 
     if len(identifiers) > 1:
@@ -51,7 +50,7 @@ def _extract_version(files):
         # bail if no valid version was found
         raise Exception('No valid version was identified within the files')
 
-    return identifiers.pop()
+    return dict(identifiers.pop())
 
 
 def does_file_name_contain_version(filename):
@@ -64,7 +63,7 @@ def does_file_name_contain_version(filename):
     return False
 
 
-def process_artifacts(path, buildid):
+def process_artifacts(path, nightly_version):
     versioned_files = [
         file_name
         for (_, __, file_names) in os.walk(path)
@@ -73,14 +72,14 @@ def process_artifacts(path, buildid):
         if does_file_name_contain_version(file_name)
     ]
     # extract their version and ensure it's unique
-    old_version = _extract_version(versioned_files)
+    old_version_dict = _extract_version(versioned_files)
+    old_version = '{major_number}.{minor_number}.{patch_number}'.format(**old_version_dict)
 
-    new_version = '{}-{}'.format(old_version, buildid)
     # walk recursively again and rename the files accordingly
     for (dirpath, _, filenames) in os.walk(args.path):
         for filename in filenames:
             if old_version in filename:
-                new_filename = filename.replace(old_version, new_version)
+                new_filename = filename.replace(old_version, nightly_version)
                 os.rename(os.path.join(dirpath, filename),
                           os.path.join(dirpath, new_filename))
 
@@ -96,9 +95,9 @@ if __name__ == "__main__":
         required=True,
     )
     parser.add_argument(
-        '--buildid',
-        help="Unique decision-task generated buildid to be inferred to all artifacts",
-        dest='buildid',
+        '--nightly-version',
+        help="Unique decision-task generated nightly-version to be inferred to all artifacts",
+        dest='nightly_version',
         required=True,
     )
     args = parser.parse_args()
@@ -107,4 +106,4 @@ if __name__ == "__main__":
         print("Provided path is not a directory")
         sys.exit(2)
 
-    process_artifacts(args.path, args.buildid)
+    process_artifacts(args.path, args.nightly_version)

--- a/automation/taskcluster/rename_artifacts.py
+++ b/automation/taskcluster/rename_artifacts.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Script to rename snapshots artifacts to a runtime centralized BUILDID
+Script to rename artifacts to a runtime centralized BUILDID-based version
 """
 
 from __future__ import print_function

--- a/automation/taskcluster/rename_artifacts.py
+++ b/automation/taskcluster/rename_artifacts.py
@@ -1,0 +1,110 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Script to rename snapshots artifacts to a runtime centralized BUILDID
+"""
+
+from __future__ import print_function
+
+import argparse
+import datetime
+import itertools
+import os
+import re
+import sys
+
+
+ARTIFACT_EXTENSIONS = ('.aar', '.pom', '-sources.jar', '.jar')
+HASH_EXTENSIONS = ('', '.sha1', '.md5')
+# TODO: to replace here with mozilla-version sanity check and parsing
+MAVEN_VERSION_REGEX = re.compile(r"(?P<major_number>\d+)\.(?P<minor_number>\d+)\.(?P<patch_number>\d+)", re.VERBOSE)
+
+
+def _extract_and_check_version(archive_filename, pattern):
+    """Function to check if a version-based regex matches a given filename"""
+    match = pattern.search(archive_filename)
+    try:
+        version = match.group()
+    except AttributeError:
+        raise Exception(
+            'File "{}" present in archive has invalid version. '
+            'Expected semver X.Y.Z within in'.format(
+                archive_filename
+            )
+        )
+
+    return version
+
+
+def _extract_version(files):
+    """Function to find and ensure that a single version has been used
+    across a component's related files"""
+    identifiers = {_extract_and_check_version(file_, MAVEN_VERSION_REGEX)
+        for file_ in files}
+
+    if len(identifiers) > 1:
+        # bail if there are different versions across the files
+        raise Exception('Different versions identified within the files')
+    elif len(identifiers) == 0:
+        # bail if no valid version was found
+        raise Exception('No valid version was identified within the files')
+
+    return identifiers.pop()
+
+
+def does_file_name_contain_version(filename):
+    """Function to filter out filenames that are part of the release but
+    they are not versioned."""
+
+    for extension, hash_extension in itertools.product(ARTIFACT_EXTENSIONS, HASH_EXTENSIONS):
+        if filename.endswith(extension + hash_extension):
+            return True
+    return False
+
+
+def process_artifacts(path, buildid):
+    versioned_files = [
+        file_name
+        for (_, __, file_names) in os.walk(path)
+        if file_names
+        for file_name in file_names
+        if does_file_name_contain_version(file_name)
+    ]
+    # extract their version and ensure it's unique
+    old_version = _extract_version(versioned_files)
+
+    new_version = '{}-{}'.format(old_version, buildid)
+    # walk recursively again and rename the files accordingly
+    for (dirpath, _, filenames) in os.walk(args.path):
+        for filename in filenames:
+            if old_version in filename:
+                new_filename = filename.replace(old_version, new_version)
+                os.rename(os.path.join(dirpath, filename),
+                          os.path.join(dirpath, new_filename))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Rename artifacts to unique runtime BUILDID'
+    )
+    parser.add_argument(
+        '--path',
+        help="Dir to specify where the local maven repo is",
+        dest='path',
+        required=True,
+    )
+    parser.add_argument(
+        '--buildid',
+        help="Unique decision-task generated buildid to be inferred to all artifacts",
+        dest='buildid',
+        required=True,
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.path):
+        print("Provided path is not a directory")
+        sys.exit(2)
+
+    process_artifacts(args.path, args.buildid)

--- a/publish.gradle
+++ b/publish.gradle
@@ -79,7 +79,7 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
         def renameScript = "${rootDir}/automation/taskcluster/rename_artifacts.py"
         def mavenBuildDir = "${project.buildDir}/maven"
 
-        commandLine 'python', renameScript, '--path', mavenBuildDir, '--buildid', (project.hasProperty('buildid') ? buildid : '')
+        commandLine 'python', renameScript, '--path', mavenBuildDir, '--nightly-version', (project.hasProperty('nightlyVersion') ? nightlyVersion : '')
     }
 
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -73,4 +73,13 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
         commandLine 'python', renameScript, '--path', mavenBuildDir, '--timestamp', (project.hasProperty('timestamp') ? timestamp : '')
     }
 
+    task renameArtifacts(type: Exec) {
+        dependsOn publish
+
+        def renameScript = "${rootDir}/automation/taskcluster/rename_artifacts.py"
+        def mavenBuildDir = "${project.buildDir}/maven"
+
+        commandLine 'python', renameScript, '--path', mavenBuildDir, '--buildid', (project.hasProperty('buildid') ? buildid : '')
+    }
+
 }

--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -26,7 +26,7 @@ def loader(kind, path, config, params, loaded_tasks):
             }
         }
         for component in get_components()
-        for build_type in ('regular', 'release', 'snapshot')
+        for build_type in ('regular', 'release', 'snapshot', 'nightly-release')
         if (
             component['name'] not in not_for_components
             and (component['shouldPublish'] or build_type == 'regular')

--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -26,7 +26,7 @@ def loader(kind, path, config, params, loaded_tasks):
             }
         }
         for component in get_components()
-        for build_type in ('regular', 'release', 'snapshot', 'nightly-release')
+        for build_type in ('regular', 'nightly', 'release', 'snapshot')
         if (
             component['name'] not in not_for_components
             and (component['shouldPublish'] or build_type == 'regular')

--- a/taskcluster/ac_taskgraph/target_tasks.py
+++ b/taskcluster/ac_taskgraph/target_tasks.py
@@ -15,6 +15,14 @@ def target_tasks_snapshot(full_task_graph, parameters, graph_config):
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 
 
+@_target_task("nightly_release")
+def target_tasks_nightly(full_task_graph, parameters, graph_config):
+    def filter(task, parameters):
+        return task.attributes.get("build-type", "") == "nightly-release"
+
+    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
+
+
 @_target_task("release")
 def target_tasks_release(full_task_graph, parameters, graph_config):
     def filter(task, parameters):

--- a/taskcluster/ac_taskgraph/target_tasks.py
+++ b/taskcluster/ac_taskgraph/target_tasks.py
@@ -15,10 +15,10 @@ def target_tasks_snapshot(full_task_graph, parameters, graph_config):
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 
 
-@_target_task("nightly_release")
+@_target_task("nightly")
 def target_tasks_nightly(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
-        return task.attributes.get("build-type", "") == "nightly-release"
+        return task.attributes.get("build-type", "") == "nightly"
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 

--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -78,9 +78,7 @@ def _get_timestamp(config):
 
 
 def _get_buildid(config):
-    push_date_string = config.params["moz_build_date"]
-    push_date_time = datetime.datetime.strptime(push_date_string, "%Y%m%d%H%M%S")
-    return push_date_time.strftime('%Y%m%d%H%M%S')
+    return config.params.moz_build_date.strftime('%Y%m%d%H%M%S')
 
 
 def _get_nightly_version(config, version):

--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -55,14 +55,15 @@ def handle_coverage(config, tasks):
 
 
 @transforms.add
-def format_component_name_and_timestamp(config, tasks):
+def interpolate_missing_values(config, tasks):
     timestamp = _get_timestamp(config)
+    buildid = _get_buildid(config)
 
     for task in tasks:
         for field in ('description', 'run.gradlew', 'treeherder.symbol'):
             component = task["attributes"]["component"]
             _deep_format(
-                task, field, component=component, timestamp=timestamp
+                task, field, component=component, timestamp=timestamp, buildid=buildid
             )
 
         yield task
@@ -72,6 +73,12 @@ def _get_timestamp(config):
     push_date_string = config.params["moz_build_date"]
     push_date_time = datetime.datetime.strptime(push_date_string, "%Y%m%d%H%M%S")
     return push_date_time.strftime('%Y%m%d.%H%M%S-1')
+
+
+def _get_buildid(config):
+    push_date_string = config.params["moz_build_date"]
+    push_date_time = datetime.datetime.strptime(push_date_string, "%Y%m%d%H%M%S")
+    return push_date_time.strftime('%Y%m%d%H%M%S')
 
 
 def _deep_format(object, field, **format_kwargs):

--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -127,7 +127,7 @@ def add_artifacts(config, tasks):
             version,
             "-SNAPSHOT" if build_type == "snapshot" else ''
         )
-        if build_type == 'nightly-release':
+        if build_type == 'nightly':
             if version in ret:
                 ret = ret.replace(version, nightly_version)
         return ret
@@ -156,8 +156,8 @@ def add_artifacts(config, tasks):
             }
 
             # XXX: rather than adding more complex logic above, we simply post-adjust the
-            # dictionary for `nightly-release` types of graphs
-            if task['attributes']['build-type'] == 'nightly-release':
+            # dictionary for `nightly` types of graphs
+            if task['attributes']['build-type'] == 'nightly':
                 for ext, path in artifact_file_names_per_extension.items():
                     if version in path:
                         artifact_file_names_per_extension[ext] = path.replace(version, nightly_version)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -22,21 +22,21 @@ job-defaults:
         by-build-type:
             release: true
             snapshot: true
-            nightly-release: true
+            nightly: true
             default: false
     attributes:
         code-review:
             by-build-type:
                 release: false
                 snapshot: false
-                nightly-release: false
+                nightly: false
                 default: true
     description: Execute Gradle tasks for component "{component}"
     include-coverage:
         by-build-type:
             release: false
             snapshot: false
-            nightly-release: false
+            nightly: false
             default: true
     run:
         gradlew:
@@ -54,7 +54,7 @@ job-defaults:
                     - ':{component}:lint'
                     - ':{component}:publish'
                     - ':{component}:renameSnapshotArtifacts'
-                nightly-release:
+                nightly:
                     - '-PnightlyVersion={nightlyVersion}'
                     - ':{component}:assemble'
                     - ':{component}:test'
@@ -80,7 +80,7 @@ job-defaults:
         by-build-type:
             release: []
             snapshot: []
-            nightly-release: []
+            nightly: []
             default: [github-pull-request, github-push]
     treeherder:
         kind: build
@@ -88,7 +88,7 @@ job-defaults:
             by-build-type:
                 release: '{component}(BR)'
                 snapshot: '{component}(BSnap)'
-                nightly-release: '{component}(BN)'
+                nightly: '{component}(BN)'
                 default: '{component}(B)'
         platform: android-all/opt
         tier: 1
@@ -107,12 +107,12 @@ overriden-jobs:
     snapshot-browser-engine-gecko-nightly:
         treeherder:
             symbol: 'browser-engine-gecko-nigh(BSnap)'
+    nightly-browser-engine-gecko-nightly:
+        treeherder:
+            symbol: 'browser-engine-gecko-nigh(BN)'
     release-browser-engine-gecko-nightly:
         treeherder:
             symbol: 'browser-engine-gecko-nigh(BR)'
-    nightly-release-browser-engine-gecko-nightly:
-        treeherder:
-            symbol: 'browser-engine-gecko-nigh(BN)'
 
     lib-fetch-httpurlconnection:
         treeherder:
@@ -120,9 +120,9 @@ overriden-jobs:
     snapshot-lib-fetch-httpurlconnection:
         treeherder:
             symbol: 'lib-fetch-httpurlconnect(BSnap)'
+    nightly-lib-fetch-httpurlconnection:
+        treeherder:
+            symbol: 'lib-fetch-httpurlconnect(BN)'
     release-lib-fetch-httpurlconnection:
         treeherder:
             symbol: 'lib-fetch-httpurlconnect(BR)'
-    nightly-release-lib-fetch-httpurlconnection:
-        treeherder:
-            symbol: 'lib-fetch-httpurlconnect(BN)'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -56,9 +56,9 @@ job-defaults:
                     - ':{component}:renameSnapshotArtifacts'
                 nightly:
                     - '-PnightlyVersion={nightlyVersion}'
-                    - ':{component}:assemble'
-                    - ':{component}:test'
-                    - ':{component}:lint'
+                    - ':{component}:assembleRelease'
+                    - ':{component}:testRelease'
+                    - ':{component}:lintRelease'
                     - ':{component}:publish'
                     - ':{component}:renameArtifacts'
                 default:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -55,7 +55,7 @@ job-defaults:
                     - ':{component}:publish'
                     - ':{component}:renameSnapshotArtifacts'
                 nightly-release:
-                    - '-Pbuildid={buildid}'
+                    - '-PnightlyVersion={nightlyVersion}'
                     - ':{component}:assemble'
                     - ':{component}:test'
                     - ':{component}:lint'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -22,18 +22,21 @@ job-defaults:
         by-build-type:
             release: true
             snapshot: true
+            nightly-release: true
             default: false
     attributes:
         code-review:
             by-build-type:
                 release: false
                 snapshot: false
+                nightly-release: false
                 default: true
     description: Execute Gradle tasks for component "{component}"
     include-coverage:
         by-build-type:
             release: false
             snapshot: false
+            nightly-release: false
             default: true
     run:
         gradlew:
@@ -51,6 +54,13 @@ job-defaults:
                     - ':{component}:lint'
                     - ':{component}:publish'
                     - ':{component}:renameSnapshotArtifacts'
+                nightly-release:
+                    - '-Pnightly'
+                    - '-Ptimestamp={timestamp}'
+                    - ':{component}:assemble'
+                    - ':{component}:test'
+                    - ':{component}:lint'
+                    - ':{component}:publish'
                 default:
                     by-component:
                         # No lintRelease on this job, gradle task isn't defined
@@ -70,6 +80,7 @@ job-defaults:
         by-build-type:
             release: []
             snapshot: []
+            nightly-release: []
             default: [github-pull-request, github-push]
     treeherder:
         kind: build
@@ -77,6 +88,7 @@ job-defaults:
             by-build-type:
                 release: '{component}(BR)'
                 snapshot: '{component}(BSnap)'
+                nightly-release: '{component}(BnR)'
                 default: '{component}(B)'
         platform: android-all/opt
         tier: 1
@@ -98,6 +110,9 @@ overriden-jobs:
     release-browser-engine-gecko-nightly:
         treeherder:
             symbol: 'browser-engine-gecko-nigh(BR)'
+    nightly-release-browser-engine-gecko-nightly:
+        treeherder:
+            symbol: 'browser-engine-gecko-nigh(BnR)'
 
     lib-fetch-httpurlconnection:
         treeherder:
@@ -108,3 +123,6 @@ overriden-jobs:
     release-lib-fetch-httpurlconnection:
         treeherder:
             symbol: 'lib-fetch-httpurlconnect(BR)'
+    nightly-release-lib-fetch-httpurlconnection:
+        treeherder:
+            symbol: 'lib-fetch-httpurlconnect(BnR)'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -88,7 +88,7 @@ job-defaults:
             by-build-type:
                 release: '{component}(BR)'
                 snapshot: '{component}(BSnap)'
-                nightly-release: '{component}(BnR)'
+                nightly-release: '{component}(BN)'
                 default: '{component}(B)'
         platform: android-all/opt
         tier: 1
@@ -112,7 +112,7 @@ overriden-jobs:
             symbol: 'browser-engine-gecko-nigh(BR)'
     nightly-release-browser-engine-gecko-nightly:
         treeherder:
-            symbol: 'browser-engine-gecko-nigh(BnR)'
+            symbol: 'browser-engine-gecko-nigh(BN)'
 
     lib-fetch-httpurlconnection:
         treeherder:
@@ -125,4 +125,4 @@ overriden-jobs:
             symbol: 'lib-fetch-httpurlconnect(BR)'
     nightly-release-lib-fetch-httpurlconnection:
         treeherder:
-            symbol: 'lib-fetch-httpurlconnect(BnR)'
+            symbol: 'lib-fetch-httpurlconnect(BN)'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -55,12 +55,12 @@ job-defaults:
                     - ':{component}:publish'
                     - ':{component}:renameSnapshotArtifacts'
                 nightly-release:
-                    - '-Pnightly'
-                    - '-Ptimestamp={timestamp}'
+                    - '-Pbuildid={buildid}'
                     - ':{component}:assemble'
                     - ':{component}:test'
                     - ':{component}:lint'
                     - ':{component}:publish'
+                    - ':{component}:renameArtifacts'
                 default:
                     by-component:
                         # No lintRelease on this job, gradle task isn't defined


### PR DESCRIPTION
Motivation for this is https://github.com/mozilla-mobile/android-components/issues/5023

WIP - ~just a stub for now~ I still need to address a bunch of things like ~artifacts exposure~, beetmover and signing jobs, etc. But the main blocker is the fact that we need to create a new subdomain within maven.mozilla.org, something like https://nightly.maven.mozilla.org/.

Later edit: this seems to be working locally just fine. Adds the `nightly-release` graph succesfully and the version to be used is e.g. `public/build/browser-awesomebar-32.0.20200212190116-sources.jar` placed within

```
      "payload": {
        "artifacts": {
          "public/build/browser-awesomebar-32.0.20200212190116-sources.jar": {
            "expires": {
              "relative-datestamp": "1 year"
            },
            "path": "/builds/worker/checkouts/src/components/browser/awesomebar/build/maven/org/mozilla/components/browser-awesomebar/32.0.20200212190116/browser-awesomebar-32.0.20200212190116-sources.jar",
            "type": "file"
          },
```