### PR TITLE
Close #6648: After AUDIOFOCUS_LOSS_TRANSIENT only resume playing if media was playing before loss

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/ext/MediaState.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/ext/MediaState.kt
@@ -145,3 +145,13 @@ fun MediaState.playIfPaused() {
         getActiveElements().play()
     }
 }
+
+/**
+ * If this state is [MediaState.State.PLAYING] then return true, else return false.
+ */
+fun MediaState.playing(): Boolean {
+    return when (aggregate.state) {
+        MediaState.State.PLAYING -> true
+        else -> false
+    }
+}

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocus.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/focus/AudioFocus.kt
@@ -12,6 +12,7 @@ import mozilla.components.feature.media.ext.getActiveElements
 import mozilla.components.feature.media.ext.pause
 import mozilla.components.feature.media.ext.pauseIfPlaying
 import mozilla.components.feature.media.ext.playIfPaused
+import mozilla.components.feature.media.ext.playing
 import mozilla.components.support.base.log.logger.Logger
 
 /**
@@ -93,9 +94,9 @@ internal class AudioFocus(
             }
 
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
-                resumeOnFocusGain = true
-                playDelayed = false
                 state.pauseIfPlaying()
+                resumeOnFocusGain = state.playing()
+                playDelayed = false
             }
 
             else -> {


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
