### PR TITLE
For #2930 - Different BrowserToolbar behaviors depending on gestures

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetector.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetector.kt
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.behavior
+
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.ScaleGestureDetector
+import androidx.annotation.VisibleForTesting
+import kotlin.math.abs
+
+/**
+ * Custom [MotionEvent] gestures detector with scroll / zoom callbacks.
+ *
+ * Favors zoom gestures in detriment of the scroll gestures with:
+ *  - higher sensitivity for multi-finger zoom gestures
+ *  - ignoring scrolls if zoom is in progress
+ *
+ *  @param applicationContext context used for registering internal gesture listeners.
+ *  @param listener client interested in zoom / scroll events.
+ */
+internal class BrowserGestureDetector(
+    applicationContext: Context,
+    listener: GesturesListener
+) {
+    /**
+     * Accepts MotionEvents and dispatches zoom / scroll events to the registered listener when appropriate.
+     *
+     * Applications should pass a complete and consistent event stream to this method.
+     * A complete and consistent event stream involves all MotionEvents from the initial ACTION_DOWN
+     * to the final ACTION_UP or ACTION_CANCEL.
+     *
+     * @return if the event was handled by any of the registered detectors
+     */
+    internal fun handleTouchEvent(event: MotionEvent): Boolean {
+        // A double tap for a quick scale gesture (quick double tap followed by a drag)
+        // would trigger a ACTION_CANCEL event before the MOVE_EVENT.
+        // This would prevent the scale detector from properly inferring the movement.
+        // We'll want to ignore ACTION_CANCEL but process the next stream of events.
+        if (event.actionMasked != MotionEvent.ACTION_CANCEL) {
+            scaleGestureDetector.onTouchEvent(event)
+        }
+
+        // Ignore scrolling if zooming is already in progress.
+        return if (!scaleGestureDetector.isInProgress) {
+            gestureDetector.onTouchEvent(event)
+        } else {
+            false
+        }
+    }
+
+    @VisibleForTesting
+    @Suppress("MaxLineLength")
+    internal val gestureDetector: GestureDetector by lazy(LazyThreadSafetyMode.NONE) {
+        GestureDetector(
+            applicationContext,
+            CustomScrollDetectorListener { previousEvent: MotionEvent, currentEvent: MotionEvent, distanceX, distanceY ->
+                run {
+                    listener.onScroll?.invoke(distanceX, distanceY)
+
+                    if (abs(currentEvent.y - previousEvent.y) >= abs(currentEvent.x - previousEvent.x)) {
+                        listener.onVerticalScroll?.invoke(distanceY)
+                    } else {
+                        listener.onHorizontalScroll?.invoke(distanceX)
+                    }
+                }
+            }
+        )
+    }
+
+    @VisibleForTesting
+    internal val scaleGestureDetector: ScaleGestureDetector by lazy(LazyThreadSafetyMode.NONE) {
+        ScaleGestureDetector(
+            applicationContext,
+            CustomScaleDetectorListener(
+                listener.onScaleBegin ?: {},
+                listener.onScale ?: {},
+                listener.onScaleEnd ?: {})
+        ).apply {
+            // Use reflection to modify two fields controlling the sensitivity of our scale detector.
+            // The lower the values the higher the sensitivity.
+            // Values of 0 here would mean all swipe events will be treated as pinch/spread to zoom gestures,
+            // in our context effectively meaning no scrolling, only zooming.
+            listOf(
+                javaClass.getDeclaredField("mSpanSlop"),
+                javaClass.getDeclaredField("mMinSpan")
+            ).forEach { field ->
+                field.isAccessible = true
+                field.set(this, (field.get(this) as Int) / 2)
+            }
+        }
+    }
+
+    /**
+     * A convenience containing listeners for zoom / scroll events
+     *
+     * Provide implementation for the events you are interested in.
+     * The others will be no-op.
+     */
+    internal class GesturesListener(
+        /**
+         * Responds to scroll events for a gesture in progress.
+         * The distance in x and y is also supplied for convenience.
+         */
+        val onScroll: ((distanceX: Float, distanceY: Float) -> Unit)? = { _, _ -> run {} },
+
+        /**
+         * Responds to an in progress scroll occuring more on the vertical axis.
+         * The scroll distance is also supplied for convenience.
+         */
+        val onVerticalScroll: ((distance: Float) -> Unit)? = {},
+
+        /**
+         * Responds to an in progress scroll occurring more on the horizontal axis.
+         * The scroll distance is also supplied for convenience.
+         */
+        val onHorizontalScroll: ((distance: Float) -> Unit)? = {},
+
+        /**
+         * Responds to the the beginning of a new scale gesture.
+         * Reported by new pointers going down.
+         */
+        val onScaleBegin: ((scaleFactor: Float) -> Unit)? = {},
+
+        /**
+         * Responds to scaling events for a gesture in progress.
+         * The scaling factor is also supplied for convenience.
+         * This value is represents the difference from the previous scale event to the current event.
+         */
+        val onScale: ((scaleFactor: Float) -> Unit)? = {},
+
+        /**
+         * Responds to the end of a scale gesture.
+         * Reported by existing pointers going up.
+         */
+        val onScaleEnd: ((scaleFactor: Float) -> Unit)? = {}
+    )
+
+    private class CustomScrollDetectorListener(
+        val onScrolling: (
+            previousEvent: MotionEvent,
+            currentEvent: MotionEvent,
+            distanceX: Float,
+            distanceY: Float
+        ) -> Unit
+    ) : GestureDetector.SimpleOnGestureListener() {
+        override fun onScroll(
+            e1: MotionEvent,
+            e2: MotionEvent,
+            distanceX: Float,
+            distanceY: Float
+        ): Boolean {
+            onScrolling(e1, e2, distanceX, distanceY)
+            return true
+        }
+    }
+
+    private class CustomScaleDetectorListener(
+        val onScaleBegin: (scaleFactor: Float) -> Unit = {},
+        val onScale: (scaleFactor: Float) -> Unit = {},
+        val onScaleEnd: (scaleFactor: Float) -> Unit = {}
+    ) : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+            onScaleBegin(detector.scaleFactor)
+            return true
+        }
+
+        override fun onScale(detector: ScaleGestureDetector): Boolean {
+            onScale(detector.scaleFactor)
+            return true
+        }
+
+        override fun onScaleEnd(detector: ScaleGestureDetector) {
+            onScaleEnd(detector.scaleFactor)
+        }
+    }
+}

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetectorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetectorTest.kt
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.behavior
+
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.MotionEvent.ACTION_CANCEL
+import android.view.MotionEvent.ACTION_DOWN
+import android.view.MotionEvent.ACTION_MOVE
+import android.view.ScaleGestureDetector
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyFloat
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class BrowserGestureDetectorTest {
+    // Robolectric currently (April 17th 2020) only offer a stub in it's `ShadowScaleGestureDetector`
+    // so unit tests based on the actual implementation of `ScaleGestureListener` are not possible.
+
+    // Used spies and not mocks as it was observed that verifying more of the below as mocks
+    // will fail the tests because of "UnfinishedVerificationException"
+    private val scrollListener = spy { _: Float, _: Float -> run {} }
+    private val verticalScrollListener = spy { _: Float -> run {} }
+    private val horizontalScrollListener = spy { _: Float -> run {} }
+    private val scaleBeginListener = spy { _: Float -> run {} }
+    private val scaleInProgressListener = spy { _: Float -> run {} }
+    private val scaleEndListener = spy { _: Float -> run {} }
+    private val gesturesListener = BrowserGestureDetector.GesturesListener(
+        onScroll = scrollListener,
+        onVerticalScroll = verticalScrollListener,
+        onHorizontalScroll = horizontalScrollListener,
+        onScaleBegin = scaleBeginListener,
+        onScale = scaleInProgressListener,
+        onScaleEnd = scaleEndListener
+    )
+
+    @Test
+    fun `Detector should not attempt to detect zoom if MotionEvent's action is ACTION_CANCEL`() {
+        val detector = spy(BrowserGestureDetector(testContext, mock()))
+        val scaleDetector: ScaleGestureDetector = mock()
+        doReturn(scaleDetector).`when`(detector).scaleGestureDetector
+
+        val downEvent = TestUtils.getMotionEvent(ACTION_DOWN)
+        val cancelEvent = TestUtils.getMotionEvent(ACTION_CANCEL, previousEvent = downEvent)
+        val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, previousEvent = downEvent)
+        detector.handleTouchEvent(downEvent)
+        detector.handleTouchEvent(cancelEvent)
+        detector.handleTouchEvent(downEvent)
+        detector.handleTouchEvent(moveEvent)
+
+        verify(scaleDetector, times(3)).onTouchEvent(any<MotionEvent>())
+    }
+
+    @Test
+    fun `Detector should not attempt to detect scrolls if a zoom gesture is in progress`() {
+        val detector = spy(BrowserGestureDetector(testContext, mock()))
+        val scrollDetector: GestureDetector = mock()
+        val scaleDetector: ScaleGestureDetector = mock()
+        doReturn(scrollDetector).`when`(detector).gestureDetector
+        doReturn(scaleDetector).`when`(detector).scaleGestureDetector
+        `when`(scaleDetector.isInProgress).thenReturn(true)
+
+        detector.handleTouchEvent(TestUtils.getMotionEvent(ACTION_DOWN))
+
+        verify(scrollDetector, never()).onTouchEvent(any<MotionEvent>())
+    }
+
+    @Test
+    fun `Detector's handleTouchEvent returns false if the event was not handled`() {
+        val detector = spy(BrowserGestureDetector(testContext, mock()))
+        val unhandledEvent = TestUtils.getMotionEvent(ACTION_DOWN)
+
+        // Neither the scale detector, nor the scroll detector should be interested
+        // in a one of a time ACTION_CANCEL MotionEvent
+        val wasEventHandled = detector.handleTouchEvent(
+            TestUtils.getMotionEvent(ACTION_CANCEL, previousEvent = unhandledEvent)
+        )
+
+        assertFalse(wasEventHandled)
+    }
+
+    @Test
+    fun `Detector's handleTouchEvent returns true if the event was handled`() {
+        val detector = spy(BrowserGestureDetector(testContext, mock()))
+        val downEvent = TestUtils.getMotionEvent(ACTION_DOWN)
+        val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, 0f, 0f, previousEvent = downEvent)
+        val moveEvent2 = TestUtils.getMotionEvent(ACTION_MOVE, 100f, 100f, previousEvent = moveEvent)
+
+        detector.handleTouchEvent(downEvent)
+        detector.handleTouchEvent(moveEvent)
+        val wasEventHandled = detector.handleTouchEvent(moveEvent2)
+
+        assertTrue(wasEventHandled)
+    }
+
+    @Test
+    fun `Detector should inform about scroll and vertical scrolls events`() {
+        val detector = spy(BrowserGestureDetector(testContext, gesturesListener))
+        val downEvent = TestUtils.getMotionEvent(ACTION_DOWN)
+        val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, 0f, 0f, previousEvent = downEvent)
+        val moveEvent2 = TestUtils.getMotionEvent(ACTION_MOVE, 100f, 200f, previousEvent = moveEvent)
+
+        detector.handleTouchEvent(downEvent)
+        detector.handleTouchEvent(moveEvent)
+        detector.handleTouchEvent(moveEvent2)
+
+        // If the movement was more on the Y axis both "onScroll" and "onVerticalScroll" callbacks
+        // should be called but no others.
+        verify(scrollListener).invoke(-100f, -200f)
+        verify(verticalScrollListener).invoke(-200f)
+        verify(horizontalScrollListener, never()).invoke(anyFloat())
+        verify(scaleBeginListener, never()).invoke(anyFloat())
+        verify(scaleInProgressListener, never()).invoke(anyFloat())
+        verify(scaleEndListener, never()).invoke(anyFloat())
+    }
+
+    @Test
+    fun `Detector should prioritize vertical scrolls over horizontal scrolls`() {
+        val detector = spy(BrowserGestureDetector(testContext, gesturesListener))
+        val downEvent = TestUtils.getMotionEvent(ACTION_DOWN)
+        val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, 0f, 0f, previousEvent = downEvent)
+        val moveEvent2 = TestUtils.getMotionEvent(ACTION_MOVE, 100f, 100f, previousEvent = moveEvent)
+
+        detector.handleTouchEvent(downEvent)
+        detector.handleTouchEvent(moveEvent)
+        detector.handleTouchEvent(moveEvent2)
+
+        // If the movement was for the same amount on both the Y axis and the X axis
+        // both "onScroll" and "onVerticalScroll" callbacks should be called but no others.
+        verify(scrollListener).invoke(-100f, -100f)
+        verify(verticalScrollListener).invoke(-100f)
+        verify(horizontalScrollListener, never()).invoke(anyFloat())
+        verify(scaleBeginListener, never()).invoke(anyFloat())
+        verify(scaleInProgressListener, never()).invoke(anyFloat())
+        verify(scaleEndListener, never()).invoke(anyFloat())
+    }
+
+    @Test
+    fun `Detector should inform about scroll and horizontal scrolls events`() {
+        val detector = spy(BrowserGestureDetector(testContext, gesturesListener))
+        val downEvent = TestUtils.getMotionEvent(ACTION_DOWN)
+        val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, 0f, 0f, previousEvent = downEvent)
+        val moveEvent2 = TestUtils.getMotionEvent(ACTION_MOVE, 101f, 100f, previousEvent = moveEvent)
+
+        detector.handleTouchEvent(downEvent)
+        detector.handleTouchEvent(moveEvent)
+        detector.handleTouchEvent(moveEvent2)
+
+        // If the movement was for the same amount on both the Y axis and the X axis
+        // both "onScroll" and "onVerticalScroll" callbacks should be called but no others.
+        verify(scrollListener).invoke(-101f, -100f)
+        verify(horizontalScrollListener).invoke(-101f)
+        verify(verticalScrollListener, never()).invoke(anyFloat())
+        verify(scaleBeginListener, never()).invoke(anyFloat())
+        verify(scaleInProgressListener, never()).invoke(anyFloat())
+        verify(scaleEndListener, never()).invoke(anyFloat())
+    }
+}

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/TestUtils.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/TestUtils.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.toolbar.behavior
+
+import android.view.MotionEvent
+
+object TestUtils {
+    fun getMotionEvent(
+        action: Int,
+        x: Float = 0f,
+        y: Float = 0f,
+        previousEvent: MotionEvent? = null
+    ): MotionEvent {
+        val currentTime = System.currentTimeMillis()
+        val downTime = previousEvent?.downTime ?: System.currentTimeMillis()
+
+        var pointerCount = previousEvent?.pointerCount ?: 0
+        if (action == MotionEvent.ACTION_POINTER_DOWN) {
+            pointerCount++
+        } else if (action == MotionEvent.ACTION_DOWN) {
+            pointerCount = 1
+        }
+
+        val properties = Array(pointerCount, ::getPointerProperties)
+        val pointerCoords = getPointerCoords(x, y, pointerCount)
+
+        return MotionEvent.obtain(
+            downTime, currentTime,
+            action, pointerCount, properties,
+            pointerCoords, 0, 0, 1f, 1f, 0, 0, 0, 0
+        )
+    }
+
+    private fun getPointerCoords(
+        x: Float,
+        y: Float,
+        pointerCount: Int,
+        previousEvent: MotionEvent? = null
+    ): Array<MotionEvent.PointerCoords?> {
+        val currentEventCoords = MotionEvent.PointerCoords().apply {
+            this.x = x; this.y = y; pressure = 1f; size = 1f
+        }
+
+        return if (pointerCount > 1 && previousEvent != null) {
+            arrayOf(
+                MotionEvent.PointerCoords().apply {
+                    this.x = previousEvent.x; this.y = previousEvent.y; pressure = 1f; size = 1f
+                },
+                currentEventCoords
+            )
+        } else {
+            arrayOf(currentEventCoords)
+        }
+    }
+
+    private fun getPointerProperties(id: Int): MotionEvent.PointerProperties =
+        MotionEvent.PointerProperties().apply {
+            this.id = id; this.toolType = MotionEvent.TOOL_TYPE_FINGER
+        }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,10 @@ permalink: /changelog/
   * Glean was updated to v29.1.0
     * ⚠️ **This is a breaking change**: glinter errors found during code generation will now return an error code.
     * The minimum and maximum values of a timing distribution can now be controlled by the `time_unit` parameter. See [bug 1630997](https://bugzilla.mozilla.org/show_bug.cgi?id=1630997) for more details.
-  
+
+* **browser-toolbar**
+  * It will only be animated for vertical scrolls inside the EngineView. Not for horizontal scrolls. Not for zoom gestures.
+
 # 40.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v39.0.0...v40.0.0)
@@ -151,7 +154,7 @@ permalink: /changelog/
 
 * **Developer ergonomics**
   * Improved autoPublication workflow. See https://mozac.org/contributing/testing-components-inside-app for updated documentation.
-
+  
 * **browser-search**
   * Added `getSearchTemplate` to reconstruct the user-entered search engine url template
 


### PR DESCRIPTION
We'll now have a more in-depth understanding of user's gestures based on which
we can trigger different BrowserToolbar behaviors depending on if the user is
scrolling or zooming.

The ConstraintLayout parent will still inform us about when the scroll begins
and when the scroll ends but then actually incrementally updating the toolbar's
translation will be done in response to GestureDetector callbacks.
This also allows us to easily differentiate between horizontal and vertical
scrolls and only react for the latter.

If the user's gestures as inferred as zoom gestures (multi-finger scale or
quick-scale) the toolbar should not be animated.
This scenario is though affected by the fact that normally scroll gestures have
a much higher sensitivity (a 1 pixel movement is enough for a gesture to be
considered a scroll gesture) and so it is possible that even in the case of a
desired zoom gesture the scroll callbacks will be fired first.
When the gesture is identified as a zoom gesture we will immediately snap the
toolbar up/down but there might be a minor visual glitch because of this.
In an effort to reduce such races between scroll and zoom gestures I've lowered
the sensitivity of the ScaleDetector, this having the other effect that
multi-finger scrolls must now be more precise. Pinching while zooming will now
more often mean a zoom gesture and not animate the toolbar.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes tests and and explanation of why not even more thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
