### PR TITLE
Fix for #6155 - Back button from migration complete notification routes back to migration screen

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AbstractMigrationService.kt
@@ -124,7 +124,7 @@ abstract class AbstractMigrationService : Service() {
                 .setContentTitle(getString(titleRes))
                 .setContentText(getString(contentRes))
                 .setContentIntent(PendingIntent.getActivity(this, 0,
-                        Intent(this, migrationDecisionActivity), 0))
+                        Intent(this, migrationDecisionActivity).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP), 0))
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setCategory(NotificationCompat.CATEGORY_PROGRESS)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)


### PR DESCRIPTION

---

Landing a rebased version of https://github.com/mozilla-mobile/android-components/pull/6178 that was reviewed and approved.
