### PR TITLE
Closes #6304: Switch storage delegates to construct over `Lazy<StorageType>`

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/HistoryDelegate.kt
@@ -13,28 +13,28 @@ import mozilla.components.concept.storage.PageVisit
 /**
  * Implementation of the [HistoryTrackingDelegate] which delegates work to an instance of [HistoryStorage].
  */
-class HistoryDelegate(private val historyStorage: HistoryStorage) : HistoryTrackingDelegate {
+class HistoryDelegate(private val historyStorage: Lazy<HistoryStorage>) : HistoryTrackingDelegate {
     override suspend fun onVisited(uri: String, visit: PageVisit) {
         // While we expect engine implementations to check URIs against `shouldStoreUri`, we don't
         // depend on them to actually do this check.
         if (shouldStoreUri(uri)) {
-            historyStorage.recordVisit(uri, visit)
+            historyStorage.value.recordVisit(uri, visit)
         }
     }
 
     override suspend fun onTitleChanged(uri: String, title: String) {
         // Ignore title changes for URIs which we're ignoring.
         if (shouldStoreUri(uri)) {
-            historyStorage.recordObservation(uri, PageObservation(title = title))
+            historyStorage.value.recordObservation(uri, PageObservation(title = title))
         }
     }
 
     override suspend fun getVisited(uris: List<String>): List<Boolean> {
-        return historyStorage.getVisited(uris)
+        return historyStorage.value.getVisited(uris)
     }
 
     override suspend fun getVisited(): List<String> {
-        return historyStorage.getVisited()
+        return historyStorage.value.getVisited()
     }
 
     /**

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -29,8 +29,8 @@ class HistoryDelegateTest {
 
     @Test
     fun `history delegate passes through onVisited calls`() = runBlocking {
-        val storage: HistoryStorage = mock()
-        val delegate = HistoryDelegate(storage)
+        val storage = mock<HistoryStorage>()
+        val delegate = HistoryDelegate(lazy { storage })
 
         delegate.onVisited("about:blank", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
         verify(storage, never()).recordVisit("about:blank", PageVisit(VisitType.TYPED, RedirectSource.NOT_A_SOURCE))
@@ -47,8 +47,8 @@ class HistoryDelegateTest {
 
     @Test
     fun `history delegate passes through onTitleChanged calls`() = runBlocking {
-        val storage: HistoryStorage = mock()
-        val delegate = HistoryDelegate(storage)
+        val storage = mock<HistoryStorage>()
+        val delegate = HistoryDelegate(lazy { storage })
 
         delegate.onTitleChanged("http://www.mozilla.org", "Mozilla")
         verify(storage).recordObservation("http://www.mozilla.org", PageObservation("Mozilla"))
@@ -135,7 +135,7 @@ class HistoryDelegateTest {
             }
         }
         val storage = TestHistoryStorage()
-        val delegate = HistoryDelegate(storage)
+        val delegate = HistoryDelegate(lazy { storage })
 
         assertFalse(storage.getVisitedPlainCalled)
         assertFalse(storage.getVisitedListCalled)

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/SyncManager.kt
@@ -76,18 +76,18 @@ interface SyncStatusObserver {
  * available instances of stores within an application.
  */
 object GlobalSyncableStoreProvider {
-    private val stores: MutableMap<String, SyncableStore> = mutableMapOf()
+    private val stores: MutableMap<String, Lazy<SyncableStore>> = mutableMapOf()
 
     /**
      * Configure an instance of [SyncableStore] for a [SyncEngine] enum.
      * @param storePair A pair associating [SyncableStore] with a [SyncEngine].
      */
-    fun configureStore(storePair: Pair<SyncEngine, SyncableStore>) {
+    fun configureStore(storePair: Pair<SyncEngine, Lazy<SyncableStore>>) {
         stores[storePair.first.nativeName] = storePair.second
     }
 
     internal fun getStore(name: String): SyncableStore? {
-        return stores[name]
+        return stores[name]?.value
     }
 }
 

--- a/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/DefaultLoginValidationDelegate.kt
+++ b/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/DefaultLoginValidationDelegate.kt
@@ -20,7 +20,7 @@ import mozilla.components.concept.storage.LoginsStorage
  * information about why it can or cannot.
  */
 class DefaultLoginValidationDelegate(
-    private val storage: LoginsStorage,
+    private val storage: Lazy<LoginsStorage>,
     private val scope: CoroutineScope = CoroutineScope(IO)
 ) : LoginValidationDelegate {
 
@@ -32,7 +32,7 @@ class DefaultLoginValidationDelegate(
                 // Internally, the library ensures to not dupe records against themselves
                 // (via a `guid <> :guid` check), which means we need to "pretend" this is a new record,
                 // in order for `ensureValid` to actually throw `DUPLICATE_LOGIN`.
-                storage.ensureValid(login.copy(guid = null))
+                storage.value.ensureValid(login.copy(guid = null))
                 Result.CanBeCreated
             } catch (e: InvalidRecordException) {
                 when (e.reason) {

--- a/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt
+++ b/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt
@@ -33,7 +33,7 @@ class GeckoLoginStorageDelegateTest {
     fun before() {
         loginsStorage = mockLoginsStorage()
         scope = TestCoroutineScope()
-        delegate = GeckoLoginStorageDelegate(loginsStorage, { false }, scope)
+        delegate = GeckoLoginStorageDelegate(lazy { loginsStorage }, { false }, scope)
     }
 
     @Test
@@ -48,7 +48,7 @@ class GeckoLoginStorageDelegateTest {
     @Test
     @Config(sdk = [21])
     fun `WHEN passed true for shouldAutofill onLoginsFetch does not return early`() {
-        delegate = GeckoLoginStorageDelegate(loginsStorage, { true }, scope)
+        delegate = GeckoLoginStorageDelegate(lazy { loginsStorage }, { true }, scope)
 
         scope.launch {
             delegate.onLoginFetch("login")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,15 @@ permalink: /changelog/
   *  ⚠️ **This is a breaking change**: `FxaWebChannelFeature` takes a `ServerConfig` as 4th parameter to ensure incoming WebChannel messages
      are sent by the expected FxA host.
 
+* **service-sync-logins**
+  * ⚠️ **This is a breaking change**: `DefaultLoginValidationDelegate`, `GeckoLoginStorageDelegate` constructors changed to take `Lazy<LoginsStorage>` instead of `LoginsStorage`, to facilitate late initialization.
+
+* **service-firefox-accounts**
+  * ⚠️ **This is a breaking change**: `GlobalSyncableStoreProvider#configureStore` changed to take `Lazy<SyncableStore>` instead of `SyncableStore`, to facilitate late initialization.
+
+* **feature-session**
+  * ⚠️ **This is a breaking change**: `HistoryDelegate` constructor changed to take `Lazy<HistoryStorage>` instead of `HistoryStorage`, to facilitate late initialization.
+
 # 36.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v35.0.0...v36.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -81,7 +81,7 @@ open class DefaultComponents(private val applicationContext: Context) {
     // Engine Settings
     val engineSettings by lazy {
         DefaultSettings().apply {
-            historyTrackingDelegate = HistoryDelegate(historyStorage)
+            historyTrackingDelegate = HistoryDelegate(lazyHistoryStorage)
             requestInterceptor = SampleRequestInterceptor(applicationContext)
             remoteDebuggingEnabled = true
             supportMultipleWindows = true
@@ -101,7 +101,8 @@ open class DefaultComponents(private val applicationContext: Context) {
     val icons by lazy { BrowserIcons(applicationContext, client) }
 
     // Storage
-    val historyStorage by lazy { InMemoryHistoryStorage() }
+    private val lazyHistoryStorage = lazy { InMemoryHistoryStorage() }
+    val historyStorage by lazy { lazyHistoryStorage.value }
 
     private val sessionStorage by lazy { SessionStorage(applicationContext, engine) }
 

--- a/samples/sync-logins/src/main/java/org/mozilla/samples/sync/logins/MainActivity.kt
+++ b/samples/sync-logins/src/main/java/org/mozilla/samples/sync/logins/MainActivity.kt
@@ -46,7 +46,7 @@ const val REDIRECT_URL = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
 class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener, CoroutineScope, SyncStatusObserver {
     private lateinit var keyStorage: SecureAbove22Preferences
 
-    private val loginsStorage by lazy {
+    private val loginsStorage = lazy {
         SyncableLoginsStorage(this, keyStorage.getString(SyncEngine.Passwords.nativeName)!!)
     }
 
@@ -164,7 +164,7 @@ class MainActivity : AppCompatActivity(), LoginFragment.OnLoginCompleteListener,
         Toast.makeText(this@MainActivity, "Logins sync success", Toast.LENGTH_SHORT).show()
 
         launch {
-            val syncedLogins = loginsStorage.list()
+            val syncedLogins = loginsStorage.value.list()
             adapter.addAll(syncedLogins.map { "Login: " + it.origin })
             adapter.notifyDataSetChanged()
         }

--- a/samples/sync/src/main/java/org/mozilla/samples/sync/MainActivity.kt
+++ b/samples/sync/src/main/java/org/mozilla/samples/sync/MainActivity.kt
@@ -61,11 +61,11 @@ class MainActivity :
         LoginFragment.OnLoginCompleteListener,
         DeviceFragment.OnDeviceListInteractionListener,
         CoroutineScope {
-    private val historyStorage by lazy {
+    private val historyStorage = lazy {
         PlacesHistoryStorage(this)
     }
 
-    private val bookmarksStorage by lazy {
+    private val bookmarksStorage = lazy {
         PlacesBookmarksStorage(this)
     }
 
@@ -78,7 +78,7 @@ class MainActivity :
             }
     }
 
-    private val passwordsStorage by lazy { SyncableLoginsStorage(this, passwordsEncryptionKey) }
+    private val passwordsStorage = lazy { SyncableLoginsStorage(this, passwordsEncryptionKey) }
 
     private val accountManager by lazy {
         FxaAccountManager(
@@ -378,7 +378,7 @@ class MainActivity :
                 syncStatus?.text = getString(R.string.sync_idle)
 
                 val historyResultTextView: TextView = findViewById(R.id.historySyncResult)
-                val visitedCount = historyStorage.getVisited().size
+                val visitedCount = historyStorage.value.getVisited().size
                 // visitedCount is passed twice: to get the correct plural form, and then as
                 // an argument for string formatting.
                 historyResultTextView.text = resources.getQuantityString(
@@ -386,7 +386,7 @@ class MainActivity :
                 )
 
                 val bookmarksResultTextView: TextView = findViewById(R.id.bookmarksSyncResult)
-                val bookmarksRoot = bookmarksStorage.getTree("root________", recursive = true)
+                val bookmarksRoot = bookmarksStorage.value.getTree("root________", recursive = true)
                 if (bookmarksRoot == null) {
                     bookmarksResultTextView.text = getString(R.string.no_bookmarks_root)
                 } else {


### PR DESCRIPTION
This allows us to initialize objects which depend on these delegates without having
to block on instantiating storage components themselves.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
