### PR TITLE
Close #6567: Return result of block in runWithSessionIdOrSelected

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -452,7 +452,7 @@ class SessionManager(
 /**
  * Tries to find a session with the provided session ID and runs the block if found.
  *
- * @return True if the session was found and run successfully.
+ * @return The result of the [block] executed.
  */
 fun SessionManager.runWithSession(
     sessionId: String?,
@@ -469,21 +469,20 @@ fun SessionManager.runWithSession(
 /**
  * Tries to find a session with the provided session ID or uses the selected session and runs the block if found.
  *
- * @return True if the session was found and run successfully.
+ * @return The result of the [block] executed.
  */
 fun SessionManager.runWithSessionIdOrSelected(
     sessionId: String?,
-    block: SessionManager.(Session) -> Unit
+    block: SessionManager.(Session) -> Boolean
 ): Boolean {
     sessionId?.let {
         findSessionById(sessionId)?.let { session ->
-            block(session)
-            return true
+            return block(session)
         }
     }
     selectedSession?.let {
-        block(it)
-        return true
+        return block(it)
     }
+
     return false
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -1161,7 +1161,7 @@ class SessionManagerTest {
 
         `when`(sessionManager.findSessionById(anyString())).thenReturn(mock())
 
-        val executed = sessionManager.runWithSessionIdOrSelected("123") { }
+        val executed = sessionManager.runWithSessionIdOrSelected("123") { true }
 
         assertTrue(executed)
     }
@@ -1170,11 +1170,11 @@ class SessionManagerTest {
     fun `SessionManager#runWithSessionIdOrSelected with null or empty session ID`() {
         val sessionManager = spy(SessionManager(mock()))
 
-        var executed = sessionManager.runWithSessionIdOrSelected(null) { }
+        var executed = sessionManager.runWithSessionIdOrSelected(null) { true }
 
         assertFalse(executed)
 
-        executed = sessionManager.runWithSessionIdOrSelected("") { }
+        executed = sessionManager.runWithSessionIdOrSelected("") { true }
         assertFalse(executed)
     }
 
@@ -1188,6 +1188,7 @@ class SessionManagerTest {
         var selectedSessionId = "123"
         val executed = sessionManager.runWithSessionIdOrSelected(null) { session ->
             selectedSessionId = session.id
+            true
         }
 
         assertTrue(executed)
@@ -1207,6 +1208,7 @@ class SessionManagerTest {
         var runSessionId = "123"
         val executed = sessionManager.runWithSessionIdOrSelected("anotherSessionId") { session ->
             runSessionId = session.id
+            true
         }
 
         assertTrue(executed)

--- a/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FxaWebChannelFeature.kt
+++ b/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FxaWebChannelFeature.kt
@@ -70,6 +70,7 @@ class FxaWebChannelFeature(
 
         sessionManager.runWithSessionIdOrSelected(customTabSessionId) { session ->
             registerFxaContentMessageHandler(session)
+            true
         }
 
         extensionController.install(engine)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -76,6 +76,9 @@ permalink: /changelog/
  * Added an optional URL view to the `TabViewHolder` to display the URL.
  * Will expose a new `layout` parameter which allows consumers to change the tabs tray layout.
 
+* **browser-session**
+  * ⚠️ **This is a breaking change**: `SessionManager.runWithSessionIdOrSelected` now returns the result from the `block` it executes. This is consistent with `runWithSession`.
+
 # 37.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v36.0.0...v37.0.0)


### PR DESCRIPTION
This is consistent with our behaviour in `runWithSession` and is more in
line with what a consumer would expect.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Closes #6567 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
