### PR TITLE
For #6501 - Increment google_materials dependency to 1.1.0.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,7 @@ object Versions {
 
     const val mozilla_glean = "25.0.0"
 
-    const val material = "1.0.0"
+    const val material = "1.1.0"
     const val nearby = "17.0.0"
 
     object AndroidX {
@@ -55,6 +55,7 @@ object Versions {
         const val arch_core_testing = "2.1.0"
         const val uiautomator = "2.2.0"
         const val localbroadcastmanager = "1.0.0"
+        const val swiperefreshlayout = "1.0.0"
     }
 
     object Firebase {
@@ -106,6 +107,7 @@ object Dependencies {
     const val androidx_work_testing = "androidx.work:work-testing:${Versions.AndroidX.work}"
     const val androidx_espresso_core = "androidx.test.espresso:espresso-core:${Versions.AndroidX.espresso}"
     const val androidx_localbroadcastmanager = "androidx.localbroadcastmanager:localbroadcastmanager:${Versions.AndroidX.localbroadcastmanager}"
+    const val androidx_swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:${Versions.AndroidX.swiperefreshlayout}"
 
     const val google_material = "com.google.android.material:material:${Versions.material}"
     const val google_nearby = "com.google.android.gms:play-services-nearby:${Versions.nearby}"

--- a/components/feature/session/build.gradle
+++ b/components/feature/session/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.google_material
+    implementation Dependencies.androidx_swiperefreshlayout
 
     testImplementation project(':support-test')
     testImplementation Dependencies.androidx_test_core

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,7 @@ permalink: /changelog/
 * **feature-session**
   * `SwipeRefreshLayout` will now trigger pull down to refresh only if the website is scrolled to top and it itself did not consume the swype event.
   * See above changes to browser-engine-*, concept-engine.
+  * Added androidx_swiperefreshlayout as a dependency because google_materials dependency was incremented to version 1.1.0 which no longer includes SwipeRefreshLayout
 
 * **lib-crash**
   * ⚠️ **This is a breaking change**: added `support-base` dependency.

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -124,6 +124,8 @@ dependencies {
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.androidx_constraintlayout
+    implementation Dependencies.androidx_swiperefreshlayout
+    implementation Dependencies.androidx_localbroadcastmanager
 
     androidTestImplementation project(':support-android-test')
     androidTestImplementation Dependencies.androidx_test_core


### PR DESCRIPTION
Keeps backwards compatibility by adding a separate dependency for androidx.swiperefreshlayout

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

For [#6501](https://github.com/mozilla-mobile/android-components/issues/6501)

**Needs landing before fix for #6500** 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR doesn't include any tests as it is only a minor change
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR  does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
