### PR TITLE
Issue #6552: Add optional DividerItemDecoration parameters in BrowserTabsTray

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.tabstray
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.concept.tabstray.TabsTray
@@ -24,7 +25,8 @@ class BrowserTabsTray @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
     val tabsAdapter: TabsAdapter = TabsAdapter(),
-    layout: LayoutManager = GridLayoutManager(context, 2)
+    layout: LayoutManager = GridLayoutManager(context, 2),
+    itemDecoration: DividerItemDecoration? = null
 ) : RecyclerView(context, attrs, defStyleAttr),
     TabsTray by tabsAdapter {
 
@@ -35,6 +37,10 @@ class BrowserTabsTray @JvmOverloads constructor(
 
         layoutManager = layout
         adapter = tabsAdapter
+
+        if (itemDecoration != null) {
+            addItemDecoration(itemDecoration)
+        }
 
         val attr = context.obtainStyledAttributes(attrs, R.styleable.BrowserTabsTray, defStyleAttr, 0)
         styling = TabsTrayStyling(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,7 +54,7 @@ permalink: /changelog/
   * Added `GeckoEngineView#getInputResult()` to return an EngineView.InputResult indicating how a MotionEvent was handled by an EngineView.
 
 * **concept-engine**
-  * Will expose a new `InputResult` enum through `getInputResult()` indicating how an EngineView handled user's MotionEvent.
+  * Expose a new `InputResult` enum through `getInputResult()` indicating how an EngineView handled user's MotionEvent.
   * See above changes to browser-engine-*.
 
 * **browser-toolbar**
@@ -74,7 +74,8 @@ permalink: /changelog/
 * **browser-tabstray**
  * Added ability to let consumers pass a custom layout of `TabViewHolder` in order to control layout inflation and view binding.
  * Added an optional URL view to the `TabViewHolder` to display the URL.
- * Will expose a new `layout` parameter which allows consumers to change the tabs tray layout.
+ * Expose a new `layout` parameter which allows consumers to change the tabs tray layout.
+ * Expose a new optional `itemDecoration` parameter which allows consumers to provide a divider item decorations to the item views.
 
 # 37.0.0
 


### PR DESCRIPTION
Fixes #6552 


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
