### PR TITLE
Add codeowners for lib-nearby

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,3 +33,6 @@
 /.cron.yml /@mozilla-mobile/releng @mozilla-mobile/act
 /automation/ @mozilla-mobile/releng @mozilla-mobile/act
 /CODEOWNERS @mozilla-mobile/releng @mozilla-mobile/act
+
+# Nearby component
+/components/lib/nearby @espertus @mozilla-mobile/act


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Adding @espertus as a code owner for the `lib-nearby` component.