### PR TITLE
Closes #3729: allow tokenserver url override

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -47,10 +47,12 @@ data class DeviceConfig(
  * @property supportedEngines A set of supported sync engines, exposed via [GlobalSyncableStoreProvider].
  * @property syncPeriodInMinutes Optional, how frequently periodic sync should happen. If this is `null`,
  * periodic syncing will be disabled.
+ * @property tokenServerUrl Optional, override default tokenServerUrl to support self-hosted sync storage.
  */
 data class SyncConfig(
     val supportedEngines: Set<SyncEngine>,
-    val syncPeriodInMinutes: Long? = null
+    val syncPeriodInMinutes: Long? = null,
+    val tokenServerUrl: String? = null
 )
 
 /**

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -908,10 +908,16 @@ open class FxaAccountManager(
             return
         }
 
+        var tokenServerUrl = syncConfig?.tokenServerUrl
+        if (tokenServerUrl == null) {
+            tokenServerUrl = account.getTokenServerEndpointURL()
+        }
+
+        logger.info("caching tokenServerUrl: $tokenServerUrl")
         // NB: this call will inform authErrorRegistry in case an auth error is encountered.
         account.getAccessTokenAsync(SCOPE_SYNC).await()?.let {
             SyncAuthInfoCache(context).setToCache(
-                it.asSyncAuthInfo(account.getTokenServerEndpointURL())
+                it.asSyncAuthInfo(tokenServerUrl)
             )
         }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,8 @@ permalink: /changelog/
       * Labels in labeled metrics now have a correct, and slightly stricter, regular expression.
         See [label format](https://mozilla.github.io/glean/user/metrics/index.html#label-format) for more information.
 
+* **services-firefox-accounts**
+  * Adds an optional `tokenServerUrl` to `SyncConfig` to support self-hosted sync. 
 
 # 32.0.0
 


### PR DESCRIPTION
The first step in supporting self hosted sync for Fenix is allowing the tokenserver url to be passed into the FxaAccountManager. This allows users to override the default tokenserver url, via Sync Config.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
