### PR TITLE
Bug 1615248 - add missing nightly entry in .cron.yml

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -12,3 +12,9 @@ jobs:
       when:
           - {hour: 13, minute: 0}
           - {hour: 19, minute: 0}
+    - name: nightly
+      job:
+          type: decision-task
+          treeherder-symbol: nightly-D
+          target-tasks-method: nightly
+      when: []  # Force hook only


### PR DESCRIPTION
Follow-up from https://github.com/mozilla-mobile/android-components/pull/5967, I forgot to add its `cron.yml` corresponding entry for nightly releases.