### PR TITLE
Fixes #5978: Ensures captureThumbnail always executes callback

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -174,6 +174,8 @@ class GeckoEngineView @JvmOverloads constructor(
                 onFinish(null)
                 GeckoResult<Void>()
             })
+        } else {
+            onFinish(null)
         }
     }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -88,6 +88,19 @@ class GeckoEngineViewTest {
 
         geckoResult.completeExceptionally(mock())
         assertNull(thumbnail)
+
+        // Verify that with `firstContentfulPaint` set to false, capturePixels returns a null bitmap
+        geckoResult = GeckoResult()
+
+        thumbnail = mock()
+        whenever(geckoSession.firstContentfulPaint).thenReturn(false)
+        engineView.captureThumbnail {
+            thumbnail = it
+        }
+        // capturePixels should not have been called again because `firstContentfulPaint` is false
+        verify(mockGeckoView, times(2)).capturePixels()
+        geckoResult.complete(mock())
+        assertNull(thumbnail)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -174,6 +174,8 @@ class GeckoEngineView @JvmOverloads constructor(
                 onFinish(null)
                 GeckoResult<Void>()
             })
+        } else {
+            onFinish(null)
         }
     }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -88,6 +88,19 @@ class GeckoEngineViewTest {
 
         geckoResult.completeExceptionally(mock())
         assertNull(thumbnail)
+
+        // Verify that with `firstContentfulPaint` set to false, capturePixels returns a null bitmap
+        geckoResult = GeckoResult()
+
+        thumbnail = mock()
+        whenever(geckoSession.firstContentfulPaint).thenReturn(false)
+        engineView.captureThumbnail {
+            thumbnail = it
+        }
+        // capturePixels should not have been called again because `firstContentfulPaint` is false
+        verify(mockGeckoView, times(2)).capturePixels()
+        geckoResult.complete(mock())
+        assertNull(thumbnail)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -175,6 +175,8 @@ class GeckoEngineView @JvmOverloads constructor(
                 onFinish(null)
                 GeckoResult<Void>()
             })
+        } else {
+            onFinish(null)
         }
     }
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineViewTest.kt
@@ -88,6 +88,32 @@ class GeckoEngineViewTest {
 
         geckoResult.completeExceptionally(mock())
         assertNull(thumbnail)
+
+        // Verify that with `firstContentfulPaint` set to false, capturePixels returns a null bitmap
+        geckoResult = GeckoResult()
+
+        thumbnail = mock()
+        whenever(geckoSession.firstContentfulPaint).thenReturn(false)
+        engineView.captureThumbnail {
+            thumbnail = it
+        }
+        // capturePixels should not have been called again because `firstContentfulPaint` is false
+        verify(mockGeckoView, times(2)).capturePixels()
+        geckoResult.complete(mock())
+        assertNull(thumbnail)
+
+        // Verify that with `firstContentfulPaint` set to false, capturePixels returns a null bitmap
+        geckoResult = GeckoResult()
+
+        thumbnail = mock()
+        whenever(geckoSession.firstContentfulPaint).thenReturn(false)
+        engineView.captureThumbnail {
+            thumbnail = it
+        }
+        // capturePixels should not have been called again because `firstContentfulPaint` is false
+        verify(mockGeckoView, times(2)).capturePixels()
+        geckoResult.complete(mock())
+        assertNull(thumbnail)
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
