### PR TITLE
Closes #6162: Provide API to speculatively create engine session

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.integration.LocaleSettingUpdater
 import mozilla.components.browser.engine.gecko.mediaquery.from
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
@@ -35,6 +36,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
+import mozilla.components.support.utils.ThreadUtils
 import org.json.JSONObject
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
@@ -63,6 +65,7 @@ class GeckoEngine(
 ) : Engine, WebExtensionRuntime {
     private val executor by lazy { executorProvider.invoke() }
     private val localeUpdater = LocaleSettingUpdater(context, runtime)
+    @VisibleForTesting internal var speculativeSession: GeckoEngineSession? = null
 
     private var webExtensionDelegate: WebExtensionDelegate? = null
     private val webExtensionActionHandler = object : ActionHandler {
@@ -133,10 +136,21 @@ class GeckoEngine(
     }
 
     /**
-     * Creates a new Gecko-based EngineSession.
+     * See [Engine.createSession].
      */
     override fun createSession(private: Boolean): EngineSession {
-        return GeckoEngineSession(runtime, private, defaultSettings)
+        ThreadUtils.assertOnUiThread()
+        val speculativeSession = this.speculativeSession?.let { speculativeSession ->
+            if (speculativeSession.geckoSession.settings.usePrivateMode == private) {
+                speculativeSession
+            } else {
+                speculativeSession.close()
+                null
+            }.also {
+                this.speculativeSession = null
+            }
+        }
+        return speculativeSession ?: GeckoEngineSession(runtime, private, defaultSettings)
     }
 
     /**
@@ -144,6 +158,17 @@ class GeckoEngine(
      */
     override fun createSessionState(json: JSONObject): EngineSessionState {
         return GeckoEngineSessionState.fromJSON(json)
+    }
+
+    /**
+     * See [Engine.speculativeCreateSession].
+     */
+    override fun speculativeCreateSession(private: Boolean) {
+        ThreadUtils.assertOnUiThread()
+        if (this.speculativeSession?.geckoSession?.settings?.usePrivateMode != private) {
+            this.speculativeSession?.geckoSession?.close()
+            this.speculativeSession = GeckoEngineSession(runtime, private, defaultSettings)
+        }
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -32,6 +32,7 @@ import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -86,7 +87,51 @@ class GeckoEngineTest {
 
     @Test
     fun createSession() {
-        assertTrue(GeckoEngine(context, runtime = runtime).createSession() is GeckoEngineSession)
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertTrue(engine.createSession() is GeckoEngineSession)
+
+        // Create a private speculative session and consume it
+        engine.speculativeCreateSession(private = true)
+        assertNotNull(engine.speculativeSession)
+        var privateSpeculativeSession = engine.speculativeSession!!
+        assertSame(privateSpeculativeSession, engine.createSession(private = true))
+        assertNull(engine.speculativeSession)
+
+        // Create a regular speculative session and make sure it is not returned
+        // if a private session is requested instead.
+        engine.speculativeCreateSession(private = false)
+        assertNotNull(engine.speculativeSession)
+        privateSpeculativeSession = engine.speculativeSession!!
+        assertNotSame(privateSpeculativeSession, engine.createSession(private = true))
+        // Make sure previous (never used) speculative session is now closed
+        assertFalse(privateSpeculativeSession.geckoSession.isOpen)
+        assertNull(engine.speculativeSession)
+    }
+
+    @Test
+    fun speculativeCreateSession() {
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertNull(engine.speculativeSession)
+
+        // Create a private speculative session
+        engine.speculativeCreateSession(private = true)
+        assertNotNull(engine.speculativeSession)
+        val privateSpeculativeSession = engine.speculativeSession!!
+        assertTrue(privateSpeculativeSession.geckoSession.settings.usePrivateMode)
+
+        // Creating another private speculative session should have no effect as
+        // session hasn't been "consumed".
+        engine.speculativeCreateSession(private = true)
+        assertSame(privateSpeculativeSession, engine.speculativeSession)
+        assertTrue(privateSpeculativeSession.geckoSession.settings.usePrivateMode)
+
+        // Creating a non-private speculative session should affect prepared session
+        engine.speculativeCreateSession(private = false)
+        assertNotSame(privateSpeculativeSession, engine.speculativeSession)
+        // Make sure previous (never used) speculative session is now closed
+        assertFalse(privateSpeculativeSession.geckoSession.isOpen)
+        val regularSpeculativeSession = engine.speculativeSession!!
+        assertFalse(regularSpeculativeSession.geckoSession.settings.usePrivateMode)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.engine.gecko
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.integration.LocaleSettingUpdater
 import mozilla.components.browser.engine.gecko.mediaquery.from
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
@@ -35,6 +36,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
+import mozilla.components.support.utils.ThreadUtils
 import org.json.JSONObject
 import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.ContentBlocking
@@ -63,6 +65,7 @@ class GeckoEngine(
 ) : Engine, WebExtensionRuntime {
     private val executor by lazy { executorProvider.invoke() }
     private val localeUpdater = LocaleSettingUpdater(context, runtime)
+    @VisibleForTesting internal var speculativeSession: GeckoEngineSession? = null
 
     private var webExtensionDelegate: WebExtensionDelegate? = null
     private val webExtensionActionHandler = object : ActionHandler {
@@ -133,10 +136,21 @@ class GeckoEngine(
     }
 
     /**
-     * Creates a new Gecko-based EngineSession.
+     * See [Engine.createSession].
      */
     override fun createSession(private: Boolean): EngineSession {
-        return GeckoEngineSession(runtime, private, defaultSettings)
+        ThreadUtils.assertOnUiThread()
+        val speculativeSession = this.speculativeSession?.let { speculativeSession ->
+            if (speculativeSession.geckoSession.settings.usePrivateMode == private) {
+                speculativeSession
+            } else {
+                speculativeSession.close()
+                null
+            }.also {
+                this.speculativeSession = null
+            }
+        }
+        return speculativeSession ?: GeckoEngineSession(runtime, private, defaultSettings)
     }
 
     /**
@@ -144,6 +158,17 @@ class GeckoEngine(
      */
     override fun createSessionState(json: JSONObject): EngineSessionState {
         return GeckoEngineSessionState.fromJSON(json)
+    }
+
+    /**
+     * See [Engine.speculativeCreateSession].
+     */
+    override fun speculativeCreateSession(private: Boolean) {
+        ThreadUtils.assertOnUiThread()
+        if (this.speculativeSession?.geckoSession?.settings?.usePrivateMode != private) {
+            this.speculativeSession?.geckoSession?.close()
+            this.speculativeSession = GeckoEngineSession(runtime, private, defaultSettings)
+        }
     }
 
     /**

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -32,6 +32,7 @@ import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -79,7 +80,51 @@ class GeckoEngineTest {
 
     @Test
     fun createSession() {
-        assertTrue(GeckoEngine(context, runtime = runtime).createSession() is GeckoEngineSession)
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertTrue(engine.createSession() is GeckoEngineSession)
+
+        // Create a private speculative session and consume it
+        engine.speculativeCreateSession(private = true)
+        assertNotNull(engine.speculativeSession)
+        var privateSpeculativeSession = engine.speculativeSession!!
+        assertSame(privateSpeculativeSession, engine.createSession(private = true))
+        assertNull(engine.speculativeSession)
+
+        // Create a regular speculative session and make sure it is not returned
+        // if a private session is requested instead.
+        engine.speculativeCreateSession(private = false)
+        assertNotNull(engine.speculativeSession)
+        privateSpeculativeSession = engine.speculativeSession!!
+        assertNotSame(privateSpeculativeSession, engine.createSession(private = true))
+        // Make sure previous (never used) speculative session is now closed
+        assertFalse(privateSpeculativeSession.geckoSession.isOpen)
+        assertNull(engine.speculativeSession)
+    }
+
+    @Test
+    fun speculativeCreateSession() {
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertNull(engine.speculativeSession)
+
+        // Create a private speculative session
+        engine.speculativeCreateSession(private = true)
+        assertNotNull(engine.speculativeSession)
+        val privateSpeculativeSession = engine.speculativeSession!!
+        assertTrue(privateSpeculativeSession.geckoSession.settings.usePrivateMode)
+
+        // Creating another private speculative session should have no effect as
+        // session hasn't been "consumed".
+        engine.speculativeCreateSession(private = true)
+        assertSame(privateSpeculativeSession, engine.speculativeSession)
+        assertTrue(privateSpeculativeSession.geckoSession.settings.usePrivateMode)
+
+        // Creating a non-private speculative session should affect prepared session
+        engine.speculativeCreateSession(private = false)
+        assertNotSame(privateSpeculativeSession, engine.speculativeSession)
+        // Make sure previous (never used) speculative session is now closed
+        assertFalse(privateSpeculativeSession.geckoSession.isOpen)
+        val regularSpeculativeSession = engine.speculativeSession!!
+        assertFalse(regularSpeculativeSession.geckoSession.settings.usePrivateMode)
     }
 
     @Test

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -78,12 +78,15 @@ interface Engine : WebExtensionRuntime {
     fun createView(context: Context, attrs: AttributeSet? = null): EngineView
 
     /**
-     * Creates a new engine session.
+     * Creates a new engine session. If [speculativeCreateSession] is supported this
+     * method returns the prepared [EngineSession] if it is still applicable i.e.
+     * the parameter(s) ([private]) are equal.
      *
      * @param private whether or not this session should use private mode.
      *
      * @return the newly created [EngineSession].
      */
+    @MainThread
     fun createSession(private: Boolean = false): EngineSession
 
     /**
@@ -109,6 +112,18 @@ interface Engine : WebExtensionRuntime {
      * Not all [Engine] implementations may actually implement this.
      */
     fun speculativeConnect(url: String)
+
+    /**
+     * Informs the engine that an [EngineSession] is likely to be requested soon
+     * via [createSession]. This is useful in case creating an engine session is
+     * costly and an application wants to decide when the session should be created
+     * without having to manage the session itself i.e. when it may or may not
+     * need it.
+     *
+     * @param private whether or not the session should use private mode.
+     */
+    @MainThread
+    fun speculativeCreateSession(private: Boolean = false) = Unit
 
     /**
      * Registers a [WebNotificationDelegate] to be notified of engine events


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/6162#issuecomment-594093161.

Another advantage of decoupling this from `speculativeConnect` is that we can also handle private sessions. Applied to all 3 engine variants.  