### PR TITLE
For 10040 & 10045 (fenix) - Toolbar: Consistently hide/show bottom to…

### DIFF
--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
@@ -29,7 +29,6 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Starting a nested scroll should cancel an ongoing snap animation`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
-        doReturn(true).`when`(behavior).shouldScroll
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -65,7 +64,6 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will snap toolbar up if toolbar is more than 50% visible`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
-        doReturn(true).`when`(behavior).shouldScroll
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -100,7 +98,6 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will snap toolbar down if toolbar is less than 50% visible`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
-        doReturn(true).`when`(behavior).shouldScroll
 
         val animator: ValueAnimator = mock()
         behavior.snapAnimator = animator
@@ -135,7 +132,6 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will apply translation to toolbar for nested scroll`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
-        doReturn(true).`when`(behavior).shouldScroll
 
         val child = mock<BrowserToolbar>()
         doReturn(100).`when`(child).height
@@ -179,7 +175,7 @@ class BrowserToolbarBottomBehaviorTest {
     @Test
     fun `Behavior will animateSnap UP when forceExpand is called`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
-        doReturn(true).`when`(behavior).shouldScroll
+
         val toolbar: BrowserToolbar = mock()
 
         behavior.forceExpand(toolbar)


### PR DESCRIPTION
…olbar

Relying on input to be handled  by Engine View provided inconsistent showing / hiding of the toolbar.

If the site is able to scroll and scrolling, show and hide the toolbar. This will consistently show the toolbar when scrolling up and hide it scrolling down.

Also if multitouch event, dont translate the toolbar to support pinch/zoom gestures without affecting the toolbar.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
