### PR TITLE
Closes #6297: GeckoEngineView: Detach SelectionActionDelegate if session is no longer rendered.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoSession
 
 /**
  * Gecko-based EngineView implementation.
@@ -101,16 +102,13 @@ class GeckoEngineView @JvmOverloads constructor(
             currentGeckoView.session?.let {
                 // Release a previously assigned session. Otherwise GeckoView will close it
                 // automatically.
+                detachSelectionActionDelegate(currentGeckoView.session)
                 currentGeckoView.releaseSession()
-                currentSelection = null
             }
 
             try {
                 currentGeckoView.setSession(internalSession.geckoSession)
-
-                currentSelection = GeckoSelectionActionDelegate.maybeCreate(context, selectionActionDelegate)
-                    ?: internalSession.geckoSession.selectionActionDelegate as? BasicSelectionActionDelegate
-                internalSession.geckoSession.selectionActionDelegate = currentSelection
+                attachSelectionActionDelegate(internalSession.geckoSession)
             } catch (e: IllegalStateException) {
                 // This is to debug "display already acquired" crashes
                 val otherActivityClassName =
@@ -120,6 +118,21 @@ class GeckoEngineView @JvmOverloads constructor(
                     "SET SESSION: Current activity: $activityClassName Other activity: $otherActivityClassName"
                 throw IllegalStateException(msg, e)
             }
+        }
+    }
+
+    private fun attachSelectionActionDelegate(session: GeckoSession) {
+        val delegate = GeckoSelectionActionDelegate.maybeCreate(context, selectionActionDelegate)
+        if (delegate != null) {
+            session.selectionActionDelegate = delegate
+            currentSelection = delegate
+        }
+    }
+
+    private fun detachSelectionActionDelegate(session: GeckoSession?) {
+        if (currentSelection != null) {
+            session?.selectionActionDelegate = null
+            currentSelection = null
         }
     }
 
@@ -134,9 +147,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
     @Synchronized
     override fun release() {
+        detachSelectionActionDelegate(currentSession?.geckoSession)
+
         currentSession?.apply { unregister(observer) }
 
-        currentSelection = null
         currentSession = null
 
         currentGeckoView.releaseSession()

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/selection/GeckoSelectionActionDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/selection/GeckoSelectionActionDelegate.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko.selection
 import android.app.Activity
 import android.content.Context
 import android.view.MenuItem
+import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 
@@ -17,7 +18,8 @@ import org.mozilla.geckoview.BasicSelectionActionDelegate
  */
 open class GeckoSelectionActionDelegate(
     activity: Activity,
-    private val customDelegate: SelectionActionDelegate
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val customDelegate: SelectionActionDelegate
 ) : BasicSelectionActionDelegate(activity) {
 
     companion object {

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoSession
 import java.lang.IllegalStateException
 
 /**
@@ -102,15 +103,13 @@ class GeckoEngineView @JvmOverloads constructor(
             currentGeckoView.session?.let {
                 // Release a previously assigned session. Otherwise GeckoView will close it
                 // automatically.
+                detachSelectionActionDelegate(currentGeckoView.session)
                 currentGeckoView.releaseSession()
-                currentSelection = null
             }
 
             try {
                 currentGeckoView.setSession(internalSession.geckoSession)
-                currentSelection = GeckoSelectionActionDelegate.maybeCreate(context, selectionActionDelegate)
-                    ?: internalSession.geckoSession.selectionActionDelegate as? BasicSelectionActionDelegate
-                internalSession.geckoSession.selectionActionDelegate = currentSelection
+                attachSelectionActionDelegate(internalSession.geckoSession)
             } catch (e: IllegalStateException) {
                 // This is to debug "display already acquired" crashes
                 val otherActivityClassName =
@@ -120,6 +119,21 @@ class GeckoEngineView @JvmOverloads constructor(
                     "SET SESSION: Current activity: $activityClassName Other activity: $otherActivityClassName"
                 throw IllegalStateException(msg, e)
             }
+        }
+    }
+
+    private fun attachSelectionActionDelegate(session: GeckoSession) {
+        val delegate = GeckoSelectionActionDelegate.maybeCreate(context, selectionActionDelegate)
+        if (delegate != null) {
+            session.selectionActionDelegate = delegate
+            currentSelection = delegate
+        }
+    }
+
+    private fun detachSelectionActionDelegate(session: GeckoSession?) {
+        if (currentSelection != null) {
+            session?.selectionActionDelegate = null
+            currentSelection = null
         }
     }
 
@@ -134,9 +148,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
     @Synchronized
     override fun release() {
+        detachSelectionActionDelegate(currentSession?.geckoSession)
+
         currentSession?.apply { unregister(observer) }
 
-        currentSelection = null
         currentSession = null
 
         currentGeckoView.releaseSession()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,9 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: add parameter `handleError` to `CustomTabWindowFeature` constructor
     * This is used to show an error when the url can't be handled
 
+* **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
+  * Fixed a memory leak when using a `SelectionActionDelegate` on `GeckoEngineView`.
+
 # 37.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v36.0.0...v37.0.0)


### PR DESCRIPTION
Our sample browser smoke tests revealed a memory leak (#6297). We attach a selection action delegate on GeckoSession but we never clear it. This leads to us leaking GeckoEngineView and its Context/Activity since the GeckoSession usually lives longer than any views.

Internally GeckoSession attaches and detaches its own selection delegate (since it also has a reference to the activity). We are now doing the same if we are using a custom delegate.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
