### PR TITLE
For #6564 - Only display URL hostname for tabstray

### DIFF
--- a/components/browser/tabstray/build.gradle
+++ b/components/browser/tabstray/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(':ui-icons')
     implementation project(':ui-colors')
     implementation project(':support-base')
+    implementation project(':support-ktx')
 
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.androidx_cardview

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 
 /**
  * A RecyclerView ViewHolder implementation for "tab" items.
@@ -47,7 +48,7 @@ class TabViewHolder(
         }
 
         titleView.text = title
-        urlView?.text = tab.url
+        urlView?.text = tab.url.tryGetHostFromUrl()
 
         itemView.setOnClickListener {
             observable.notifyObservers { onTabSelected(tab) }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabViewHolderTest.kt
@@ -40,7 +40,19 @@ class TabViewHolderTest {
         holder.bind(session, isSelected = false, observable = mock())
 
         assertEquals("https://www.mozilla.org", titleView.text)
-        assertEquals("https://www.mozilla.org", urlView.text)
+        assertEquals("www.mozilla.org", urlView.text)
+    }
+
+    @Test
+    fun `URL text is set to tab URL when exception is thrown`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
+        val holder = TabViewHolder(view, mockTabsTrayWithStyles())
+        val session = Tab("a", "about:home")
+
+        holder.bind(session, isSelected = false, observable = mock())
+
+        assertEquals("about:home", urlView.text)
     }
 
     @Test
@@ -96,7 +108,7 @@ class TabViewHolderTest {
         holder.bind(session, isSelected = true, observable = registry)
 
         assertEquals(session.url, titleView.text)
-        assertEquals(session.url, urlView.text)
+        assertEquals("www.mozilla.org", urlView.text)
     }
 
     @Test
@@ -116,7 +128,7 @@ class TabViewHolderTest {
         holder.bind(session, isSelected = true, observable = registry)
 
         assertEquals("Mozilla Firefox", titleView.text)
-        assertEquals("https://www.mozilla.org", urlView.text)
+        assertEquals("www.mozilla.org", urlView.text)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -81,6 +81,7 @@ permalink: /changelog/
  * Added ability to let consumers pass a custom layout of `TabViewHolder` in order to control layout inflation and view binding.
  * Added an optional URL view to the `TabViewHolder` to display the URL.
  * Will expose a new `layout` parameter which allows consumers to change the tabs tray layout.
+ * Will only display a URL's hostname instead of the entire URL
 
 # 37.0.0
 


### PR DESCRIPTION
Fixes #6564. We don't want the entire URL, just the hostname, per @topotropic's direction.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
