### PR TITLE
Closes issue #6030: Set the default add-on icon when failing to fetch it

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -23,6 +23,7 @@
     <TextView
         android:id="@+id/action_label"
         style="@style/Mozac.Browser.Menu.Item.Text"
+        android:background="@android:color/transparent"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
         android:gravity="center_vertical"

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -227,6 +227,7 @@ class AddonsManagerAdapter(
                     val context = iconView.context
                     val att = context.theme.resolveAttribute(android.R.attr.textColorPrimary)
                     iconView.setColorFilter(ContextCompat.getColor(context, att))
+                    iconView.setImageDrawable(context.getDrawable(R.drawable.mozac_ic_extensions))
                 }
                 logger.error("Attempt to fetch the ${addon.id} icon failed", e)
             }

--- a/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
+++ b/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
@@ -28,8 +28,8 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:layout_gravity="center"
-                android:src="@drawable/mozac_ic_extensions"
                 android:importantForAccessibility="no"
+                android:src="@android:color/transparent"
                 android:scaleType="fitCenter" />
 
     </androidx.cardview.widget.CardView>


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/fenix/issues/8111#issuecomment-590220306 and https://github.com/mozilla-mobile/fenix/issues/8698
