### PR TITLE
Issue #6255: Increase addon migration version

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
@@ -96,7 +96,7 @@ sealed class Migration(val currentVersion: Int) {
     /**
      * Migrates / Disables all currently unsupported Add-ons.
      */
-    object Addons : Migration(currentVersion = 2)
+    object Addons : Migration(currentVersion = 3)
 
     /**
      * Migrates Fennec's telemetry identifiers.


### PR DESCRIPTION
This is to re-run the add-on migration step to correct for https://bugzilla.mozilla.org/show_bug.cgi?id=1623173 which left addons in an inconsistent state after the
upgrade to 76 Nightly.