### PR TITLE
For #6731 - Provide styling for URL text in the tabs tray

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
@@ -43,6 +43,9 @@ class BrowserTabsTray @JvmOverloads constructor(
                 DEFAULT_ITEM_BACKGROUND_SELECTED_COLOR),
             attr.getColor(R.styleable.BrowserTabsTray_tabsTrayItemTextColor, DEFAULT_ITEM_TEXT_COLOR),
             attr.getColor(R.styleable.BrowserTabsTray_tabsTraySelectedItemTextColor, DEFAULT_ITEM_TEXT_SELECTED_COLOR),
+            attr.getColor(R.styleable.BrowserTabsTray_tabsTrayItemUrlTextColor, DEFAULT_ITEM_TEXT_COLOR),
+            attr.getColor(R.styleable.BrowserTabsTray_tabsTraySelectedItemUrlTextColor,
+                DEFAULT_ITEM_TEXT_SELECTED_COLOR),
             attr.getDimensionPixelSize(R.styleable.BrowserTabsTray_tabsTrayItemElevation, 0).toFloat()
         )
         attr.recycle()
@@ -61,5 +64,7 @@ internal data class TabsTrayStyling(
     val selectedItemBackgroundColor: Int,
     val itemTextColor: Int,
     val selectedItemTextColor: Int,
+    val itemUrlTextColor: Int,
+    val selectedItemUrlTextColor: Int,
     val itemElevation: Float
 )

--- a/components/browser/tabstray/src/main/res/values/attrs.xml
+++ b/components/browser/tabstray/src/main/res/values/attrs.xml
@@ -6,8 +6,10 @@
     <declare-styleable name="BrowserTabsTray">
         <attr name="tabsTrayItemBackgroundColor" format="reference|color" />
         <attr name="tabsTrayItemTextColor" format="reference|color" />
+        <attr name="tabsTrayItemUrlTextColor" format="reference|color" />
         <attr name="tabsTraySelectedItemBackgroundColor" format="reference|color" />
         <attr name="tabsTraySelectedItemTextColor" format="reference|color" />
+        <attr name="tabsTraySelectedItemUrlTextColor" format="reference|color" />
         <attr name="tabsTrayItemElevation" format="reference|dimension" />
     </declare-styleable>
 </resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,7 @@ permalink: /changelog/
 
 * **browser-tabstray**
   * The iconView is no longer required in the template.
+  * The URL text for items may be styled.
 
 # 38.0.0
 


### PR DESCRIPTION
The tab tray in Fenix will need the URL view styled a different color when selected and not selected, so this will be helpful to us.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
