### PR TITLE
Closes #6012: Run the FxA extension on non-prod servers

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -382,6 +382,10 @@ class GeckoPort(
         return nativePort.name
     }
 
+    override fun senderUrl(): String {
+        return nativePort.sender.url
+    }
+
     override fun disconnect() {
         nativePort.disconnect()
     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -382,6 +382,10 @@ class GeckoPort(
         return nativePort.name
     }
 
+    override fun senderUrl(): String {
+        return nativePort.sender.url
+    }
+
     override fun disconnect() {
         nativePort.disconnect()
     }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -302,6 +302,10 @@ class GeckoPort(
         return nativePort.name
     }
 
+    override fun senderUrl(): String {
+        return nativePort.sender.url
+    }
+
     override fun disconnect() {
         nativePort.disconnect()
     }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -306,6 +306,11 @@ abstract class Port(val engineSession: EngineSession? = null) {
     abstract fun name(): String
 
     /**
+     * Returns the URL of the port sender.
+     */
+    abstract fun senderUrl(): String
+
+    /**
      * Disconnects this port.
      */
     abstract fun disconnect()

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -53,6 +53,10 @@ class WebExtensionTest {
 
             override fun disconnect() {}
 
+            override fun senderUrl(): String {
+                return "https://foo.bar"
+            }
+
             override fun postMessage(message: JSONObject) { }
         }
 

--- a/components/feature/accounts/build.gradle
+++ b/components/feature/accounts/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(":browser-session")
     implementation project(':feature-tabs')
     implementation project(':service-firefox-accounts')
+    implementation project(':support-ktx')
     implementation project(':support-webextensions')
 
     testImplementation Dependencies.androidx_test_junit

--- a/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
+++ b/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
@@ -4,7 +4,13 @@
   "version": "1.0",
   "content_scripts": [
     {
-      "matches": ["https://accounts.firefox.com/*"],
+      "matches": [
+        "https://accounts.firefox.com/*",
+        "https://stable.dev.lcip.org/*",
+        "https://accounts.stage.mozaws.net/*",
+        "https://latest.dev.lcip.org/*",
+        "https://accounts.firefox.com.cn/*"
+      ],
       "js": ["fxawebchannel.js"],
       "run_at": "document_start"
     }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("TooManyFunctions")
+
 package mozilla.components.support.ktx.kotlin
 
 import mozilla.components.support.utils.URLStringUtils
@@ -106,4 +108,18 @@ fun String.tryGetHostFromUrl(): String = try {
     URL(this).host
 } catch (e: MalformedURLException) {
     this
+}
+
+/**
+ * Compares 2 URLs and returns true if they have the same origin,
+ * which means: same protocol, same host, same port.
+ */
+fun String.isSameOriginAs(other: String): Boolean {
+    fun canonicalizeOrigin(urlStr: String): String {
+        val url = URL(urlStr)
+        val port = if (url.port == -1) url.defaultPort else url.port
+        val canonicalized = URL(url.protocol, url.host, port, "")
+        return canonicalized.toString()
+    }
+    return canonicalizeOrigin(this) == canonicalizeOrigin(other)
 }

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -154,4 +154,25 @@ class StringTest {
         val new = urlTest.tryGetHostFromUrl()
         assertEquals(new, "notarealurl")
     }
+
+    @Test
+    fun isSameOriginAs() {
+        // Host mismatch.
+        assertFalse("https://foo.bar".isSameOriginAs("https://foo.baz"))
+        // Scheme mismatch.
+        assertFalse("http://127.0.0.1".isSameOriginAs("https://127.0.0.1"))
+        // Port mismatch (implicit + explicit).
+        assertFalse("https://foo.bar:444".isSameOriginAs("https://foo.bar"))
+        // Port mismatch (explicit).
+        assertFalse("https://foo.bar:444".isSameOriginAs("https://foo.bar:555"))
+        // Port OK but scheme different.
+        assertFalse("https://foo.bar".isSameOriginAs("http://foo.bar:443"))
+        // Port OK (explicit) but scheme different.
+        assertFalse("https://foo.bar:443".isSameOriginAs("ftp://foo.bar:443"))
+
+        assertTrue("https://foo.bar".isSameOriginAs("https://foo.bar"))
+        assertTrue("https://foo.bar/bobo".isSameOriginAs("https://foo.bar/obob"))
+        assertTrue("https://foo.bar".isSameOriginAs("https://foo.bar:443"))
+        assertTrue("https://foo.bar:333".isSameOriginAs("https://foo.bar:333"))
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,12 @@ permalink: /changelog/
 
 * **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
   * Updated `removeAll()` from `TrackingProtectionExceptionFileStorage` to notify active sessions when all exceptions are removed.
+  * Added `GeckoPort.senderUrl` which returns the associated content URL.
+
+* **feature-accounts**
+  * It should now be possible to log-in on stable, stage and china FxA servers using a WebChannel flow.
+  *  ⚠️ **This is a breaking change**: `FxaWebChannelFeature` takes a `ServerConfig` as 4th parameter to ensure incoming WebChannel messages
+     are sent by the expected FxA host.
 
 # 36.0.0
 


### PR DESCRIPTION
Thanks to `GeckoPort.senderUrl`  exposing the content URL, we can now assert in `FxaWebChannelFeature` that a WebChannel message comes from the right content page.
This allows us to inject the extension content script in more FxA server instances while ensuring that a non-prod instance can mess up a prod-instance account data.
 
---
<!-- Text above this line will be added to the commit once "bors" merges this PRR -->

Also fixes https://github.com/mozilla/application-services/issues/2795.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [x] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
