### PR TITLE
Bug 1615248 - fix paths in build jobs; add signing jobs in nightly releases

### DIFF
--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -119,19 +119,6 @@ def _deep_format(object, field, **format_kwargs):
 
 @transforms.add
 def add_artifacts(config, tasks):
-
-    def _craft_path_version(version, build_type, nightly_version):
-        """Helper function to craft the correct version to bake in the artifacts full
-        path section"""
-        ret = "{}{}".format(
-            version,
-            "-SNAPSHOT" if build_type == "snapshot" else ''
-        )
-        if build_type == 'nightly':
-            if version in ret:
-                ret = ret.replace(version, nightly_version)
-        return ret
-
     timestamp = _get_timestamp(config)
     version = get_version()
     nightly_version = _get_nightly_version(config, version)
@@ -154,7 +141,6 @@ def add_artifacts(config, tasks):
                 )
                 for extension in all_extensions
             }
-
             # XXX: rather than adding more complex logic above, we simply post-adjust the
             # dictionary for `nightly` types of graphs
             if task['attributes']['build-type'] == 'nightly':
@@ -172,8 +158,10 @@ def add_artifacts(config, tasks):
                     "path": artifact_template["path"].format(
                         component_path=get_path(component),
                         component=component,
-                        version_with_snapshot=_craft_path_version(version,
-                            task['attributes']['build-type'], nightly_version),
+                        version_with_snapshot="{}{}".format(
+                            version,
+                            "-SNAPSHOT" if task["attributes"]["build-type"] == "snapshot" else ''
+                        ),
                         artifact_file_name=artifact_file_name,
                     ),
                 })

--- a/taskcluster/ci/post-signing/kind.yml
+++ b/taskcluster/ci/post-signing/kind.yml
@@ -24,5 +24,6 @@ job-template:
             by-build-type:
                 release: post-signing-release
                 snapshot: post-signing-snapshot
+                nightly: post-signing-nightly
                 default: post-signing
         tier: 1

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -19,6 +19,7 @@ group-by: component
 
 only-for-build-types:
     - release
+    - nightly
     - snapshot
 
 job-template:
@@ -38,5 +39,6 @@ job-template:
             by-build-type:
                 release: BRs
                 snapshot: BSnaps
+                nightly: BNs
                 default: Bs
         kind: build


### PR DESCRIPTION
Follow-up from https://github.com/mozilla-mobile/android-components/pull/5967/ - to fix the build paths. The artifacts are correctly generated by gradle (as they would for a normal github release), and renamed correctly to encompass the `buildid` within them. But I initially thought I need to amend the version as well (like GV does) but that is not needed as we can do that directly in beetmover. 

After all, the renaming script, at runtime, renames only individual filenames, not folders. So I should've done the same at generation time, and not touch the folders.

This is pretty much revert to what we used to have before I landed my PR, in this particular piece of code.

Local diff:
```
331c331
<             "path": "/builds/worker/checkouts/src/components/browser/awesomebar/build/maven/org/mozilla/components/browser-awesomebar/34.0.20200212190116/browser-awesomebar-34.0.20200212190116-sources.jar",
---
>             "path": "/builds/worker/checkouts/src/components/browser/awesomebar/build/maven/org/mozilla/components/browser-awesomebar/34.0.0/browser-awesomebar-34.0.20200212190116-sources.jar",
338c338
``` 