### PR TITLE
Close #6494: Delay initialize RedirectDialogFragment and browserPackageNames

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksFeature.kt
@@ -36,7 +36,7 @@ class AppLinksFeature(
     private val sessionManager: SessionManager,
     private val sessionId: String? = null,
     private val fragmentManager: FragmentManager? = null,
-    private val dialog: RedirectDialogFragment = SimpleRedirectDialogFragment.newInstance(),
+    private var dialog: RedirectDialogFragment? = null,
     private val launchInApp: () -> Boolean = { false },
     private val useCases: AppLinksUseCases = AppLinksUseCases(context, launchInApp),
     private val failedToLaunchAction: () -> Unit = {}
@@ -62,6 +62,7 @@ class AppLinksFeature(
                 return
             }
 
+            val dialog = getOrCreateDialog()
             dialog.setAppLinkRedirectUrl(url)
             dialog.onConfirmRedirect = doOpenApp
 
@@ -85,6 +86,18 @@ class AppLinksFeature(
 
     override fun stop() {
         observer.stop()
+    }
+
+    private fun getOrCreateDialog(): RedirectDialogFragment {
+        val existingDialog = dialog
+        if (existingDialog != null) {
+            return existingDialog
+        }
+
+        SimpleRedirectDialogFragment.newInstance().also {
+            dialog = it
+            return it
+        }
     }
 
     private fun isAlreadyADialogCreated(): Boolean {

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -169,12 +169,23 @@ class AppLinksUseCasesTest {
     }
 
     @Test
+    fun `browser package names is lazily intialized`() {
+        val unguessable = "https://unguessable-test-url.com"
+        val context = createContext(unguessable to browserPackage)
+        val subject = AppLinksUseCases(context, unguessableWebUrl = unguessable)
+        assertFalse(subject.browserPackageNames.isInitialized())
+    }
+
+    @Test
     fun `A list of browser package names can be generated if not supplied`() {
         val unguessable = "https://unguessable-test-url.com"
         val context = createContext(unguessable to browserPackage)
         val subject = AppLinksUseCases(context, unguessableWebUrl = unguessable)
+        assertFalse(subject.browserPackageNames.isInitialized())
 
-        assertEquals(subject.browserPackageNames, setOf(browserPackage))
+        subject.appLinkRedirect(unguessable)
+        assertTrue(subject.browserPackageNames.isInitialized())
+        assertEquals(subject.browserPackageNames.value, setOf(browserPackage))
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
