### PR TITLE
Fixes #6094: Check if we are able to open url 

### DIFF
--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
     implementation project(':ui-icons')
-    implementation project(':lib-crash')
 
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,10 @@ permalink: /changelog/
 * **concept-storage**, **service-sync-logins**
   * 🆕 New API: `PlacesStorage#warmUp`, `SyncableLoginsStorage#warmUp` - allows consumers to ensure that underlying storage database connections are fully established.
 
+* **feature-customtabs**
+  * ⚠️ **This is a breaking change**: add parameter `handleError` to `CustomTabWindowFeature` constructor
+    * This is used to show an error when the url can't be handled
+
 # 37.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v36.0.0...v37.0.0)

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -98,7 +98,6 @@ dependencies {
     implementation project(':feature-webcompat')
     implementation project(':feature-webnotifications')
     implementation project(':feature-addons')
-    implementation project(':lib-crash')
 
     implementation project(':ui-autocomplete')
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -68,7 +68,9 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
             requireActivity(),
             components.store,
             sessionId!!
-        )
+        ) {
+            // No-op. Client may override this
+        }
         lifecycle.addObserver(windowFeature)
 
         if (manifest != null) {


### PR DESCRIPTION
There are cases when a user opens url with scheme that we are not handling in
the app so we need to check if we can resolve them before opening.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
