### PR TITLE
Closes #5975: Make StreamingSessionStoreParser less strict.

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/session/StreamingSessionStoreParser.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/session/StreamingSessionStoreParser.kt
@@ -25,6 +25,7 @@ internal object StreamingSessionStoreParser {
 
         file.inputStream().bufferedReader().use {
             val reader = JsonReader(it)
+            reader.isLenient = true
 
             reader.beginObject()
 


### PR DESCRIPTION
> Configure this parser to be be liberal in what it accepts. By default, this parser is strict and only accepts JSON as specified by RFC 4627.
> https://developer.android.com/reference/android/util/JsonReader#setLenient(boolean)