### PR TITLE
Improve Exception.shouldReport on add-on workers

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/migration/SupportedAddonsChecker.kt
@@ -161,7 +161,7 @@ internal class SupportedAddonsWorker(
             }
         } catch (exception: Exception) {
             logger.error("An exception happened trying to check for new supported add-ons, re-schedule ${exception.message}", exception)
-            if (!exception.shouldReport()) {
+            if (exception.shouldReport()) {
                 GlobalAddonDependencyProvider.onCrash?.invoke(exception)
             }
         }

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
@@ -596,7 +596,7 @@ internal class AddonUpdaterWorker(
                         exception
                 )
                 saveUpdateAttempt(extensionId, AddonUpdater.Status.Error(exception.message ?: "", exception))
-                if (!exception.shouldReport()) {
+                if (exception.shouldReport()) {
                     GlobalAddonDependencyProvider.onCrash?.invoke(exception)
                 }
                 continuation.resume(Result.retry())

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/worker/Extensions.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/worker/Extensions.kt
@@ -9,4 +9,4 @@ import kotlinx.coroutines.CancellationException
 /**
  * Indicates if an exception should be reported to the crash reporter.
  */
-internal fun Exception.shouldReport(): Boolean = cause is IOException || this is CancellationException
+internal fun Exception.shouldReport(): Boolean = cause !is IOException && cause !is CancellationException

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/worker/ExtensionsTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/worker/ExtensionsTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.addons.worker
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.assertFalse
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import org.junit.Test
@@ -15,12 +15,12 @@ import org.junit.runner.RunWith
 class ExtensionsTest {
 
     @Test
-    fun `shouldReport - when cause is an IOException must be reported`() {
-        assertTrue(Exception(IOException()).shouldReport())
+    fun `shouldReport - when cause is an IOException must NOT be reported`() {
+        assertFalse(Exception(IOException()).shouldReport())
     }
 
     @Test
-    fun `shouldReport - a CancellationException must be reported`() {
-        assertTrue(CancellationException().shouldReport())
+    fun `shouldReport - when cause is a CancellationException must NOT be reported`() {
+        assertFalse(Exception(CancellationException()).shouldReport())
     }
 }


### PR DESCRIPTION
We are still seeing new many not [actionable exceptions on Sentry](https://sentry.prod.mozaws.net/operations/fenix-nightly/issues/7512699/?query=is:unresolved). This is because the actual condition is not taking in consideration that `JobCancellationException` are being wrapped into `AddonManagerException` for this reason, we need to check `Exception.cause` that contains the wrapped exception.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
