### PR TITLE
[ci skip] Bug 1620585 - reduce frequency for building snapshots

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -10,8 +10,9 @@ jobs:
           treeherder-symbol: snapshot-D
           target-tasks-method: snapshot
       when:
-          - {hour: 13, minute: 0}
-          - {hour: 19, minute: 0}
+          - {weekday: 'Monday', hour: 13, minute: 0}
+          - {weekday: 'Wednesday', hour: 13, minute: 0}
+          - {weekday: 'Friday', hour: 13, minute: 0}
     - name: nightly
       job:
           type: decision-task


### PR DESCRIPTION
We've added reproducible nightlies in https://bugzilla.mozilla.org/show_bug.cgi?id=1615248 to be published under nightly.maven.mozilla.org/. As far as I understood, all the major projects have switched to using them instead of snapshots. Time to retire the latter then. 

First let's start with reducing the frequency from 10 times a week to three times a week and see if there are any downstream consumers that we don't know of that might have oversight. If nobody complains, I'll remove them completely in a week from now on.