### PR TITLE
Closes #6281: Do not automatically dismiss confirm dialogs

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -533,6 +533,7 @@ class PromptFeature private constructor(
                         title,
                         message,
                         promptAbuserDetector.areDialogsBeingAbused(),
+                        false,
                         positiveButton,
                         negativeButton,
                         neutralButtonTitle

--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragment.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AlertDialog
 import mozilla.components.feature.prompts.R
 
 private const val KEY_MANY_ALERTS = "KEY_MANY_ALERTS"
+private const val KEY_SHOULD_DISMISS_ON_LOAD = "KEY_SHOULD_DISMISS_ON_LOAD"
 private const val KEY_USER_CHECK_BOX = "KEY_USER_CHECK_BOX"
 private const val KEY_POSITIVE_BUTTON_TITLE = "KEY_POSITIVE_BUTTON_TITLE"
 private const val KEY_NEGATIVE_BUTTON_TITLE = "KEY_NEGATIVE_BUTTON_TITLE"
@@ -35,6 +36,8 @@ internal class MultiButtonDialogFragment : PromptDialogFragment() {
     internal val negativeButtonTitle: String? by lazy { safeArguments.getString(KEY_NEGATIVE_BUTTON_TITLE) }
 
     internal val neutralButtonTitle: String? by lazy { safeArguments.getString(KEY_NEUTRAL_BUTTON_TITLE) }
+
+    override fun shouldDismissOnLoad() = safeArguments.getBoolean(KEY_SHOULD_DISMISS_ON_LOAD, true)
 
     /**
      * Stores the user's decision from the checkbox
@@ -100,6 +103,7 @@ internal class MultiButtonDialogFragment : PromptDialogFragment() {
             title: String,
             message: String,
             hasShownManyDialogs: Boolean,
+            shouldDismissOnLoad: Boolean,
             positiveButton: String = "",
             negativeButton: String = "",
             neutralButton: String = ""
@@ -113,6 +117,7 @@ internal class MultiButtonDialogFragment : PromptDialogFragment() {
                 putString(KEY_TITLE, title)
                 putString(KEY_MESSAGE, message)
                 putBoolean(KEY_MANY_ALERTS, hasShownManyDialogs)
+                putBoolean(KEY_SHOULD_DISMISS_ON_LOAD, shouldDismissOnLoad)
                 putString(KEY_POSITIVE_BUTTON_TITLE, positiveButton)
                 putString(KEY_NEGATIVE_BUTTON_TITLE, negativeButton)
                 putString(KEY_NEUTRAL_BUTTON_TITLE, neutralButton)

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -53,6 +53,8 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -933,6 +935,30 @@ class PromptFeatureTest {
         store.dispatch(ContentAction.UpdateProgressAction(tabId, 100)).joinBlocking()
 
         verify(fragment, times(0)).dismiss()
+    }
+
+    @Test
+    fun `confirm dialogs will not be automatically dismissed`() {
+        val feature = spy(PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager, shareDelegate = mock()) { })
+        feature.start()
+
+        val promptRequest = PromptRequest.Confirm(
+            "title",
+            "message",
+            false,
+            "positive",
+            "negative",
+            "neutral",
+            { },
+            { },
+            { },
+            { }
+        )
+        store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
+
+        val prompt = feature.activePrompt?.get()
+        assertNotNull(prompt)
+        assertFalse(prompt!!.shouldDismissOnLoad())
     }
 
     private fun mockFragmentManager(): FragmentManager {

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragmentTest.kt
@@ -44,6 +44,7 @@ class MultiButtonDialogFragmentTest {
                 "title",
                 "message",
                 true,
+                false,
                 "positiveButton",
                 "negativeButton",
                 "neutralButton"
@@ -86,6 +87,7 @@ class MultiButtonDialogFragmentTest {
                 "title",
                 "message",
                 false,
+                false,
                 "positiveButton",
                 "negativeButton",
                 "neutralButton"
@@ -111,6 +113,7 @@ class MultiButtonDialogFragmentTest {
                 "sessionId",
                 "title",
                 "message",
+                false,
                 false,
                 "positiveButton"
             )
@@ -138,6 +141,7 @@ class MultiButtonDialogFragmentTest {
                 "title",
                 "message",
                 false,
+                false,
                 negativeButton = "negative"
             )
         )
@@ -163,6 +167,7 @@ class MultiButtonDialogFragmentTest {
                 "sessionId",
                 "title",
                 "message",
+                false,
                 false,
                 neutralButton = "neutral"
             )
@@ -190,6 +195,7 @@ class MultiButtonDialogFragmentTest {
                 "title",
                 "message",
                 true,
+                false,
                 positiveButton = "positive"
             )
         )
@@ -219,6 +225,7 @@ class MultiButtonDialogFragmentTest {
                 "title",
                 "message",
                 true,
+                false,
                 positiveButton = "positive"
             )
         )


### PR DESCRIPTION
The feature to automatically dismiss can maybe be made more robust to not be affected by lifecycle changes (https://github.com/mozilla-mobile/android-components/issues/6281#issuecomment-599739212), but in either case we don't want to automatically dismiss confirmation dialogs, as these require user interaction before the next page load anyway.

Similar fix to: https://github.com/mozilla-mobile/android-components/pull/5704/