### PR TITLE
For #6269: Notify active sessions when all exceptions are removed.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -103,8 +103,13 @@ internal class TrackingProtectionExceptionFileStorage(
         persist()
     }
 
-    override fun removeAll() {
+    override fun removeAll(activeSessions: List<EngineSession?>?) {
         runtime.contentBlockingController.clearExceptionList()
+        activeSessions?.forEach {
+            it?.notifyObservers {
+                onExcludedOnTrackingProtectionChange(false)
+            }
+        }
         removeFileFromDisk(context)
     }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
@@ -117,6 +117,8 @@ class TrackingProtectionExceptionFileStorageTest {
         val mockGeckoSession = mock<GeckoSession>()
         val mockExceptionList =
             listOf(ContentBlockingException.fromJson(JSONObject("{\"principal\":\"eyIxIjp7IjAiOiJodHRwczovL3d3dy5jbm4uY29tLyJ9fQ==\",\"uri\":\"https:\\/\\/www.cnn.com\\/\"}")))
+        val engineSession: EngineSession = mock()
+        val activeSessions: List<EngineSession?> = listOf(engineSession)
 
         whenever(session.geckoSession).thenReturn(mockGeckoSession)
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlocking)
@@ -136,9 +138,10 @@ class TrackingProtectionExceptionFileStorageTest {
         assertNotNull(storage.getFile(context).readAndDeserialize { })
 
         // Removing exceptions
-        storage.removeAll()
+        storage.removeAll(activeSessions)
         verify(mockContentBlocking).clearExceptionList()
         assertNull(storage.getFile(context).readAndDeserialize { })
+        verify(engineSession).notifyObservers(any())
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -103,8 +103,13 @@ internal class TrackingProtectionExceptionFileStorage(
         persist()
     }
 
-    override fun removeAll() {
+    override fun removeAll(activeSessions: List<EngineSession?>?) {
         runtime.contentBlockingController.clearExceptionList()
+        activeSessions?.forEach {
+            it?.notifyObservers {
+                onExcludedOnTrackingProtectionChange(false)
+            }
+        }
         removeFileFromDisk(context)
     }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
@@ -117,6 +117,8 @@ class TrackingProtectionExceptionFileStorageTest {
         val mockGeckoSession = mock<GeckoSession>()
         val mockExceptionList =
             listOf(ContentBlockingException.fromJson(JSONObject("{\"principal\":\"eyIxIjp7IjAiOiJodHRwczovL3d3dy5jbm4uY29tLyJ9fQ==\",\"uri\":\"https:\\/\\/www.cnn.com\\/\"}")))
+        val engineSession: EngineSession = mock()
+        val activeSessions: List<EngineSession?> = listOf(engineSession)
 
         whenever(session.geckoSession).thenReturn(mockGeckoSession)
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlocking)
@@ -136,9 +138,10 @@ class TrackingProtectionExceptionFileStorageTest {
         assertNotNull(storage.getFile(context).readAndDeserialize { })
 
         // Removing exceptions
-        storage.removeAll()
+        storage.removeAll(activeSessions)
         verify(mockContentBlocking).clearExceptionList()
         assertNull(storage.getFile(context).readAndDeserialize { })
+        verify(engineSession).notifyObservers(any())
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -103,8 +103,13 @@ internal class TrackingProtectionExceptionFileStorage(
         persist()
     }
 
-    override fun removeAll() {
+    override fun removeAll(activeSessions: List<EngineSession?>?) {
         runtime.contentBlockingController.clearExceptionList()
+        activeSessions?.forEach {
+            it?.notifyObservers {
+                onExcludedOnTrackingProtectionChange(false)
+            }
+        }
         removeFileFromDisk(context)
     }
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
@@ -111,6 +111,8 @@ class TrackingProtectionExceptionFileStorageTest {
         val mockGeckoSession = mock<GeckoSession>()
         val mockExceptionList =
             listOf(ContentBlockingException.fromJson(JSONObject("{\"principal\":\"eyIxIjp7IjAiOiJodHRwczovL3d3dy5jbm4uY29tLyJ9fQ==\",\"uri\":\"https:\\/\\/www.cnn.com\\/\"}")))
+        val engineSession: EngineSession = mock()
+        val activeSessions: List<EngineSession?> = listOf(engineSession)
 
         whenever(session.geckoSession).thenReturn(mockGeckoSession)
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlocking)
@@ -130,9 +132,10 @@ class TrackingProtectionExceptionFileStorageTest {
         assertNotNull(storage.getFile(context).readAndDeserialize { })
 
         // Removing exceptions
-        storage.removeAll()
+        storage.removeAll(activeSessions)
         verify(mockContentBlocking).clearExceptionList()
         assertNull(storage.getFile(context).readAndDeserialize { })
+        verify(engineSession).notifyObservers(any())
     }
 
     @Test

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/content/blocking/TrackingProtectionExceptionStorage.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/content/blocking/TrackingProtectionExceptionStorage.kt
@@ -47,8 +47,10 @@ interface TrackingProtectionExceptionStorage {
 
     /**
      * Removes all domains from the exception list.
+     * @param activeSessions A list of all active sessions (including CustomTab
+     * sessions) to be notified.
      */
-    fun removeAll()
+    fun removeAll(activeSessions: List<EngineSession?>? = null)
 
     /**
      * Restore all domains stored in the storage.

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/TrackingProtectionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/TrackingProtectionUseCases.kt
@@ -83,9 +83,17 @@ class TrackingProtectionUseCases(
     ) {
         /**
          * Removes all domains from the exception list.
+         *
+         * As we are applying this on all the sessions it could cause a
+         * performance hit, right now we don't have a straightforward way to
+         * avoid it, as it will required that we introduce the browser store,
+         * we are going to address this on #6283
+         * (https://github.com/mozilla-mobile/android-components/issues/6283).
          */
         operator fun invoke() {
-            engine.trackingProtectionExceptionStore.removeAll()
+            engine.trackingProtectionExceptionStore.removeAll(sessionManager.all.map {
+                sessionManager.getEngineSession(it)
+            })
         }
     }
 

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/TrackingProtectionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/TrackingProtectionUseCasesTest.kt
@@ -133,7 +133,7 @@ class TrackingProtectionUseCasesTest {
     @Test
     fun `removeAll exceptions`() {
         useCases.removeAllExceptions()
-        verify(mockStore).removeAll()
+        verify(mockStore).removeAll(any())
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **lib-state**, **browser-state**
   * Added the ability to add `Middleware` instances to a `Store`. A `Middleware` can rewrite or intercept an `Action`, as well as dispatch additional `Action`s or perform side-effects when an `Action` gets dispatched.
 
+* **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
+  * Updated `removeAll()` from `TrackingProtectionExceptionFileStorage` to notify active sessions when all exceptions are removed.
+
 # 36.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v35.0.0...v36.0.0)


### PR DESCRIPTION
I also updated the tests accordingly.
Made this change because the tracking protection icon is not updated after the
exceptions are removed.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
