### PR TITLE
For #3182 - Separate behaviours depending on user's MotionEvents

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -168,6 +168,12 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
+    override fun getInputResult(): EngineView.InputResult {
+        // Direct mapping of GeckoView's returned values.
+        // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
+        return EngineView.InputResult.values().first { it.value == currentGeckoView.inputResult }
+    }
+
     override fun setVerticalClipping(clippingHeight: Int) {
         currentGeckoView.setVerticalClipping(clippingHeight)
     }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -10,8 +10,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.view.NestedScrollingChild
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import mozilla.components.concept.engine.EngineView
 import org.mozilla.geckoview.GeckoView
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 
 /**
@@ -42,8 +42,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
     @VisibleForTesting
     internal var childHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
 
-    @VisibleForTesting
-    internal var shouldScroll = true
+    /**
+     * Integer indicating how user's MotionEvent was handled.
+     *
+     * There must be a 1-1 relation between this values and [EngineView.InputResult]'s.
+     */
+    internal var inputResult: Int = INPUT_RESULT_UNHANDLED
 
     init {
         isNestedScrollingEnabled = true
@@ -60,41 +64,31 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         }
 
         // Execute event handler from parent class in all cases
-        val eventHandled = handleEvent(event)
+        inputResult = handleEvent(event)
 
         when (action) {
             MotionEvent.ACTION_MOVE -> {
-                if (shouldScroll) {
-                    val allowScroll = !shouldPinOnScreen()
-                    var deltaY = lastY - eventY
+                val allowScroll = !shouldPinOnScreen()
+                var deltaY = lastY - eventY
 
-                    if (allowScroll && dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
-                        deltaY -= scrollConsumed[1]
-                        event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
-                        nestedOffsetY += scrollOffset[1]
-                    }
+                if (allowScroll && dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
+                    deltaY -= scrollConsumed[1]
+                    event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
+                    nestedOffsetY += scrollOffset[1]
+                }
 
-                    lastY = eventY - scrollOffset[1]
+                lastY = eventY - scrollOffset[1]
 
-                    if (allowScroll && dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
-                        lastY -= scrollOffset[1]
-                        event.offsetLocation(0f, scrollOffset[1].toFloat())
-                        nestedOffsetY += scrollOffset[1]
-                    }
+                if (allowScroll && dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
+                    lastY -= scrollOffset[1]
+                    event.offsetLocation(0f, scrollOffset[1].toFloat())
+                    nestedOffsetY += scrollOffset[1]
                 }
             }
 
             MotionEvent.ACTION_DOWN -> {
-                // Only scroll for certain eventHandled responses
-                // See https://github.com/mozilla-mobile/fenix/issues/8768#issuecomment-592718468
-                shouldScroll = (eventHandled != INPUT_RESULT_HANDLED_CONTENT && eventHandled != INPUT_RESULT_UNHANDLED)
-
-                if (shouldScroll) {
-                    lastY = eventY
-                    startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
-                } else {
-                    stopNestedScroll()
-                }
+                lastY = eventY
+                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
             }
 
             // We don't care about other touch events
@@ -104,7 +98,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         // Recycle previously obtained event
         event.recycle()
 
-        return eventHandled
+        return inputResult
     }
 
     // Helper function to make testing of this method easier

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -13,21 +13,17 @@ import android.view.MotionEvent.ACTION_UP
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.any
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
@@ -74,42 +70,13 @@ class NestedGeckoViewTest {
     }
 
     @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_HANDLED`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
+    fun `verify onTouchEvent when ACTION_DOWN`() {
+        val nestedWebView = NestedGeckoView(context)
         val mockChildHelper: NestedScrollingChildHelper = mock()
-
         nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_HANDLED).`when`(nestedWebView).handleEvent(any())
 
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
         verify(mockChildHelper).startNestedScroll(SCROLL_AXIS_VERTICAL)
-    }
-
-    @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_HANDLED_CONTENT`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
-        val mockChildHelper: NestedScrollingChildHelper = mock()
-
-        nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_HANDLED_CONTENT).`when`(nestedWebView).handleEvent(any())
-
-        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
-        verify(mockChildHelper).stopNestedScroll()
-    }
-
-    @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_UNHANDLED`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
-        val mockChildHelper: NestedScrollingChildHelper = mock()
-
-        nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_UNHANDLED).`when`(nestedWebView).handleEvent(any())
-
-        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
-        verify(mockChildHelper).stopNestedScroll()
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -170,6 +170,12 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
+    override fun getInputResult(): EngineView.InputResult {
+        // Direct mapping of GeckoView's returned values.
+        // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
+        return EngineView.InputResult.values().first { it.value == currentGeckoView.inputResult }
+    }
+
     override fun setVerticalClipping(clippingHeight: Int) {
         currentGeckoView.setVerticalClipping(clippingHeight)
     }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -10,8 +10,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.view.NestedScrollingChild
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import mozilla.components.concept.engine.EngineView
 import org.mozilla.geckoview.GeckoView
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 
 /**
@@ -42,8 +42,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
     @VisibleForTesting
     internal var childHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
 
-    @VisibleForTesting
-    internal var shouldScroll = true
+    /**
+     * Integer indicating how user's MotionEvent was handled.
+     *
+     * There must be a 1-1 relation between this values and [EngineView.InputResult]'s.
+     */
+    internal var inputResult: Int = INPUT_RESULT_UNHANDLED
 
     init {
         isNestedScrollingEnabled = true
@@ -60,41 +64,31 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         }
 
         // Execute event handler from parent class in all cases
-        val eventHandled = handleEvent(event)
+        inputResult = handleEvent(event)
 
         when (action) {
             MotionEvent.ACTION_MOVE -> {
-                if (shouldScroll) {
-                    val allowScroll = !shouldPinOnScreen()
-                    var deltaY = lastY - eventY
+                val allowScroll = !shouldPinOnScreen()
+                var deltaY = lastY - eventY
 
-                    if (allowScroll && dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
-                        deltaY -= scrollConsumed[1]
-                        event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
-                        nestedOffsetY += scrollOffset[1]
-                    }
+                if (allowScroll && dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
+                    deltaY -= scrollConsumed[1]
+                    event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
+                    nestedOffsetY += scrollOffset[1]
+                }
 
-                    lastY = eventY - scrollOffset[1]
+                lastY = eventY - scrollOffset[1]
 
-                    if (allowScroll && dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
-                        lastY -= scrollOffset[1]
-                        event.offsetLocation(0f, scrollOffset[1].toFloat())
-                        nestedOffsetY += scrollOffset[1]
-                    }
+                if (allowScroll && dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
+                    lastY -= scrollOffset[1]
+                    event.offsetLocation(0f, scrollOffset[1].toFloat())
+                    nestedOffsetY += scrollOffset[1]
                 }
             }
 
             MotionEvent.ACTION_DOWN -> {
-                // Only scroll for certain eventHandled responses
-                // See https://github.com/mozilla-mobile/fenix/issues/8768#issuecomment-592718468
-                shouldScroll = (eventHandled != INPUT_RESULT_HANDLED_CONTENT && eventHandled != INPUT_RESULT_UNHANDLED)
-
-                if (shouldScroll) {
-                    lastY = eventY
-                    startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
-                } else {
-                    stopNestedScroll()
-                }
+                lastY = eventY
+                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
             }
 
             // We don't care about other touch events
@@ -104,7 +98,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         // Recycle previously obtained event
         event.recycle()
 
-        return eventHandled
+        return inputResult
     }
 
     // Helper function to make testing of this method easier

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -13,21 +13,17 @@ import android.view.MotionEvent.ACTION_UP
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.any
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
@@ -74,42 +70,13 @@ class NestedGeckoViewTest {
     }
 
     @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_HANDLED`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
+    fun `verify onTouchEvent when ACTION_DOWN`() {
+        val nestedWebView = NestedGeckoView(context)
         val mockChildHelper: NestedScrollingChildHelper = mock()
-
         nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_HANDLED).`when`(nestedWebView).handleEvent(any())
 
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
         verify(mockChildHelper).startNestedScroll(SCROLL_AXIS_VERTICAL)
-    }
-
-    @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_HANDLED_CONTENT`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
-        val mockChildHelper: NestedScrollingChildHelper = mock()
-
-        nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_HANDLED_CONTENT).`when`(nestedWebView).handleEvent(any())
-
-        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
-        verify(mockChildHelper).stopNestedScroll()
-    }
-
-    @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_UNHANDLED`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
-        val mockChildHelper: NestedScrollingChildHelper = mock()
-
-        nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_UNHANDLED).`when`(nestedWebView).handleEvent(any())
-
-        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
-        verify(mockChildHelper).stopNestedScroll()
     }
 
     @Test

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -169,6 +169,12 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun canScrollVerticallyDown() = true // waiting for this issue https://bugzilla.mozilla.org/show_bug.cgi?id=1507569
 
+    override fun getInputResult(): EngineView.InputResult {
+        // Direct mapping of GeckoView's returned values.
+        // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
+        return EngineView.InputResult.values().first { it.value == currentGeckoView.inputResult }
+    }
+
     override fun setVerticalClipping(clippingHeight: Int) {
         currentGeckoView.setVerticalClipping(clippingHeight)
     }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -10,8 +10,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.view.NestedScrollingChild
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import mozilla.components.concept.engine.EngineView
 import org.mozilla.geckoview.GeckoView
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 
 /**
@@ -42,8 +42,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
     @VisibleForTesting
     internal var childHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
 
-    @VisibleForTesting
-    internal var shouldScroll = true
+    /**
+     * Integer indicating how user's MotionEvent was handled.
+     *
+     * There must be a 1-1 relation between this values and [EngineView.InputResult]'s.
+     */
+    internal var inputResult: Int = INPUT_RESULT_UNHANDLED
 
     init {
         isNestedScrollingEnabled = true
@@ -60,41 +64,31 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         }
 
         // Execute event handler from parent class in all cases
-        val eventHandled = handleEvent(event)
+        inputResult = handleEvent(event)
 
         when (action) {
             MotionEvent.ACTION_MOVE -> {
-                if (shouldScroll) {
-                    val allowScroll = !shouldPinOnScreen()
-                    var deltaY = lastY - eventY
+                val allowScroll = !shouldPinOnScreen()
+                var deltaY = lastY - eventY
 
-                    if (allowScroll && dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
-                        deltaY -= scrollConsumed[1]
-                        event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
-                        nestedOffsetY += scrollOffset[1]
-                    }
+                if (allowScroll && dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
+                    deltaY -= scrollConsumed[1]
+                    event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
+                    nestedOffsetY += scrollOffset[1]
+                }
 
-                    lastY = eventY - scrollOffset[1]
+                lastY = eventY - scrollOffset[1]
 
-                    if (allowScroll && dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
-                        lastY -= scrollOffset[1]
-                        event.offsetLocation(0f, scrollOffset[1].toFloat())
-                        nestedOffsetY += scrollOffset[1]
-                    }
+                if (allowScroll && dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
+                    lastY -= scrollOffset[1]
+                    event.offsetLocation(0f, scrollOffset[1].toFloat())
+                    nestedOffsetY += scrollOffset[1]
                 }
             }
 
             MotionEvent.ACTION_DOWN -> {
-                // Only scroll for certain eventHandled responses
-                // See https://github.com/mozilla-mobile/fenix/issues/8768#issuecomment-592718468
-                shouldScroll = (eventHandled != INPUT_RESULT_HANDLED_CONTENT && eventHandled != INPUT_RESULT_UNHANDLED)
-
-                if (shouldScroll) {
-                    lastY = eventY
-                    startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
-                } else {
-                    stopNestedScroll()
-                }
+                lastY = eventY
+                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
             }
 
             // We don't care about other touch events
@@ -104,7 +98,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         // Recycle previously obtained event
         event.recycle()
 
-        return eventHandled
+        return inputResult
     }
 
     // Helper function to make testing of this method easier

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -13,21 +13,17 @@ import android.view.MotionEvent.ACTION_UP
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.any
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED_CONTENT
-import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
 import org.robolectric.Robolectric.buildActivity
 
 @RunWith(AndroidJUnit4::class)
@@ -74,42 +70,13 @@ class NestedGeckoViewTest {
     }
 
     @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_HANDLED`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
+    fun `verify onTouchEvent when ACTION_DOWN`() {
+        val nestedWebView = NestedGeckoView(context)
         val mockChildHelper: NestedScrollingChildHelper = mock()
-
         nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_HANDLED).`when`(nestedWebView).handleEvent(any())
 
         nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
         verify(mockChildHelper).startNestedScroll(SCROLL_AXIS_VERTICAL)
-    }
-
-    @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_HANDLED_CONTENT`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
-        val mockChildHelper: NestedScrollingChildHelper = mock()
-
-        nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_HANDLED_CONTENT).`when`(nestedWebView).handleEvent(any())
-
-        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
-        verify(mockChildHelper).stopNestedScroll()
-    }
-
-    @Test
-    fun `verify onTouchEvent when ACTION_DOWN and INPUT_RESULT_UNHANDLED`() {
-        val nestedWebView = Mockito.spy(NestedGeckoView(context))
-        val mockChildHelper: NestedScrollingChildHelper = mock()
-
-        nestedWebView.childHelper = mockChildHelper
-
-        doReturn(INPUT_RESULT_UNHANDLED).`when`(nestedWebView).handleEvent(any())
-
-        nestedWebView.onTouchEvent(mockMotionEvent(ACTION_DOWN))
-        verify(mockChildHelper).stopNestedScroll()
     }
 
     @Test

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -701,6 +701,16 @@ class SystemEngineView @JvmOverloads constructor(
 
     override fun canScrollVerticallyDown() = session?.webView?.canScrollVertically(1) ?: false
 
+    override fun getInputResult(): EngineView.InputResult {
+        (session?.webView as? NestedWebView)?.let { nestedWebView ->
+            // Direct mapping of WebView's returned values.
+            // There should be a 1-1 relation. If not fail fast to allow for a quick fix.
+            return EngineView.InputResult.values().first { it.value == nestedWebView.inputResult }
+        }
+        // Let's be preventive about not knowing if user's touch was handled and say no.
+        return EngineView.InputResult.INPUT_RESULT_UNHANDLED
+    }
+
     override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) {
         val webView = session?.webView
         if (webView == null) {

--- a/components/browser/toolbar/build.gradle
+++ b/components/browser/toolbar/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     api project(':ui-autocomplete')
     api project(':support-base')
 
+    implementation project(':concept-engine')
     implementation project(':browser-menu')
     implementation project(':ui-icons')
     implementation project(':ui-colors')

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
@@ -28,7 +28,8 @@ class BrowserToolbarBottomBehaviorTest {
 
     @Test
     fun `Starting a nested scroll should cancel an ongoing snap animation`() {
-        val behavior = BrowserToolbarBottomBehavior(testContext, attrs = null)
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        doReturn(true).`when`(behavior).shouldScroll
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -64,6 +65,7 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will snap toolbar up if toolbar is more than 50% visible`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        doReturn(true).`when`(behavior).shouldScroll
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -98,6 +100,7 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will snap toolbar down if toolbar is less than 50% visible`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        doReturn(true).`when`(behavior).shouldScroll
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -132,6 +135,7 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will apply translation to toolbar for nested scroll`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        doReturn(true).`when`(behavior).shouldScroll
 
         val child = mock<BrowserToolbar>()
         doReturn(100).`when`(child).height
@@ -175,6 +179,7 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will animateSnap UP when forceExpand is called`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        doReturn(true).`when`(behavior).shouldScroll
         val toolbar: BrowserToolbar = mock()
 
         behavior.forceExpand(toolbar)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -90,6 +90,11 @@ interface EngineView {
     fun canScrollVerticallyDown(): Boolean = true
 
     /**
+     * @return [InputResult] indicating how user's last [android.view.MotionEvent] was handled.
+     */
+    fun getInputResult(): InputResult = InputResult.INPUT_RESULT_UNHANDLED
+
+    /**
      * Request a screenshot of the visible portion of the web page currently being rendered.
      * @param onFinish A callback to inform that process of capturing a thumbnail has finished.
      */
@@ -119,6 +124,31 @@ interface EngineView {
      * A delegate that will handle interactions with text selection context menus.
      */
     var selectionActionDelegate: SelectionActionDelegate?
+
+    /**
+     * Enumeration of all possible ways user's [android.view.MotionEvent] was handled.
+     *
+     * @see [INPUT_RESULT_UNHANDLED]
+     * @see [INPUT_RESULT_HANDLED]
+     * @see [INPUT_RESULT_HANDLED_CONTENT]
+     */
+    enum class InputResult(val value: Int) {
+        /**
+         * Last [android.view.MotionEvent] was not handled by neither us nor the webpage.
+         */
+        INPUT_RESULT_UNHANDLED(0),
+
+        /**
+         * We handled the last [android.view.MotionEvent].
+         */
+        INPUT_RESULT_HANDLED(1),
+
+        /**
+         * Webpage handled the last [android.view.MotionEvent].
+         * (through it's own touch event listeners)
+         */
+        INPUT_RESULT_HANDLED_CONTENT(2),
+    }
 }
 
 /**

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SwipeRefreshFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SwipeRefreshFeature.kt
@@ -39,12 +39,13 @@ class SwipeRefreshFeature(
 
     /**
      * Callback that checks whether it is possible for the child view to scroll up.
-     * If the child view cannot scroll up, attempted to scroll up triggers a refresh gesture.
+     * If the child view cannot scroll up and the scroll event is not handled by the webpage
+     * it means we need to trigger the pull down to refresh functionality.
      */
     override fun canChildScrollUp(parent: SwipeRefreshLayout, child: View?) =
         if (child is EngineView) {
-            val result = child.canScrollVerticallyUp()
-            result
+            child.canScrollVerticallyUp() ||
+                (child.getInputResult() == EngineView.InputResult.INPUT_RESULT_HANDLED_CONTENT)
         } else {
             true
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,6 +45,21 @@ permalink: /changelog/
 
 * **feature-p2p**
   * Add new `P2PFeature` to send URLs and web pages through peer-to-peer networking.
+  
+* **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly, **browser-engine-system**
+  * Added `GeckoEngineView#getInputResult()` to return an EngineView.InputResult indicating how a MotionEvent was handled by an EngineView.
+
+* **concept-engine**
+  * Will expose a new `InputResult` enum through `getInputResult()` indicating how an EngineView handled user's MotionEvent.
+  * See above changes to browser-engine-*. 
+  
+* **browser-toolbar**
+  * `BrowserToolbarBottomBehavior` is now solely responsible to decide if the dynamic nav bar should animate or not.
+  * See above changes to browser-engine-*, concept-engine. 
+
+* **feature-session**
+  * `SwipeRefreshLayout` will now trigger pull down to refresh only if the website is scrolled to top and it itself did not consume the swype event.
+  * See above changes to browser-engine-*, concept-engine. 
 
 # 37.0.0
 


### PR DESCRIPTION
There are currently 3 Views interested in handling user's MotionEvents:
- GeckoView which renders web content
- SwipeRefreshLayout which handles pull down to refresh
- BrowserToolbar which can be dynamically hidden

Each of them have different behaviours based on different conditions so I
- removed the coupling of BrowserToolbar and Geckoview from `NestedGeckoView`.
It's `onTouchEventForResult` will now only set behaviour for GeckoView.
- created a new EngineView enum to expose the `PanZoomController` possible
result of how a specific user touch was handled to any components that have a
reference to an instance of EngineView without the need to have
`concept-engine` as a dependency.
- implemented specific behaviour in `SwipeRefreshFeature` for the pull down to
refresh functionality and in the `BrowserToolbarBottomBehavior` for the dynamic
navigation bar functionality.

Mapped PanZoomController's INPUT_RESULT to a new enum in order to not enforce
the need of including geckoview as a dependency in all components interested in
how a user's `MotionEvent` was handled and also because webview doesn't expose
such values so we needed a wrapper for it's handled or not boolean return.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR updated tests but didn't add new ones as the changes are in components not yet testes.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
