### PR TITLE
For Fenix #8706: Add padding to web-ext menu item badge text

### DIFF
--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -43,6 +43,7 @@
         android:id="@+id/badge_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:padding="3dp"
         android:textSize="12sp"
         tools:text="18" />
 


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/issues/8706