### PR TITLE
Add dummy assembleRelease task

### DIFF
--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -90,6 +90,21 @@ task assembleAndroidTest {
     // behaves like our others and we do not need to special case it in automation.
   }
 }
+
+task assembleRelease {
+  doLast {
+    // Do nothing. Like the `lint` task above this is just a dummy task so that this module
+    // behaves like our others and we do not need to special case it in automation.
+  }
+}
+
+task testRelease {
+  doLast {
+    // Do nothing. Like the `lint` task above this is just a dummy task so that this module
+    // behaves like our others and we do not need to special case it in automation.
+  }
+}
+
 compileKotlin {
     kotlinOptions {
         jvmTarget = "1.8"


### PR DESCRIPTION
As reported by @pocmo on Slack:

> Hm, the fix landed but it seems like our release process is broken
> We are getting: `[task 2020-02-18T18:43:51.330Z] Task 'assembleRelease' not found in project ':tooling-glean-gradle'`.
> To unblock our release I am going to disable that project in .buildconfig.yml in our release branch only.

Adding a dummy task seems to get around this.  I think [looked here](https://github.com/mozilla-mobile/android-components/blob/master/taskcluster/ci/build/kind.yml#L41) to see all of the tasks that are run on a release, and added all that were missing to make them all work.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
