### PR TITLE
On memory pressure close engine sessions and keep state for restoring later.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/LegacySessionManager.kt
@@ -516,20 +516,6 @@ class LegacySessionManager(
         values.find { session -> session.id == id }
     }
 
-    /**
-     * Informs this [SessionManager] that the OS is in low memory condition so it
-     * can reduce its allocated objects.
-     */
-    fun onLowMemory() {
-        // Removing the all the thumbnails except for the selected session to
-        // reduce memory consumption.
-        sessions.forEach {
-            if (it != selectedSession) {
-                it.thumbnail = null
-            }
-        }
-    }
-
     companion object {
         const val NO_SELECTION = -1
     }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -753,6 +753,7 @@ class SessionManagerTest {
     }
 
     @Test
+    @Suppress("Deprecation")
     fun `thumbnails of all but selected session should be removed on low memory`() {
         val manager = SessionManager(mock())
 

--- a/components/browser/state/build.gradle
+++ b/components/browser/state/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation Dependencies.kotlin_stdlib
 
     testImplementation project(':support-test')
+    testImplementation project(':support-test-libstate')
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_junit
     testImplementation Dependencies.testing_mockito

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -22,9 +22,9 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.search.SearchRequest
 import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.concept.engine.webextension.WebExtensionPageAction
-import mozilla.components.concept.engine.search.SearchRequest
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.lib.state.Action
 
@@ -40,8 +40,13 @@ sealed class SystemAction : BrowserAction() {
     /**
      * Optimizes the [BrowserState] by removing unneeded and optional
      * resources if the system is in a low memory condition.
+     *
+     * @param states map of session ids to engine session states where the engine session was closed
+     * by SessionManager.
      */
-    object LowMemoryAction : SystemAction()
+    data class LowMemoryAction(
+        val states: Map<String, EngineSessionState>
+    ) : SystemAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SystemReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SystemReducer.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.state.reducer
 
 import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.EngineState
 
 internal object SystemReducer {
     /**
@@ -16,7 +17,17 @@ internal object SystemReducer {
             is SystemAction.LowMemoryAction -> {
                 val updatedTabs = state.tabs.map {
                     if (state.selectedTabId != it.id) {
-                        it.copy(content = it.content.copy(thumbnail = null))
+                        it.copy(
+                            content = it.content.copy(thumbnail = null),
+                            engineState = if (it.id in action.states) {
+                                EngineState(
+                                    engineSession = null,
+                                    engineSessionState = action.states[it.id]
+                                )
+                            } else {
+                                it.engineState
+                            }
+                        )
                     } else {
                         it
                     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/SystemActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/SystemActionTest.kt
@@ -5,8 +5,12 @@
 package mozilla.components.browser.state.action
 
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.EngineState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertNotNull
@@ -17,11 +21,13 @@ class SystemActionTest {
 
     @Test
     fun `LowMemoryAction removes thumbnails`() {
-        val initialState = BrowserState(tabs = listOf(
-            createTab(url = "https://www.mozilla.org", id = "0"),
-            createTab(url = "https://www.firefox.com", id = "1"),
-            createTab(url = "https://www.firefox.com", id = "2")
-        ))
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(url = "https://www.mozilla.org", id = "0"),
+                createTab(url = "https://www.firefox.com", id = "1"),
+                createTab(url = "https://www.firefox.com", id = "2")
+            )
+        )
         val store = BrowserStore(initialState)
 
         store.dispatch(ContentAction.UpdateThumbnailAction("0", mock())).joinBlocking()
@@ -32,10 +38,79 @@ class SystemActionTest {
         assertNotNull(store.state.tabs[1].content.thumbnail)
         assertNotNull(store.state.tabs[2].content.thumbnail)
 
-        store.dispatch(SystemAction.LowMemoryAction).joinBlocking()
+        store.dispatch(
+            SystemAction.LowMemoryAction(
+                states = emptyMap()
+            )
+        ).joinBlocking()
+
         assertNull(store.state.tabs[0].content.thumbnail)
         assertNull(store.state.tabs[1].content.thumbnail)
         // Thumbnail of selected tab should not have been removed
         assertNotNull(store.state.tabs[2].content.thumbnail)
     }
+
+    @Test
+    fun `LowMemoryAction removes EngineSession references and adds state`() {
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTabWithMockEngineSession(url = "https://www.mozilla.org", id = "0"),
+                createTabWithMockEngineSession(url = "https://www.firefox.com", id = "1"),
+                createTabWithMockEngineSession(url = "https://www.firefox.com", id = "2")
+            ),
+            selectedTabId = "1"
+        )
+        val store = BrowserStore(initialState)
+
+        val state0: EngineSessionState = mock()
+        val state2: EngineSessionState = mock()
+
+        store.state.tabs[0].apply {
+            assertNotNull(engineState.engineSession)
+            assertNull(engineState.engineSessionState)
+        }
+
+        store.state.tabs[1].apply {
+            assertNotNull(engineState.engineSession)
+            assertNull(engineState.engineSessionState)
+        }
+
+        store.state.tabs[2].apply {
+            assertNotNull(engineState.engineSession)
+            assertNull(engineState.engineSessionState)
+        }
+
+        store.dispatch(
+            SystemAction.LowMemoryAction(
+                states = mapOf(
+                    "0" to state0,
+                    "2" to state2
+                )
+            )
+        ).joinBlocking()
+
+        store.state.tabs[0].apply {
+            assertNull(engineState.engineSession)
+            assertNotNull(engineState.engineSessionState)
+        }
+
+        store.state.tabs[1].apply {
+            assertNotNull(engineState.engineSession)
+            assertNull(engineState.engineSessionState)
+        }
+
+        store.state.tabs[2].apply {
+            assertNull(engineState.engineSession)
+            assertNotNull(engineState.engineSessionState)
+        }
+    }
 }
+
+private fun createTabWithMockEngineSession(
+    id: String,
+    url: String
+) = TabSessionState(
+    id,
+    content = ContentState(url),
+    engineState = EngineState(engineSession = mock())
+)

--- a/components/support/base/src/main/java/mozilla/components/support/base/memory/MemoryConsumer.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/memory/MemoryConsumer.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.memory
+
+import android.content.ComponentCallbacks2
+
+/**
+ * Interface for components that can seize large amounts of memory and support trimming in low
+ * memory situations.
+ *
+ * Also see [ComponentCallbacks2].
+ */
+interface MemoryConsumer {
+    /**
+     * Notifies this component that it should try to release memory.
+     *
+     * Should be called from a [ComponentCallbacks2] providing the level passed to
+     * [ComponentCallbacks2.onTrimMemory].
+     *
+     * @param level The context of the trim, giving a hint of the amount of
+     * trimming the application may like to perform. See constants in [ComponentCallbacks2].
+     */
+    fun onTrimMemory(level: Int)
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,10 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: Added `defaultTabsFilter` to `TabsFeature` for initial presenting of tabs.
     * `TabsFeature.filterTabs` also uses the same filter if no new filter is provided.
 
+* **browser-session**
+  * SessionManager will now close internal `EngineSession` instances on memory pressure when `onTrimMemory()` gets called
+  * `SessionManager.onLowMemory()` is now deprecated and `SessionManager.onTrimMemory(level)` should be used instead.
+
 # 34.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v33.0.0...v34.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -85,11 +85,6 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
             else -> super.onCreateView(parent, name, context, attrs)
         }
 
-    override fun onTrimMemory(level: Int) {
-        components.sessionManager.onLowMemory()
-        components.icons.onLowMemory()
-    }
-
     private fun openPopup(webExtensionState: WebExtensionState) {
         val intent = Intent(this, WebExtensionActionPopupActivity::class.java)
         intent.putExtra("web_extension_id", webExtensionState.id)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -17,6 +17,8 @@ import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.webextensions.WebExtensionSupport
 
 class SampleApplication : Application() {
+    private val logger = Logger("SampleApplication")
+
     val components by lazy { Components(this) }
 
     override fun onCreate() {
@@ -72,6 +74,8 @@ class SampleApplication : Application() {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
+
+        logger.debug("onTrimMemory: $level")
 
         components.sessionManager.onTrimMemory(level)
         components.icons.onTrimMemory(level)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -69,4 +69,11 @@ class SampleApplication : Application() {
             Logger.error("Failed to initialize web extension support", e)
         }
     }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+
+        components.sessionManager.onTrimMemory(level)
+        components.icons.onTrimMemory(level)
+    }
 }


### PR DESCRIPTION
Unfortunately the implementation for this needs to live in SessionManager as long as it keeps
references to EngineSession instances and thumbnails. Therefore we determine what to trim in
SessionManager and notify BrowserStore to perform the same changes.

Hopefully in a not to distant future we can move that to BrowserStore.

Closes #5933.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
