### PR TITLE
For Fenix #8524 - Use SwitchCompat for BrowserMenuImageSwitch

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
@@ -6,10 +6,10 @@ package mozilla.components.browser.menu.item
 
 import android.content.Context
 import android.view.View
-import android.widget.Switch
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.SwitchCompat
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
 import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
@@ -35,7 +35,7 @@ class BrowserMenuImageSwitch(
     override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_image_switch
 
     override fun bind(menu: BrowserMenu, view: View) {
-        super.bind(menu, view.findViewById<Switch>(R.id.switch_widget))
+        super.bind(menu, view.findViewById<SwitchCompat>(R.id.switch_widget))
         bindImage(view)
     }
 

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_switch.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_switch.xml
@@ -18,7 +18,7 @@
         android:importantForAccessibility="no"
         tools:src="@android:drawable/screen_background_dark" />
 
-    <Switch
+    <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/switch_widget"
         style="@style/Mozac.Browser.Menu.Item.Text"
         android:textAlignment="viewStart"


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
