### PR TITLE
Closes #6633: Reduce AMO read timeout for migration

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonsProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonsProvider.kt
@@ -14,6 +14,8 @@ interface AddonsProvider {
      *
      * @param allowCache whether or not the result may be provided
      * from a previously cached response, defaults to true.
+     * @param readTimeoutInSeconds optional timeout in seconds to use when fetching
+     * available add-ons from a remote endpoint.
      */
-    suspend fun getAvailableAddons(allowCache: Boolean = true): List<Addon>
+    suspend fun getAvailableAddons(allowCache: Boolean = true, readTimeoutInSeconds: Long? = null): List<Addon>
 }

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -31,7 +31,7 @@ internal const val DEFAULT_SERVER_URL = "https://addons.mozilla.org"
 internal const val DEFAULT_COLLECTION_NAME = "7e8d6dc651b54ab385fb8791bf9dac"
 internal const val COLLECTION_FILE_NAME = "mozilla_components_addon_collection_%s.json"
 internal const val MINUTE_IN_MS = 60 * 1000
-internal const val READ_TIMEOUT_IN_SECONDS = 20L
+internal const val DEFAULT_READ_TIMEOUT_IN_SECONDS = 20L
 
 /**
  * Provide access to the collections AMO API.
@@ -64,11 +64,14 @@ class AddonCollectionProvider(
      *
      * @param allowCache whether or not the result may be provided
      * from a previously cached response, defaults to true.
+     * @param readTimeoutInSeconds optional timeout in seconds to use when fetching
+     * available add-ons from a remote endpoint. If not specified [DEFAULT_READ_TIMEOUT_IN_SECONDS]
+     * will be used.
      * @throws IOException if the request failed, or could not be executed due to cancellation,
      * a connectivity problem or a timeout.
      */
     @Throws(IOException::class)
-    override suspend fun getAvailableAddons(allowCache: Boolean): List<Addon> {
+    override suspend fun getAvailableAddons(allowCache: Boolean, readTimeoutInSeconds: Long?): List<Addon> {
         val cachedAddons = if (allowCache && !cacheExpired(context)) {
             readFromDiskCache()
         } else {
@@ -78,7 +81,7 @@ class AddonCollectionProvider(
         return cachedAddons ?: client.fetch(
                 Request(
                     url = "$serverURL/$API_VERSION/accounts/account/mozilla/collections/$collectionName/addons",
-                    readTimeout = Pair(READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+                    readTimeout = Pair(readTimeoutInSeconds ?: DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
                 )
             )
             .use { response ->

--- a/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
+++ b/components/feature/addons/src/test/java/AddonCollectionProviderTest.kt
@@ -135,11 +135,33 @@ class AddonCollectionProviderTest {
             assertTrue(addon.authors.isEmpty())
             verify(mockedClient).fetch(Request(
                 url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/7e8d6dc651b54ab385fb8791bf9dac/addons",
-                readTimeout = Pair(READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
+                readTimeout = Pair(DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
             ))
 
             // Ratings
             assertNull(addon.rating)
+        }
+    }
+
+    @Test
+    fun `getAvailableAddons - read timeout can be configured`() {
+        val jsonResponse = loadResourceAsString("/collection_with_empty_values.json")
+        val mockedClient = mock<Client>()
+        val mockedResponse = mock<Response>()
+        val mockedBody = mock<Response.Body>()
+        whenever(mockedBody.string(any())).thenReturn(jsonResponse)
+        whenever(mockedResponse.body).thenReturn(mockedBody)
+        whenever(mockedResponse.status).thenReturn(200)
+        whenever(mockedClient.fetch(any())).thenReturn(mockedResponse)
+
+        val provider = spy(AddonCollectionProvider(testContext, client = mockedClient))
+
+        runBlocking {
+            provider.getAvailableAddons(readTimeoutInSeconds = 5)
+            verify(mockedClient).fetch(Request(
+                url = "https://addons.mozilla.org/api/v4/accounts/account/mozilla/collections/7e8d6dc651b54ab385fb8791bf9dac/addons",
+                readTimeout = Pair(5, TimeUnit.SECONDS)
+            ))
         }
     }
 

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -47,6 +47,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
@@ -77,7 +78,7 @@ class AddonManagerTest {
         val addon2 = Addon(id = "ext2")
         val addon3 = Addon(id = "ext3")
         val addonsProvider: AddonsProvider = mock()
-        whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenReturn(listOf(addon1, addon2, addon3))
+        whenever(addonsProvider.getAvailableAddons(anyBoolean(), eq(null))).thenReturn(listOf(addon1, addon2, addon3))
 
         // Prepare engine
         val engine: Engine = mock()
@@ -164,7 +165,7 @@ class AddonManagerTest {
         }
 
         val addonsProvider: AddonsProvider = mock()
-        whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenThrow(IllegalStateException("test"))
+        whenever(addonsProvider.getAvailableAddons(anyBoolean(), anyLong())).thenThrow(IllegalStateException("test"))
         WebExtensionSupport.initialize(engine, store)
 
         AddonManager(store, mock(), addonsProvider, mock()).getAddons()
@@ -189,7 +190,7 @@ class AddonManagerTest {
         }
 
         val addonsProvider: AddonsProvider = mock()
-        whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenReturn(listOf(addon))
+        whenever(addonsProvider.getAvailableAddons(anyBoolean(), eq(null))).thenReturn(listOf(addon))
         WebExtensionSupport.initialize(engine, store)
 
         val addons = AddonManager(store, mock(), addonsProvider, mock()).getAddons()
@@ -221,7 +222,7 @@ class AddonManagerTest {
         val addonsProvider: AddonsProvider = mock()
 
         runBlocking {
-            whenever(addonsProvider.getAvailableAddons(anyBoolean())).thenReturn(listOf(addon))
+            whenever(addonsProvider.getAvailableAddons(anyBoolean(), eq(null))).thenReturn(listOf(addon))
             WebExtensionSupport.initialize(engine, store)
             WebExtensionSupport.installedExtensions[addon.id] = extension
         }

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
@@ -18,6 +18,9 @@ import mozilla.components.feature.addons.update.AddonUpdater
 @VisibleForTesting
 internal var supportedAddonsFallback = listOf("uBlock0@raymondhill.net")
 
+@VisibleForTesting
+internal const val AMO_READ_TIMEOUT_IN_SECONDS = 5L
+
 /**
  * Wraps [AddonMigrationResult] in an exception so that it can be returned via [Result.Failure].
  *
@@ -106,7 +109,9 @@ internal object AddonMigration {
         }
 
         val supportedAddonIds = try {
-            addonCollectionProvider.getAvailableAddons().mapNotNull { it.id }
+            addonCollectionProvider.getAvailableAddons(
+                readTimeoutInSeconds = AMO_READ_TIMEOUT_IN_SECONDS
+            ).mapNotNull { it.id }
         } catch (e: Exception) {
             supportedAddonsFallback
         }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/AddonMigrationTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.feature.addons.amo.AddonCollectionProvider
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
@@ -61,7 +62,9 @@ class AddonMigrationTest {
         val engine: Engine = mock()
         val addonCollectionProvider: AddonCollectionProvider = mock()
         val supportedAddons = listOf(Addon(addon1.id), Addon(addon2.id))
-        whenever(addonCollectionProvider.getAvailableAddons(anyBoolean())).thenReturn(supportedAddons)
+        whenever(
+            addonCollectionProvider.getAvailableAddons(anyBoolean(), eq(AMO_READ_TIMEOUT_IN_SECONDS))
+        ).thenReturn(supportedAddons)
 
         val listSuccessCallback = argumentCaptor<((List<WebExtension>) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(listSuccessCallback.capture(), any())).thenAnswer {
@@ -160,7 +163,9 @@ class AddonMigrationTest {
         val engine: Engine = mock()
         val addonCollectionProvider: AddonCollectionProvider = mock()
         // No supported add-on
-        whenever(addonCollectionProvider.getAvailableAddons(anyBoolean())).thenReturn(emptyList())
+        whenever(
+            addonCollectionProvider.getAvailableAddons(anyBoolean(), eq(AMO_READ_TIMEOUT_IN_SECONDS))
+        ).thenReturn(emptyList())
 
         val listSuccessCallback = argumentCaptor<((List<WebExtension>) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(listSuccessCallback.capture(), any())).thenAnswer {


### PR DESCRIPTION
Makes the timeout configurable and uses 5s for migration.