### PR TITLE
For #6510 - Allow a different LayoutManager for TabsTray

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
@@ -23,7 +23,8 @@ class BrowserTabsTray @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-    val tabsAdapter: TabsAdapter = TabsAdapter()
+    val tabsAdapter: TabsAdapter = TabsAdapter(),
+    layout: LayoutManager = GridLayoutManager(context, 2)
 ) : RecyclerView(context, attrs, defStyleAttr),
     TabsTray by tabsAdapter {
 
@@ -32,7 +33,7 @@ class BrowserTabsTray @JvmOverloads constructor(
     init {
         tabsAdapter.tabsTray = this
 
-        layoutManager = GridLayoutManager(context, 2)
+        layoutManager = layout
         adapter = tabsAdapter
 
         val attr = context.obtainStyledAttributes(attrs, R.styleable.BrowserTabsTray, defStyleAttr, 0)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,6 +54,10 @@ permalink: /changelog/
   * Will expose a new `InputResult` enum through `getInputResult()` indicating how an EngineView handled user's MotionEvent.
   * See above changes to browser-engine-*.
 
+* **browser-tabstray**
+  * Will expose a new `layout` parameter which allows consumers to change the
+  tab tray layout.
+
 * **browser-toolbar**
   * `BrowserToolbarBottomBehavior` is now solely responsible to decide if the dynamic nav bar should animate or not.
   * See above changes to browser-engine-*, concept-engine.


### PR DESCRIPTION
Fixes #6510 
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
