### PR TITLE
Bug 1615248 - add same cron entries for nightlies as we do for snapsh…

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -17,4 +17,6 @@ jobs:
           type: decision-task
           treeherder-symbol: nightly-D
           target-tasks-method: nightly
-      when: []  # Force hook only
+      when:
+          - {hour: 13, minute: 0}
+          - {hour: 19, minute: 0}


### PR DESCRIPTION
Now that https://nightly.maven.mozilla.org/ is up and running, let's automate the nightlies delivery, at the same cadence as snapshots. Once we're happy with this in the downstream consumers, we can gradually retire snapshots.