### PR TITLE
Closes #6053: Register an account state persistence callback for offline migration recovery

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -711,6 +711,8 @@ open class FxaAccountManager(
                 when (via) {
                     Event.RetryMigration,
                     Event.InFlightReuseMigration -> {
+                        logger.info("Registering persistence callback")
+                        account.registerPersistenceCallback(statePersistenceCallback)
                         return retryMigration(reuseAccount = true)
                     }
                     else -> null
@@ -720,6 +722,8 @@ open class FxaAccountManager(
                 when (via) {
                     Event.RetryMigration,
                     Event.InFlightCopyMigration -> {
+                        logger.info("Registering persistence callback")
+                        account.registerPersistenceCallback(statePersistenceCallback)
                         return retryMigration(reuseAccount = false)
                     }
                     else -> null
@@ -774,7 +778,9 @@ open class FxaAccountManager(
                     is Event.SignedInShareableAccount -> {
                         // Note that we are not registering an account persistence callback here like
                         // we do in other `AuthenticatedNoProfile` methods, because it would have been
-                        // already registered while handling `Event.SignInShareableAccount`.
+                        // already registered while handling any of the pre-cursor events, such as
+                        // `Event.SignInShareableAccount`, `Event.InFlightCopyMigration`
+                        // or `Event.InFlightReuseMigration`.
                         logger.info("Registering device constellation observer")
                         account.deviceConstellation().register(deviceEventsIntegration)
 

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -602,6 +602,8 @@ class FxaAccountManagerTest {
 
         assertNull(account.persistenceCallback)
         manager.initAsync().await()
+        // Make sure a persistence callback was registered while pumping the state machine.
+        assertNotNull(account.persistenceCallback)
 
         // Assert that neither ensureCapabilities nor initialization fired.
         verify(constellation, never()).ensureCapabilitiesAsync(setOf(DeviceCapability.SEND_TAB))
@@ -638,6 +640,8 @@ class FxaAccountManagerTest {
 
         assertNull(account.persistenceCallback)
         manager.initAsync().await()
+        // Make sure a persistence callback was registered while pumping the state machine.
+        assertNotNull(account.persistenceCallback)
 
         verify(constellation).ensureCapabilitiesAsync(setOf(DeviceCapability.SEND_TAB))
         verify(constellation, never()).initDeviceAsync(any(), any(), any())


### PR DESCRIPTION
This fixes a problem where an account state persistence callback was not registered
during the recovery part of the offline fxa migration flow.

This caused us to successfully migrate, but then migrate again and again (always successfully)
upon application restart, since we wouldn't remember our own success.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
