### PR TITLE
Bug 1618128 - Import WebCompat 8.0.0 sources into feature-webcompat.

### DIFF
--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/data/injections.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/data/injections.js
@@ -444,6 +444,21 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1610344",
+    platform: "android",
+    domain: "directv.com.co",
+    bug: "1610344",
+    contentScripts: {
+      matches: ["https://*.directv.com.co/*"],
+      css: [
+        {
+          file:
+            "injections/css/bug1610344-directv.com.co-hide-unsupported-message.css",
+        },
+      ],
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
@@ -218,30 +218,8 @@ const AVAILABLE_UA_OVERRIDES = [
   },
   {
     /*
-     * Bug 1480710 - m.imgur.com - Build UA override
-     * WebCompat issue #13154 - https://webcompat.com/issues/13154
-     *
-     * imgur returns a 404 for requests to CSS and JS file if requested with a Fennec
-     * User Agent. By removing the Fennec identifies and adding Chrome Mobile's, we
-     * receive the correct CSS and JS files.
-     */
-    id: "bug1480710",
-    platform: "android",
-    domain: "m.imgur.com",
-    bug: "1480710",
-    config: {
-      matches: ["*://m.imgur.com/*"],
-      uaTransformer: originalUA => {
-        return (
-          UAHelpers.getPrefix(originalUA) +
-          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36"
-        );
-      },
-    },
-  },
-  {
-    /*
      * Bug 945963 - tieba.baidu.com serves simplified mobile content to Firefox Android
+     * additionally, Bug 1525839 for more domains
      * WebCompat issue #18455 - https://webcompat.com/issues/18455
      *
      * tieba.baidu.com and tiebac.baidu.com serve a heavily simplified and less functional
@@ -254,8 +232,12 @@ const AVAILABLE_UA_OVERRIDES = [
     bug: "945963",
     config: {
       matches: [
+        "*://baike.baidu.com/*",
+        "*://image.baidu.com/*",
+        "*://news.baidu.com/*",
         "*://tieba.baidu.com/*",
         "*://tiebac.baidu.com/*",
+        "*://wenku.baidu.com/*",
         "*://zhidao.baidu.com/*",
       ],
       uaTransformer: originalUA => {
@@ -298,25 +280,6 @@ const AVAILABLE_UA_OVERRIDES = [
       matches: ["*://*.nhk.or.jp/*"],
       uaTransformer: originalUA => {
         return originalUA + " AppleWebKit";
-      },
-    },
-  },
-  {
-    /*
-     * Bug 1338260 - Add UA override for directTV
-     * (Imported from ua-update.json.in)
-     *
-     * DirectTV has issues with scrolling and cut-off images. Pretending to be
-     * Chrome for Android fixes those issues.
-     */
-    id: "bug1338260",
-    platform: "android",
-    domain: "directv.com",
-    bug: "1338260",
-    config: {
-      matches: ["*://*.directv.com/*"],
-      uaTransformer: _ => {
-        return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36";
       },
     },
   },
@@ -438,25 +401,6 @@ const AVAILABLE_UA_OVERRIDES = [
       matches: ["*://posts.google.com/*"],
       uaTransformer: _ => {
         return "Mozilla/5.0 (Linux; Android 6.0.1; SM-G900M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36";
-      },
-    },
-  },
-  {
-    /*
-     * Bug 1567945 - Create UA override for beeg.com on Firefox Android
-     * WebCompat issue #16648 - https://webcompat.com/issues/16648
-     *
-     * beeg.com is hiding content of a page with video if Firefox exists in UA,
-     * replacing "Firefox" with an empty string makes the page load
-     */
-    id: "bug1567945",
-    platform: "android",
-    domain: "beeg.com",
-    bug: "1567945",
-    config: {
-      matches: ["*://beeg.com/*"],
-      uaTransformer: originalUA => {
-        return originalUA.replace(/Firefox.+$/, "");
       },
     },
   },
@@ -644,6 +588,27 @@ const AVAILABLE_UA_OVERRIDES = [
       matches: ["*://*.uniqlo.com/*"],
       uaTransformer: originalUA => {
         return originalUA + " Mobile Safari";
+      },
+    },
+  },
+  {
+    /*
+     * Bug 1442050 - UA overrides for my.nintendo.com
+     * Webcompat issue #12887 - https://webcompat.com/issues/12887
+     *
+     * Nintendo ships a broken version of their mobile interface to mobile
+     * browsers that are not Chrome or Safari. In our tests, appending the
+     * "AppleWebKit" identifier to the UA string results in a version that
+     * works very well.
+     */
+    id: "bug1442050",
+    platform: "android",
+    domain: "nintendo.com",
+    bug: "1442050",
+    config: {
+      matches: ["*://my.nintendo.com/*"],
+      uaTransformer: originalUA => {
+        return originalUA + " AppleWebKit";
       },
     },
   },

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1610344-directv.com.co-hide-unsupported-message.css
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/injections/css/bug1610344-directv.com.co-hide-unsupported-message.css
@@ -1,0 +1,13 @@
+/**
+ * directv.com.co - Browser is not supported message
+ * Bug #1610344 - https://bugzilla.mozilla.org/show_bug.cgi?id=1610344
+ * WebCompat issue #41822 - https://webcompat.com/issues/41822
+ *
+ * directv.com.co is showing a "This browser is not supported" message in
+ * Firefox. Our tests indicated that everything is working just fine, and our
+ * previous contact attempts have not been successful. This intervention
+ * hides the large red unsupported banner.
+ */
+.browser-compatible.compatible.incompatible {
+  display: none;
+}

--- a/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Web Compat",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "7.0.0",
+  "version": "8.0.0",
 
   "applications": {
     "gecko": {


### PR DESCRIPTION
It's close to the end of a Gecko release cycle, which brings us to the end of the WebCompat release cycle. New version, wohoo!

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
