### PR TITLE
For #5866: Don't crash when failed to launch new window request in custom tab

### DIFF
--- a/components/feature/customtabs/build.gradle
+++ b/components/feature/customtabs/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
     implementation project(':ui-icons')
+    implementation project(':lib-crash')
 
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     implementation project(':feature-webcompat')
     implementation project(':feature-webnotifications')
     implementation project(':feature-addons')
+    implementation project(':lib-crash')
 
     implementation project(':ui-autocomplete')
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
