### PR TITLE
Closes #6073: Adds animation to showPopupWhereBestFits menu

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -172,22 +172,31 @@ internal fun PopupWindow.displayPopup(
             showPopupWithUpOrientation(anchor, availableHeightToBottom, containerHeight)
         }
         else -> {
-            showPopupWhereBestFits(anchor, fitsUp, fitsDown, availableHeightToBottom, containerHeight)
+            showPopupWhereBestFits(
+                anchor,
+                fitsUp,
+                fitsDown,
+                availableHeightToTop,
+                availableHeightToBottom,
+                containerHeight
+            )
         }
     }
 }
 
+@Suppress("LongParameterList")
 private fun PopupWindow.showPopupWhereBestFits(
     anchor: View,
     fitsUp: Boolean,
     fitsDown: Boolean,
+    availableHeightToTop: Int,
     availableHeightToBottom: Int,
     containerHeight: Int
 ) {
     // We don't have enough space to show the menu UP neither DOWN.
     // Let's just show the popup at the location of the anchor.
     if (!fitsUp && !fitsDown) {
-        showAtAnchorLocation(anchor)
+        showAtAnchorLocation(anchor, availableHeightToTop < availableHeightToBottom)
     } else {
         if (fitsDown) {
             showPopupWithDownOrientation(anchor)
@@ -218,8 +227,16 @@ private fun PopupWindow.showPopupWithDownOrientation(anchor: View) {
     showAsDropDown(anchor, xOffset, -anchor.height)
 }
 
-private fun PopupWindow.showAtAnchorLocation(anchor: View) {
+private fun PopupWindow.showAtAnchorLocation(anchor: View, isCloserToTop: Boolean) {
     val anchorPosition = IntArray(2)
+
+    // Apply the best fit animation style based on positioning
+    animationStyle = if (isCloserToTop) {
+        R.style.Mozac_Browser_Menu_Animation_OverflowMenuTop
+    } else {
+        R.style.Mozac_Browser_Menu_Animation_OverflowMenuBottom
+    }
+
     anchor.getLocationOnScreen(anchorPosition)
     val x = anchorPosition[0]
     val y = anchorPosition[1]

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -319,7 +319,6 @@ class BrowserMenuTest {
         doReturn(Int.MAX_VALUE).`when`(containerView).measuredHeight
 
         popupWindow.displayPopup(containerView, anchor, BrowserMenu.Orientation.DOWN)
-        assertEquals(popupWindow.animationStyle, -1)
         verify(popupWindow).showAtLocation(anchor, Gravity.START or Gravity.TOP, 0, 0)
     }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
