### PR TITLE
Closes #6441: Add contextId support to ContextMenuCandidate

### DIFF
--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -45,12 +45,27 @@ data class ContextMenuCandidate(
             snackBarParentView: View,
             snackbarDelegate: SnackbarDelegate = DefaultSnackbarDelegate()
         ): List<ContextMenuCandidate> = listOf(
-            createOpenInNewTabCandidate(context, tabsUseCases, snackBarParentView, snackbarDelegate),
-            createOpenInPrivateTabCandidate(context, tabsUseCases, snackBarParentView, snackbarDelegate),
+            createOpenInNewTabCandidate(
+                context,
+                tabsUseCases,
+                snackBarParentView,
+                snackbarDelegate
+            ),
+            createOpenInPrivateTabCandidate(
+                context,
+                tabsUseCases,
+                snackBarParentView,
+                snackbarDelegate
+            ),
             createCopyLinkCandidate(context, snackBarParentView, snackbarDelegate),
             createDownloadLinkCandidate(context, contextMenuUseCases),
             createShareLinkCandidate(context),
-            createOpenImageInNewTabCandidate(context, tabsUseCases, snackBarParentView, snackbarDelegate),
+            createOpenImageInNewTabCandidate(
+                context,
+                tabsUseCases,
+                snackBarParentView,
+                snackbarDelegate
+            ),
             createSaveImageCandidate(context, contextMenuUseCases),
             createSaveVideoAudioCandidate(context, contextMenuUseCases),
             createCopyImageLocationCandidate(context, snackBarParentView, snackbarDelegate)
@@ -70,7 +85,12 @@ data class ContextMenuCandidate(
             showFor = { tab, hitResult -> hitResult.isLink() && !tab.content.private },
             action = { parent, hitResult ->
                 val tab = tabsUseCases.addTab(
-                    hitResult.getLink(), selectTab = false, startLoading = true, parentId = parent.id, contextId = parent.contextId)
+                    hitResult.getLink(),
+                    selectTab = false,
+                    startLoading = true,
+                    parentId = parent.id,
+                    contextId = parent.contextId
+                )
 
                 snackbarDelegate.show(
                     snackBarParentView = snackBarParentView,
@@ -97,7 +117,11 @@ data class ContextMenuCandidate(
             showFor = { _, hitResult -> hitResult.isLink() },
             action = { parent, hitResult ->
                 val tab = tabsUseCases.addPrivateTab(
-                    hitResult.getLink(), selectTab = false, startLoading = true, parentId = parent.id)
+                    hitResult.getLink(),
+                    selectTab = false,
+                    startLoading = true,
+                    parentId = parent.id
+                )
 
                 snackbarDelegate.show(
                     snackBarParentView,
@@ -148,10 +172,16 @@ data class ContextMenuCandidate(
             action = { parent, hitResult ->
                 val tab = if (parent.content.private) {
                     tabsUseCases.addPrivateTab(
-                        hitResult.src, selectTab = false, startLoading = true, parentId = parent.id)
+                        hitResult.src, selectTab = false, startLoading = true, parentId = parent.id
+                    )
                 } else {
                     tabsUseCases.addTab(
-                        hitResult.src, selectTab = false, startLoading = true, parentId = parent.id, contextId = parent.contextId)
+                        hitResult.src,
+                        selectTab = false,
+                        startLoading = true,
+                        parentId = parent.id,
+                        contextId = parent.contextId
+                    )
                 }
 
                 snackbarDelegate.show(
@@ -256,7 +286,8 @@ data class ContextMenuCandidate(
             label = context.getString(R.string.mozac_feature_contextmenu_copy_link),
             showFor = { _, hitResult -> hitResult.isLink() },
             action = { _, hitResult ->
-                val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                val clipboardManager =
+                    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 val clip = ClipData.newPlainText(hitResult.getLink(), hitResult.getLink())
                 clipboardManager.setPrimaryClip(clip)
 
@@ -280,7 +311,8 @@ data class ContextMenuCandidate(
             label = context.getString(R.string.mozac_feature_contextmenu_copy_image_location),
             showFor = { _, hitResult -> hitResult.isImage() },
             action = { _, hitResult ->
-                val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                val clipboardManager =
+                    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 val clip = ClipData.newPlainText(hitResult.getLink(), hitResult.src)
                 clipboardManager.setPrimaryClip(clip)
 
@@ -333,8 +365,7 @@ private fun HitResult.isIntent(): Boolean =
     (this is HitResult.UNKNOWN && src.isNotEmpty() &&
         getLink().startsWith("intent"))
 
-private fun HitResult.canOpenInExternalApp(appLinksUseCases: AppLinksUseCases): Boolean
-{
+private fun HitResult.canOpenInExternalApp(appLinksUseCases: AppLinksUseCases): Boolean {
     if (isLink() || isIntent()) {
         val redirect = appLinksUseCases.appLinkRedirectIncludeInstall(getLink())
         return redirect.hasExternalApp() || redirect.hasMarketplaceIntent()
@@ -368,7 +399,8 @@ class DefaultSnackbarDelegate : ContextMenuCandidate.SnackbarDelegate {
         val snackbar = Snackbar.make(
             snackBarParentView,
             text,
-            duration)
+            duration
+        )
 
         if (action != 0 && listener != null) {
             snackbar.setAction(action, listener)

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -70,7 +70,7 @@ data class ContextMenuCandidate(
             showFor = { tab, hitResult -> hitResult.isLink() && !tab.content.private },
             action = { parent, hitResult ->
                 val tab = tabsUseCases.addTab(
-                    hitResult.getLink(), selectTab = false, startLoading = true, parentId = parent.id)
+                    hitResult.getLink(), selectTab = false, startLoading = true, parentId = parent.id, contextId = parent.contextId)
 
                 snackbarDelegate.show(
                     snackBarParentView = snackBarParentView,
@@ -151,7 +151,7 @@ data class ContextMenuCandidate(
                         hitResult.src, selectTab = false, startLoading = true, parentId = parent.id)
                 } else {
                     tabsUseCases.addTab(
-                        hitResult.src, selectTab = false, startLoading = true, parentId = parent.id)
+                        hitResult.src, selectTab = false, startLoading = true, parentId = parent.id, contextId = parent.contextId)
                 }
 
                 snackbarDelegate.show(

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -87,6 +87,28 @@ class ContextMenuCandidateTest {
     }
 
     @Test
+    fun `Candidate "Open Link in New Tab" action properly executes for session with a contextId`() {
+        val store = BrowserStore()
+        val sessionManager = spy(SessionManager(mock(), store))
+        doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any())
+        sessionManager.add(Session("https://www.mozilla.org", contextId = "1"))
+
+        val tabsUseCases = TabsUseCases(sessionManager)
+        val parentView = CoordinatorLayout(testContext)
+        val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
+            testContext, tabsUseCases, parentView, snackbarDelegate)
+
+        assertEquals(1, store.state.tabs.size)
+        assertEquals("1", store.state.tabs.first().contextId)
+
+        openInNewTab.action.invoke(store.state.tabs.first(), HitResult.UNKNOWN("https://firefox.com"))
+
+        assertEquals(2, store.state.tabs.size)
+        assertEquals("https://firefox.com", store.state.tabs.last().content.url)
+        assertEquals("1", store.state.tabs.last().contextId)
+    }
+
+    @Test
     fun `Candidate "Open Link in New Tab" action properly executes and shows snackbar`() {
         val store = BrowserStore()
         val sessionManager = spy(SessionManager(mock(), store))
@@ -334,6 +356,31 @@ class ContextMenuCandidateTest {
         assertEquals(2, store.state.tabs.size)
         assertTrue(store.state.tabs.last().content.private)
         assertEquals("https://firefox.com", store.state.tabs.last().content.url)
+    }
+
+    @Test
+    fun `Candidate "Open Image in New Tab" opens with the session's contextId`() {
+        val store = BrowserStore()
+        val sessionManager = spy(SessionManager(mock(), store))
+        doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any())
+        sessionManager.add(Session("https://www.mozilla.org", contextId = "1"))
+
+        val tabsUseCases = TabsUseCases(sessionManager)
+        val parentView = CoordinatorLayout(testContext)
+
+        val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(
+            testContext, tabsUseCases, parentView, snackbarDelegate)
+
+        assertEquals(1, store.state.tabs.size)
+        assertEquals("1", store.state.tabs.first().contextId)
+
+        openImageInTab.action.invoke(
+            store.state.tabs.first(),
+            HitResult.IMAGE_SRC("https://firefox.com", "https://getpocket.com"))
+
+        assertEquals(2, store.state.tabs.size)
+        assertEquals("https://firefox.com", store.state.tabs.last().content.url)
+        assertEquals("1", store.state.tabs.last().contextId)
     }
 
     @Test


### PR DESCRIPTION
Fixes #6441. 

In `ContextMenuCandidate`, we can pass the `contextId` from the parent's `SessionState` to the `tabsUseCases.addTab` callers. This happens for the context menu items "Open Link in New Tab" and "Open Image in New Tab".

Might be easier to review this PR by looking at individual commits. Part 2 simply does a re-format of ContextMenuCandidate.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
