### PR TITLE
Closes #4397: Migrate feature-readerview to browser-state

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -28,7 +28,6 @@ import mozilla.components.browser.state.action.ContentAction.UpdateTitleAction
 import mozilla.components.browser.state.action.ContentAction.UpdateUrlAction
 import mozilla.components.browser.state.action.CustomTabListAction.RemoveCustomTabAction
 import mozilla.components.browser.state.action.EngineAction
-import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.TabListAction.AddTabAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.selector.findTabOrCustomTab
@@ -103,8 +102,6 @@ class Session(
         fun onContentPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onAppPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onCrashStateChanged(session: Session, crashed: Boolean) = Unit
-        fun onReaderableStateUpdated(session: Session, readerable: Boolean) = Unit
-        fun onReaderModeChanged(session: Session, enabled: Boolean) = Unit
         fun onRecordingDevicesChanged(session: Session, devices: List<RecordingDevice>) = Unit
         fun onLaunchIntentRequest(session: Session, url: String, appIntent: Intent?) = Unit
     }
@@ -454,22 +451,6 @@ class Session(
      */
     var crashed: Boolean by Delegates.observable(false) { _, old, new ->
         notifyObservers(old, new) { onCrashStateChanged(this@Session, new) }
-    }
-
-    /**
-     * Readerable state, whether or not the current page can be shown in a reader view.
-     */
-    var readerable: Boolean by Delegates.observable(false) { _, _, new ->
-        notifyObservers { onReaderableStateUpdated(this@Session, new) }
-        store?.syncDispatch(ReaderAction.UpdateReaderableAction(id, new))
-    }
-
-    /**
-     * Reader mode state, whether or not reader view is enabled, otherwise false.
-     */
-    var readerMode: Boolean by Delegates.observable(false) { _, old, new ->
-        notifyObservers(old, new) { onReaderModeChanged(this@Session, new) }
-        store?.syncDispatch(ReaderAction.UpdateReaderActiveAction(id, new))
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt
@@ -7,7 +7,6 @@ package mozilla.components.browser.session.ext
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.CustomTabSessionState
-import mozilla.components.browser.state.state.ReaderState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
@@ -22,7 +21,6 @@ fun Session.toTabSessionState(): TabSessionState {
         toContentState(),
         toTrackingProtectionState(),
         parentId = parentId,
-        readerState = toReaderState(),
         contextId = contextId
     )
 }
@@ -53,13 +51,6 @@ private fun Session.toContentState(): ContentState {
         securityInfo.toSecurityInfoState(),
         thumbnail
     )
-}
-
-/**
- * Creates a matching [ReaderState] from a [Session]
- */
-fun Session.toReaderState(): ReaderState {
-    return ReaderState(readerable, readerMode)
 }
 
 /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -18,7 +18,6 @@ import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.session.ext.toTabSessionState
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CustomTabListAction
-import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.CustomTabConfig
 import mozilla.components.browser.state.store.BrowserStore
@@ -731,7 +730,6 @@ class SessionTest {
         defaultObserver.onContentPermissionRequested(session, contentPermissionRequest)
         defaultObserver.onAppPermissionRequested(session, appPermissionRequest)
         defaultObserver.onWebAppManifestChanged(session, mock())
-        defaultObserver.onReaderableStateUpdated(session, true)
         defaultObserver.onRecordingDevicesChanged(session, emptyList())
     }
 
@@ -872,74 +870,6 @@ class SessionTest {
         session.crashed = false
         assertFalse(session.crashed)
         assertFalse(observedCrashState!!)
-    }
-
-    @Test
-    fun `observer is notified when readerable state updated`() {
-        val observer = mock(Session.Observer::class.java)
-
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-        assertFalse(session.readerable)
-
-        session.readerable = true
-
-        verify(observer).onReaderableStateUpdated(
-                eq(session),
-                eq(true))
-
-        // We want to notify observers every time readerability is determined,
-        // not only when the state changed.
-        session.readerable = true
-
-        verify(observer, times(2)).onReaderableStateUpdated(
-                eq(session),
-                eq(true))
-
-        assertTrue(session.readerable)
-    }
-
-    @Test
-    fun `action is dispatched when readerable state changes`() {
-        val store: BrowserStore = mock()
-        `when`(store.dispatch(any())).thenReturn(mock())
-
-        val session = Session("https://www.mozilla.org")
-        session.store = store
-        session.readerable = true
-
-        verify(store).dispatch(ReaderAction.UpdateReaderableAction(session.id, true))
-        verifyNoMoreInteractions(store)
-    }
-
-    @Test
-    fun `observer is notified when reader mode state changes`() {
-        val observer = mock(Session.Observer::class.java)
-
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-        assertFalse(session.readerMode)
-
-        session.readerMode = true
-
-        verify(observer).onReaderModeChanged(
-                eq(session),
-                eq(true))
-
-        assertTrue(session.readerMode)
-    }
-
-    @Test
-    fun `action is dispatched when reader mode state changes`() {
-        val store: BrowserStore = mock()
-        `when`(store.dispatch(any())).thenReturn(mock())
-
-        val session = Session("https://www.mozilla.org")
-        session.store = store
-        session.readerMode = true
-
-        verify(store).dispatch(ReaderAction.UpdateReaderActiveAction(session.id, true))
-        verifyNoMoreInteractions(store)
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/ext/SessionExtensionsTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/ext/SessionExtensionsTest.kt
@@ -30,20 +30,6 @@ class SessionExtensionsTest {
     }
 
     @Test
-    fun `toTabSessionState - Can convert tab session with reader state`() {
-        val session = Session("https://mozilla.org")
-        session.readerable = true
-        session.readerMode = true
-
-        val tabState = session.toTabSessionState()
-        assertEquals(tabState.id, session.id)
-        assertEquals(tabState.content.url, session.url)
-        assertEquals(tabState.readerState.readerable, true)
-        assertEquals(tabState.readerState.active, true)
-        assertNull(tabState.contextId)
-    }
-
-    @Test
     fun `toTabSessionState - Can convert tab session with contextId`() {
         val session = Session("https://mozilla.org", contextId = "1")
         val tabState = session.toTabSessionState()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -397,6 +397,16 @@ sealed class ReaderAction : BrowserAction() {
      * Updates the [ReaderState.active] flag.
      */
     data class UpdateReaderActiveAction(val tabId: String, val active: Boolean) : ReaderAction()
+
+    /**
+     * Updates the [ReaderState.checkRequired] flag.
+     */
+    data class UpdateReaderableCheckRequiredAction(val tabId: String, val checkRequired: Boolean) : ReaderAction()
+
+    /**
+     * Updates the [ReaderState.connectRequired] flag.
+     */
+    data class UpdateReaderConnectRequiredAction(val tabId: String, val connectRequired: Boolean) : ReaderAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
@@ -22,6 +22,12 @@ internal object ReaderStateReducer {
         is ReaderAction.UpdateReaderActiveAction -> state.copyWithReaderState(action.tabId) {
             it.copy(active = action.active)
         }
+        is ReaderAction.UpdateReaderableCheckRequiredAction -> state.copyWithReaderState(action.tabId) {
+            it.copy(checkRequired = action.checkRequired)
+        }
+        is ReaderAction.UpdateReaderConnectRequiredAction -> state.copyWithReaderState(action.tabId) {
+            it.copy(connectRequired = action.connectRequired)
+        }
     }
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
@@ -10,8 +10,14 @@ package mozilla.components.browser.state.state
  * @property readerable whether or not the current page can be transformed to
  * be displayed in a reader view.
  * @property active whether or not reader view is active.
+ * @property checkRequired whether or not a readerable check is required for the
+ * current page.
+ * @property connectRequired whether or not a new connection to the reader view
+ * content script is required.
  */
 data class ReaderState(
     val readerable: Boolean = false,
-    val active: Boolean = false
+    val active: Boolean = false,
+    val checkRequired: Boolean = false,
+    val connectRequired: Boolean = false
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
@@ -62,4 +62,34 @@ class ReaderActionTest {
 
         assertFalse(readerState().active)
     }
+
+    @Test
+    fun `UpdateReaderableCheckRequiredAction - Updates check required flag of ReaderState`() {
+        assertFalse(readerState().active)
+
+        store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(tabId = tab.id, checkRequired = true))
+            .joinBlocking()
+
+        assertTrue(readerState().checkRequired)
+
+        store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(tabId = tab.id, checkRequired = false))
+            .joinBlocking()
+
+        assertFalse(readerState().checkRequired)
+    }
+
+    @Test
+    fun `UpdateReaderConnectRequiredAction - Updates connect required flag of ReaderState`() {
+        assertFalse(readerState().active)
+
+        store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tabId = tab.id, connectRequired = true))
+            .joinBlocking()
+
+        assertTrue(readerState().connectRequired)
+
+        store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(tabId = tab.id, connectRequired = false))
+            .joinBlocking()
+
+        assertFalse(readerState().connectRequired)
+    }
 }

--- a/components/feature/readerview/build.gradle
+++ b/components/feature/readerview/build.gradle
@@ -21,9 +21,15 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
     implementation project(':browser-menu')
-    implementation project(':browser-session')
+    implementation project(':browser-state')
     implementation project(':concept-engine')
     implementation project(':support-base')
     implementation project(':support-ktx')
@@ -42,6 +48,7 @@ dependencies {
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
+    testImplementation Dependencies.testing_coroutines
 }
 
 apply from: '../../../publish.gradle'

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.readerview
+
+import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.action.ReaderAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_URL
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareStore
+import mozilla.components.support.webextensions.WebExtensionController
+
+/**
+ * [Middleware] implementation for translating [BrowserAction]s to
+ * [ReaderAction]s (e.g. if the URL is updated a new "readerable"
+ * check should be executed.)
+ */
+class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
+
+    @VisibleForTesting
+    internal var extensionController = WebExtensionController(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL)
+
+    override fun invoke(
+        store: MiddlewareStore<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction
+    ) {
+        preProcess(store, action)
+        next(action)
+        postProcess(store, action)
+    }
+
+    private fun preProcess(
+        store: MiddlewareStore<BrowserState, BrowserAction>,
+        action: BrowserAction
+    ) {
+        when (action) {
+            // We want to bind the feature instance to the lifecycle of the browser
+            // fragment so it won't necessarily be active when a tab is removed
+            // (e.g. via a tabs tray fragment). In order to disconnect the port as
+            // early as possible it's best to do it here directly.
+            is EngineAction.UnlinkEngineSessionAction -> {
+                store.state.findTab(action.sessionId)?.engineState?.engineSession?.let {
+                    extensionController.disconnectPort(it, READER_VIEW_EXTENSION_ID)
+                }
+            }
+        }
+    }
+
+    private fun postProcess(
+        store: MiddlewareStore<BrowserState, BrowserAction>,
+        action: BrowserAction
+    ) {
+        when (action) {
+            is TabListAction.SelectTabAction -> {
+                store.dispatch(ReaderAction.UpdateReaderableAction(action.tabId, false))
+                store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.tabId, true))
+            }
+            is ContentAction.UpdateUrlAction -> {
+                store.dispatch(ReaderAction.UpdateReaderableAction(action.sessionId, false))
+                store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.sessionId, true))
+            }
+            is EngineAction.LinkEngineSessionAction -> {
+                store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(action.sessionId, true))
+            }
+        }
+    }
+}

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewMiddlewareTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewMiddlewareTest.kt
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.readerview
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import mozilla.components.support.webextensions.WebExtensionController
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class ReaderViewMiddlewareTest {
+
+    @Test
+    fun `state is updated to connect content script port when tab is added and engine session linked`() {
+        val store = BrowserStore(
+            initialState = BrowserState(),
+            middleware = listOf(ReaderViewMiddleware())
+        )
+
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
+        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, mock())).joinBlocking()
+
+        val readerState = store.state.findTab(tab.id)!!.readerState
+        assertTrue(readerState.connectRequired)
+    }
+
+    @Test
+    fun `state is updated to disconnect content script port when tab is removed`() {
+        val tab = createTab("https://www.mozilla.org", id = "test-tab")
+        val engineSession: EngineSession = mock()
+        val controller: WebExtensionController = mock()
+        val middleware = ReaderViewMiddleware().apply {
+            extensionController = controller
+        }
+        val store = BrowserStore(
+            initialState = BrowserState(tabs = listOf(tab)),
+            middleware = listOf(middleware)
+        )
+
+        store.dispatch(EngineAction.LinkEngineSessionAction(tab.id, engineSession)).joinBlocking()
+        assertSame(engineSession, store.state.findTab(tab.id)?.engineState?.engineSession)
+        verify(controller, never()).disconnectPort(engineSession, READER_VIEW_EXTENSION_ID)
+
+        store.dispatch(EngineAction.UnlinkEngineSessionAction(tab.id)).joinBlocking()
+        assertNull(store.state.findTab(tab.id)?.engineState?.engineSession)
+        verify(controller).disconnectPort(engineSession, READER_VIEW_EXTENSION_ID)
+    }
+
+    @Test
+    fun `state is updated to trigger readerable check when new tab is selected`() {
+        val tab1 = createTab("https://www.mozilla.org", id = "test-tab1")
+        val tab2 = createTab("https://www.firefox.com", id = "test-tab2",
+            readerState = ReaderState(readerable = true)
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(tabs = listOf(tab1, tab2)),
+            middleware = listOf(ReaderViewMiddleware())
+        )
+        assertFalse(store.state.findTab(tab1.id)!!.readerState.checkRequired)
+        assertFalse(store.state.findTab(tab1.id)!!.readerState.readerable)
+        assertFalse(store.state.findTab(tab2.id)!!.readerState.checkRequired)
+        assertTrue(store.state.findTab(tab2.id)!!.readerState.readerable)
+
+        store.dispatch(TabListAction.SelectTabAction(tab2.id)).joinBlocking()
+        assertFalse(store.state.findTab(tab1.id)!!.readerState.readerable)
+        assertFalse(store.state.findTab(tab1.id)!!.readerState.checkRequired)
+        assertFalse(store.state.findTab(tab2.id)!!.readerState.readerable)
+        assertTrue(store.state.findTab(tab2.id)!!.readerState.checkRequired)
+    }
+
+    @Test
+    fun `state is updated to trigger readerable check when URL changes`() {
+        val tab = createTab("https://www.mozilla.org", id = "test-tab1")
+        val store = BrowserStore(
+            initialState = BrowserState(tabs = listOf(tab)),
+            middleware = listOf(ReaderViewMiddleware())
+        )
+        assertFalse(store.state.findTab(tab.id)!!.readerState.checkRequired)
+
+        store.dispatch(ContentAction.UpdateUrlAction(tab.id, "https://www.firefox.com")).joinBlocking()
+        assertTrue(store.state.findTab(tab.id)!!.readerState.checkRequired)
+    }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -71,7 +71,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             feature = ReaderViewIntegration(
                 requireContext(),
                 components.engine,
-                components.sessionManager,
+                components.store,
                 layout.toolbar,
                 layout.readerViewBar,
                 layout.readerViewAppearanceButton

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -53,6 +53,7 @@ import mozilla.components.feature.pwa.WebAppShortcutManager
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.pwa.intent.TrustedWebActivityIntentProcessor
 import mozilla.components.feature.pwa.intent.WebAppIntentProcessor
+import mozilla.components.feature.readerview.ReaderViewMiddleware
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.feature.session.SessionUseCases
@@ -108,7 +109,8 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     val store by lazy {
         BrowserStore(middleware = listOf(
-            MediaMiddleware(applicationContext, MediaService::class.java)
+            MediaMiddleware(applicationContext, MediaService::class.java),
+            ReaderViewMiddleware()
         ))
     }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
@@ -7,7 +7,8 @@ package org.mozilla.samples.browser.integration
 import android.content.Context
 import androidx.core.content.ContextCompat
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.selector.selectedTab
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.readerview.ReaderViewFeature
@@ -20,7 +21,7 @@ import org.mozilla.samples.browser.R
 class ReaderViewIntegration(
     context: Context,
     engine: Engine,
-    sessionManager: SessionManager,
+    store: BrowserStore,
     toolbar: BrowserToolbar,
     view: ReaderViewControlsView,
     readerViewAppearanceButton: FloatingActionButton
@@ -35,7 +36,7 @@ class ReaderViewIntegration(
         },
         contentDescription = context.getString(R.string.mozac_reader_view_description),
         contentDescriptionSelected = context.getString(R.string.mozac_reader_view_description_selected),
-        selected = sessionManager.selectedSession?.readerMode ?: false,
+        selected = store.state.selectedTab?.readerState?.active ?: false,
         visible = { readerViewButtonVisible }
     ) { enabled ->
         if (enabled) {
@@ -53,18 +54,11 @@ class ReaderViewIntegration(
         readerViewAppearanceButton.setOnClickListener { feature.showControls() }
     }
 
-    private val feature = ReaderViewFeature(context, engine, sessionManager, view) { available ->
+    private val feature = ReaderViewFeature(context, engine, store, view) { available, active ->
         readerViewButtonVisible = available
+        readerViewButton.setSelected(active)
 
-        // We've got an update on reader view availability e.g. because the page
-        // was refreshed or a new session selected. Let's make sure to also update
-        // the selected state of the reader mode toolbar button and show the
-        // appearance controls button if needed.
-        val readerModeActive = sessionManager.selectedSession?.readerMode ?: false
-        readerViewButton.setSelected(readerModeActive)
-
-        if (readerModeActive) readerViewAppearanceButton.show() else readerViewAppearanceButton.hide()
-
+        if (active) readerViewAppearanceButton.show() else readerViewAppearanceButton.hide()
         toolbar.invalidateActions()
     }
 


### PR DESCRIPTION
@pocmo Super happy with how the middleware worked out. It basically maps state to other (action/state), as relevant to reader view e.g. the url has changed -> a new reader check is required.

The other cases handled by the middleware are:
- User opens a tab via the context menu (may or may not switch to it directly)
- A new tab is selected
- A tab is removed (see comment in middleware)

All other functionality remains the same. Diff is big mostly because of test refactorings :)

I found another way that allows us to remove all reader state from the session right away! I am storing the state in the snapshot directly (same as `engineState`) and let the `SessionManager` deal with adding/deleting it based on the state in the store. This way we don't need to pass the store along to the serializer / session storage.