### PR TITLE
Closes #5965: Migrate concept-tabstray and browser-tabstray to use browser-state.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.state.state
 
+import android.graphics.Bitmap
 import java.util.UUID
 
 /**
@@ -40,11 +41,18 @@ fun createTab(
     id: String = UUID.randomUUID().toString(),
     parent: TabSessionState? = null,
     extensions: Map<String, WebExtensionState> = emptyMap(),
-    readerState: ReaderState = ReaderState()
+    readerState: ReaderState = ReaderState(),
+    title: String = "",
+    thumbnail: Bitmap? = null
 ): TabSessionState {
     return TabSessionState(
         id = id,
-        content = ContentState(url, private),
+        content = ContentState(
+            url,
+            private,
+            title = title,
+            thumbnail = thumbnail
+        ),
         parentId = parent?.id,
         extensionState = extensions,
         readerState = readerState

--- a/components/browser/tabstray/build.gradle
+++ b/components/browser/tabstray/build.gradle
@@ -28,15 +28,16 @@ android {
 
 dependencies {
     api project(':concept-tabstray')
-    implementation project(':browser-session')
     implementation project(':ui-icons')
     implementation project(':ui-colors')
+    implementation project(':support-base')
 
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.androidx_cardview
     api Dependencies.androidx_recyclerview
 
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.kotlin_coroutines
 
     testImplementation project(':support-test')
 

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
@@ -47,15 +47,6 @@ class BrowserTabsTray @JvmOverloads constructor(
         attr.recycle()
     }
 
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-
-        // Multiple tabs that we are currently displaying may be subscribed to a Session to update
-        // automatically. Unsubscribe all of them now so that we do not reference them and keep them
-        // in memory.
-        tabsAdapter.unsubscribeHolders()
-    }
-
     /**
      * Convenience method to cast this object to an Android View object.
      */

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabTouchCallback.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabTouchCallback.kt
@@ -19,7 +19,7 @@ open class TabTouchCallback(
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
         with(viewHolder as TabViewHolder) {
-            session?.let { observable.notifyObservers { onTabClosed(it) } }
+            tab?.let { observable.notifyObservers { onTabClosed(it) } }
         }
     }
 

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -11,8 +11,8 @@ import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.cardview.widget.CardView
 import androidx.recyclerview.widget.RecyclerView
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
+import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
 
@@ -22,7 +22,7 @@ import mozilla.components.support.base.observer.Observable
 class TabViewHolder(
     itemView: View,
     private val tabsTray: BrowserTabsTray
-) : RecyclerView.ViewHolder(itemView), Session.Observer {
+) : RecyclerView.ViewHolder(itemView) {
     private val cardView: CardView = (itemView as CardView).apply {
         elevation = tabsTray.styling.itemElevation
     }
@@ -31,28 +31,28 @@ class TabViewHolder(
     private val closeView: AppCompatImageButton = itemView.findViewById(R.id.mozac_browser_tabstray_close)
     private val thumbnailView: TabThumbnailView = itemView.findViewById(R.id.mozac_browser_tabstray_thumbnail)
 
-    internal var session: Session? = null
+    internal var tab: Tab? = null
 
     /**
      * Displays the data of the given session and notifies the given observable about events.
      */
-    fun bind(session: Session, isSelected: Boolean, observable: Observable<TabsTray.Observer>) {
-        this.session = session.also { it.register(this) }
+    fun bind(tab: Tab, isSelected: Boolean, observable: Observable<TabsTray.Observer>) {
+        this.tab = tab
 
-        val title = if (session.title.isNotEmpty()) {
-            session.title
+        val title = if (tab.title.isNotEmpty()) {
+            tab.title
         } else {
-            session.url
+            tab.url
         }
 
         tabView.text = title
 
         itemView.setOnClickListener {
-            observable.notifyObservers { onTabSelected(session) }
+            observable.notifyObservers { onTabSelected(tab) }
         }
 
         closeView.setOnClickListener {
-            observable.notifyObservers { onTabClosed(session) }
+            observable.notifyObservers { onTabClosed(tab) }
         }
 
         if (isSelected) {
@@ -65,19 +65,8 @@ class TabViewHolder(
             closeView.imageTintList = ColorStateList.valueOf(tabsTray.styling.itemTextColor)
         }
 
-        thumbnailView.setImageBitmap(session.thumbnail)
+        thumbnailView.setImageBitmap(tab.thumbnail)
 
-        iconView.setImageBitmap(session.icon)
-    }
-
-    /**
-     * The attached view no longer needs to display any data.
-     */
-    fun unbind() {
-        session?.unregister(this)
-    }
-
-    override fun onUrlChanged(session: Session, url: String) {
-        tabView.text = url
+        iconView.setImageBitmap(tab.icon)
     }
 }

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -7,7 +7,7 @@ package mozilla.components.browser.tabstray
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import mozilla.components.browser.session.Session
+import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -24,9 +24,7 @@ class TabsAdapter(
 
     internal lateinit var tabsTray: BrowserTabsTray
 
-    private val holders = mutableListOf<TabViewHolder>()
-    private var sessions: List<Session> = listOf()
-    private var selectedIndex: Int = -1
+    private var tabs: Tabs? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabViewHolder {
         return TabViewHolder(
@@ -35,46 +33,26 @@ class TabsAdapter(
                 parent,
                 false),
             tabsTray
-        ).also {
-            holders.add(it)
-        }
+        )
     }
 
-    override fun getItemCount() = sessions.size
+    override fun getItemCount() = tabs?.list?.size ?: 0
 
     override fun onBindViewHolder(holder: TabViewHolder, position: Int) {
-        holder.bind(sessions[position], position == selectedIndex, this)
+        val tabs = tabs ?: return
+
+        holder.bind(tabs.list[position], position == tabs.selectedIndex, this)
     }
 
-    override fun onViewRecycled(holder: TabViewHolder) {
-        holder.unbind()
+    override fun updateTabs(tabs: Tabs) {
+        this.tabs = tabs
     }
 
-    fun unsubscribeHolders() {
-        holders.forEach { it.unbind() }
-        holders.clear()
-    }
+    override fun onTabsInserted(position: Int, count: Int) = notifyItemRangeInserted(position, count)
 
-    override fun displaySessions(sessions: List<Session>, selectedIndex: Int) {
-        this.sessions = sessions
-        this.selectedIndex = selectedIndex
-        notifyDataSetChanged()
-    }
+    override fun onTabsRemoved(position: Int, count: Int) = notifyItemRangeRemoved(position, count)
 
-    override fun updateSessions(sessions: List<Session>, selectedIndex: Int) {
-        this.sessions = sessions
-        this.selectedIndex = selectedIndex
-    }
+    override fun onTabsMoved(fromPosition: Int, toPosition: Int) = notifyItemMoved(fromPosition, toPosition)
 
-    override fun onSessionsInserted(position: Int, count: Int) =
-        notifyItemRangeInserted(position, count)
-
-    override fun onSessionsRemoved(position: Int, count: Int) =
-        notifyItemRangeRemoved(position, count)
-
-    override fun onSessionMoved(fromPosition: Int, toPosition: Int) =
-        notifyItemMoved(fromPosition, toPosition)
-
-    override fun onSessionsChanged(position: Int, count: Int) =
-        notifyItemRangeChanged(position, count, null)
+    override fun onTabsChanged(position: Int, count: Int) = notifyItemRangeChanged(position, count)
 }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/BrowserTabsTrayTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/BrowserTabsTrayTest.kt
@@ -5,53 +5,38 @@
 package mozilla.components.browser.tabstray
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Session
+import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
-import org.robolectric.Shadows
 
 @RunWith(AndroidJUnit4::class)
 class BrowserTabsTrayTest {
-
-    @Test
-    fun `holders will unsubscribe if view gets detached`() {
-        val adapter: TabsAdapter = mock()
-        val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter)
-
-        val shadow = Shadows.shadowOf(tabsTray)
-        shadow.callOnDetachedFromWindow()
-
-        verify(adapter).unsubscribeHolders()
-    }
 
     @Test
     fun `TabsTray concept methods are forwarded to adapter`() {
         val adapter: TabsAdapter = mock()
         val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter)
 
-        val sessions = listOf<Session>()
+        val tabs = Tabs(emptyList(), -1)
 
-        tabsTray.displaySessions(sessions, -1)
-        verify(adapter).displaySessions(sessions, -1)
+        tabsTray.updateTabs(tabs)
+        verify(adapter).updateTabs(tabs)
 
-        tabsTray.updateSessions(sessions, -2)
-        verify(adapter).updateSessions(sessions, -2)
+        tabsTray.onTabsInserted(2, 5)
+        verify(adapter).onTabsInserted(2, 5)
 
-        tabsTray.onSessionsInserted(2, 5)
-        verify(adapter).onSessionsInserted(2, 5)
+        tabsTray.onTabsRemoved(4, 1)
+        verify(adapter).onTabsRemoved(4, 1)
 
-        tabsTray.onSessionsRemoved(4, 1)
-        verify(adapter).onSessionsRemoved(4, 1)
+        tabsTray.onTabsMoved(7, 1)
+        verify(adapter).onTabsMoved(7, 1)
 
-        tabsTray.onSessionMoved(7, 1)
-        verify(adapter).onSessionMoved(7, 1)
-
-        tabsTray.onSessionsChanged(0, 1)
-        verify(adapter).onSessionsChanged(0, 1)
+        tabsTray.onTabsChanged(0, 1)
+        verify(adapter).onTabsChanged(0, 1)
     }
 
     @Test

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
@@ -38,7 +38,7 @@ class TabTouchCallbackTest {
         verify(observer, never()).onTabClosed(any())
 
         // With a session available.
-        `when`(viewHolder.session).thenReturn(mock())
+        `when`(viewHolder.tab).thenReturn(mock())
 
         touchCallback.onSwiped(viewHolder, 0)
 

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
@@ -10,20 +10,16 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Session
+import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.ObserverRegistry
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.never
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -38,45 +34,10 @@ class TabViewHolderTest {
 
         assertEquals("", urlView.text)
 
-        val session = Session("https://www.mozilla.org")
+        val session = Tab("a", "https://www.mozilla.org")
 
         holder.bind(session, isSelected = false, observable = mock())
 
-        assertEquals("https://www.mozilla.org", urlView.text)
-    }
-
-    @Test
-    fun `Holder registers to session and updates view`() {
-        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
-
-        val holder = TabViewHolder(view, mockTabsTrayWithStyles())
-        val session = Session("https://www.mozilla.org")
-
-        holder.bind(session, isSelected = false, observable = mock())
-
-        assertEquals("https://www.mozilla.org", urlView.text)
-
-        session.url = "https://getpocket.com"
-
-        assertEquals("https://getpocket.com", urlView.text)
-    }
-
-    @Test
-    fun `After unbind holder is no longer registered to session`() {
-        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
-
-        val holder = TabViewHolder(view, mockTabsTrayWithStyles())
-        val session = Session("https://www.mozilla.org")
-
-        holder.bind(session, isSelected = false, observable = mock())
-
-        assertEquals("https://www.mozilla.org", urlView.text)
-
-        holder.unbind()
-
-        session.url = "https://getpocket.com"
         assertEquals("https://www.mozilla.org", urlView.text)
     }
 
@@ -90,7 +51,7 @@ class TabViewHolderTest {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
-        val session = Session("https://www.mozilla.org")
+        val session = Tab("a", "https://www.mozilla.org")
         holder.bind(session, isSelected = false, observable = registry)
 
         view.performClick()
@@ -108,7 +69,7 @@ class TabViewHolderTest {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
-        val session = Session("https://www.mozilla.org")
+        val session = Tab("a", "https://www.mozilla.org")
         holder.bind(session, isSelected = true, observable = registry)
 
         view.findViewById<View>(R.id.mozac_browser_tabstray_close).performClick()
@@ -126,7 +87,7 @@ class TabViewHolderTest {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
-        val session = Session("https://www.mozilla.org")
+        val session = Tab("a", "https://www.mozilla.org")
         val titleView = holder.itemView.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
         holder.bind(session, isSelected = true, observable = registry)
@@ -144,38 +105,12 @@ class TabViewHolderTest {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
 
-        val session = Session("https://www.mozilla.org")
+        val session = Tab("a", "https://www.mozilla.org", title = "Mozilla Firefox")
         val titleView = holder.itemView.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
-
-        session.title = "Mozilla Firefox"
 
         holder.bind(session, isSelected = true, observable = registry)
 
         assertEquals("Mozilla Firefox", titleView.text)
-    }
-
-    @Test
-    fun `session unregisters on unbind`() {
-        val observer: TabsTray.Observer = mock()
-        val registry = ObserverRegistry<TabsTray.Observer>().also {
-            it.register(observer)
-        }
-
-        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val holder = TabViewHolder(view, mockTabsTrayWithStyles())
-        val session = spy(Session("https://www.mozilla.org"))
-
-        holder.unbind()
-
-        assertNull(holder.session)
-        verify(session, never()).unregister(holder)
-
-        holder.bind(session, isSelected = true, observable = registry)
-
-        holder.unbind()
-
-        assertNotNull(holder.session)
-        verify(session).unregister(holder)
     }
 
     @Test
@@ -186,9 +121,9 @@ class TabViewHolderTest {
         val holder = TabViewHolder(view, mockTabsTrayWithStyles())
         assertEquals(null, thumbnailView.drawable)
 
-        val session = Session("https://www.mozilla.org")
         val emptyBitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
-        session.thumbnail = emptyBitmap
+        val session = Tab("a", "https://www.mozilla.org", thumbnail = emptyBitmap)
+
         holder.bind(session, isSelected = false, observable = mock())
         assertTrue(thumbnailView.drawable != null)
     }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -4,18 +4,15 @@
 
 package mozilla.components.browser.tabstray
 
-import android.widget.LinearLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Session
+import mozilla.components.concept.tabstray.Tab
+import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoMoreInteractions
 
 @RunWith(AndroidJUnit4::class)
 class TabsAdapterTest {
@@ -25,63 +22,64 @@ class TabsAdapterTest {
         val adapter = TabsAdapter()
         assertEquals(0, adapter.itemCount)
 
-        adapter.displaySessions(listOf(Session("A"), Session("B")), 0)
+        adapter.updateTabs(
+            Tabs(
+                list = listOf(
+                    Tab("A", "https://www.mozilla.org"),
+                    Tab("B", "https://www.firefox.com")
+                ),
+                selectedIndex = 0)
+        )
         assertEquals(2, adapter.itemCount)
 
-        adapter.updateSessions(listOf(
-            Session("A"),
-            Session("B"),
-            Session("C")), 0)
+        adapter.updateTabs(
+            Tabs(
+                list = listOf(
+                    Tab("A", "https://www.mozilla.org"),
+                    Tab("B", "https://www.firefox.com"),
+                    Tab("C", "https://getpocket.com")
+                ),
+                selectedIndex = 0)
+        )
 
         assertEquals(3, adapter.itemCount)
     }
 
     @Test
-    fun `adapter will ask holder to unbind if view gets recycled`() {
+    fun `onBindViewHolder calls bind on matching holder`() {
         val adapter = TabsAdapter()
+        adapter.tabsTray = mock()
+
         val holder: TabViewHolder = mock()
 
-        adapter.onViewRecycled(holder)
+        val tab = Tab("A", "https://www.mozilla.org")
 
-        verify(holder).unbind()
+        adapter.updateTabs(
+            Tabs(
+                list = listOf(tab),
+                selectedIndex = 0)
+        )
+
+        adapter.onBindViewHolder(holder, 0)
+
+        verify(holder).bind(tab, true, adapter)
     }
 
     @Test
-    fun `holders get registered and unregistered from session`() {
-        val adapter = TabsAdapter()
-        adapter.tabsTray = mockTabsTrayWithStyles()
+    fun `underlying adapter is notified about data set changes`() {
+        val adapter = spy(TabsAdapter())
+        adapter.tabsTray = mock()
 
-        val view = LinearLayout(testContext)
+        adapter.onTabsInserted(27, 101)
+        verify(adapter).notifyItemRangeInserted(27, 101)
 
-        val holder1 = adapter.createViewHolder(view, 0)
-        val holder2 = adapter.createViewHolder(view, 0)
+        adapter.onTabsRemoved(11, 202)
+        verify(adapter).notifyItemRangeRemoved(11, 202)
 
-        val session1: Session = spy(Session("A"))
-        val session2: Session = spy(Session("B"))
-        val session3: Session = spy(Session("C"))
+        adapter.onTabsMoved(13, 23)
+        verify(adapter).notifyItemMoved(13, 23)
 
-        adapter.displaySessions(listOf(session1, session2, session3), 0)
-
-        adapter.onBindViewHolder(holder1, 0)
-        adapter.onBindViewHolder(holder2, 1)
-
-        verify(session1).register(holder1)
-        verify(session2).register(holder2)
-        verifyNoMoreInteractions(session3)
-
-        adapter.unsubscribeHolders()
-
-        verify(session1).unregister(holder1)
-        verify(session2).unregister(holder2)
-        verifyNoMoreInteractions(session3)
-    }
-
-    private fun mockTabsTrayWithStyles(): BrowserTabsTray {
-        val styles: TabsTrayStyling = mock()
-
-        val tabsTray: BrowserTabsTray = mock()
-        Mockito.doReturn(styles).`when`(tabsTray).styling
-
-        return tabsTray
+        adapter.onTabsChanged(42, 78)
+        verify(adapter).notifyItemRangeChanged(42, 78)
     }
 }

--- a/components/concept/tabstray/build.gradle
+++ b/components/concept/tabstray/build.gradle
@@ -22,7 +22,6 @@ android {
 }
 
 dependencies {
-    implementation project(':browser-session')
     implementation project(':support-base')
 
     implementation Dependencies.kotlin_stdlib

--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tab.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tab.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.tabstray
+
+import android.graphics.Bitmap
+
+/**
+ * Data class representing a tab to be displayed in a [TabsTray].
+ *
+ * @property id Unique ID of the tab.
+ * @property url Current URL of the tab.
+ * @property title Current title of the tab (or an empty [String]]).
+ * @property icon Current icon of the tab (or null)
+ * @property thumbnail Current thumbnail of the tab (or null)
+ */
+data class Tab(
+    val id: String,
+    val url: String,
+    val title: String = "",
+    val icon: Bitmap? = null,
+    val thumbnail: Bitmap? = null
+)

--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tabs.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/Tabs.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.tabstray
+
+/**
+ * Aggregate data type keeping a reference to the list of tabs and the index of the selected tab.
+ *
+ * @property list The list of tabs.
+ * @property selectedIndex Index of the selected tab in the list of tabs (or -1).
+ */
+data class Tabs(
+    val list: List<Tab>,
+    val selectedIndex: Int
+)

--- a/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
+++ b/components/concept/tabstray/src/main/java/mozilla/components/concept/tabstray/TabsTray.kt
@@ -5,7 +5,6 @@
 package mozilla.components.concept.tabstray
 
 import android.view.View
-import mozilla.components.browser.session.Session
 import mozilla.components.support.base.observer.Observable
 
 /**
@@ -19,58 +18,45 @@ interface TabsTray : Observable<TabsTray.Observer> {
         /**
          * A new tab has been selected.
          */
-        fun onTabSelected(session: Session)
+        fun onTabSelected(tab: Tab)
 
         /**
          * A tab has been closed.
          */
-        fun onTabClosed(session: Session)
+        fun onTabClosed(tab: Tab)
     }
 
     /**
-     * Displays the given list of sessions.
+     * Updates the list of tabs.
      *
-     * This method will be invoked with the initial list of sessions that should be displayed.
-     *
-     * @param sessions The list of sessions to be displayed.
-     * @param selectedIndex The list index of the currently selected session.
-     */
-    fun displaySessions(sessions: List<Session>, selectedIndex: Int)
-
-    /**
-     * Updates the list of sessions.
-     *
-     * Calling this method is usually followed by calling onSession*() methods to indicate what
+     * Calling this method is usually followed by calling onTabs*() methods to indicate what
      * exactly has changed. This allows the tabs tray implementation to animate between the old and
      * new state.
-     *
-     * @param sessions The list of sessions to be displayed.
-     * @param selectedIndex The list index of the currently selected session.
      */
-    fun updateSessions(sessions: List<Session>, selectedIndex: Int)
+    fun updateTabs(tabs: Tabs)
 
     /**
-     * Called after updateSessions() when <code>count</code> number of sessions are inserted at the
+     * Called after updateTabs() when <code>count</code> number of tabs are inserted at the
      * given position.
      */
-    fun onSessionsInserted(position: Int, count: Int)
+    fun onTabsInserted(position: Int, count: Int)
 
     /**
-     * Called after updateSessions() when <code>count</code> number of sessions are removed from
+     * Called after updateTabs() when <code>count</code> number of tabs are removed from
      * the given position.
      */
-    fun onSessionsRemoved(position: Int, count: Int)
+    fun onTabsRemoved(position: Int, count: Int)
 
     /**
-     * Called after updateSessions() when a session changes it position.
+     * Called after updateTabs() when a tab changes it position.
      */
-    fun onSessionMoved(fromPosition: Int, toPosition: Int)
+    fun onTabsMoved(fromPosition: Int, toPosition: Int)
 
     /**
-     * Called after updateSessions() when <code>count</code> number of sessions are updated at the
+     * Called after updateTabs() when <code>count</code> number of tabs are updated at the
      * given position.
      */
-    fun onSessionsChanged(position: Int, count: Int)
+    fun onTabsChanged(position: Int, count: Int)
 
     /**
      * Convenience method to cast the implementation of this interface to an Android View object.

--- a/components/feature/tabs/build.gradle
+++ b/components/feature/tabs/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation Dependencies.testing_coroutines
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation project(":support-test-libstate")
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -21,7 +21,15 @@ class TabsUseCases(
      * Contract for use cases that select a tab.
      */
     interface SelectTabUseCase {
+        /**
+         * Select given [session].
+         */
         operator fun invoke(session: Session)
+
+        /**
+         * Select [Session] with the given [tabId].
+         */
+        operator fun invoke(tabId: String)
     }
 
     class DefaultSelectTabUseCase internal constructor(
@@ -35,6 +43,13 @@ class TabsUseCases(
          */
         override operator fun invoke(session: Session) {
             sessionManager.select(session)
+        }
+
+        override fun invoke(tabId: String) {
+            val session = sessionManager.findSessionById(tabId)
+            if (session != null) {
+                invoke(session)
+            }
         }
     }
 

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/BrowserState.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/BrowserState.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.tabs.ext
+
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.concept.tabstray.Tabs
+
+internal fun BrowserState.toTabs(
+    tabsFilter: (TabSessionState) -> Boolean = { true }
+) = Tabs(
+    list = tabs
+        .filter(tabsFilter)
+        .map { it.toTab() },
+    selectedIndex = tabs.indexOfFirst { it.id == selectedTabId }
+)

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.tabs.ext
+
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.concept.tabstray.Tab
+
+internal fun TabSessionState.toTab() = Tab(
+    id,
+    content.url,
+    content.title,
+    content.icon,
+    content.thumbnail
+)

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractor.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractor.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.tabs.tabstray
 
-import mozilla.components.browser.session.Session
+import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.TabsUseCases
 
@@ -27,12 +27,12 @@ class TabsTrayInteractor(
         tabsTray.unregister(this)
     }
 
-    override fun onTabSelected(session: Session) {
-        selectTabUseCase.invoke(session)
+    override fun onTabSelected(tab: Tab) {
+        selectTabUseCase.invoke(tab.id)
         closeTabsTray.invoke()
     }
 
-    override fun onTabClosed(session: Session) {
-        removeTabUseCase.invoke(session)
+    override fun onTabClosed(tab: Tab) {
+        removeTabUseCase.invoke(tab.id)
     }
 }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
@@ -6,9 +6,19 @@ package mozilla.components.feature.tabs.tabstray
 
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListUpdateCallback
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.concept.tabstray.TabsTray
+import mozilla.components.feature.tabs.ext.toTabs
+import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 
 /**
  * Presenter implementation for a tabs tray implementation in order to update the tabs tray whenever
@@ -16,43 +26,46 @@ import mozilla.components.concept.tabstray.TabsTray
  */
 class TabsTrayPresenter(
     private val tabsTray: TabsTray,
-    private val sessionManager: SessionManager,
+    private val store: BrowserStore,
     private val closeTabsTray: () -> Unit,
-    internal var sessionsFilter: (Session) -> Boolean = { true }
-) : SessionManager.Observer {
-    private var sessions = sessionManager.sessions.filter { sessionsFilter(it) }
-    private var selectedIndex = sessions.indexOf(sessionManager.selectedSession)
+    internal var tabsFilter: (TabSessionState) -> Boolean = { true }
+) {
+    private var tabs: Tabs? = null
+    private var scope: CoroutineScope? = null
 
     fun start() {
-        sessionManager.register(this)
-
-        tabsTray.displaySessions(sessions, selectedIndex)
+        scope = store.flowScoped { flow -> collect(flow) }
     }
 
     fun stop() {
-        sessionManager.unregister(this)
+        scope?.cancel()
     }
 
-    override fun onSessionRemoved(session: Session) {
-        calculateDiffAndUpdateTabsTray()
+    private suspend fun collect(flow: Flow<BrowserState>) {
+        flow.map { state -> state.toTabs(tabsFilter) }
+            .ifChanged()
+            .collect { tabs ->
+                updateTabs(tabs)
 
-        if (sessions.isEmpty()) {
-            closeTabsTray.invoke()
+                if (tabs.list.isEmpty()) {
+                    closeTabsTray.invoke()
+                }
+            }
+    }
+
+    internal fun updateTabs(tabs: Tabs) {
+        val currentTabs = this.tabs
+
+        if (currentTabs == null) {
+            this.tabs = tabs
+            if (tabs.list.isNotEmpty()) {
+                tabsTray.updateTabs(tabs)
+                tabsTray.onTabsInserted(0, tabs.list.size)
+            }
+            return
+        } else {
+            calculateDiffAndUpdateTabsTray(currentTabs, tabs)
         }
-    }
-
-    override fun onSessionAdded(session: Session) {
-        calculateDiffAndUpdateTabsTray()
-    }
-
-    override fun onSessionSelected(session: Session) {
-        calculateDiffAndUpdateTabsTray()
-    }
-
-    override fun onAllSessionsRemoved() {
-        calculateDiffAndUpdateTabsTray()
-
-        closeTabsTray.invoke()
     }
 
     /**
@@ -60,68 +73,55 @@ class TabsTrayPresenter(
      * tab tray with the new data and notifies it about what changes happened so that it can animate
      * those changes.
      */
-    internal fun calculateDiffAndUpdateTabsTray() {
-        val updatedSessions = sessionManager.sessions.filter { sessionsFilter(it) }
-        val updatedIndex = if (updatedSessions.isNotEmpty()) {
-            updatedSessions.indexOf(sessionManager.selectedSession)
-        } else {
-            -1
-        }
+    private fun calculateDiffAndUpdateTabsTray(currentTabs: Tabs, updatedTabs: Tabs) {
+        val result = DiffUtil.calculateDiff(DiffCallback(currentTabs, updatedTabs), false)
 
-        val result = DiffUtil.calculateDiff(
-            DiffCallback(sessions, updatedSessions, selectedIndex, updatedIndex),
-            false)
+        this.tabs = updatedTabs
 
-        sessions = updatedSessions
-        selectedIndex = updatedIndex
-
-        tabsTray.updateSessions(updatedSessions, updatedIndex)
+        tabsTray.updateTabs(updatedTabs)
 
         result.dispatchUpdatesTo(object : ListUpdateCallback {
             override fun onChanged(position: Int, count: Int, payload: Any?) {
-                tabsTray.onSessionsChanged(position, count)
+                tabsTray.onTabsChanged(position, count)
             }
 
             override fun onMoved(fromPosition: Int, toPosition: Int) {
-                tabsTray.onSessionMoved(fromPosition, toPosition)
+                tabsTray.onTabsMoved(fromPosition, toPosition)
             }
 
             override fun onInserted(position: Int, count: Int) {
-                tabsTray.onSessionsInserted(position, count)
+                tabsTray.onTabsInserted(position, count)
             }
 
             override fun onRemoved(position: Int, count: Int) {
-                tabsTray.onSessionsRemoved(position, count)
+                tabsTray.onTabsRemoved(position, count)
             }
         })
     }
 }
 
 internal class DiffCallback(
-    private var currentSessions: List<Session>,
-    private var updatedSessions: List<Session>,
-    private var currentIndex: Int,
-    private var updatedIndex: Int
+    private val currentTabs: Tabs,
+    private val updatedTabs: Tabs
 ) : DiffUtil.Callback() {
     override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-        currentSessions[oldItemPosition] == updatedSessions[newItemPosition]
+        currentTabs.list[oldItemPosition].id == updatedTabs.list[newItemPosition].id
 
-    override fun getOldListSize(): Int = currentSessions.size
+    override fun getOldListSize(): Int = currentTabs.list.size
 
-    override fun getNewListSize(): Int = updatedSessions.size
+    override fun getNewListSize(): Int = updatedTabs.list.size
 
     override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        if (oldItemPosition == currentIndex && newItemPosition != updatedIndex) {
+        if (oldItemPosition == currentTabs.selectedIndex && newItemPosition != updatedTabs.selectedIndex) {
             // This item was previously selected and is not selected anymore (-> changed).
             return false
         }
 
-        if (newItemPosition == updatedIndex && oldItemPosition != currentIndex) {
+        if (newItemPosition == updatedTabs.selectedIndex && oldItemPosition != currentTabs.selectedIndex) {
             // This item was not selected previously and is now selected (-> changed).
             return false
         }
 
-        // If the URL of both items is the same then we treat this item as the same (-> unchanged).
-        return currentSessions[oldItemPosition].url == updatedSessions[newItemPosition].url
+        return updatedTabs.list[newItemPosition] == currentTabs.list[oldItemPosition]
     }
 }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
@@ -4,14 +4,15 @@
 
 package mozilla.components.feature.tabs.tabstray
 
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
-
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
@@ -20,10 +21,11 @@ class TabsFeatureTest {
     @Test
     fun `asserting getters`() {
         val sessionManager = SessionManager(engine = mock())
+        val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
         val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock()))
 
         assertNotEquals(tabsFeature.interactor, interactor)
         assertNotEquals(tabsFeature.presenter, presenter)
@@ -38,10 +40,11 @@ class TabsFeatureTest {
     @Test
     fun start() {
         val sessionManager = SessionManager(engine = mock())
+        val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
         val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock()))
 
         tabsFeature.presenter = presenter
         tabsFeature.interactor = interactor
@@ -55,10 +58,11 @@ class TabsFeatureTest {
     @Test
     fun stop() {
         val sessionManager = SessionManager(engine = mock())
+        val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
         val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock()))
 
         tabsFeature.presenter = presenter
         tabsFeature.interactor = interactor
@@ -72,19 +76,20 @@ class TabsFeatureTest {
     @Test
     fun filterTabs() {
         val sessionManager = SessionManager(engine = mock())
+        val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
         val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), sessionManager, useCases, mock()))
+        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock()))
 
         tabsFeature.presenter = presenter
         tabsFeature.interactor = interactor
 
-        val filter: (Session) -> Boolean = { true }
+        val filter: (TabSessionState) -> Boolean = { true }
 
         tabsFeature.filterTabs(filter)
 
-        verify(presenter).sessionsFilter = filter
-        verify(presenter).calculateDiffAndUpdateTabsTray()
+        verify(presenter).tabsFilter = filter
+        verify(presenter).updateTabs(Tabs(emptyList(), -1))
     }
 }

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractorTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayInteractorTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.tabs.tabstray
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.session.Session
+import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.mock
@@ -36,10 +36,10 @@ class TabsTrayInteractorTest {
         val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
         val interactor = TabsTrayInteractor(mock(), selectTabUseCase, mock(), mock())
 
-        val session = Session("https://www.mozilla.org")
-        interactor.onTabSelected(session)
+        val tab = Tab("1", "https://www.mozilla.org")
+        interactor.onTabSelected(tab)
 
-        verify(selectTabUseCase).invoke(session)
+        verify(selectTabUseCase).invoke(tab.id)
     }
 
     @Test
@@ -47,9 +47,9 @@ class TabsTrayInteractorTest {
         val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
         val interactor = TabsTrayInteractor(mock(), mock(), removeTabUseCase, mock())
 
-        val session = Session("https://www.mozilla.org")
-        interactor.onTabClosed(session)
+        val tab = Tab("1", "https://www.mozilla.org")
+        interactor.onTabClosed(tab)
 
-        verify(removeTabUseCase).invoke(session)
+        verify(removeTabUseCase).invoke(tab.id)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,16 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **concept-tabstray**
+  * ⚠️ **This is a breaking change**: Removed dependency on `browser-session` and introduced tabs tray specific data classes.
+
+* **browser-tabstray**
+  * ⚠️ **This is a breaking change**: Refactored component to implement updated `concept-tabstray` interfaces.
+
+* **feature-tabs**
+  * ⚠️ **This is a breaking change**: Refactored component to use `browser-state` instead of `browser-session`.
+  * Added additional method to `TabsUseCases` to select a tab based on its id.
+
 * **browser-icons**
   * ⚠️ **This is a breaking change**: Migrated this component to use `browser-state` instead of `browser-session`. It is now required to pass a `BrowserStore` instance (instead of `SessionManager`) to `BrowserIcons.install()`.
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -45,7 +45,7 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
 
         tabsFeature = TabsFeature(
             tabsTray,
-            components.sessionManager,
+            components.store,
             components.tabsUseCases,
             ::closeTabsTray
         ).also { lifecycle.addObserver(it) }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
