### PR TITLE
Closes #5434: Notify user when previously unsupported addons become available

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
@@ -1,0 +1,246 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.feature.addons.migration
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import androidx.annotation.VisibleForTesting
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequest
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.R
+import mozilla.components.feature.addons.migration.SupportedAddonsChecker.Frequency
+import mozilla.components.feature.addons.ui.translatedName
+import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
+import mozilla.components.support.base.ids.SharedIdsHelper
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.content.appName
+import mozilla.components.support.ktx.android.notification.ChannelData
+import mozilla.components.support.ktx.android.notification.ensureNotificationChannelExists
+import java.util.concurrent.TimeUnit
+
+/**
+ * Contract to define the behavior for a periodic checker for newly supported add-ons.
+ */
+interface SupportedAddonsChecker {
+    /**
+     * Registers for periodic checks for new available add-ons.
+     */
+    fun registerForChecks()
+
+    /**
+     * Unregisters for periodic checks for new available add-ons.
+     */
+    fun unregisterForChecks()
+
+    /**
+     * Indicates how often checks for newly supported add-ons should happen.
+     * @property repeatInterval Integer indicating how often the update should happen.
+     * @property repeatIntervalTimeUnit The time unit of the [repeatInterval].
+     */
+    data class Frequency(val repeatInterval: Long, val repeatIntervalTimeUnit: TimeUnit)
+}
+
+/**
+ * An implementation of [SupportedAddonsChecker] that uses the work manager api for scheduling checks.
+ * @property applicationContext The application context.
+ * @param frequency (Optional) indicates how often checks should be performed, defaults
+ * to once per day.
+ * @param onNotificationClickIntent (Optional) Indicates which intent should be passed to the notification
+ * when new supported add-ons are available.
+ */
+@Suppress("TooManyFunctions", "LargeClass")
+class DefaultSupportedAddonsChecker(
+    private val applicationContext: Context,
+    private val frequency: Frequency = Frequency(1, TimeUnit.DAYS),
+    onNotificationClickIntent: Intent = createDefaultNotificationIntent(applicationContext)
+) : SupportedAddonsChecker {
+    private val logger = Logger("DefaultSupportedAddonsChecker")
+
+    init {
+        SupportedAddonsWorker.onNotificationClickIntent = onNotificationClickIntent
+    }
+
+    /**
+     * See [SupportedAddonsChecker.registerForChecks]
+     */
+    override fun registerForChecks() {
+        WorkManager.getInstance(applicationContext).enqueueUniquePeriodicWork(
+                CHECKER_UNIQUE_PERIODIC_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                createPeriodicWorkerRequest()
+        )
+        logger.info("Register check for new supported add-ons")
+    }
+
+    /**
+     * See [SupportedAddonsChecker.unregisterForChecks]
+     */
+    override fun unregisterForChecks() {
+        WorkManager.getInstance(applicationContext)
+                .cancelUniqueWork(CHECKER_UNIQUE_PERIODIC_WORK_NAME)
+        logger.info("Unregister check for new supported add-ons")
+    }
+
+    @VisibleForTesting
+    internal fun createPeriodicWorkerRequest(): PeriodicWorkRequest {
+        return PeriodicWorkRequestBuilder<SupportedAddonsWorker>(
+                frequency.repeatInterval,
+                frequency.repeatIntervalTimeUnit
+        ).apply {
+            setConstraints(getWorkerConstrains())
+            addTag(WORK_TAG_PERIODIC)
+        }.build()
+    }
+
+    @VisibleForTesting
+    internal fun getWorkerConstrains() = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+    companion object {
+        private const val IDENTIFIER_PREFIX = "mozilla.components.feature.addons.migration"
+
+        @VisibleForTesting
+        internal const val CHECKER_UNIQUE_PERIODIC_WORK_NAME =
+                "$IDENTIFIER_PREFIX.DefaultSupportedAddonsChecker.periodicWork"
+
+        /**
+         * Identifies all the workers that periodically check for new add-ons.
+         */
+        @VisibleForTesting
+        internal const val WORK_TAG_PERIODIC =
+                "$IDENTIFIER_PREFIX.DefaultSupportedAddonsChecker.periodicWork"
+
+        internal fun createDefaultNotificationIntent(content: Context): Intent {
+            return content.packageManager.getLaunchIntentForPackage(content.packageName)?.apply {
+                flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
+            } ?: throw IllegalStateException("Package has no launcher intent")
+        }
+    }
+}
+
+/**
+ * A implementation which uses WorkManager APIs to check for newly available supported add-ons.
+ */
+internal class SupportedAddonsWorker(
+    val context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+    private val logger = Logger("SupportedAddonsWorker")
+
+    @Suppress("TooGenericExceptionCaught", "MaxLineLength")
+    override suspend fun doWork(): Result {
+        try {
+            logger.info("Trying to check for new supported add-ons")
+
+            val addonManager = GlobalAddonDependencyProvider.requireAddonManager()
+
+            val newSupportedAddons = addonManager.getAddons().filter { addon ->
+                addon.isSupported() && addon.isDisabledAsUnsupported()
+            }
+
+            if (newSupportedAddons.isNotEmpty()) {
+                val extIds = newSupportedAddons.joinToString { it.id }
+                logger.info("New supported add-ons available $extIds")
+                createNotification(newSupportedAddons)
+            }
+        } catch (exception: Exception) {
+            logger.error("An exception happened trying to check for new supported add-ons, re-schedule ${exception.message}", exception)
+            GlobalAddonDependencyProvider.onCrash?.invoke(exception)
+        }
+        return Result.success()
+    }
+
+    @VisibleForTesting
+    internal fun createNotification(newSupportedAddons: List<Addon>): Notification {
+        val notificationId = SharedIdsHelper.getIdForTag(context, NOTIFICATION_TAG)
+
+        val channel = ChannelData(
+                NOTIFICATION_CHANNEL_ID,
+                R.string.mozac_feature_addons_supported_checker_notification_channel,
+                NotificationManagerCompat.IMPORTANCE_LOW
+        )
+        val channelId = ensureNotificationChannelExists(context, channel)
+        return NotificationCompat.Builder(context, channelId)
+                .setSmallIcon(mozilla.components.ui.icons.R.drawable.mozac_ic_extensions)
+                .setContentTitle(getNotificationTitle(plural = newSupportedAddons.size > 1))
+                .setContentText(getNotificationBody(newSupportedAddons))
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setContentIntent(createContentIntent())
+                .setAutoCancel(true)
+                .build().also {
+                    NotificationManagerCompat.from(context).notify(notificationId, it)
+                }
+    }
+
+    @VisibleForTesting
+    internal fun getNotificationTitle(plural: Boolean = false): String {
+        val stringId = if (plural) {
+            R.string.mozac_feature_addons_supported_checker_notification_title_plural
+        } else {
+            R.string.mozac_feature_addons_supported_checker_notification_title
+        }
+        return applicationContext.getString(stringId)
+    }
+
+    @VisibleForTesting
+    internal fun getNotificationBody(newSupportedAddons: List<Addon>): String? {
+        return when (newSupportedAddons.size) {
+            0 -> null
+            1 -> {
+                val addonName = newSupportedAddons.first().translatedName
+                applicationContext.getString(
+                        R.string.mozac_feature_addons_supported_checker_notification_content_one,
+                        addonName,
+                        applicationContext.appName)
+            }
+            2 -> {
+                val firstAddonName = newSupportedAddons.first().translatedName
+                val secondAddonName = newSupportedAddons[1].translatedName
+                applicationContext.getString(
+                        R.string.mozac_feature_addons_supported_checker_notification_content_two,
+                        firstAddonName,
+                        secondAddonName,
+                        applicationContext.appName)
+            }
+            else -> {
+                /* There's a restriction in the amount of characters that,
+                   we can put in notification. To be safe we just use two variations,
+                   as we don't know how long the name of an add-on could be.*/
+                applicationContext.getString(
+                        R.string.mozac_feature_addons_supported_checker_notification_content_more_than_two,
+                        applicationContext.appName)
+            }
+        }
+    }
+
+    private fun createContentIntent(): PendingIntent {
+        return PendingIntent.getActivity(
+                context, 0, onNotificationClickIntent, PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+    @Suppress("MaxLineLength")
+    companion object {
+        private const val NOTIFICATION_CHANNEL_ID =
+                "mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker.generic.channel"
+
+        @VisibleForTesting
+        internal const val NOTIFICATION_TAG = "mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker"
+
+        internal var onNotificationClickIntent: Intent = Intent()
+    }
+}

--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -113,6 +113,18 @@
     <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d new permissions are required</string>
     <!-- Name of the "notification channel" used for displaying a notification for updating an add-on. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_updater_notification_channel">Add-on updates</string>
+    <!-- Name of the "notification channel" used for displaying a notification for new supported add-ons. See https://developer.android.com/training/notify-user/channels -->
+    <string name="mozac_feature_addons_supported_checker_notification_channel">Supported add-ons checker</string>
+    <!-- The tile of the notification, this will be shown to the user when one newly supported add-on is available.-->
+    <string name="mozac_feature_addons_supported_checker_notification_title">New add-on available</string>
+    <!-- The tile of the notification, this will be shown to the user when more than one newly supported add-ons are available.-->
+    <string name="mozac_feature_addons_supported_checker_notification_title_plural">New add-ons available</string>
+    <!-- The content of the notification, this will be shown to the user when one newly supported add-on is available. %1$s is the add-on name and %2$s is the app name most of the case it will be Firefox. -->
+    <string name="mozac_feature_addons_supported_checker_notification_content_one">Add %1$s to %2$s</string>
+    <!-- The content of the notification, this will be shown to the user when two newly supported add-ons are available. %1$s is the first add-on name and %2$s is second and %3$s is the app name most of the cases it will be Firefox. -->
+    <string name="mozac_feature_addons_supported_checker_notification_content_two">Add %1$s and %2$s to %3$s</string>
+    <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %3$s is the app name most of the cases it will be Firefox. -->
+    <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">Add them to %1$s</string>
     <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption">Firefox add-on technology is modernizing. These add-ons use frameworks that are not compatible with Firefox 75 &amp; beyond.</string>
     <!-- This is the caption for the add-on installation progress overlay -->
@@ -139,7 +151,7 @@
     <string name="mozac_feature_addons_successfully_removed" tools:ignore="UnusedResources">Successfully removed %1$s</string>
     <!-- Text shown after failed to remove an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_failed_to_remove" tools:ignore="UnusedResources">Failed to remove %1$s</string>
-    <!-- Label shown to indicate that the add-on was migrated from a previous version of the app. %1$s is the app name most of the case it will be FireFox. -->
+    <!-- Label shown to indicate that the add-on was migrated from a previous version of the app. %1$s is the app name most of the case it will be Firefox. -->
     <string name="mozac_feature_addons_migrated_from_a_previous_version_label" tools:ignore="UnusedResources">This add-on was migrated from a previous version of %1$s</string>
     <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
     <string name="mozac_feature_addons_unsupported_caption">1 add-on</string>

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/DefaultSupportedAddonCheckerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/DefaultSupportedAddonCheckerTest.kt
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.migration
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.await
+import androidx.work.testing.WorkManagerTestInitHelper
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker.Companion.WORK_TAG_PERIODIC
+import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker.Companion.CHECKER_UNIQUE_PERIODIC_WORK_NAME
+import mozilla.components.feature.addons.migration.SupportedAddonsChecker.Frequency
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class DefaultSupportedAddonCheckerTest {
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        val configuration = Configuration.Builder().build()
+        context = spy(testContext).also {
+            val packageManager: PackageManager = mock()
+            doReturn(Intent()).`when`(packageManager).getLaunchIntentForPackage(
+                    ArgumentMatchers.anyString()
+            )
+            doReturn(packageManager).`when`(it).packageManager
+        }
+
+        // Initialize WorkManager (early) for instrumentation tests.
+        WorkManagerTestInitHelper.initializeTestWorkManager(testContext, configuration)
+        SupportedAddonsWorker.onNotificationClickIntent = Intent()
+    }
+
+    @Test
+    fun `registerForChecks - schedule work for future checks`() {
+        val frequency = Frequency(1, TimeUnit.DAYS)
+        val intent = Intent()
+        val checker = DefaultSupportedAddonsChecker(context, frequency, intent)
+
+        val workId = CHECKER_UNIQUE_PERIODIC_WORK_NAME
+
+        runBlocking {
+            val workManger = WorkManager.getInstance(testContext)
+            val workData = workManger.getWorkInfosForUniqueWork(workId).await()
+
+            assertTrue(workData.isEmpty())
+
+            checker.registerForChecks()
+
+            assertExtensionIsRegisteredForChecks()
+            assertEquals(intent, SupportedAddonsWorker.onNotificationClickIntent)
+            // Cleaning work manager
+            workManger.cancelUniqueWork(workId)
+        }
+    }
+
+    @Test
+    fun `unregisterForChecks - will remove scheduled work for future checks`() {
+        val frequency = Frequency(1, TimeUnit.DAYS)
+        val checker = DefaultSupportedAddonsChecker(context, frequency)
+
+        val workId = CHECKER_UNIQUE_PERIODIC_WORK_NAME
+
+        runBlocking {
+            val workManger = WorkManager.getInstance(testContext)
+            var workData = workManger.getWorkInfosForUniqueWork(workId).await()
+
+            assertTrue(workData.isEmpty())
+
+            checker.registerForChecks()
+
+            assertExtensionIsRegisteredForChecks()
+
+            checker.unregisterForChecks()
+
+            workData = workManger.getWorkInfosForUniqueWork(workId).await()
+
+            assertEquals(WorkInfo.State.CANCELLED, workData.first().state)
+        }
+    }
+
+    private suspend fun assertExtensionIsRegisteredForChecks() {
+        val workId = CHECKER_UNIQUE_PERIODIC_WORK_NAME
+        val workManger = WorkManager.getInstance(testContext)
+        val workData = workManger.getWorkInfosForUniqueWork(workId).await()
+
+        assertFalse(workData.isEmpty())
+
+        val work = workData.first()
+
+        assertEquals(WorkInfo.State.ENQUEUED, work.state)
+        assertTrue(work.tags.contains(workId))
+        assertTrue(work.tags.contains(WORK_TAG_PERIODIC))
+    }
+}

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/SupportedAddonsWorkerTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/migration/SupportedAddonsWorkerTest.kt
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.migration
+
+import android.app.NotificationManager
+import androidx.core.content.getSystemService
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.ListenableWorker
+import androidx.work.await
+import androidx.work.testing.TestListenableWorkerBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonManager
+import mozilla.components.feature.addons.R
+import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
+import mozilla.components.feature.addons.migration.SupportedAddonsWorker.Companion.NOTIFICATION_TAG
+import mozilla.components.feature.addons.ui.translatedName
+import mozilla.components.support.base.ids.SharedIdsHelper
+import mozilla.components.support.ktx.android.content.appName
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.whenever
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SupportedAddonsWorkerTest {
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @Before
+    fun setUp() {
+        GlobalAddonDependencyProvider.addonManager = null
+    }
+
+    @After
+    fun after() {
+        GlobalAddonDependencyProvider.addonManager = null
+    }
+
+    @Test
+    fun `doWork - will return Result_success and create a notification when a new supported add-on is found`() {
+        val addonManager = mock<AddonManager>()
+        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
+
+        val unsupportedAddon = mock<Addon> {
+            whenever(translatableName).thenReturn(mapOf("en-US" to "one"))
+            whenever(isSupported()).thenReturn(true)
+            whenever(isDisabledAsUnsupported()).thenReturn(true)
+        }
+        GlobalAddonDependencyProvider.initialize(addonManager, mock())
+
+        runBlocking {
+            whenever(addonManager.getAddons()).thenReturn(listOf(unsupportedAddon))
+            val result = worker.startWork().await()
+
+            assertEquals(ListenableWorker.Result.success(), result)
+
+            val notificationId = SharedIdsHelper.getIdForTag(testContext, NOTIFICATION_TAG)
+            assertTrue(isNotificationVisible(notificationId))
+        }
+    }
+
+    @Test
+    fun `doWork - will try pass any exceptions to the crashReporter`() {
+        val addonManager = mock<AddonManager>()
+        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
+        var crashWasReported = false
+        val crashReporter: ((Throwable) -> Unit) = { _ ->
+            crashWasReported = true
+        }
+
+        GlobalAddonDependencyProvider.initialize(addonManager, mock(), crashReporter)
+        GlobalAddonDependencyProvider.addonManager = null
+
+        runBlocking {
+            val result = worker.startWork().await()
+
+            assertEquals(ListenableWorker.Result.success(), result)
+            assertTrue(crashWasReported)
+        }
+    }
+
+    @Test
+    fun `getNotificationTitle - must return the correct singular or plural version of the string`() {
+        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
+
+        var stringId = worker.getNotificationTitle(plural = true)
+        var expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_title_plural)
+
+        assertEquals(expectedString, stringId)
+
+        stringId = worker.getNotificationTitle()
+        expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_title)
+
+        assertEquals(expectedString, stringId)
+    }
+
+    @Test
+    fun `getNotificationBody - must return the correct singular or plural version of the string`() {
+        val worker = TestListenableWorkerBuilder<SupportedAddonsWorker>(testContext).build()
+
+        val appName = testContext.appName
+        val firstAddon = Addon("one", translatableName = mapOf("en-US" to "one"))
+        val secondAddon = Addon("two", translatableName = mapOf("en-US" to "two"))
+        val thirdAddon = Addon("three", translatableName = mapOf("en-US" to "three"))
+
+        // One add-on
+        var contentString = worker.getNotificationBody(listOf(firstAddon))
+        var expectedString: String? = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_content_one, firstAddon.translatedName, appName)
+
+        assertEquals(expectedString, contentString)
+
+        // Two add-ons
+        contentString = worker.getNotificationBody(listOf(firstAddon, secondAddon))
+        expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_content_two, firstAddon.translatedName, secondAddon.translatedName, appName)
+
+        assertEquals(expectedString, contentString)
+
+        // More than two add-ons
+        contentString = worker.getNotificationBody(listOf(firstAddon, secondAddon, thirdAddon))
+        expectedString = testContext.getString(R.string.mozac_feature_addons_supported_checker_notification_content_more_than_two, appName)
+
+        assertEquals(expectedString, contentString)
+
+        // Zero add-ons :(
+        contentString = worker.getNotificationBody(emptyList())
+        expectedString = null
+
+        assertEquals(expectedString, contentString)
+    }
+
+    private fun isNotificationVisible(notificationId: Int): Boolean {
+        val manager = testContext.getSystemService<NotificationManager>()!!
+
+        val notifications = manager.activeNotifications
+
+        return notifications.any { it.id == notificationId }
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-addons**
+  * Added `DefaultSupportedAddonsChecker` which checks for add-ons that were previously unsupported, and creates a notification to let the user known when they are available to be used.
+
 # 35.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v34.0.0...v35.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -37,6 +37,8 @@ import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.DefaultAddonUpdater
+import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
+import mozilla.components.feature.addons.migration.SupportedAddonsChecker
 import mozilla.components.feature.app.links.AppLinksInterceptor
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
@@ -144,6 +146,10 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     val addonCollectionProvider by lazy {
         AddonCollectionProvider(applicationContext, client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
+    }
+
+    val supportedAddonsChecker by lazy {
+        DefaultSupportedAddonsChecker(applicationContext, SupportedAddonsChecker.Frequency(1, TimeUnit.DAYS))
     }
 
     // Search

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -64,6 +64,7 @@ class SampleApplication : Application() {
                 onUpdatePermissionRequest = components.addonUpdater::onUpdatePermissionRequest,
                 onExtensionsLoaded = { extensions ->
                     components.addonUpdater.registerForFutureUpdates(extensions)
+                    components.supportedAddonsChecker.registerForChecks()
                 }
             )
         } catch (e: UnsupportedOperationException) {


### PR DESCRIPTION
To be defined: A way to indicate in which section of the app the consumers to go after clicking the notification. Related https://github.com/mozilla-mobile/android-components/issues/5434