### PR TITLE
Closes #6079: Add strictSocialTrackingProtection on SessionTypes PrivateOnly and RegularOnly 

### DIFF
--- a/components/concept/engine/build.gradle
+++ b/components/concept/engine/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.kotlin_reflect
 
     testImplementation project(':support-test')
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -345,7 +345,8 @@ abstract class EngineSession(
             trackingCategories = trackingCategories,
             useForPrivateSessions = true,
             useForRegularSessions = false,
-            cookiePolicy = cookiePolicy
+            cookiePolicy = cookiePolicy,
+            strictSocialTrackingProtection = strictSocialTrackingProtection
         )
 
         /**
@@ -355,7 +356,8 @@ abstract class EngineSession(
             trackingCategories = trackingCategories,
             useForPrivateSessions = false,
             useForRegularSessions = true,
-            cookiePolicy = cookiePolicy
+            cookiePolicy = cookiePolicy,
+            strictSocialTrackingProtection = strictSocialTrackingProtection
         )
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,7 @@ permalink: /changelog/
 * **concept-engine**
   * ⚠️ **This is a breaking change**: remove deprecated GeckoView setting `allowAutoplayMedia`
     * This should now be controlled for individual sites via `SitePermissionsRules`
+  * Fixed a bug that would cause `TrackingProtectionPolicyForSessionTypes` to lose some information during transformations.
 
 * **feature-downloads**
   * ⚠️ **This is a breaking change**: `customTabId` is renamed to `tabId`.


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
