### PR TITLE
Closes #1912: Call speculativeConnect from toolbar and awesomebar

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -465,7 +465,7 @@ private class AsyncAutocompleteDelegate(
     override val coroutineContext: CoroutineContext,
     private val logger: Logger = Logger("AsyncAutocompleteDelegate")
 ) : AutocompleteDelegate, CoroutineScope {
-    override fun applyAutocompleteResult(result: AutocompleteResult) {
+    override fun applyAutocompleteResult(result: AutocompleteResult, onApplied: () -> Unit) {
         // Bail out if we were cancelled already.
         if (!parentScope.isActive) {
             logger.debug("Autocomplete request cancelled. Discarding results.")
@@ -483,6 +483,7 @@ private class AsyncAutocompleteDelegate(
                         totalItems = result.totalItems
                     )
                 )
+                onApplied()
             } else {
                 logger.debug("Discarding stale autocomplete result.")
             }

--- a/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/AutocompleteDelegate.kt
+++ b/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/AutocompleteDelegate.kt
@@ -11,8 +11,11 @@ package mozilla.components.concept.toolbar
 interface AutocompleteDelegate {
     /**
      * @param result Apply result of autocompletion.
+     * @param onApplied a lambda/callback invoked if (and only if) the result has been
+     * applied. A result may be discarded by implementations because it is stale or
+     * the autocomplete request has been cancelled.
      */
-    fun applyAutocompleteResult(result: AutocompleteResult)
+    fun applyAutocompleteResult(result: AutocompleteResult, onApplied: () -> Unit = { })
 
     /**
      * Autocompletion was invoked and no match was returned.

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -12,8 +12,10 @@ import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
@@ -62,15 +64,25 @@ class AwesomeBarFeature(
 
     /**
      * Adds a [AwesomeBar.SuggestionProvider] for search engine suggestions to the [AwesomeBar].
+     *
+     * @param searchEngine The search engine to request suggestions from.
+     * @param searchUseCase The use case to invoke for searches.
+     * @param fetchClient The HTTP client for requesting suggestions from the search engine.
+     * @param limit The maximum number of suggestions that should be returned. It needs to be >= 1.
+     * @param mode Whether to return a single search suggestion (with chips) or one suggestion per item.
+     * @param engine optional [Engine] instance to call [Engine.speculativeConnect] for the
+     * highest scored search suggestion URL.
      */
+    @Suppress("LongParameterList")
     fun addSearchProvider(
         searchEngine: SearchEngine,
         searchUseCase: SearchUseCases.SearchUseCase,
         fetchClient: Client,
         limit: Int = 15,
-        mode: SearchSuggestionProvider.Mode = SearchSuggestionProvider.Mode.SINGLE_SUGGESTION
+        mode: SearchSuggestionProvider.Mode = SearchSuggestionProvider.Mode.SINGLE_SUGGESTION,
+        engine: Engine? = null
     ): AwesomeBarFeature {
-        awesomeBar.addProviders(SearchSuggestionProvider(searchEngine, searchUseCase, fetchClient, limit, mode))
+        awesomeBar.addProviders(SearchSuggestionProvider(searchEngine, searchUseCase, fetchClient, limit, mode, engine))
         return this
     }
 
@@ -79,6 +91,15 @@ class AwesomeBarFeature(
      * If the default search engine is to be used for fetching search engine suggestions then
      * this method is preferable over [addSearchProvider], as it will lazily load the default
      * search engine using the provided [SearchEngineManager].
+     *
+     * @param context the activity or application context, required to load search engines.
+     * @param searchEngineManager The search engine manager to look up search engines.
+     * @param searchUseCase The use case to invoke for searches.
+     * @param fetchClient The HTTP client for requesting suggestions from the search engine.
+     * @param limit The maximum number of suggestions that should be returned. It needs to be >= 1.
+     * @param mode Whether to return a single search suggestion (with chips) or one suggestion per item.
+     * @param engine optional [Engine] instance to call [Engine.speculativeConnect] for the
+     * highest scored search suggestion URL.
      */
     @Suppress("LongParameterList")
     fun addSearchProvider(
@@ -87,30 +108,47 @@ class AwesomeBarFeature(
         searchUseCase: SearchUseCases.SearchUseCase,
         fetchClient: Client,
         limit: Int = 15,
-        mode: SearchSuggestionProvider.Mode = SearchSuggestionProvider.Mode.SINGLE_SUGGESTION
+        mode: SearchSuggestionProvider.Mode = SearchSuggestionProvider.Mode.SINGLE_SUGGESTION,
+        engine: Engine? = null
     ): AwesomeBarFeature {
         awesomeBar.addProviders(
-            SearchSuggestionProvider(context, searchEngineManager, searchUseCase, fetchClient, limit, mode)
+            SearchSuggestionProvider(context, searchEngineManager, searchUseCase, fetchClient, limit, mode, engine)
         )
         return this
     }
 
     /**
      * Add a [AwesomeBar.SuggestionProvider] for browsing history to the [AwesomeBar].
+     *
+     * @param historyStorage and instance of the [BookmarksStorage] used to query matching bookmarks.
+     * @param loadUrlUseCase the use case invoked to load the url when the user clicks on the suggestion.
+     * @param engine optional [Engine] instance to call [Engine.speculativeConnect] for the
+     * highest scored suggestion URL.
      */
     fun addHistoryProvider(
         historyStorage: HistoryStorage,
-        loadUrlUseCase: SessionUseCases.LoadUrlUseCase
+        loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
+        engine: Engine? = null
     ): AwesomeBarFeature {
-        awesomeBar.addProviders(HistoryStorageSuggestionProvider(historyStorage, loadUrlUseCase, icons))
+        awesomeBar.addProviders(HistoryStorageSuggestionProvider(historyStorage, loadUrlUseCase, icons, engine))
         return this
     }
 
+    /**
+     * Add a [AwesomeBar.SuggestionProvider] for clipboard items to the [AwesomeBar].
+     *
+     * @param context the activity or application context, required to look up the clipboard manager.
+     * @param loadUrlUseCase the use case invoked to load the url when
+     * the user clicks on the suggestion.
+     * @param engine optional [Engine] instance to call [Engine.speculativeConnect] for the
+     * highest scored suggestion URL.
+     */
     fun addClipboardProvider(
         context: Context,
-        loadUrlUseCase: SessionUseCases.LoadUrlUseCase
+        loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
+        engine: Engine? = null
     ): AwesomeBarFeature {
-        awesomeBar.addProviders(ClipboardSuggestionProvider(context, loadUrlUseCase))
+        awesomeBar.addProviders(ClipboardSuggestionProvider(context, loadUrlUseCase, engine = engine))
         return this
     }
 

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.awesomebar.R
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.utils.WebURLFinder
@@ -20,13 +21,24 @@ private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
 /**
  * An [AwesomeBar.SuggestionProvider] implementation that returns a suggestions for an URL in the clipboard (if there's
  * any).
+ *
+ * @property context the activity or application context, required to look up the clipboard manager.
+ * @property loadUrlUseCase the use case invoked to load the url when
+ * the user clicks on the suggestion.
+ * @property icon optional icon used for the [AwesomeBar.Suggestion].
+ * @property title optional title used for the [AwesomeBar.Suggestion].
+ * @property requireEmptyText whether or no the input text must be empty for a
+ * clipboard suggestion to be provided, defaults to true.
+ * @property engine optional [Engine] instance to call [Engine.speculativeConnect] for the
+ * highest scored suggestion URL.
  */
 class ClipboardSuggestionProvider(
     private val context: Context,
     private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
     private val icon: Bitmap? = null,
     private val title: String? = null,
-    private val requireEmptyText: Boolean = true
+    private val requireEmptyText: Boolean = true,
+    internal val engine: Engine? = null
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
 
@@ -41,6 +53,8 @@ class ClipboardSuggestionProvider(
         val url = getTextFromClipboard(clipboardManager)?.let {
             findUrl(it)
         } ?: return emptyList()
+
+        engine?.speculativeConnect(url)
 
         return listOf(AwesomeBar.Suggestion(
             provider = this,

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
@@ -10,7 +10,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.toolbar.Toolbar
+import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
+import mozilla.components.feature.awesomebar.provider.HistoryStorageSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
@@ -26,6 +29,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -131,6 +135,23 @@ class AwesomeBarFeatureTest {
     }
 
     @Test
+    fun `addSearchProvider adds browser engine to suggestion provider`() {
+        val engine: Engine = mock()
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+        feature.addSearchProvider(testContext, mock(), mock(), mock(), engine = engine)
+
+        val provider = argumentCaptor<SearchSuggestionProvider>()
+        verify(awesomeBar).addProviders(provider.capture())
+        assertSame(engine, provider.value.engine)
+
+        feature.addSearchProvider(mock(), mock(), mock(), engine = engine)
+        verify(awesomeBar, times(2)).addProviders(provider.capture())
+        assertSame(engine, provider.allValues.last().engine)
+    }
+
+    @Test
     fun `addHistoryProvider adds provider`() {
         val awesomeBar: AwesomeBar = mock()
 
@@ -144,6 +165,19 @@ class AwesomeBarFeatureTest {
     }
 
     @Test
+    fun `addHistoryProvider adds browser engine to suggestion provider`() {
+        val engine: Engine = mock()
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+        feature.addHistoryProvider(mock(), mock(), engine = engine)
+
+        val provider = argumentCaptor<HistoryStorageSuggestionProvider>()
+        verify(awesomeBar).addProviders(provider.capture())
+        assertSame(engine, provider.value.engine)
+    }
+
+    @Test
     fun `addClipboardProvider adds provider`() {
         val awesomeBar: AwesomeBar = mock()
 
@@ -154,6 +188,19 @@ class AwesomeBarFeatureTest {
         feature.addClipboardProvider(testContext, mock())
 
         verify(awesomeBar).addProviders(any())
+    }
+
+    @Test
+    fun `addClipboardProvider adds browser engine to suggestion provider`() {
+        val engine: Engine = mock()
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+        feature.addClipboardProvider(testContext, mock(), engine = engine)
+
+        val provider = argumentCaptor<ClipboardSuggestionProvider>()
+        verify(awesomeBar).addProviders(provider.capture())
+        assertSame(engine, provider.value.engine)
     }
 
     @Test

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -31,10 +31,11 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     private val webExtToolbarFeature = ViewBoundFeatureWrapper<WebExtensionToolbarFeature>()
     private val searchFeature = ViewBoundFeatureWrapper<SearchFeature>()
 
+    @Suppress("LongMethod")
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val layout = super.onCreateView(inflater, container, savedInstanceState)
 
-        ToolbarAutocompleteFeature(layout.toolbar).apply {
+        ToolbarAutocompleteFeature(layout.toolbar, components.engine).apply {
             addHistoryStorageProvider(components.historyStorage)
             addDomainProvider(components.shippedDomainsProvider)
         }
@@ -44,15 +45,26 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         AwesomeBarFeature(layout.awesomeBar, layout.toolbar, layout.engineView, components.icons)
             .addHistoryProvider(
                 components.historyStorage,
-                components.sessionUseCases.loadUrl)
-            .addSessionProvider(resources, components.sessionManager, components.tabsUseCases.selectTab)
+                components.sessionUseCases.loadUrl,
+                components.engine
+            )
+            .addSessionProvider(
+                resources,
+                components.sessionManager,
+                components.tabsUseCases.selectTab
+            )
             .addSearchProvider(
                 requireContext(),
                 components.searchEngineManager,
                 components.searchUseCases.defaultSearch,
                 fetchClient = components.client,
-                mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS)
-            .addClipboardProvider(requireContext(), components.sessionUseCases.loadUrl)
+                mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
+                engine = components.engine)
+            .addClipboardProvider(
+                requireContext(),
+                components.sessionUseCases.loadUrl,
+                components.engine
+            )
 
         readerViewFeature.set(
             feature = ReaderViewIntegration(

--- a/samples/toolbar/build.gradle
+++ b/samples/toolbar/build.gradle
@@ -29,6 +29,7 @@ android {
 
 
 dependencies {
+    implementation project(':concept-engine')
     implementation project(':browser-toolbar')
     implementation project(':browser-menu')
     implementation project(':browser-domains')


### PR DESCRIPTION
This introduces calls to `Engine.speculativeConnect` from our toolbar and awesomebar.

In the toolbar, we now call `speculativeConnect` on successful autocompletion from our domain list or history (re-using the existing logic to discard stale results.)

In the awesomebar, we now call `speculativeConnect` for the highest ranked search suggestion. This worked quite well when I tested this. When typing a search term instead of a URL, `speculativeConnect` will be called with the corresponding search URL of the configured search engine. So, when hitting enter, the URL will have already been "pre-fetched."

This is "inspired by": 
- https://searchfox.org/mozilla-esr68/source/mobile/android/base/java/org/mozilla/gecko/home/BrowserSearch.java#522-525
- https://searchfox.org/mozilla-esr68/source/mobile/android/base/java/org/mozilla/gecko/home/BrowserSearch.java#623-627

@pocmo I've decided to break this apart from the speculative gecko session mechanism, which I'll work on as a follow-up.
