### PR TITLE
Closes #5716: Do less during account recovery

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -812,11 +812,8 @@ open class FxaAccountManager(
                         logger.info("Registering device constellation observer")
                         account.deviceConstellation().register(accountEventsIntegration)
 
-                        logger.info("Initializing device")
-                        // NB: underlying API is expected to 'ensureCapabilities' as part of device initialization.
-                        account.deviceConstellation().initDeviceAsync(
-                                deviceConfig.name, deviceConfig.type, deviceConfig.capabilities
-                        ).await()
+                        // NB: we're running neither `initDevice` nor `ensureCapabilities` here, since
+                        // this is a recovery flow, and these calls already ran at some point before.
 
                         postAuthenticated(AuthType.Recovered)
 
@@ -968,8 +965,8 @@ open class FxaAccountManager(
             type = deviceConfig.type.intoSyncType()
         ))
 
-        // If device supports SEND_TAB...
-        if (deviceConfig.capabilities.contains(DeviceCapability.SEND_TAB)) {
+        // If device supports SEND_TAB, and we're not recovering from an auth problem...
+        if (deviceConfig.capabilities.contains(DeviceCapability.SEND_TAB) && authType != AuthType.Recovered) {
             // ... update constellation state
             account.deviceConstellation().refreshDevicesAsync().await()
         }


### PR DESCRIPTION
It is not strictly necessary to re-initialize the device, and refresh device constellation when
we perform an account recovery. This patch removes these operations from the recovery flow,
which helps ease the server load.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
