### PR TITLE
Bug 16231471 - Fixes samples-glean: validateBaselinePingTest

### DIFF
--- a/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
+++ b/samples/glean/src/androidTest/java/org/mozilla/samples/glean/pings/BaselinePingTest.kt
@@ -9,7 +9,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
-import org.junit.Assert.assertEquals
 
 import org.junit.Rule
 import org.junit.Test
@@ -71,8 +70,6 @@ class BaselinePingTest {
 
         // Validate the received data.
         val baselinePing = waitForPingContent("baseline")!!
-        assertEquals("baseline", baselinePing.getJSONObject("ping_info")["ping_type"])
-
         val metrics = baselinePing.getJSONObject("metrics")
 
         // Make sure we have a 'duration' field with a reasonable value: it should be >= 1, since

--- a/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
+++ b/samples/glean/src/main/java/org/mozilla/samples/glean/MainActivity.kt
@@ -72,6 +72,11 @@ open class MainActivity : AppCompatActivity(), ExperimentUpdateReceiver.Experime
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterReceiver(experimentUpdateReceiver)
+    }
+
     /**
      * This function will be called by the ExperimentUpdateListener interface when the experiments
      * are updated.  This is not relevant to the Glean SDK, but to the experiments library.


### PR DESCRIPTION
- Fixes an error in samples-glean where the experiments intent receiver was not properly unregistered.
- Fixes a test assert that was referencing a field in the baseline ping that has been removed (`ping_type`).
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
