### PR TITLE
Closes #6367: Do not intercept app initiated load requests by default

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "76.0.20200327094805"
+    const val nightly_version = "76.0.20200330094747"
 
     /**
      * GeckoView Beta Version.

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1151,6 +1151,8 @@ class GeckoEngineSessionTest {
         var interceptorCalledWithUri: String? = null
 
         val interceptor = object : RequestInterceptor {
+            override fun interceptsAppInitiatedRequests() = true
+
             override fun onLoadRequest(
                 engineSession: EngineSession,
                 uri: String,
@@ -1163,10 +1165,7 @@ class GeckoEngineSessionTest {
         }
 
         val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
-
-        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider,
-                defaultSettings = defaultSettings)
-
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider, defaultSettings = defaultSettings)
         captureDelegates()
 
         navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about"))
@@ -1180,6 +1179,8 @@ class GeckoEngineSessionTest {
         var interceptorCalledWithUri: String? = null
 
         val interceptor = object : RequestInterceptor {
+            override fun interceptsAppInitiatedRequests() = true
+
             override fun onLoadRequest(
                 engineSession: EngineSession,
                 uri: String,
@@ -1192,13 +1193,10 @@ class GeckoEngineSessionTest {
         }
 
         val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
-
-        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider,
-                defaultSettings = defaultSettings)
-
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider, defaultSettings = defaultSettings)
         captureDelegates()
 
-        navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about"))
+        navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about", "trigger:uri"))
 
         assertEquals("sample:about", interceptorCalledWithUri)
         verify(geckoSession).loadUri(
@@ -1207,6 +1205,35 @@ class GeckoEngineSessionTest {
             GeckoSession.LOAD_FLAGS_NONE,
             null as Map<String, String>?
         )
+    }
+
+    @Test
+    fun settingInterceptorCanIgnoreAppInitiatedRequests() {
+        var interceptorCalled = false
+
+        val interceptor = object : RequestInterceptor {
+            override fun interceptsAppInitiatedRequests() = false
+
+            override fun onLoadRequest(
+                engineSession: EngineSession,
+                uri: String,
+                hasUserGesture: Boolean,
+                isSameDomain: Boolean
+            ): RequestInterceptor.InterceptionResponse? {
+                interceptorCalled = true
+                return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
+            }
+        }
+
+        val defaultSettings = DefaultSettings(requestInterceptor = interceptor)
+        GeckoEngineSession(mock(), geckoSessionProvider = geckoSessionProvider, defaultSettings = defaultSettings)
+        captureDelegates()
+
+        navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about", isDirectNavigation = true))
+        assertFalse(interceptorCalled)
+
+        navigationDelegate.value.onLoadRequest(geckoSession, mockLoadRequest("sample:about", isDirectNavigation = false))
+        assertTrue(interceptorCalled)
     }
 
     @Test
@@ -1228,6 +1255,8 @@ class GeckoEngineSessionTest {
         var interceptorCalledWithUri: String? = null
 
         val interceptor = object : RequestInterceptor {
+            override fun interceptsAppInitiatedRequests() = true
+
             override fun onLoadRequest(
                 engineSession: EngineSession,
                 uri: String,
@@ -1761,7 +1790,7 @@ class GeckoEngineSessionTest {
         captureDelegates()
 
         val result = navigationDelegate.value.onLoadRequest(geckoSession,
-                mockLoadRequest("sample:about", GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW))
+                mockLoadRequest("sample:about", null, GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW))
 
         assertNotNull(result)
         assertEquals(result!!.poll(0), AllowOrDeny.ALLOW)
@@ -1863,6 +1892,8 @@ class GeckoEngineSessionTest {
         var observedIntent: Intent? = null
 
         engineSession.settings.requestInterceptor = object : RequestInterceptor {
+            override fun interceptsAppInitiatedRequests() = true
+
             override fun onLoadRequest(
                 engineSession: EngineSession,
                 uri: String,
@@ -1913,6 +1944,8 @@ class GeckoEngineSessionTest {
         var observedTriggeredByWebContent: Boolean? = null
 
         engineSession.settings.requestInterceptor = object : RequestInterceptor {
+            override fun interceptsAppInitiatedRequests() = true
+
             override fun onLoadRequest(
                 engineSession: EngineSession,
                 uri: String,
@@ -2355,9 +2388,11 @@ class GeckoEngineSessionTest {
 
     private fun mockLoadRequest(
         uri: String,
+        triggerUri: String? = null,
         target: Int = 0,
         triggeredByRedirect: Boolean = false,
-        hasUserGesture: Boolean = false
+        hasUserGesture: Boolean = false,
+        isDirectNavigation: Boolean = false
     ): GeckoSession.NavigationDelegate.LoadRequest {
         var flags = 0
         if (triggeredByRedirect) {
@@ -2369,9 +2404,10 @@ class GeckoEngineSessionTest {
             String::class.java,
             Int::class.java,
             Int::class.java,
+            Boolean::class.java,
             Boolean::class.java)
         constructor.isAccessible = true
 
-        return constructor.newInstance(uri, uri, target, flags, hasUserGesture)
+        return constructor.newInstance(uri, triggerUri, target, flags, hasUserGesture, isDirectNavigation)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.engine.EngineSession
  * Interface for classes that want to intercept load requests to allow custom behavior.
  */
 interface RequestInterceptor {
+
     /**
      * An alternative response for an intercepted request.
      */
@@ -77,4 +78,15 @@ interface RequestInterceptor {
      * provided error type.
      */
     fun onErrorRequest(session: EngineSession, errorType: ErrorType, uri: String?): ErrorResponse? = null
+
+    /**
+     * Returns whether or not this [RequestInterceptor] should intercept load
+     * requests initiated by the app (via direct calls to [EngineSession.loadUrl]).
+     * All other requests triggered by users interacting with web content
+     * (e.g. following links) or redirects will always be intercepted.
+     *
+     * @return true if app initiated requests should be intercepted,
+     * otherwise false. Defaults to false.
+     */
+    fun interceptsAppInitiatedRequests() = false
 }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
@@ -15,6 +15,8 @@ import org.mozilla.samples.browser.ext.components
 
 class SampleRequestInterceptor(val context: Context) : RequestInterceptor {
 
+    override fun interceptsAppInitiatedRequests() = true
+
     override fun onLoadRequest(
         engineSession: EngineSession,
         uri: String,


### PR DESCRIPTION
Our interceptors in Fenix and R-B do not need to be invoked for load requests initiated by the application (e.g. the user loading a URL via the toolbar). With this, the interceptors can control whether or not they want to be invoked in that case.

This is a performance optimization, as we want to minimize the time we block GeckoView from initiating the page load (it has to wait for the result of `onLoadRequest`.)

Full discussion in: https://github.com/mozilla-mobile/fenix/issues/8782#issuecomment-603411945
