### PR TITLE
Closes #6394 - Add warm-up API to places and logins storage layers

### DIFF
--- a/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
+++ b/components/browser/storage-memory/src/main/java/mozilla/components/browser/storage/memory/InMemoryHistoryStorage.kt
@@ -30,6 +30,10 @@ class InMemoryHistoryStorage : HistoryStorage {
     @VisibleForTesting
     internal val pageMeta: HashMap<String, PageObservation> = hashMapOf()
 
+    override suspend fun warmUp() {
+        // No-op for an in-memory store
+    }
+
     override suspend fun recordVisit(uri: String, visit: PageVisit) {
         val now = System.currentTimeMillis()
         if (visit.redirectSource != RedirectSource.NOT_A_SOURCE) {

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.storage.Storage
 import mozilla.components.concept.sync.SyncStatus
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.utils.logElapsedTime
 
 /**
  * A base class for concrete implementations of PlacesStorages
@@ -38,6 +39,13 @@ abstract class PlacesStorage(context: Context) : Storage, SyncableStore {
 
     internal val writer: PlacesWriterConnection by lazy { places.writer() }
     internal val reader: PlacesReaderConnection by lazy { places.reader() }
+
+    override suspend fun warmUp() {
+        logElapsedTime(logger, "Warming up places storage") {
+            writer
+            reader
+        }
+    }
 
     /**
      * Internal database maintenance tasks. Ideally this should be called once a day.

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -17,6 +17,7 @@ import mozilla.appservices.remotetabs.RemoteTabsProvider
 import mozilla.appservices.remotetabs.SyncAuthInfo as RustSyncAuthInfo
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
+import mozilla.components.support.utils.logElapsedTime
 
 /**
  * An interface which defines read/write methods for remote tabs data.
@@ -24,7 +25,11 @@ import mozilla.components.concept.sync.SyncStatus
 open class RemoteTabsStorage : Storage, SyncableStore {
     internal val api by lazy { RemoteTabsProvider() }
     private val scope by lazy { CoroutineScope(Dispatchers.IO) }
-    internal val logger = Logger("PlacesHistoryStorage")
+    internal val logger = Logger("RemoteTabsStorage")
+
+    override suspend fun warmUp() {
+        logElapsedTime(logger, "Warming up storage") { api }
+    }
 
     /**
      * Store the locally opened tabs.

--- a/components/concept/storage/src/main/java/mozilla/components/concept/storage/Storage.kt
+++ b/components/concept/storage/src/main/java/mozilla/components/concept/storage/Storage.kt
@@ -8,6 +8,10 @@ package mozilla.components.concept.storage
  * An interface which provides generic operations for storing browser data like history and bookmarks.
  */
 interface Storage {
+    /**
+     * Make sure underlying database connections are established.
+     */
+    suspend fun warmUp()
 
     /**
      * Runs internal database maintenance tasks

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -115,6 +115,10 @@ class BookmarksStorageSuggestionProviderTest {
     class testableBookmarksStorage : BookmarksStorage {
         val bookmarkMap: HashMap<String, BookmarkNode> = hashMapOf()
 
+        override suspend fun warmUp() {
+            throw NotImplementedError()
+        }
+
         override suspend fun getTree(guid: String, recursive: Boolean): BookmarkNode? {
             // "Not needed for the test"
             throw NotImplementedError()

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -63,6 +63,10 @@ class HistoryDelegateTest {
             var getVisitedListCalled = false
             var getVisitedPlainCalled = false
 
+            override suspend fun warmUp() {
+                fail()
+            }
+
             override suspend fun recordVisit(uri: String, visit: PageVisit) {
                 fail()
             }

--- a/components/service/sync-logins/build.gradle
+++ b/components/service/sync-logins/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     implementation project(':concept-storage')
     implementation project(':support-sync-telemetry')
+    implementation project(':support-utils')
     implementation project(':service-glean')
 
     implementation Dependencies.kotlin_stdlib

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/Performance.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/Performance.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * Executes the given [block] and logs the elapsed time in milliseconds.
+ * Uses [System.nanoTime] for measurements, since it isn't tied to a wall-clock.
+ *
+ * @param logger [Logger] to use for logging.
+ * @param op Name of the operation [block] performs.
+ * @param block A lambda to measure.
+ * @return [T] result of running [block].
+ */
+@SuppressWarnings("MagicNumber")
+inline fun <T> logElapsedTime(logger: Logger, op: String, block: () -> T): T {
+    logger.info("$op...")
+    val start = System.nanoTime()
+    val res = block()
+    logger.info("'$op' took ${(System.nanoTime() - start) / 1_000_000} ms")
+    return res
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ permalink: /changelog/
   * **feature-addons**
     * Added `DefaultAddonUpdater.UpdateAttemptStorage` allows to query the last known state for a previous attempt to update an add-on.
 
+* **concept-storage**, **service-sync-logins**
+  * 🆕 New API: `PlacesStorage#warmUp`, `SyncableLoginsStorage#warmUp` - allows consumers to ensure that underlying storage database connections are fully established.
+
 # 37.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v36.0.0...v37.0.0)


### PR DESCRIPTION
This allows consumers to ensure that underlying database connections are fully established.
After `warmUp` is called, there should be no additional overhead upon first access to the storage.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
