### PR TITLE
Closes #6204: GeneralError should not log as fatal

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -17,6 +17,7 @@ import mozilla.appservices.push.AlreadyRegisteredError
 import mozilla.appservices.push.CommunicationError
 import mozilla.appservices.push.CommunicationServerError
 import mozilla.appservices.push.CryptoError
+import mozilla.appservices.push.GeneralError
 import mozilla.appservices.push.MissingRegistrationTokenError
 import mozilla.appservices.push.RecordNotFoundError
 import mozilla.appservices.push.StorageError
@@ -356,6 +357,7 @@ internal fun CoroutineScope.launchAndTry(
             block()
         } catch (e: RustPushError) {
             val result = when (e) {
+                is GeneralError,
                 is CryptoError,
                 is CommunicationError,
                 is CommunicationServerError,

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureKtTest.kt
@@ -11,6 +11,7 @@ import mozilla.appservices.push.AlreadyRegisteredError
 import mozilla.appservices.push.CommunicationError
 import mozilla.appservices.push.CommunicationServerError
 import mozilla.appservices.push.CryptoError
+import mozilla.appservices.push.GeneralError
 import mozilla.appservices.push.InternalPanic
 import mozilla.appservices.push.MissingRegistrationTokenError
 import mozilla.appservices.push.RecordNotFoundError
@@ -94,6 +95,11 @@ class AutoPushFeatureKtTest {
 
         CoroutineScope(coroutineContext).launchAndTry(
             { throw UrlParseError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw GeneralError("should not fail test") },
             { assert(true) }
         )
     }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
A quick fix to follow the existing pattern that we have so that we log the error as fatal.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
