### PR TITLE
Closes #6290: Do not remove FxA push scope on logout

### DIFF
--- a/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt
+++ b/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt
@@ -141,7 +141,6 @@ internal class AccountObserver(
         // Delete cached value of last verified timestamp and scope when we log out.
         preference(context).edit()
             .remove(PREF_LAST_VERIFIED)
-            .remove(PREF_FXA_SCOPE)
             .apply()
     }
 }

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AccountObserverTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AccountObserverTest.kt
@@ -91,7 +91,7 @@ class AccountObserverTest {
         observer.onLoggedOut()
 
         assertFalse(preference(testContext).contains(PREF_LAST_VERIFIED))
-        assertFalse(preference(testContext).contains(PREF_FXA_SCOPE))
+        assertTrue(preference(testContext).contains(PREF_FXA_SCOPE))
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **service-accounts-push**
+  * Fixed a bug where the push subscription was incorrectly cached and caused some `GeneralError`s.
 
 # 37.0.0
 


### PR DESCRIPTION
We're caching the `fxaPushScope` in memory and also saving it to our
prefs. When we log out, we delete the pref, but the in-memory isn't
removed.

We could always fetch from the prefs instead of using an in-memory
caching, however this could be a bit expensive to always read from prefs
since we need to do this check when receiving any push message.

An easier solution would be to never remove the scope in prefs once
generated. It is safe to persist the push scope across different
accounts since the combination of scope + UAID is unique per install.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Closes #6290

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
