### PR TITLE
Closes #6550: Update Flank templates to use single and same device

### DIFF
--- a/automation/taskcluster/androidTest/flank-arm.yml
+++ b/automation/taskcluster/androidTest/flank-arm.yml
@@ -34,11 +34,7 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: shamu
-     version: 21
-   - model: sailfish 
-     version: 25
-   - model: sailfish 
+   - model: walleye
      version: 28
 
 flank:

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -34,8 +34,8 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: Nexus7
-     version: 21
+   - model: Pixel2
+     version: 28
 
 flank:
   project: GOOGLE_PROJECT


### PR DESCRIPTION
Similar to https://github.com/mozilla-mobile/fenix/pull/9745 and https://github.com/mozilla-mobile/reference-browser/pull/1109

> To reduce automation costs, one immediate action is to limit all Firebase Test Lab runs to one Android Virtual Device. This PR sets all Flank configuration templates to use the Pixel 2 on API 28. Note: On ARM the device is walleye

