### PR TITLE
Closes #5748: Provide API to cancel add-on installation

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
@@ -4,9 +4,12 @@
 
 package mozilla.components.browser.engine.gecko
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.launch
+import mozilla.components.concept.engine.CancellableOperation
 import org.mozilla.geckoview.GeckoResult
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -25,6 +28,26 @@ suspend fun <T> GeckoResult<T>.await() = suspendCoroutine<T?> { continuation ->
         continuation.resumeWithException(it)
         GeckoResult<Void>()
     })
+}
+
+/**
+ * Converts a [GeckoResult] to a [CancellableOperation].
+ */
+fun <T> GeckoResult<T>.asCancellableOperation(): CancellableOperation {
+    val geckoResult = this
+    return object : CancellableOperation {
+        override fun cancel(): Deferred<Boolean> {
+            val result = CompletableDeferred<Boolean>()
+            geckoResult.cancel().then({
+                result.complete(it ?: false)
+                GeckoResult<Void>()
+            }, { throwable ->
+                result.completeExceptionally(throwable)
+                GeckoResult<Void>()
+            })
+            return result
+        }
+    }
 }
 
 /**

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
@@ -4,9 +4,12 @@
 
 package mozilla.components.browser.engine.gecko
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.launch
+import mozilla.components.concept.engine.CancellableOperation
 import org.mozilla.geckoview.GeckoResult
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -25,6 +28,26 @@ suspend fun <T> GeckoResult<T>.await() = suspendCoroutine<T?> { continuation ->
         continuation.resumeWithException(it)
         GeckoResult<Void>()
     })
+}
+
+/**
+ * Converts a [GeckoResult] to a [CancellableOperation].
+ */
+fun <T> GeckoResult<T>.asCancellableOperation(): CancellableOperation {
+    val geckoResult = this
+    return object : CancellableOperation {
+        override fun cancel(): Deferred<Boolean> {
+            val result = CompletableDeferred<Boolean>()
+            geckoResult.cancel().then({
+                result.complete(it ?: false)
+                GeckoResult<Void>()
+            }, { throwable ->
+                result.completeExceptionally(throwable)
+                GeckoResult<Void>()
+            })
+            return result
+        }
+    }
 }
 
 /**

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/CancellableOperation.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/CancellableOperation.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+
+/**
+ * Represents an async operation that can be cancelled.
+ */
+interface CancellableOperation {
+
+    /**
+     * Implementation of [CancellableOperation] that does nothing (for
+     * testing purposes or implementing default methods.)
+     */
+    class Noop : CancellableOperation {
+        override fun cancel(): Deferred<Boolean> {
+            return CompletableDeferred(true)
+        }
+    }
+
+    /**
+     * Cancels this operation.
+     *
+     * @return a deferred value indicating whether or not cancellation was successful.
+     */
+    fun cancel(): Deferred<Boolean>
+}

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.engine.webextension
 
+import mozilla.components.concept.engine.CancellableOperation
 import java.lang.UnsupportedOperationException
 
 /**
@@ -37,7 +38,10 @@ interface WebExtensionRuntime {
         supportActions: Boolean = false,
         onSuccess: ((WebExtension) -> Unit) = { },
         onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): Unit = onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
+    ): CancellableOperation {
+        onError(id, UnsupportedOperationException("Web extension support is not available in this engine"))
+        return CancellableOperation.Noop()
+    }
 
     /**
      * Updates the provided [extension] if a new version is available.


### PR DESCRIPTION
This is working but ran into a crash that happens when cancelling too late (after the extension was downloaded but before it was installed): https://bugzilla.mozilla.org/show_bug.cgi?id=1629952

So, let's not wire up the UI just yet: https://github.com/mozilla-mobile/android-components/issues/6644

Notes:
- We may eventually turn the returned operation into a full `CompletableFuture`-like type that supports `cancel` as well, and remove our callbacks, but this is a pretty big refactoring that I am not fully convinced of yet :)
- Cancel returns another `GeckoResult` to indicate if cancellation worked, which I am wrapping in a `Deferred` so we can `await` on it and prevent another round of callbacks. This works out quite well in the UI: https://github.com/mozilla-mobile/android-components/commit/1dbbd7eba02cdac80c43f9ed8eaf12bb0a3c754b