### PR TITLE
Fix #6155 - Back button from migration complete notification routes back to migration screen

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
@@ -124,7 +124,7 @@ abstract class AbstractMigrationService : Service() {
                 .setContentTitle(getString(titleRes))
                 .setContentText(getString(contentRes))
                 .setContentIntent(PendingIntent.getActivity(this, 0,
-                        Intent(this, migrationDecisionActivity), 0))
+                        Intent(this, migrationDecisionActivity).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP), 0))
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setCategory(NotificationCompat.CATEGORY_PROGRESS)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)


### PR DESCRIPTION
Tapping the migration complete notification would cause activities stack to be
polluted with the migration progress activity which means that popping an
activity from the onboarding screen would lead back to the migration progress
activity, rather than finishing the app instance.

Placing the FLAG_ACTIVITY_CLEAR_TOP flag to the migration complete
notification's intent will ensure us that, once in the onboarding screen, we
can never go back to the migration one, by clearing everything that is at the
top.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR is already covered by tests
- [x] **Changelog**: This PR does not need one
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
