### PR TITLE
Closes #4021: Use save image candidate be used with video and audio elements

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -795,11 +795,11 @@ class GeckoEngineSession(
         return when (elementType) {
             GeckoSession.ContentDelegate.ContextElement.TYPE_AUDIO ->
                 elementSrc?.let {
-                    HitResult.AUDIO(it)
+                    HitResult.AUDIO(it, title)
                 }
             GeckoSession.ContentDelegate.ContextElement.TYPE_VIDEO ->
                 elementSrc?.let {
-                    HitResult.VIDEO(it)
+                    HitResult.VIDEO(it, title)
                 }
             GeckoSession.ContentDelegate.ContextElement.TYPE_IMAGE -> {
                 when {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -799,11 +799,11 @@ class GeckoEngineSession(
         return when (elementType) {
             GeckoSession.ContentDelegate.ContextElement.TYPE_AUDIO ->
                 elementSrc?.let {
-                    HitResult.AUDIO(it)
+                    HitResult.AUDIO(it, title)
                 }
             GeckoSession.ContentDelegate.ContextElement.TYPE_VIDEO ->
                 elementSrc?.let {
-                    HitResult.VIDEO(it)
+                    HitResult.VIDEO(it, title)
                 }
             GeckoSession.ContentDelegate.ContextElement.TYPE_IMAGE -> {
                 when {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -787,11 +787,11 @@ class GeckoEngineSession(
         return when (elementType) {
             GeckoSession.ContentDelegate.ContextElement.TYPE_AUDIO ->
                 elementSrc?.let {
-                    HitResult.AUDIO(it)
+                    HitResult.AUDIO(it, title)
                 }
             GeckoSession.ContentDelegate.ContextElement.TYPE_VIDEO ->
                 elementSrc?.let {
-                    HitResult.VIDEO(it)
+                    HitResult.VIDEO(it, title)
                 }
             GeckoSession.ContentDelegate.ContextElement.TYPE_IMAGE -> {
                 when {

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/HitResult.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/HitResult.kt
@@ -23,12 +23,12 @@ sealed class HitResult(open val src: String) {
     /**
      * If the HTML element was of type 'HTMLVideoElement'.
      */
-    data class VIDEO(override val src: String) : HitResult(src)
+    data class VIDEO(override val src: String, val title: String? = null) : HitResult(src)
 
     /**
      * If the HTML element was of type 'HTMLAudioElement'.
      */
-    data class AUDIO(override val src: String) : HitResult(src)
+    data class AUDIO(override val src: String, val title: String? = null) : HitResult(src)
 
     /**
      * If the HTML element was of type 'HTMLImageElement' and contained a URI.

--- a/components/feature/contextmenu/src/main/res/values/strings.xml
+++ b/components/feature/contextmenu/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="mozac_feature_contextmenu_copy_image_location">Copy image location</string>
     <!-- Text for context menu item to save / download the image. -->
     <string name="mozac_feature_contextmenu_save_image">Save image</string>
+    <!-- Text for context menu item to save / download the file. -->
+    <string name="mozac_feature_contextmenu_save_file_to_device">Save file to device</string>
     <!-- Text for confirmation "snackbar" shown after opening a link in a new tab.  -->
     <string name="mozac_feature_contextmenu_snackbar_new_tab_opened">New tab opened</string>
     <!-- Text for confirmation "snackbar" shown after opening a link in a new private tab.  -->
@@ -25,6 +27,7 @@
     <string name="mozac_feature_contextmenu_snackbar_link_copied">Link copied to clipboard</string>
     <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
     <string name="mozac_feature_contextmenu_snackbar_action_switch">Switch</string>
+    <!-- Text for context menu item to open the link in an external app. -->
     <string name="mozac_feature_contextmenu_open_link_in_external_app">Open link in external app</string>
     <!-- Action shown in a text selection context menu. This will prompt a search using the selected text. The first parameter is the name of the application (For example: Fenix)-->
     <string name="mozac_selection_context_menu_search">%s Search</string>

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuFragmentTest.kt
@@ -205,7 +205,22 @@ class ContextMenuFragmentTest {
     }
 
     @Test
-    fun `Fragment shows about blank as title for AUDIO HitResult`() {
+    fun `Fragment shows src as title for AUDIO HitResult with blank title`() {
+        val ids = listOf("A", "B", "C")
+        val labels = listOf("Item A", "Item B", "Item C")
+        val tab = createTab("https://www.mozilla.org")
+        val titleString = " "
+
+        val hitResult = HitResult.AUDIO("https://www.mozilla.org", titleString)
+        val title = hitResult.getLink()
+
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+
+        assertEquals("https://www.mozilla.org", fragment.title)
+    }
+
+    @Test
+    fun `Fragment shows src as title for AUDIO HitResult with null title`() {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
@@ -215,11 +230,26 @@ class ContextMenuFragmentTest {
 
         val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
 
-        assertEquals("about:blank", fragment.title)
+        assertEquals("https://www.mozilla.org", fragment.title)
     }
 
     @Test
-    fun `Fragment shows about blank as title for VIDEO HitResult`() {
+    fun `Fragment shows src as title for VIDEO HitResult with blank title`() {
+        val ids = listOf("A", "B", "C")
+        val labels = listOf("Item A", "Item B", "Item C")
+        val tab = createTab("https://www.mozilla.org")
+        val titleString = " "
+
+        val hitResult = HitResult.VIDEO("https://www.mozilla.org", titleString)
+        val title = hitResult.getLink()
+
+        val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
+
+        assertEquals("https://www.mozilla.org", fragment.title)
+    }
+
+    @Test
+    fun `Fragment shows src as title for VIDEO HitResult with null title`() {
         val ids = listOf("A", "B", "C")
         val labels = listOf("Item A", "Item B", "Item C")
         val tab = createTab("https://www.mozilla.org")
@@ -229,7 +259,7 @@ class ContextMenuFragmentTest {
 
         val fragment = spy(ContextMenuFragment.create(tab, title, ids, labels))
 
-        assertEquals("about:blank", fragment.title)
+        assertEquals("https://www.mozilla.org", fragment.title)
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
