### PR TITLE
Downgrade application services dependencies to 0.52.0.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "0.53.0"
+    const val mozilla_appservices = "0.52.0"
 
     const val mozilla_glean = "25.0.0"
 


### PR DESCRIPTION
Due to a regression in AS 0.53.0 we are downgrading to 0.52.0 for the upcoming Fenix 4.1 release. See:
* https://github.com/mozilla-mobile/fenix/issues/9027#issuecomment-597328582
* https://github.com/mozilla/application-services/issues/2791