### PR TITLE
Fix #6041 - Use MATCH_DEFAULT_ONLY in Browsers resolveActivity() calls

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
@@ -247,7 +247,7 @@ class Browsers private constructor(
             intent.data = uri
             intent.setPackage(browser.packageName)
 
-            val info = packageManager.resolveActivity(intent, 0)
+            val info = packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
                 ?: continue
 
             if (info.activityInfo == null || !info.activityInfo.exported) {
@@ -261,7 +261,7 @@ class Browsers private constructor(
     private fun findDefault(context: Context, packageManager: PackageManager, uri: Uri): ActivityInfo? {
         val intent = Intent(Intent.ACTION_VIEW, uri)
 
-        val resolveInfo = packageManager.resolveActivity(intent, 0)
+        val resolveInfo = packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
             ?: return null
 
         if (resolveInfo.activityInfo == null || !resolveInfo.activityInfo.exported) {


### PR DESCRIPTION
On Huawei devices it was seen that not using this flag would result in the
default apps status being lost.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include tests as the changes are very small.
- [x] **Changelog**: This PR includes or does not need a changelog entry.
- [x] **Accessibility**: The code in this PR follows does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
