### PR TITLE
Closes #6171: Simplify push error handling; reduce non-fatal reporting

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/ext/Connection.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/ext/Connection.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.push.ext
+
+import mozilla.components.feature.push.PushConnection
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * Executes the block if the Push Manager is initialized.
+ */
+internal inline fun PushConnection.ifInitialized(block: PushConnection.() -> Unit) {
+    if (isInitialized()) {
+        block()
+    } else {
+        Logger.error("Native push layer is not yet initialized.")
+    }
+}

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/ext/CoroutineScope.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/ext/CoroutineScope.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.push.ext
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import mozilla.appservices.push.PushError
+
+/**
+ * Catches all fatal push errors to notify the callback before re-throwing.
+ */
+internal fun CoroutineScope.launchAndTry(
+    errorBlock: (Exception) -> Unit = {},
+    block: suspend CoroutineScope.() -> Unit
+): Job {
+    return launch {
+        try {
+            block()
+        } catch (e: PushError) {
+            errorBlock(e)
+
+            // rethrow
+            throw e
+        }
+    }
+}

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
@@ -16,7 +16,6 @@ import org.junit.Test
 
 class ConnectionKtTest {
     @Test
-    @Suppress("Deprecation")
     fun `transform response to PushSubscription`() {
         val response = SubscriptionResponse(
             "992a0f0542383f1ea5ef51b7cf4ae6c4",

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
@@ -26,7 +26,6 @@ import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
-@Suppress("Deprecation")
 class RustPushConnectionTest {
 
     @Ignore("Requires push-forUnitTests; seems unnecessary to introduce it for this one test.")

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ext/ConnectionKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ext/ConnectionKtTest.kt
@@ -2,27 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.feature.push
+package mozilla.components.feature.push.ext
 
+import mozilla.components.feature.push.PushConnection
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.`when`
 
-class DeliveryManagerTest {
+class ConnectionKtTest {
     @Test
-    fun `DeliveryManager executes block with initialized connection`() {
+    fun `executes block with initialized connection`() {
         val connection: PushConnection = mock()
         var invoked = false
 
-        DeliveryManager.runWithInitialized(connection) { invoked = true }
+        connection.ifInitialized { invoked = true }
 
         assertFalse(invoked)
 
         `when`(connection.isInitialized()).thenReturn(true)
 
-        DeliveryManager.runWithInitialized(connection) { invoked = true }
+        connection.ifInitialized { invoked = true }
 
         assertTrue(invoked)
     }

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ext/CoroutineScopeKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ext/CoroutineScopeKtTest.kt
@@ -1,0 +1,103 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.feature.push.ext
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.appservices.push.AlreadyRegisteredError
+import mozilla.appservices.push.CommunicationError
+import mozilla.appservices.push.CommunicationServerError
+import mozilla.appservices.push.CryptoError
+import mozilla.appservices.push.GeneralError
+import mozilla.appservices.push.InternalPanic
+import mozilla.appservices.push.MissingRegistrationTokenError
+import mozilla.appservices.push.RecordNotFoundError
+import mozilla.appservices.push.StorageError
+import mozilla.appservices.push.StorageSqlError
+import mozilla.appservices.push.TranscodingError
+import mozilla.appservices.push.UrlParseError
+import mozilla.components.feature.push.exceptionHandler
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class CoroutineScopeKtTest {
+
+    @Test(expected = InternalPanic::class)
+    fun `launchAndTry throws on unrecoverable Rust exceptions`() = runBlockingTest {
+        CoroutineScope(coroutineContext).launchAndTry(
+            errorBlock = { throw InternalPanic("unit test") },
+            block = { throw MissingRegistrationTokenError() }
+        )
+    }
+
+    @Test(expected = ArithmeticException::class)
+    fun `launchAndTry throws original exception`() = runBlockingTest {
+        CoroutineScope(coroutineContext).launchAndTry(
+            errorBlock = { throw InternalPanic("unit test") },
+            block = { throw ArithmeticException() }
+        )
+    }
+
+    @Test
+    fun `launchAndTry should NOT throw on recoverable Rust exceptions`() = runBlockingTest {
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw CryptoError("should not fail test") },
+            { assert(true) }
+        ) + exceptionHandler {}
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw CommunicationServerError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw CommunicationError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw AlreadyRegisteredError() },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw StorageError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw MissingRegistrationTokenError() },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw StorageSqlError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw TranscodingError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw RecordNotFoundError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw UrlParseError("should not fail test") },
+            { assert(true) }
+        )
+
+        CoroutineScope(coroutineContext).launchAndTry(
+            { throw GeneralError("should not fail test") },
+            { assert(true) }
+        )
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ permalink: /changelog/
 
 * **feature-top-sites**
   * Added `isDefault` to the top site entity, which allows application to specify a default top site that is added by the application. This is called through `TopSiteStorage.addTopSite`.
+  
+* **feature-push**
+  * Simplified error handling and reduced non-fatal exception reporting.
 
 # 39.0.0
 
@@ -115,7 +118,6 @@ permalink: /changelog/
 
 * **service-accounts-push**
   * Fixed a bug where the push subscription was incorrectly cached and caused some `GeneralError`s.
-
 * **feature-addons**
   * Added `DefaultAddonUpdater.UpdateAttemptStorage` allows to query the last known state for a previous attempt to update an add-on.
 


### PR DESCRIPTION
Based on the our crash reporting there are only a hand few of exceptions
that are non-fatal. For the rest, we can simply notify the crash
reporter.

 - Simplified state requirements for native invocation by replacing the
 `DeliveryManager.with` to an extension `PushConnection.ifInitialized`.
 - The new `CoroutineExceptionHandler` now notifies the crash reporter
 of fatal or unknown exceptions.
 - Moved extension functions to their equivalent files in an `.ext`
 package.
 - Added more tests to increase coverage. 🎉


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Closes #6171

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
