### PR TITLE
Closes #6315: Include engine session when migrating custom tab

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -27,6 +27,7 @@ import mozilla.components.browser.state.action.ContentAction.UpdateThumbnailActi
 import mozilla.components.browser.state.action.ContentAction.UpdateTitleAction
 import mozilla.components.browser.state.action.ContentAction.UpdateUrlAction
 import mozilla.components.browser.state.action.CustomTabListAction.RemoveCustomTabAction
+import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.TabListAction.AddTabAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
@@ -290,6 +291,9 @@ class Session(
         if (old != new && new == null) {
             store?.syncDispatch(RemoveCustomTabAction(id))
             store?.syncDispatch(AddTabAction(toTabSessionState()))
+            engineSessionHolder.engineSession?.let { engineSession ->
+                store?.syncDispatch(EngineAction.LinkEngineSessionAction(id, engineSession))
+            }
         }
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -109,6 +109,8 @@ class SessionManagerMigrationTest {
 
         val customTabSession = Session("https://www.mozilla.org")
         customTabSession.customTabConfig = mock()
+        val engineSession: EngineSession = mock()
+        customTabSession.engineSessionHolder.engineSession = engineSession
         sessionManager.add(customTabSession)
 
         assertEquals(0, sessionManager.sessions.size)
@@ -127,6 +129,7 @@ class SessionManagerMigrationTest {
 
         val tab = store.state.tabs[0]
         assertEquals("https://www.mozilla.org", tab.content.url)
+        assertSame(engineSession, tab.engineState.engineSession)
     }
 
     @Test


### PR DESCRIPTION
When migrating a custom tab to a regular tab we forgot to migrate the engine session. This is the easy solution.

Alternatively, we could migrate the engine state as part of `toTabSessionState`: https://github.com/mozilla-mobile/android-components/blob/master/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt#L20

This affects a lot of parts though and is probably not needed for other callers e.g. `add` and `restore`? In those cases we either don't have an engine session or we will link one anyway.
