### PR TITLE
Closes #6210: Stop sending clear task when launching intent in third party app

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -137,12 +137,11 @@ class AppLinksUseCases(
 
         private fun createBrowsableIntents(url: String): RedirectData {
             val intent = Intent.parseUri(url, 0)
-
             if (intent.action == Intent.ACTION_VIEW) {
                 intent.addCategory(Intent.CATEGORY_BROWSABLE)
                 intent.component = null
                 intent.selector = null
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
 
             val fallbackIntent = intent.getStringExtra(EXTRA_BROWSER_FALLBACK_URL)?.let {

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -39,6 +39,7 @@ class AppLinksUseCasesTest {
 
     private val appUrl = "https://example.com"
     private val appIntent = "intent://example.com"
+    private val appSchemeIntent = "example://example.com"
     private val appPackage = "com.example.app"
     private val browserPackage = "com.browser"
     private val testBrowserPackage = "com.current.browser"
@@ -299,12 +300,11 @@ class AppLinksUseCasesTest {
     }
 
     @Test
-    fun `A intent scheme uri with package name will have marketplace intent reguardless user preference`() {
+    fun `A intent scheme uri with package name will have marketplace intent regardless user preference`() {
         val context = createContext(appUrl to browserPackage)
-        var subject = AppLinksUseCases(context, { false }, browserPackageNames = setOf(browserPackage))
-
         val uri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
 
+        var subject = AppLinksUseCases(context, { false }, browserPackageNames = setOf(browserPackage))
         var redirect = subject.interceptedAppLinkRedirect(uri)
         assertFalse(redirect.hasExternalApp())
         assertFalse(redirect.hasFallback())
@@ -317,5 +317,47 @@ class AppLinksUseCasesTest {
         assertFalse(redirect.hasFallback())
         assertNotNull(redirect.marketplaceIntent)
         assertNull(redirect.fallbackUrl)
+    }
+
+    @Test
+    fun `A app scheme uri will redirect regardless user preference`() {
+        val context = createContext(appSchemeIntent to appPackage)
+
+        var subject = AppLinksUseCases(context, { false }, browserPackageNames = setOf(browserPackage))
+        var redirect = subject.interceptedAppLinkRedirect(appSchemeIntent)
+        assertTrue(redirect.hasExternalApp())
+        assertFalse(redirect.hasFallback())
+        assertNull(redirect.marketplaceIntent)
+        assertNull(redirect.fallbackUrl)
+        assertTrue(redirect.appIntent?.flags?.and(Intent.FLAG_ACTIVITY_CLEAR_TASK) == 0)
+
+        subject = AppLinksUseCases(context, { true }, browserPackageNames = setOf(browserPackage))
+        redirect = subject.interceptedAppLinkRedirect(appSchemeIntent)
+        assertTrue(redirect.hasExternalApp())
+        assertFalse(redirect.hasFallback())
+        assertNull(redirect.marketplaceIntent)
+        assertNull(redirect.fallbackUrl)
+        assertTrue(redirect.appIntent?.flags?.and(Intent.FLAG_ACTIVITY_CLEAR_TASK) == 0)
+    }
+
+    @Test
+    fun `A app intent uri will redirect regardless user preference`() {
+        val context = createContext(appIntent to appPackage)
+
+        var subject = AppLinksUseCases(context, { false }, browserPackageNames = setOf(browserPackage))
+        var redirect = subject.interceptedAppLinkRedirect(appIntent)
+        assertTrue(redirect.hasExternalApp())
+        assertFalse(redirect.hasFallback())
+        assertNull(redirect.marketplaceIntent)
+        assertNull(redirect.fallbackUrl)
+        assertTrue(redirect.appIntent?.flags?.and(Intent.FLAG_ACTIVITY_CLEAR_TASK) == 0)
+
+        subject = AppLinksUseCases(context, { true }, browserPackageNames = setOf(browserPackage))
+        redirect = subject.interceptedAppLinkRedirect(appIntent)
+        assertTrue(redirect.hasExternalApp())
+        assertFalse(redirect.hasFallback())
+        assertNull(redirect.marketplaceIntent)
+        assertNull(redirect.fallbackUrl)
+        assertTrue(redirect.appIntent?.flags?.and(Intent.FLAG_ACTIVITY_CLEAR_TASK) == 0)
     }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
