### PR TITLE
For #6137: Set BrowserMenuCategory padding same as other items in menu

### DIFF
--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -28,8 +28,8 @@
     <!-- BrowserMenuCategory -->
     <dimen name="mozac_browser_menu_category_text_size">14sp</dimen>
     <dimen name="mozac_browser_menu_category_layout_height">40dp</dimen>
-    <dimen name="mozac_browser_menu_category_padding_start">24dp</dimen>
-    <dimen name="mozac_browser_menu_category_padding_end">24dp</dimen>
+    <dimen name="mozac_browser_menu_category_padding_start">16dp</dimen>
+    <dimen name="mozac_browser_menu_category_padding_end">16dp</dimen>
     <!-- BrowserMenuCategory -->
 
     <!--BrowserMenuCheckbox -->


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
