### PR TITLE
Bug 1620585 - remove snapshots from cron.

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -4,15 +4,6 @@
 ---
 
 jobs:
-    - name: snapshot
-      job:
-          type: decision-task
-          treeherder-symbol: snapshot-D
-          target-tasks-method: snapshot
-      when:
-          - {weekday: 'Monday', hour: 13, minute: 0}
-          - {weekday: 'Wednesday', hour: 13, minute: 0}
-          - {weekday: 'Friday', hour: 13, minute: 0}
     - name: nightly
       job:
           type: decision-task


### PR DESCRIPTION
Follow-up from https://github.com/mozilla-mobile/android-components/pull/6598 to reduce the snapshots building close to zero. It's been almost a week and AFAIk nobody complained. So I'd say we stop generating these, wait for another week and then retire all the associated logic as well + TC resources.