### PR TITLE
Closes #6300: Use a non-common version prefix for local publication

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,10 @@ gradle.projectsLoaded { ->
     if (gradle.rootProject.hasProperty("nightlyVersion")) {
         version = gradle.rootProject.nightlyVersion
     }
+    // To support local auto-publication workflow, we use a version prefix we wouldn't normally encounter.
+    if (gradle.rootProject.hasProperty("local")) {
+        version = "0.0.1"
+    }
     // Wait until root project is "loaded" before we set "config"
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
     // gradle files. This means that they can just access "config.<value>", and it'll function properly

--- a/substitute-local-ac.gradle
+++ b/substitute-local-ac.gradle
@@ -22,7 +22,7 @@ configurations.all { config ->
                     def group = dependency.requested.group
                     if (group == 'org.mozilla.components') {
                         def name = dependency.requested.module
-                        dependency.useTarget([group: group, name: name, version: '+'])
+                        dependency.useTarget([group: group, name: name, version: '0.0.1-+'])
                     }
                 }
             }


### PR DESCRIPTION
This change makes sure that gradle will not pick a remote version over a
locally published one. We don't expect any available remote versions
to be of the form "0.0.1-somenumber"!

This addresses an issue seen in Fenix - it switched to using a "pinned"
version of A-C, which broke the existing auto-publication logic.
Local changes would be published, but gradle version resolution would
always pick up the pinned version of A-C instead, likely due to how it
alpha-numberically sorted the versions (e.g. it considered 37.0.1-234553
to be newer than 37.0.1-local55554).


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
