### PR TITLE
For mozilla-mobile/fenix#9413 - Workaround Android 8 to update layoutDirection on activity recreation

### DIFF
--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleAwareAppCompatActivity.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleAwareAppCompatActivity.kt
@@ -5,6 +5,8 @@
 package mozilla.components.support.locale
 
 import android.content.Context
+import android.os.Build
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 
 /**
@@ -14,5 +16,16 @@ open class LocaleAwareAppCompatActivity : AppCompatActivity() {
     override fun attachBaseContext(base: Context) {
         val context = LocaleManager.updateResources(base)
         super.attachBaseContext(context)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Android 8 has a bug which doesn't change the layoutDirection on activity recreation.
+        // https://github.com/mozilla-mobile/fenix/issues/9413
+        // https://stackoverflow.com/questions/46296202/rtl-layout-bug-in-android-oreo#comment98890942_46298101
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
+            window.decorView.layoutDirection = resources.configuration.layoutDirection
+        }
     }
 }

--- a/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleAwareAppCompatActivity.kt
+++ b/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleAwareAppCompatActivity.kt
@@ -7,6 +7,7 @@ package mozilla.components.support.locale
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 
 /**
@@ -20,10 +21,16 @@ open class LocaleAwareAppCompatActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setLayoutDirectionIfNeeded()
+    }
 
-        // Android 8 has a bug which doesn't change the layoutDirection on activity recreation.
-        // https://github.com/mozilla-mobile/fenix/issues/9413
-        // https://stackoverflow.com/questions/46296202/rtl-layout-bug-in-android-oreo#comment98890942_46298101
+    /**
+     * Compensates for a bug in Android 8 which doesn't change the layoutDirection on activity recreation
+     * https://github.com/mozilla-mobile/fenix/issues/9413
+     * https://stackoverflow.com/questions/46296202/rtl-layout-bug-in-android-oreo#comment98890942_46298101
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun setLayoutDirectionIfNeeded() {
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
             window.decorView.layoutDirection = resources.configuration.layoutDirection
         }

--- a/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleAwareAppCompatActivityTest.kt
+++ b/components/support/locale/src/test/java/mozilla/components/support/locale/LocaleAwareAppCompatActivityTest.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.locale
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+class LocaleAwareAppCompatActivityTest {
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N, Build.VERSION_CODES.P])
+    fun `when version is not Android 8 don't set layoutDirection`() {
+        val activity = spy(Robolectric.buildActivity(LocaleAwareAppCompatActivity::class.java).get())
+        activity.setLayoutDirectionIfNeeded()
+        verify(activity, Mockito.times(0)).window
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O])
+    fun `when version is Android 8 set layoutDirection`() {
+        val activity = spy(Robolectric.buildActivity(LocaleAwareAppCompatActivity::class.java).get())
+        activity.setLayoutDirectionIfNeeded()
+        verify(activity, Mockito.times(1)).window
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-locale**
+  * Added fix for respecting RTL/LTR changes when activity is recreated in Android 8
+
 * **feature-sitepermissions**
   * ⚠️ **This is a breaking change**: The `SitePermissionsFeature`'s constructor, now requires a new parameter `onShouldShowRequestPermissionRationale` a lambda to allow the feature to query [ActivityCompat.shouldShowRequestPermissionRationale](https://developer.android.com/reference/androidx/core/app/ActivityCompat#shouldShowRequestPermissionRationale(android.app.Activity,%20java.lang.String)) or [Fragment.shouldShowRequestPermissionRationale](https://developer.android.com/reference/androidx/fragment/app/Fragment#shouldShowRequestPermissionRationale(java.lang.String)). This allows the `SitePermissionsFeature` to handle when a user clicks "Deny & don't ask again" button in a system permission dialog, for more information see [issue #6565](https://github.com/mozilla-mobile/android-components/issues/6565).
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
