### PR TITLE
Update Kotlin version to 1.3.7.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,8 +4,8 @@
 
 // Synchronized version numbers for dependencies used by (some) modules
 object Versions {
-    const val kotlin = "1.3.61"
-    const val coroutines = "1.3.3"
+    const val kotlin = "1.3.70"
+    const val coroutines = "1.3.5"
 
     const val junit = "4.12"
     const val robolectric = "4.1"


### PR DESCRIPTION
[Release notes](https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/)