### PR TITLE
Closes #6149: Notify push observers for onSubscriptionChange events

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.53.0"
+    const val mozilla_appservices = "0.54.0"
 
     const val mozilla_glean = "25.0.0"
 

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -262,19 +262,14 @@ class AutoPushFeature(
     internal fun verifyActiveSubscriptions() {
         DeliveryManager.with(connection) {
             coroutineScope.launchAndTry {
-                val notifyObservers = verifyConnection()
+                val subscriptionChanges = verifyConnection()
 
-                if (notifyObservers) {
+                if (subscriptionChanges.isNotEmpty()) {
                     logger.info("Subscriptions have changed; notifying observers..")
 
-                    // TODO update this when an a-s change lands to give us the scope of subs that changed.
-                    //  See: https://github.com/mozilla/application-services/issues/2049
-                    // subscriptionChangedList.forEach { pushScope ->
-                    //     notifyObservers { onSubscriptionChanged(pushScope) }
-                    // }
-
-                    // We only notify the fake_scope because we're aware of it and it helps with verifying tests.
-                    notifyObservers { onSubscriptionChanged("fake_scope") }
+                    subscriptionChanges.forEach { sub ->
+                        notifyObservers { onSubscriptionChanged(sub.scope) }
+                    }
                 }
             }
         }
@@ -420,6 +415,14 @@ data class AutoPushSubscription(
     val publicKey: String,
     val authKey: String,
     val appServerKey: String?
+)
+
+/**
+ * The subscription from AutoPush that has changed on the remote push servers.
+ */
+data class AutoPushSubscriptionChanged(
+    val scope: PushScope,
+    val channelId: String
 )
 
 /**

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -249,11 +249,17 @@ class AutoPushFeatureTest {
 
         verify(observers, never()).onSubscriptionChanged(any())
 
-        // When there are subscription updates, observers should not be notified.
-        whenever(connection.verifyConnection()).thenReturn(true)
+        // When there are no subscription updates, observers should not be notified.
+        whenever(connection.verifyConnection()).thenReturn(emptyList())
         feature.verifyActiveSubscriptions()
 
-        verify(observers).onSubscriptionChanged(any())
+        verify(observers, never()).onSubscriptionChanged(any())
+
+        // When there are subscription updates, observers should be notified.
+        whenever(connection.verifyConnection()).thenReturn(listOf(AutoPushSubscriptionChanged("scope", "1246")))
+        feature.verifyActiveSubscriptions()
+
+        verify(observers).onSubscriptionChanged("scope")
     }
 
     @Test
@@ -337,7 +343,7 @@ class AutoPushFeatureTest {
 
         override suspend fun updateToken(token: String) = true
 
-        override suspend fun verifyConnection(): Boolean = false
+        override suspend fun verifyConnection(): List<AutoPushSubscriptionChanged> = emptyList()
 
         override suspend fun decryptMessage(
             channelId: String,

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.push
 
 import mozilla.appservices.push.BridgeType
 import mozilla.appservices.push.KeyInfo
+import mozilla.appservices.push.PushSubscriptionChanged as SubscriptionChanged
 import mozilla.appservices.push.SubscriptionInfo
 import mozilla.appservices.push.SubscriptionResponse
 import org.junit.Assert.assertEquals
@@ -47,5 +48,16 @@ class ConnectionKtTest {
     fun `Protocol to string`() {
         assertEquals("http", Protocol.HTTP.asString())
         assertEquals("https", Protocol.HTTPS.asString())
+    }
+
+    @Test
+    fun `transform response to PushSubscriptionChanged`() {
+        val response = SubscriptionChanged(
+            "992a0f0542383f1ea5ef51b7cf4ae6c4",
+            "scope"
+        )
+        val sub = response.toPushSubscriptionChanged()
+        assertEquals(response.channelID, sub.channelId)
+        assertEquals(response.scope, sub.scope)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,10 @@ permalink: /changelog/
 * **feature-addons**
   * Added `DefaultSupportedAddonsChecker` which checks for add-ons that were previously unsupported, and creates a notification to let the user known when they are available to be used.
 
+* **feature-push**
+  * `AutoPushFeature` now properly notifies observers that they have changed by the `Observer.onSubscriptionChanged` callback.
+  *  ⚠️ **This is a breaking change**: `RustPushConnection.verifyConnection` now returns a list of subscriptions that have changed.
+
 # 35.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v34.0.0...v35.0.0)
@@ -48,7 +52,7 @@ permalink: /changelog/
 
 * **feature-accounts-push**
   * Add known prefix to FxA push scope.
-  
+
 * **browser-toolbar**
   * Add the possibility to listen to menu dismissal through `setMenuDismissAction` in `DisplayToolbar`
 


### PR DESCRIPTION
Incorporates the breaking API changes that will come out in the next release of a-s - cannot be merged until then.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Closes #6149

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
