### PR TITLE
For #6246 - use validation delegate for login update/create operations

### DIFF
--- a/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt
+++ b/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt
@@ -8,12 +8,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
-import mozilla.components.support.test.mock
-import org.junit.Assert.assertEquals
-import org.junit.Before
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.times
@@ -66,154 +65,12 @@ class GeckoLoginStorageDelegateTest {
             verify(loginsStorage, times(1)).touch(any())
         }
     }
-
-    @Test
-    @Config(sdk = [21])
-    fun `WHEN guid is null or empty THEN should create a new record`() {
-        val serverPassword = createLogin()
-
-        val fromNull = delegate.getPersistenceOperation(createLogin(guid = null), serverPassword)
-        val fromEmpty = delegate.getPersistenceOperation(createLogin(guid = ""), serverPassword)
-
-        assertEquals(Operation.CREATE, fromNull)
-        assertEquals(Operation.CREATE, fromEmpty)
-    }
-
-    @Test
-    @Config(sdk = [21])
-    fun `WHEN guid matches existing record AND saved record has an empty username THEN should update existing record`() {
-        val serverPassword = createLogin(guid = "1", username = "")
-        val login = createLogin(guid = "1")
-
-        assertEquals(Operation.UPDATE, delegate.getPersistenceOperation(login, serverPassword))
-    }
-
-    @Test
-    @Config(sdk = [21])
-    fun `WHEN guid matches existing record AND new username is different from saved THEN should create new record`() {
-        val serverPassword = createLogin(guid = "1", username = "old")
-        val login = createLogin(guid = "1", username = "new")
-
-        assertEquals(Operation.CREATE, delegate.getPersistenceOperation(login, serverPassword))
-    }
-
-    @Test
-    @Config(sdk = [21])
-    fun `WHEN guid and username match THEN update existing record`() {
-        val serverPassword = createLogin(guid = "1", username = "username")
-        val login = createLogin(guid = "1", username = "username")
-
-        assertEquals(Operation.UPDATE, delegate.getPersistenceOperation(login, serverPassword))
-    }
-
-    @Test
-    @Config(sdk = [21])
-    fun `GIVEN login is non-null, non-empty WHEN mergeWithLogin THEN result should use values from login`() {
-        val login = Login(
-            guid = "guid",
-            origin = "origin",
-            formActionOrigin = "fao",
-            httpRealm = "httpRealm",
-            username = "username",
-            password = "password"
-        )
-        val serverPassword = createLogin(
-            guid = "spId",
-            origin = "spHost",
-            username = "spUser",
-            password = "spPassword",
-            httpRealm = "spHttpRealm",
-            formActionOrigin = "spFormSubmitUrl"
-        )
-
-        val expected = createLogin(
-            guid = "spId",
-            origin = "origin",
-            username = "username",
-            password = "password",
-            httpRealm = "httpRealm",
-            formActionOrigin = "fao"
-        )
-
-        assertEquals(expected, serverPassword.mergeWithLogin(login))
-    }
-
-    @Test
-    @Config(sdk = [21])
-    fun `GIVEN login has null values WHEN mergeWithLogin THEN those values should be taken from serverPassword`() {
-        val login = Login(
-            guid = null,
-            origin = "origin",
-            formActionOrigin = null,
-            httpRealm = null,
-            username = "username",
-            password = "password"
-        )
-        val serverPassword = createLogin(
-            guid = "spId",
-            origin = "spHost",
-            username = "spUser",
-            password = "spPassword",
-            httpRealm = "spHttpRealm",
-            formActionOrigin = "spFormSubmitUrl"
-        )
-
-        val expected = createLogin(
-            guid = "spId",
-            origin = "origin",
-            username = "username",
-            password = "password",
-            httpRealm = "spHttpRealm",
-            formActionOrigin = "spFormSubmitUrl"
-        )
-
-        assertEquals(expected, serverPassword.mergeWithLogin(login))
-    }
-
-    @Test
-    @Config(sdk = [21])
-    fun `GIVEN login has empty values WHEN mergeWithLogin THEN those values should be taken from serverPassword`() {
-        val login = Login(
-            guid = "",
-            origin = "",
-            formActionOrigin = "",
-            httpRealm = "",
-            username = "",
-            password = ""
-        )
-        val serverPassword = createLogin(
-            guid = "spId",
-            origin = "spHost",
-            username = "spUser",
-            password = "spPassword",
-            httpRealm = "spHttpRealm",
-            formActionOrigin = "spFormSubmitUrl"
-        )
-
-        val expected = createLogin(
-            guid = "spId",
-            origin = "spHost",
-            username = "spUser",
-            password = "spPassword",
-            httpRealm = "spHttpRealm",
-            formActionOrigin = "spFormSubmitUrl"
-        )
-
-        assertEquals(expected, serverPassword.mergeWithLogin(login))
-    }
 }
 
 fun mockLoginsStorage(): LoginsStorage {
     val loginsStorage = mock<LoginsStorage>()
     return loginsStorage
 }
-
-fun createLogin(guid: String?, username: String = "username") = Login(
-    guid = guid,
-    username = username,
-    password = "password",
-    origin = "origin"
-)
 
 fun createLogin(
     guid: String = "id",


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Not urgent but I would love to kill these two functions! I've tested saving/updating locally in Fenix, the only weirdness that I noticed is when a login doesn't have a username (ie it was synced from desktop) and you add a password, we "save" instead of updating. I think this is maybe something the `ensureValid` should take care of and give us `CanBeUpdated` result? 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
