### PR TITLE
For #6500 - Custom color for error text & icon in TextInputLayout

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/widget/LoginPanelTextInputLayout.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/widget/LoginPanelTextInputLayout.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.widget
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import androidx.annotation.StyleableRes
+import androidx.core.content.ContextCompat
+import androidx.core.content.withStyledAttributes
+import com.google.android.material.textfield.TextInputLayout
+import mozilla.components.feature.prompts.R
+
+internal class LoginPanelTextInputLayout(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : TextInputLayout(context, attrs, defStyleAttr) {
+    constructor(context: Context) : this(context, null, 0)
+
+    constructor(context: Context, attrs: AttributeSet? = null) : this(context, attrs, 0)
+
+    init {
+        context.withStyledAttributes(
+            attrs,
+            R.styleable.LoginPanelTextInputLayout,
+            defStyleAttr,
+            0
+        ) {
+
+            defaultHintTextColor = ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    context,
+                    R.color.mozacBoxStrokeColor
+                )
+            )
+
+            getColorOrNull(R.styleable.LoginPanelTextInputLayout_mozacInputLayoutErrorTextColor)?.let { color ->
+                setErrorTextColor(ColorStateList.valueOf(color))
+            }
+
+            getColorOrNull(R.styleable.LoginPanelTextInputLayout_mozacInputLayoutErrorIconColor)?.let { color ->
+                setErrorIconTintList(ColorStateList.valueOf(color))
+            }
+        }
+    }
+
+    private fun TypedArray.getColorOrNull(@StyleableRes styleableRes: Int): Int? {
+        val resourceId = this.getResourceId(styleableRes, 0)
+        return if (resourceId > 0) ContextCompat.getColor(context, resourceId) else null
+    }
+}

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompt_login_prompt.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompt_login_prompt.xml
@@ -47,9 +47,9 @@
         app:layout_goneMarginTop="8dp"
         tools:text="@string/mozac_feature_prompt_logins_save_message" />
 
-    <com.google.android.material.textfield.TextInputLayout
+    <mozilla.components.feature.prompts.widget.LoginPanelTextInputLayout
         android:id="@+id/userNameLayout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        style="@style/MozTextInputLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
@@ -67,11 +67,11 @@
             android:singleLine="true"
             android:textColor="?android:textColorPrimary"
             android:textSize="16sp" />
-    </com.google.android.material.textfield.TextInputLayout>
+    </mozilla.components.feature.prompts.widget.LoginPanelTextInputLayout>
 
-    <com.google.android.material.textfield.TextInputLayout
+    <mozilla.components.feature.prompts.widget.LoginPanelTextInputLayout
         android:id="@+id/password_text_input_layout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        style="@style/MozTextInputLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
@@ -96,18 +96,18 @@
             android:textColor="?android:textColorPrimary"
             android:textSize="16sp" />
 
-    </com.google.android.material.textfield.TextInputLayout>
+    </mozilla.components.feature.prompts.widget.LoginPanelTextInputLayout>
 
     <Button
         android:id="@+id/save_cancel"
-        style="?android:attr/borderlessButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="12dp"
+        android:backgroundTint="?android:colorEdgeEffect"
         android:text="@string/mozac_feature_prompt_dont_save"
         android:textAllCaps="false"
-        android:textColor="?android:colorEdgeEffect"
+        android:textColor="?android:windowBackground"
         android:textSize="14sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/components/feature/prompts/src/main/res/values/attrs.xml
+++ b/components/feature/prompts/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="LoginPanelTextInputLayout">
+        <attr name="mozacInputLayoutErrorTextColor" format="reference"/>
+        <attr name="mozacInputLayoutErrorIconColor" format="reference"/>
+    </declare-styleable>
+</resources>

--- a/components/feature/prompts/src/main/res/values/colors.xml
+++ b/components/feature/prompts/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <array name="mozac_feature_prompts_default_colors">
         <item>#D73920</item>
         <item>#FF8605</item>
@@ -14,4 +14,7 @@
         <item>#D4DDE4</item>
         <item>#FFFFFF</item>
     </array>
+    <color name="mozacBoxStrokeColor">#828282</color>
+    <color tools:override="true"
+        name="mtrl_textinput_default_box_stroke_color">@color/mozacBoxStrokeColor</color>
 </resources>

--- a/components/feature/prompts/src/main/res/values/styles.xml
+++ b/components/feature/prompts/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MozTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        <item name="boxStrokeColor">@color/mozacBoxStrokeColor</item>
+        <item name="boxStrokeWidth">2dp</item>
+    </style>
+</resources>


### PR DESCRIPTION
In addition, some changes to the look of the mentioned TextInputLayouts and Buttons needed to be done to be in compliance with the requirements.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
For https://github.com/mozilla-mobile/android-components/issues/6500

**Note:** Needs [PR 6504](https://github.com/mozilla-mobile/android-components/pull/6504) merged for this to work! 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR does not include any tests as it is only a minor visual change.
- [x] **Changelog**: This PR does not need a changelog entry
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

Screenshots contain some [changes to Fenix](https://github.com/mozilla-mobile/fenix/issues/8546) as well:

<img src="https://user-images.githubusercontent.com/60002907/78335658-b4f94280-7596-11ea-8ad2-859c571783b2.png" width="240"/>
<img src="https://user-images.githubusercontent.com/60002907/78335654-b296e880-7596-11ea-9b1e-8d6a14fb1ba3.png" width="240"/>

