### PR TITLE
Closes #5911: Update test coverage for feature-addons/ui

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -141,11 +141,12 @@ class AddonsManagerAdapter(
         holder.titleView.setText(section.title)
     }
 
-    private fun bindNotYetSupportedSection(
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun bindNotYetSupportedSection(
         holder: UnsupportedSectionViewHolder,
         section: NotYetSupportedSection
     ) {
-        val context = holder.titleView.context
+        val context = holder.itemView.context
         holder.titleView.setText(section.title)
         holder.descriptionView.text =
             if (unsupportedAddons.size == 1) {
@@ -162,7 +163,8 @@ class AddonsManagerAdapter(
         }
     }
 
-    private fun bindAddon(holder: AddonViewHolder, addon: Addon) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun bindAddon(holder: AddonViewHolder, addon: Addon) {
         val context = holder.itemView.context
         addon.rating?.let {
             val userCount = context.getString(R.string.mozac_feature_addons_user_rating_count)

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
@@ -5,7 +5,10 @@
 package mozilla.components.feature.addons.amo.mozilla.components.feature.addons.ui
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.ui.getFormattedAmount
 import mozilla.components.feature.addons.ui.translate
+import mozilla.components.feature.addons.ui.translatedName
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +16,34 @@ import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class ExtensionsTest {
+
+    @Test
+    fun `add-on translateName`() {
+        val addon = Addon(
+            id = "id",
+            authors = emptyList(),
+            categories = emptyList(),
+            downloadUrl = "downloadUrl",
+            version = "version",
+            permissions = emptyList(),
+            rating = Addon.Rating(4.5f, 1000),
+            createdAt = "",
+            updatedAt = "",
+            translatableName = mapOf("en-US" to "name", "de" to "Name", "es" to "nombre")
+        )
+
+        Locale.setDefault(Locale("es"))
+
+        assertEquals("nombre", addon.translatedName)
+
+        Locale.setDefault(Locale.GERMAN)
+
+        assertEquals("Name", addon.translatedName)
+
+        Locale.setDefault(Locale.ENGLISH)
+
+        assertEquals("name", addon.translatedName)
+    }
 
     @Test
     fun translate() {
@@ -29,5 +60,19 @@ class ExtensionsTest {
         Locale.setDefault(Locale.ENGLISH)
 
         assertEquals("Hello", map.translate())
+    }
+
+    @Test
+    fun getFormattedAmountTest() {
+        val amount = 1000
+
+        Locale.setDefault(Locale.ENGLISH)
+        assertEquals("1,000", getFormattedAmount(amount))
+
+        Locale.setDefault(Locale.GERMAN)
+        assertEquals("1.000", getFormattedAmount(amount))
+
+        Locale.setDefault(Locale("es"))
+        assertEquals("1.000", getFormattedAmount(amount))
     }
 }


### PR DESCRIPTION
Add more coverage for:
- `AddonsManagerAdapterDelegate`
- `CustomViewHolder`
- `Extensions`

I don't think we need test coverage for `AddonPermissionsAdapter` since it's mostly android `RecyclerView` logic.