### PR TITLE
For #6499 - Add min/max width support for BrowserMenu

### DIFF
--- a/components/browser/menu/README.md
+++ b/components/browser/menu/README.md
@@ -29,11 +29,20 @@ There are multiple properties that you customize of the menu browser by just add
     <!--Change the width of the menu-->
     <dimen name="mozac_browser_menu_width" tools:ignore="UnusedResources">250dp</dimen>
 
+    <!--Change the dynamic width of the menu-->
+    <dimen name="mozac_browser_menu_width_min" tools:ignore="UnusedResources">200dp</dimen>
+    <dimen name="mozac_browser_menu_width_max" tools:ignore="UnusedResources">300dp</dimen>
+
     <!--Change the top and bottom padding of the menu-->
     <dimen name="mozac_browser_menu_padding_vertical" tools:ignore="UnusedResources">8dp</dimen>
 
 </resources>
 ```
+BrowserMenu can have a dynamic width:
+- Using the same value for `mozac_browser_menu_width_min` and `mozac_browser_menu_width_max` means BrowserMenu will have a fixed width - `mozac_browser_menu_width`.
+_This is the default behavior_.
+- Different values for `mozac_browser_menu_width_min` and `mozac_browser_menu_width_max` means BrowserMenu will have a dynamic width depending on the widest BrowserMenuItem and between the aforementioned dimensions also taking into account display width.
+
 
 ### BrowserMenuDivider
 ```kotlin

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerView.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerView.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import androidx.annotation.VisibleForTesting
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.browser.menu.R
+
+/**
+ * [RecylerView] with automatically set width between widthMin / widthMax xml attributes.
+ */
+class DynamicWidthRecyclerView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : RecyclerView(context, attrs) {
+    @VisibleForTesting internal var minWidth: Int = -1
+    @VisibleForTesting internal var maxWidth: Int = -1
+
+    init {
+        context.obtainStyledAttributes(attrs, R.styleable.DynamicWidthRecyclerView).apply {
+            minWidth = getDimension(R.styleable.DynamicWidthRecyclerView_minWidth, minWidth.toFloat()).toInt()
+            maxWidth = getDimension(R.styleable.DynamicWidthRecyclerView_maxWidth, maxWidth.toFloat()).toInt()
+            recycle()
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    override fun onMeasure(widthSpec: Int, heightSpec: Int) {
+        if (minWidth in 1 until maxWidth) {
+            // Ignore any bounds set in xml. Allow for children to expand entirely.
+            callParentOnMeasure(MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED), heightSpec)
+
+            // Children now have "unspecified" width. Let's set some bounds.
+            setReconciledDimensions(measuredWidth, measuredHeight)
+        } else {
+            // Default behavior. layout_width / layout_height properties will be used for measuring.
+            callParentOnMeasure(widthSpec, heightSpec)
+        }
+    }
+
+    @VisibleForTesting()
+    internal fun setReconciledDimensions(
+        desiredWidth: Int,
+        desiredHeight: Int
+    ) {
+        val minimumWidth = desiredWidth.coerceAtLeast(minWidth)
+
+        val reconciledWidth = minimumWidth
+            .coerceAtMost(maxWidth)
+            // Sanity check our xml set maxWidth.
+            .coerceAtMost(getScreenWidth())
+
+        callSetMeasuredDimension(reconciledWidth, desiredHeight)
+    }
+
+    @VisibleForTesting()
+    internal fun getScreenWidth(): Int = resources.displayMetrics.widthPixels
+
+    @SuppressLint("WrongCall")
+    @VisibleForTesting()
+    // Used for testing protected super.onMeasure(..) calls will be executed.
+    internal fun callParentOnMeasure(widthSpec: Int, heightSpec: Int) {
+        super.onMeasure(widthSpec, heightSpec)
+    }
+
+    @VisibleForTesting()
+    // Used for testing final protected setMeasuredDimension(..) calls were executed
+    internal fun callSetMeasuredDimension(width: Int, height: Int) {
+        setMeasuredDimension(width, height)
+    }
+}

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu.xml
@@ -12,13 +12,15 @@
     app:cardElevation="@dimen/mozac_browser_menu_elevation"
     app:cardUseCompatPadding="true">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <mozilla.components.browser.menu.view.DynamicWidthRecyclerView
         android:id="@+id/mozac_browser_menu_recyclerView"
         android:paddingTop="@dimen/mozac_browser_menu_padding_vertical"
         android:paddingBottom="@dimen/mozac_browser_menu_padding_vertical"
         android:overScrollMode="never"
         android:layout_width="@dimen/mozac_browser_menu_width"
         android:layout_height="wrap_content"
+        app:maxWidth="@dimen/mozac_browser_menu_width_max"
+        app:minWidth="@dimen/mozac_browser_menu_width_min"
         tools:listitem="@layout/mozac_browser_menu_item_simple" />
 
 </androidx.cardview.widget.CardView>

--- a/components/browser/menu/src/main/res/values/attrs.xml
+++ b/components/browser/menu/src/main/res/values/attrs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<resources>
+    <declare-styleable name="DynamicWidthRecyclerView">
+        <!-- The minimum width the RecyclerView is allowed to be. -->
+        <attr name="minWidth" format="dimension"/>
+        <!-- The maximum width the RecyclerView is allowed to be.
+        Value will always be coerced to at most screen's width.-->
+        <attr name="maxWidth" format="dimension"/>
+    </declare-styleable>
+</resources>

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -6,6 +6,8 @@
     <dimen name="mozac_browser_menu_corner_radius">4dp</dimen>
     <dimen name="mozac_browser_menu_elevation">8dp</dimen>
     <dimen name="mozac_browser_menu_width">250dp</dimen>
+    <dimen name="mozac_browser_menu_width_min">250dp</dimen>
+    <dimen name="mozac_browser_menu_width_max">250dp</dimen>
     <dimen name="mozac_browser_menu_padding_vertical">0dp</dimen>
 
     <!--Menu Item -->

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerViewTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerViewTest.kt
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.view
+
+import android.util.AttributeSet
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+class DynamicWidthRecyclerViewTest {
+
+    @Test
+    fun `minWidth and maxWidth should be initialized from xml attributes`() {
+        val dynamicRecyclerView = DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 123, 456))
+
+        assertEquals(123, dynamicRecyclerView.minWidth)
+        assertEquals(456, dynamicRecyclerView.maxWidth)
+    }
+
+    @Test
+    fun `If minWidth and maxWidth are not provided view should use layout_width`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100)))
+
+        dynamicRecyclerView.measure(100, 100)
+
+        // View should not try calculate/reconcile new dimensions, it should just call super.onMeasure(..)
+        verify(dynamicRecyclerView).callParentOnMeasure(100, 100)
+        verify(dynamicRecyclerView, never()).setReconciledDimensions(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `If only minWidth is provided view should use layout_width`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(
+            testContext,
+            getCustomAttributesSet(layoutWidth = 100, minWidth = 50)
+        ))
+
+        dynamicRecyclerView.measure(100, 100)
+
+        // View should not try calculate/reconcile new dimensions, it should just call super.onMeasure(..)
+        verify(dynamicRecyclerView).callParentOnMeasure(100, 100)
+        verify(dynamicRecyclerView, never()).setReconciledDimensions(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `If only maxWidth is provided view should use layout_width`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(
+            testContext,
+            getCustomAttributesSet(layoutWidth = 100, maxWidth = 300)
+        ))
+
+        dynamicRecyclerView.measure(100, 100)
+
+        // View should not try calculate/reconcile new dimensions, it should just call super.onMeasure(..)
+        verify(dynamicRecyclerView).callParentOnMeasure(100, 100)
+        verify(dynamicRecyclerView, never()).setReconciledDimensions(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `Should only allow for dynamic width if minWidth has a positive value`() {
+        val dynamicRecyclerView = spy(
+            DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, -1, 100)))
+
+        dynamicRecyclerView.measure(1, 2)
+
+        // If minWidth has a negative value we should only just call super.onMeasure(..)
+        verify(dynamicRecyclerView).callParentOnMeasure(1, 2)
+        verify(dynamicRecyclerView, never()).setReconciledDimensions(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `Should only allow for dynamic width if minWidth is smaller than maxWidth`() {
+        val dynamicRecyclerView = spy(
+            DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 100, 100)))
+
+        dynamicRecyclerView.measure(1, 2)
+
+        // If minWidth is >= to maxWidth we should only just call super.onMeasure(..)
+        verify(dynamicRecyclerView).callParentOnMeasure(1, 2)
+        verify(dynamicRecyclerView, never()).setReconciledDimensions(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `To allow for dynamic width children can expand entirely between minWidth and maxWidth`() {
+        val dynamicRecyclerView = spy(
+            DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 50, 100)))
+
+        dynamicRecyclerView.measure(10, 10)
+
+        // To allow for children to be as wide as they want widthSpec should be 0
+        verify(dynamicRecyclerView).callParentOnMeasure(0, 10)
+        // Robolectric doesn't do any kind of measuring and always returns 0 for View measurements.
+        verify(dynamicRecyclerView).setReconciledDimensions(0, 0)
+    }
+
+    @Test
+    @Config(qualifiers = "w333dp")
+    fun `getScreenWidth() should return display's width in pixels`() {
+        val dynamicRecyclerView = DynamicWidthRecyclerView(testContext, null)
+
+        assertEquals(333, dynamicRecyclerView.getScreenWidth())
+    }
+
+    @Test
+    fun `setReconciledDimensions() must set minWidth even if children width is smaller`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 50, 100)))
+
+        dynamicRecyclerView.setReconciledDimensions(20, 100)
+
+        verify(dynamicRecyclerView).callSetMeasuredDimension(50, 100)
+    }
+
+    @Test
+    fun `setReconciledDimensions() will set children width if it is bigger than minWidth and smaller than maxWidth`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 50, 100)))
+
+        dynamicRecyclerView.setReconciledDimensions(60, 100)
+
+        verify(dynamicRecyclerView).callSetMeasuredDimension(60, 100)
+    }
+
+    @Test
+    fun `setReconciledDimensions() must set maxWidth even if children width is bigger`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 50, 100)))
+
+        dynamicRecyclerView.setReconciledDimensions(60, 100)
+
+        verify(dynamicRecyclerView).callSetMeasuredDimension(60, 100)
+    }
+
+    @Test
+    @Config(qualifiers = "w33dp")
+    fun `setReconciledDimensions() must set the width to as much as screen width even if maxWidth is bigger`() {
+        val dynamicRecyclerView = spy(DynamicWidthRecyclerView(testContext, getCustomAttributesSet(100, 50, 100)))
+
+        dynamicRecyclerView.setReconciledDimensions(60, 100)
+
+        verify(dynamicRecyclerView).callSetMeasuredDimension(33, 100)
+    }
+
+    private fun getCustomAttributesSet(layoutWidth: Int, minWidth: Int? = null, maxWidth: Int? = null): AttributeSet {
+        return Robolectric.buildAttributeSet().apply {
+            // android.R.attr.layout_width needs to always be set
+            addAttribute(android.R.attr.layout_width, "${layoutWidth}dp")
+
+            // R.attr.minWidth and R.attr.maxWidth are optional
+            minWidth?.let { addAttribute(R.attr.minWidth, "${minWidth}dp") }
+            maxWidth?.let { addAttribute(R.attr.maxWidth, "${maxWidth}dp") }
+        }.build()
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **feature-addons**
   * Added optional `addonAllowPrivateBrowsingLabelDrawableRes` DrawableRes parameter to `AddonPermissionsAdapter.Style` constructor to allow the clients to add their own drawable. This is used to clearly label the WebExtensions that run in private browsing.
 
+* **browser-menu**
+  * BrowserMenu will now support dynamic width based on two new attributes: `mozac_browser_menu_width_min` and `mozac_browser_menu_width_max`.
+
 # 40.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v39.0.0...v40.0.0)


### PR DESCRIPTION
BrowserMenu can now have a dynamic width allowing for a better fit for all menu items.:
- Using the same value for `mozac_browser_menu_width_min` and `mozac_browser_menu_width_max` means BrowserMenu will have a fixed width - `mozac_browser_menu_width`.
_This is the default behavior_.
- Different values for `mozac_browser_menu_width_min` and `mozac_browser_menu_width_max` means BrowserMenu will have a dynamic width depending on the widest BrowserMenuItem and between the aforementioned dimensions also taking into account display width.




[Video showing this being used by Fenix with a  `mozac_browser_menu_width_max` of 600dp.](https://drive.google.com/file/d/1MO8s3W0MN8v9Y2M0h3WyFFhgKEQal8gg/view?usp=sharing)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: No tests. Small layout change.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

Video showing how Fenix will 

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
