### PR TITLE
bugfix/#6686 - Added search engine template getter

### DIFF
--- a/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngine.kt
+++ b/components/browser/search/src/main/java/mozilla/components/browser/search/SearchEngine.kt
@@ -28,6 +28,14 @@ class SearchEngine internal constructor(
     }
 
     /**
+     * Gets the user-entered search url template
+     */
+    fun getSearchTemplate(): String {
+        val template = Uri.decode(resultsUris[0].toString())
+        return paramSubstitution(template, USER_QUERY_TEMPLATE)
+    }
+
+    /**
      * Builds a URL to search for the given search terms with this search engine.
      */
     fun buildSearchUrl(searchTerm: String): String {
@@ -92,6 +100,8 @@ class SearchEngine internal constructor(
         private const val OS_PARAM_LANGUAGE = "{" + "language" + "}"
         private const val OS_PARAM_OUTPUT_ENCODING = "{" + "outputEncoding" + "}"
         private const val OS_PARAM_OPTIONAL = "\\{" + "(?:\\w+:)?\\w+?" + "\\}"
+
+        private const val USER_QUERY_TEMPLATE = "%s"
 
         private fun normalize(input: String): String {
             val trimmedInput = input.trim { it <= ' ' }

--- a/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineTest.kt
+++ b/components/browser/search/src/test/java/mozilla/components/browser/search/SearchEngineTest.kt
@@ -83,6 +83,20 @@ class SearchEngineTest {
     }
 
     @Test
+    fun `get engine template`() {
+        val searchUri = Uri.parse("https://mozilla.org/search/?q={searchTerms}")
+        val suggestionsUri = Uri.parse("https://mozilla.org/search/suggestions?q={searchTerms}")
+        val searchEngine = SearchEngine(
+            "mozsearch",
+            "Mozilla Search",
+            mock(Bitmap::class.java),
+            listOf(searchUri),
+            suggestionsUri)
+
+        assertEquals("https://mozilla.org/search/?q=%s", searchEngine.getSearchTemplate())
+    }
+
+    @Test
     fun `Build search suggestion URL`() {
         val searchUri = Uri.parse("https://mozilla.org/search/?q={searchTerms}")
         val suggestionsUri = Uri.parse("https://mozilla.org/search/suggestions?q={searchTerms}")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ permalink: /changelog/
 * **browser-tabstray**
   * The iconView is no longer required in the template.
 
+* **browser-search**
+  * Added `getSearchTemplate` to reconstruct the user-entered search engine url template
+
 # 38.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v37.0.0...v38.0.0)


### PR DESCRIPTION
Method used for custom search engines to reconstruct the user template that was used when the engine was added.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
