### PR TITLE
Bug 1615248 - add beetmover jobs in the nightly graphs

### DIFF
--- a/taskcluster/ac_taskgraph/transforms/beetmover.py
+++ b/taskcluster/ac_taskgraph/transforms/beetmover.py
@@ -10,7 +10,7 @@ from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
 
 from ..build_config import get_version
-from .build import _get_nightly_version
+from .build import get_nightly_version
 
 transforms = TransformSequence()
 
@@ -36,20 +36,21 @@ def set_artifact_map(config, tasks):
     def _craft_path_version(version, build_type, nightly_version):
         """Helper function to craft the correct version to bake in the artifacts full
         path section"""
-        ret = "{}{}".format(
+        path_version = "{}{}".format(
             version,
             "-SNAPSHOT" if build_type == "snapshot" else ''
         )
-        # XXX: for nightly releases we need to s/X.0.0/X.0.<buildid>/g for the
-        # version within the destination path
-        # e.g. maven2/org/mozilla/components/browser-awesomebar/34.0.20200212190116/
+        # XXX: for nightly releases we need to s/X.0.0/X.0.<buildid>/g in version
+        # within the destination path. This change is needed to ensure the version folder is set correctly so that
+        # maven2/org/mozilla/components/<component>/34.0.0/<component>-34.0.20200212190116-sources.jar
+        # becomes ->
+        # maven2/org/mozilla/components/<component>/34.0.20200212190116/<component>-34.0.20200212190116-sources.jar
         if build_type == 'nightly':
-            if version in ret:
-                ret = ret.replace(version, nightly_version)
-        return ret
+            path_version = path_version.replace(version, nightly_version)
+        return path_version
 
     version = get_version()
-    nightly_version = _get_nightly_version(config, version)
+    nightly_version = get_nightly_version(config, version)
 
     for task in tasks:
         maven_destination = task.pop("maven-destination")

--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -59,7 +59,7 @@ def handle_coverage(config, tasks):
 def interpolate_missing_values(config, tasks):
     timestamp = _get_timestamp(config)
     version = get_version()
-    nightly_version = _get_nightly_version(config, version)
+    nightly_version = get_nightly_version(config, version)
 
     for task in tasks:
         for field in ('description', 'run.gradlew', 'treeherder.symbol'):
@@ -81,7 +81,7 @@ def _get_buildid(config):
     return config.params.moz_build_date.strftime('%Y%m%d%H%M%S')
 
 
-def _get_nightly_version(config, version):
+def get_nightly_version(config, version):
     buildid = _get_buildid(config)
     # TODO: to replace here with mozilla-version sanity check and parsing
     pattern = re.compile(r"""
@@ -121,7 +121,7 @@ def _deep_format(object, field, **format_kwargs):
 def add_artifacts(config, tasks):
     timestamp = _get_timestamp(config)
     version = get_version()
-    nightly_version = _get_nightly_version(config, version)
+    nightly_version = get_nightly_version(config, version)
 
     for task in tasks:
         artifact_template = task.pop("artifact-template", {})

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -19,6 +19,7 @@ primary-dependency: signing
 
 only-for-build-types:
     - release
+    - nightly
     - snapshot
 
 group-by: component
@@ -32,6 +33,7 @@ job-template:
         job-symbol:
             by-build-type:
                 release: BM-R
+                nightly: BM-N
                 snapshot: BM-Snap
                 default: BM-B
         kind: build
@@ -43,6 +45,10 @@ job-template:
                     by-level:
                         '3': maven-production
                         default: maven-staging
+                nightly:
+                    by-level:
+                        '3': maven-nightly-production
+                        default: maven-nightly-staging
                 snapshot:
                     by-level:
                         '3': maven-snapshot-production
@@ -51,5 +57,6 @@ job-template:
             by-build-type:
                 release: components
                 snapshot: snapshot_components
+                nightly: nightly_components
                 default: UNDEFINED
     worker-type: beetmover


### PR DESCRIPTION
Now that we have fully functional builds + signing in the AC nightly graphs, time to add beetmover counterpart as well. Artifacts generated are going to go under https://nightly.maven.mozilla.org/, for example:

```
maven2/org/mozilla/components/browser-awesomebar/34.0.20191005130104/browser-awesomebar-34.0.20191005130104-sources.jar.asc
maven2/org/mozilla/components/browser-awesomebar/34.0.20191005130104/browser-awesomebar-34.0.20191005130104-sources.jar
```

I checked with `taskgraph-diff`, there are no other changes in the `release` or `snapshots` graph. The PR only adds the beetmover counterparts. 

I won't land this until I'm done with the changes in the beetmoverscript, cloudops-infra and SOPS too for all the credentials stuff. 