### PR TITLE
Manual GV Nightly upgrade to 75.0.20200304084140

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "75.0.20200303095030"
+    const val nightly_version = "75.0.20200304084140"
 
     /**
      * GeckoView Beta Version.

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -256,6 +256,7 @@ class GeckoEngine(
     /**
      * See [Engine.registerWebExtensionDelegate].
      */
+    @Suppress("Deprecation")
     override fun registerWebExtensionDelegate(
         webExtensionDelegate: WebExtensionDelegate
     ) {

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -131,7 +131,7 @@ class GeckoWebExtension(
         }
 
         val geckoSession = (session as GeckoEngineSession).geckoSession
-        geckoSession.setMessageDelegate(nativeExtension, messageDelegate, name)
+        geckoSession.webExtensionController.setMessageDelegate(nativeExtension, messageDelegate, name)
     }
 
     /**
@@ -139,7 +139,7 @@ class GeckoWebExtension(
      */
     override fun hasContentMessageHandler(session: EngineSession, name: String): Boolean {
         val geckoSession = (session as GeckoEngineSession).geckoSession
-        return geckoSession.getMessageDelegate(nativeExtension, name) != null
+        return geckoSession.webExtensionController.getMessageDelegate(nativeExtension, name) != null
     }
 
     /**
@@ -243,7 +243,7 @@ class GeckoWebExtension(
         }
 
         val geckoSession = (session as GeckoEngineSession).geckoSession
-        geckoSession.setWebExtensionActionDelegate(nativeExtension, actionDelegate)
+        geckoSession.webExtensionController.setActionDelegate(nativeExtension, actionDelegate)
     }
 
     /**
@@ -251,7 +251,7 @@ class GeckoWebExtension(
      */
     override fun hasActionHandler(session: EngineSession): Boolean {
         val geckoSession = (session as GeckoEngineSession).geckoSession
-        return geckoSession.getWebExtensionActionDelegate(nativeExtension) != null
+        return geckoSession.webExtensionController.getActionDelegate(nativeExtension) != null
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -631,6 +631,7 @@ class GeckoEngineTest {
     }
 
     @Test
+    @Suppress("Deprecation")
     fun `web extension delegate handles opening a new tab`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionController: WebExtensionController = mock()
@@ -667,6 +668,7 @@ class GeckoEngineTest {
     }
 
     @Test
+    @Suppress("Deprecation")
     fun `web extension delegate handles closing tab`() {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -95,6 +95,7 @@ class GeckoWebExtensionTest {
     @Test
     fun `register content message handler`() {
         val webExtensionController: WebExtensionController = mock()
+        val webExtensionSessionController: WebExtension.SessionController = mock()
         val nativeGeckoWebExt: WebExtension = mock()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
@@ -103,6 +104,7 @@ class GeckoWebExtensionTest {
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
+        whenever(geckoSession.webExtensionController).thenReturn(webExtensionSessionController)
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
@@ -115,7 +117,7 @@ class GeckoWebExtensionTest {
         )
         assertFalse(extension.hasContentMessageHandler(session, "mozacTest"))
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
-        verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
+        verify(webExtensionSessionController).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
 
         // Verify messages are forwarded to message handler and return value passed on
         val message: Any = mock()
@@ -156,6 +158,7 @@ class GeckoWebExtensionTest {
 
     @Test
     fun `disconnect port from content script`() {
+        val webExtensionSessionController: WebExtension.SessionController = mock()
         val webExtensionController: WebExtensionController = mock()
         val nativeGeckoWebExt: WebExtension = mock()
         val messageHandler: MessageHandler = mock()
@@ -163,6 +166,7 @@ class GeckoWebExtensionTest {
         val geckoSession: GeckoSession = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
 
+        whenever(geckoSession.webExtensionController).thenReturn(webExtensionSessionController)
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
@@ -174,7 +178,7 @@ class GeckoWebExtensionTest {
             nativeExtension = nativeGeckoWebExt
         )
         extension.registerContentMessageHandler(session, "mozacTest", messageHandler)
-        verify(geckoSession).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
+        verify(webExtensionSessionController).setMessageDelegate(eq(nativeGeckoWebExt), messageDelegateCaptor.capture(), eq("mozacTest"))
 
         // Connect port
         val port: WebExtension.Port = mock()
@@ -275,8 +279,10 @@ class GeckoWebExtensionTest {
     @Test
     fun `register session-specific action handler`() {
         val webExtensionController: WebExtensionController = mock()
+        val webExtensionSessionController: WebExtension.SessionController = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
+        whenever(geckoSession.webExtensionController).thenReturn(webExtensionSessionController)
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val nativeGeckoWebExt: WebExtension = mock()
@@ -297,9 +303,9 @@ class GeckoWebExtensionTest {
             nativeExtension = nativeGeckoWebExt
         )
         extension.registerActionHandler(session, actionHandler)
-        verify(geckoSession).setWebExtensionActionDelegate(eq(nativeGeckoWebExt), actionDelegateCaptor.capture())
+        verify(webExtensionSessionController).setActionDelegate(eq(nativeGeckoWebExt), actionDelegateCaptor.capture())
 
-        whenever(geckoSession.getWebExtensionActionDelegate(nativeGeckoWebExt)).thenReturn(actionDelegateCaptor.value)
+        whenever(webExtensionSessionController.getActionDelegate(nativeGeckoWebExt)).thenReturn(actionDelegateCaptor.value)
         assertTrue(extension.hasActionHandler(session))
 
         // Verify that browser actions are forwarded to the handler


### PR DESCRIPTION
Fixes breaking changes for web ext. APIs. I will address the deprecation of the tab delegate later today as part of https://github.com/mozilla-mobile/android-components/issues/4965 which we can fix with this.