### PR TITLE
For #3182 - canScrollVerticallyUp considers websites handling motion events.

### DIFF
--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -17,7 +18,7 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 import org.mozilla.geckoview.GeckoResult
-import java.lang.IllegalStateException
+import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
 
 /**
  * Gecko-based EngineView implementation.
@@ -50,6 +51,12 @@ class GeckoEngineView @JvmOverloads constructor(
 
             super.onDetachedFromWindow()
         }
+
+        override fun onTouchEventForResult(ev: MotionEvent): Int {
+            return super.onTouchEventForResult(ev).also {
+                isMotionEventHandledByWebContent = (it == INPUT_RESULT_HANDLED_CONTENT)
+            }
+        }
     }.apply {
         // Explicitly mark this view as important for autofill. The default "auto" doesn't seem to trigger any
         // autofill behavior for us here.
@@ -78,6 +85,8 @@ class GeckoEngineView @JvmOverloads constructor(
     internal var currentSelection: BasicSelectionActionDelegate? = null
 
     override var selectionActionDelegate: SelectionActionDelegate? = null
+
+    private var isMotionEventHandledByWebContent: Boolean = false
 
     init {
         // Currently this is just a FrameLayout with a single GeckoView instance. Eventually this
@@ -150,7 +159,13 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun canClearSelection() = currentSelection?.selection != null
 
-    override fun canScrollVerticallyUp() = currentSession?.let { it.scrollY > 0 } != false
+    override fun canScrollVerticallyUp(): Boolean {
+        return (currentSession?.let { session ->
+            val canScrollVerticallyUp = session.scrollY > 0
+
+            canScrollVerticallyUp || isMotionEventHandledByWebContent
+        } ?: false)
+    }
 
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,9 @@ permalink: /changelog/
 
 * **concept-storage**, **service-sync-logins**
   * 🆕 New API: `PlacesStorage#warmUp`, `SyncableLoginsStorage#warmUp` - allows consumers to ensure that underlying storage database connections are fully established.
+  
+* **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
+  * Updated `GeckoEngineView#canScrollVerticallyUp()` to also consider and return `true` when websites handle themselves the swipe down motion.
 
 # 37.0.0
 


### PR DESCRIPTION
Beside the check for the website being scrolled to top we also need to check if
it wants the consume the swipe down motion event, case in which
`canScrollVerticallyUp` will always return false.

The result of this method can be used for the `pull down to refresh`
functionality.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR adds very little code. No tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

Video showcasing the result - https://drive.google.com/file/d/1USVgp8IirznWWJoYPi6XPETdROYYxzTQ/view

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
