### PR TITLE
Closes #6011: Integrate DebuggerDelegate to support temporary extensions

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -332,8 +332,15 @@ class GeckoEngine(
             }
         }
 
+        val debuggerDelegate = object : WebExtensionController.DebuggerDelegate {
+            override fun onExtensionListUpdated() {
+                webExtensionDelegate.onExtensionListUpdated()
+            }
+        }
+
         runtime.webExtensionController.promptDelegate = promptDelegate
         runtime.webExtensionController.tabDelegate = tabsDelegate
+        runtime.webExtensionController.setDebuggerDelegate(debuggerDelegate)
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -940,6 +940,23 @@ class GeckoEngineTest {
     }
 
     @Test
+    fun `web extension delegate notified of extension list change`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val debuggerDelegateCaptor = argumentCaptor<WebExtensionController.DebuggerDelegate>()
+        verify(webExtensionController).setDebuggerDelegate(debuggerDelegateCaptor.capture())
+
+        debuggerDelegateCaptor.value.onExtensionListUpdated()
+        verify(webExtensionsDelegate).onExtensionListUpdated()
+    }
+
+    @Test
     fun `update web extension successfully`() {
         val runtime = mock<GeckoRuntime>()
         val extensionController: WebExtensionController = mock()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -289,6 +289,12 @@ sealed class WebExtensionAction : BrowserAction() {
     data class UninstallWebExtensionAction(val extensionId: String) : WebExtensionAction()
 
     /**
+     * Removes state of all extensions from [BrowserState.extensions]
+     * and [TabSessionState.extensionState].
+     */
+    object UninstallAllWebExtensionsAction : WebExtensionAction()
+
+    /**
      * Updates the [WebExtensionState.enabled] flag.
      */
     data class UpdateWebExtensionEnabledAction(val extensionId: String, val enabled: Boolean) :

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
@@ -14,6 +14,7 @@ internal object WebExtensionReducer {
      * [WebExtensionAction] Reducer function for modifying a specific [WebExtensionState] in
      *  both [SessionState.extensionState] or [BrowserState.extensions].
      */
+    @Suppress("LongMethod")
     fun reduce(state: BrowserState, action: WebExtensionAction): BrowserState {
         return when (action) {
             is WebExtensionAction.InstallWebExtensionAction -> {
@@ -33,6 +34,12 @@ internal object WebExtensionReducer {
                 state.copy(
                     extensions = state.extensions - action.extensionId,
                     tabs = state.tabs.map { it.copy(extensionState = it.extensionState - action.extensionId) }
+                )
+            }
+            is WebExtensionAction.UninstallAllWebExtensionsAction -> {
+                state.copy(
+                    extensions = emptyMap(),
+                    tabs = state.tabs.map { it.copy(extensionState = emptyMap()) }
                 )
             }
             is WebExtensionAction.UpdateWebExtensionEnabledAction -> {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -125,4 +125,12 @@ interface WebExtensionDelegate {
         newPermissions: List<String>,
         onPermissionsGranted: ((Boolean) -> Unit)
     ) = Unit
+
+    /**
+     * Invoked when the list of installed extensions has been updated in the engine
+     * (the web extension runtime). This happens as a result of debugging tools (e.g
+     * web-ext) installing temporary extensions. It does not happen in the regular flow
+     * of installing / uninstalling extensions by the user.
+     */
+    fun onExtensionListUpdated() = Unit
 }

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -204,6 +204,12 @@ object WebExtensionSupport {
                     onPermissionsGranted
                 )
             }
+
+            override fun onExtensionListUpdated() {
+                installedExtensions.clear()
+                store.dispatch(WebExtensionAction.UninstallAllWebExtensionsAction)
+                registerInstalledExtensions(store, runtime)
+            }
         })
     }
 


### PR DESCRIPTION
GeckoView calls us back now when a debug / temporary extension was installed so we can refresh the list of installed extensions to make sure action handlers are hooked up. 

We're gonna have to uninstall all extensions and call `listInstalledExtensions` again to re-install everything that is there now incl. the new temporary extension. This is fine as it's for debugging purposes only.