### PR TITLE
Closes #6212: Only run [component].onTrimMemory on main process

### DIFF
--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -14,6 +14,7 @@ import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.components.support.ktx.android.content.isMainProcess
+import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
 import mozilla.components.support.webextensions.WebExtensionSupport
 
 class SampleApplication : Application() {
@@ -78,7 +79,9 @@ class SampleApplication : Application() {
 
         logger.debug("onTrimMemory: $level")
 
-        components.sessionManager.onTrimMemory(level)
-        components.icons.onTrimMemory(level)
+        runOnlyInMainProcess {
+            components.sessionManager.onTrimMemory(level)
+            components.icons.onTrimMemory(level)
+        }
     }
 }


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/6212#issue-578293952