### PR TITLE
Close #6456: Allow empty body in AutoPush messages.

### DIFF
--- a/components/concept/push/src/main/java/mozilla/components/concept/push/PushProcessor.kt
+++ b/components/concept/push/src/main/java/mozilla/components/concept/push/PushProcessor.kt
@@ -70,7 +70,7 @@ interface PushProcessor {
  */
 data class EncryptedPushMessage(
     val channelId: String,
-    val body: String,
+    val body: String?,
     val encoding: String,
     val salt: String = "",
     val cryptoKey: String = "" // diffie–hellman key
@@ -84,7 +84,7 @@ data class EncryptedPushMessage(
          */
         operator fun invoke(
             channelId: String,
-            body: String,
+            body: String?,
             encoding: String,
             salt: String? = null,
             cryptoKey: String? = null

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/Connection.kt
@@ -7,8 +7,8 @@ package mozilla.components.feature.push
 import androidx.annotation.GuardedBy
 import androidx.annotation.VisibleForTesting
 import mozilla.appservices.push.BridgeType
+import mozilla.appservices.push.GeneralError
 import mozilla.appservices.push.PushAPI
-import mozilla.appservices.push.PushError
 import mozilla.appservices.push.PushManager
 import mozilla.appservices.push.PushSubscriptionChanged as SubscriptionChanged
 import mozilla.appservices.push.SubscriptionResponse
@@ -171,9 +171,7 @@ internal class RustPushConnection(
         // This call will fail if we haven't 'subscribed' yet.
         return try {
             pushApi.update(token)
-        } catch (e: PushError) {
-            // Once we get GeneralError, let's catch that instead:
-            // https://github.com/mozilla/application-services/issues/2541
+        } catch (e: GeneralError) {
             val fakeChannelId = "fake".toChannelId()
             // It's possible that we have a race (on a first run) between 'subscribing' and setting a token.
             // 'update' expects that we've called 'subscribe' (which would obtain a 'uaid' from an autopush

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -141,7 +141,7 @@ class AutoPushFeatureTest {
         whenever(encryptedMessage.channelId).thenReturn("992a0f0542383f1ea5ef51b7cf4ae6c4")
         whenever(connection.decryptMessage(any(), any(), any(), any(), any()))
             .thenReturn(null) // If we get null, we shouldn't notify observers.
-            .thenReturn("testScope" to "test".toByteArray())
+            .thenReturn(DecryptedMessage("testScope", "test".toByteArray()))
 
         val feature = spy(AutoPushFeature(testContext, mock(), mock(), coroutineContext, connection))
 
@@ -347,13 +347,11 @@ class AutoPushFeatureTest {
 
         override suspend fun decryptMessage(
             channelId: String,
-            body: String,
+            body: String?,
             encoding: String,
             salt: String,
             cryptoKey: String
-        ): Pair<PushScope, ByteArray>? {
-            TODO("not implemented")
-        }
+        ): DecryptedMessage? = null
 
         override fun isInitialized() = init
 

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/ConnectionKtTest.kt
@@ -11,6 +11,7 @@ import mozilla.appservices.push.SubscriptionInfo
 import mozilla.appservices.push.SubscriptionResponse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ConnectionKtTest {
@@ -59,5 +60,41 @@ class ConnectionKtTest {
         val sub = response.toPushSubscriptionChanged()
         assertEquals(response.channelID, sub.channelId)
         assertEquals(response.scope, sub.scope)
+    }
+
+    @Test
+    fun `decrypted message equals`() {
+        val message1 = DecryptedMessage("test", "message1".toByteArray())
+        val message2 = DecryptedMessage("test", "message2".toByteArray())
+
+        assertTrue(message1 != message2)
+
+        val message3 = DecryptedMessage("test", "message".toByteArray())
+        val message4 = DecryptedMessage("test", null)
+
+        assertTrue(message3 != message4)
+
+        val message5 = DecryptedMessage("test", null)
+        val message6 = DecryptedMessage("test", "message".toByteArray())
+
+        assertTrue(message5 != message6)
+
+        val message7 = DecryptedMessage("test", "message".toByteArray())
+        val message8 = DecryptedMessage("test", "message".toByteArray())
+
+        assertTrue(message7 == message8)
+    }
+
+    @Test
+    fun `decrypted message hashcode`() {
+        val message1 = DecryptedMessage("test", "message1".toByteArray())
+        val message2 = DecryptedMessage("test", "message2".toByteArray())
+
+        assertTrue(message1.hashCode() != message2.hashCode())
+
+        val message3 = DecryptedMessage("test", "message".toByteArray())
+        val message4 = DecryptedMessage("test", "message".toByteArray())
+
+        assertTrue(message3.hashCode() == message4.hashCode())
     }
 }

--- a/components/lib/push-amazon/src/main/java/mozilla/components/lib/push/amazon/AbstractAmazonPushService.kt
+++ b/components/lib/push-amazon/src/main/java/mozilla/components/lib/push/amazon/AbstractAmazonPushService.kt
@@ -59,8 +59,8 @@ abstract class AbstractAmazonPushService : ADMMessageHandlerBase("AbstractAmazon
             val message = try {
                 EncryptedPushMessage(
                     channelId = it.getStringWithException("chid"),
-                    body = it.getStringWithException("body"),
                     encoding = it.getStringWithException("con"),
+                    body = it.getString("body"),
                     salt = it.getString("enc"),
                     cryptoKey = it.getString("cryptokey")
                 )

--- a/components/lib/push-amazon/src/test/java/mozilla/components/lib/push/amazon/AbstractAmazonPushServiceTest.kt
+++ b/components/lib/push-amazon/src/test/java/mozilla/components/lib/push/amazon/AbstractAmazonPushServiceTest.kt
@@ -102,7 +102,7 @@ class AbstractAmazonPushServiceTest {
     fun `malformed message exception handled with the processor`() {
         val messageIntent = Intent()
         val bundleExtra = Bundle()
-        bundleExtra.putString("body", "contents")
+        bundleExtra.putString("con", "qu2to2")
 
         val captor = argumentCaptor<PushError>()
         messageIntent.putExtras(bundleExtra)

--- a/components/lib/push-firebase/src/main/java/mozilla/components/lib/push/firebase/AbstractFirebasePushService.kt
+++ b/components/lib/push-firebase/src/main/java/mozilla/components/lib/push/firebase/AbstractFirebasePushService.kt
@@ -53,8 +53,8 @@ abstract class AbstractFirebasePushService(
             val message = try {
                 EncryptedPushMessage(
                     channelId = it.data.getValue(MESSAGE_KEY_CHANNEL_ID),
-                    body = it.data.getValue(MESSAGE_KEY_BODY),
                     encoding = it.data.getValue(MESSAGE_KEY_ENCODING),
+                    body = it.data[MESSAGE_KEY_BODY],
                     salt = it.data[MESSAGE_KEY_SALT],
                     cryptoKey = it.data[MESSAGE_KEY_CRYPTO_KEY]
                 )

--- a/components/lib/push-firebase/src/test/java/mozilla/components/lib/push/firebase/AbstractFirebasePushServiceTest.kt
+++ b/components/lib/push-firebase/src/test/java/mozilla/components/lib/push/firebase/AbstractFirebasePushServiceTest.kt
@@ -77,8 +77,8 @@ class AbstractFirebasePushServiceTest {
         val remoteMessage: RemoteMessage = mock()
         val data = mapOf(
             "chid" to "1234",
-            "con" to "encoding",
             "enc" to "salt",
+            "body" to "oo3j532j4",
             "cryptokey" to "dh256"
         )
         val captor = argumentCaptor<PushError>()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -85,6 +85,9 @@ permalink: /changelog/
 * **browser-session**
   * ⚠️ **This is a breaking change**: `SessionManager.runWithSessionIdOrSelected` now returns the result from the `block` it executes. This is consistent with `runWithSession`.
 
+* **feature-push**
+  * Allow nullable AutoPush messages to be delivered to observers.
+
 # 37.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v36.0.0...v37.0.0)


### PR DESCRIPTION
Allows nullable messages to be delivered to all observers. This was partly handled from the consumer-facing public API, but nullable messages were dropped when they were received from the push services.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Close #6456

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- [ ] **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
