### PR TITLE
Issue #6097: Remove IntentProcessor.matches().

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
@@ -26,7 +26,7 @@ class CustomTabIntentProcessor(
     private val isPrivate: Boolean = false
 ) : IntentProcessor {
 
-    override fun matches(intent: Intent): Boolean {
+    private fun matches(intent: Intent): Boolean {
         val safeIntent = intent.toSafeIntent()
         return safeIntent.action == ACTION_VIEW && isCustomTabIntent(safeIntent)
     }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/IntentProcessor.kt
@@ -10,12 +10,6 @@ import android.content.Intent
  * Processor for Android intents which should trigger session-related actions.
  */
 interface IntentProcessor {
-
-    /**
-     * Returns true if this intent processor will handle the intent.
-     */
-    fun matches(intent: Intent): Boolean
-
     /**
      * Processes the given [Intent].
      *

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -101,15 +101,6 @@ class TabIntentProcessor(
         }
     }
 
-    override fun matches(intent: Intent): Boolean {
-        val safeIntent = SafeIntent(intent)
-        return safeIntent.action == ACTION_VIEW ||
-            safeIntent.action == ACTION_SEND ||
-            safeIntent.action == ACTION_NDEF_DISCOVERED ||
-            safeIntent.action == ACTION_SEARCH ||
-            safeIntent.action == ACTION_WEB_SEARCH
-    }
-
     /**
      * Processes the given intent by invoking the registered handler.
      *

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -47,7 +47,7 @@ class TrustedWebActivityIntentProcessor(
     private val verifier = OriginVerifierFeature(httpClient, packageManager, apiKey) { store.dispatch(it) }
     private val scope = MainScope()
 
-    override fun matches(intent: Intent): Boolean {
+    private fun matches(intent: Intent): Boolean {
         val safeIntent = intent.toSafeIntent()
         return safeIntent.action == ACTION_VIEW && isTrustedWebActivityIntent(safeIntent)
     }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
@@ -30,7 +30,7 @@ class WebAppIntentProcessor(
     /**
      * Returns true if this intent should launch a progressive web app.
      */
-    override fun matches(intent: Intent) =
+    private fun matches(intent: Intent) =
         intent.toSafeIntent().action == ACTION_VIEW_PWA
 
     /**

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
@@ -48,29 +48,6 @@ class TrustedWebActivityIntentProcessorTest {
     }
 
     @Test
-    fun `matches checks if intent is a trusted web activity intent`() {
-        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), apiKey, mock())
-
-        assertFalse(processor.matches(Intent(ACTION_VIEW_PWA)))
-        assertFalse(processor.matches(Intent(ACTION_VIEW)))
-        assertFalse(processor.matches(
-            Intent(ACTION_VIEW).apply { putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true) }
-        ))
-        assertFalse(processor.matches(
-            Intent(ACTION_VIEW).apply {
-                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, false)
-                putExtra(EXTRA_SESSION, null as Bundle?)
-            }
-        ))
-        assertTrue(processor.matches(
-            Intent(ACTION_VIEW).apply {
-                putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true)
-                putExtra(EXTRA_SESSION, null as Bundle?)
-            }
-        ))
-    }
-
-    @Test
     fun `process checks if intent action is not valid`() = runBlockingTest {
         val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), apiKey, mock())
 

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
@@ -30,15 +30,6 @@ import org.mockito.Mockito.`when`
 @RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi
 class WebAppIntentProcessorTest {
-
-    @Test
-    fun `matches checks if intent action is ACTION_VIEW_PWA`() {
-        val processor = WebAppIntentProcessor(mock(), mock(), mock())
-
-        assertTrue(processor.matches(Intent(ACTION_VIEW_PWA)))
-        assertFalse(processor.matches(Intent(ACTION_VIEW)))
-    }
-
     @Test
     fun `process checks if intent action is not valid`() = runBlockingTest {
         val processor = WebAppIntentProcessor(mock(), mock(), mock())

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationIntentProcessor.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationIntentProcessor.kt
@@ -15,12 +15,6 @@ import mozilla.components.support.migration.state.MigrationStore
  * ⚠️ When using this processor, ensure this is the first processor to be invoked if there are multiple.
  */
 class MigrationIntentProcessor(private val store: MigrationStore) : IntentProcessor {
-
-    /**
-     * Matches itself with all intents in order to ensure processing all of incoming intents.
-     */
-    override fun matches(intent: Intent): Boolean = store.state.progress == MigrationProgress.MIGRATING
-
     /**
      * Processes all incoming intents if a migration is in progress.
      *

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationIntentProcessorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationIntentProcessorTest.kt
@@ -16,19 +16,6 @@ import org.junit.Test
 
 class MigrationIntentProcessorTest {
     @Test
-    fun `matches against all view action intents`() = runBlockingTest {
-        val store = MigrationStore()
-        val processor = MigrationIntentProcessor(store)
-        val intent: Intent = mock()
-
-        assertFalse(processor.matches(intent))
-
-        store.dispatch(MigrationAction.Started).joinBlocking()
-
-        assertTrue(processor.matches(intent))
-    }
-
-    @Test
     fun `process updates intent`() = runBlockingTest {
         val store = MigrationStore()
         val processor = MigrationIntentProcessor(store)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-awesomebar**
   *  ⚠️ **This is a breaking change**: Refactored component to use `browser-state` instead of `browser-session`. Feature and `SuggestionProvider` implementations may require a `BrowserStore` instance instead of a `SessionManager` now.
 
+* **feature-intent**
+  * ⚠️ **This is a breaking change**: Removed `IntentProcessor.matches()` method from interface. Calling `process()` and examining the boolean return value is enough to know whether an `Intent` matched.
+
 * **feature-downloads**
   * Fixed APK downloads not prompting to install when the notification is clicked.
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/IntentReceiverActivity.kt
@@ -28,25 +28,19 @@ class IntentReceiverActivity : Activity() {
             // LauncherActivity is started with the "excludeFromRecents" flag (set in manifest). We
             // do not want to propagate this flag from the launcher activity to the browser.
             intent.flags = intent.flags and Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS.inv()
-            intentProcessors.any { it.process(intent) }
 
-            setBrowserActivity(intent)
+            val processor = intentProcessors.firstOrNull { it.process(intent) }
+
+            val activityClass = if (processor in components.externalAppIntentProcessors) {
+                ExternalAppBrowserActivity::class
+            } else {
+                BrowserActivity::class
+            }
+
+            intent.setClassName(applicationContext, activityClass.java.name)
 
             finish()
             startActivity(intent)
         }
-    }
-
-    /**
-     * Sets the activity that this [intent] will launch.
-     */
-    private fun setBrowserActivity(intent: Intent) {
-        val className = if (components.externalAppIntentProcessors.any { it.matches(intent) }) {
-            ExternalAppBrowserActivity::class
-        } else {
-            BrowserActivity::class
-        }
-
-        intent.setClassName(applicationContext, className.java.name)
     }
 }


### PR DESCRIPTION
IntentProcessor.process() already checks whether the Intent matches and returns true or
false. Another call to matches() is not necessary. Fenix was already refactored and we
removed the matches() call.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
