### PR TITLE
Bug 1630944 - part 2: Use gecko-like routes

### DIFF
--- a/taskcluster/ac_taskgraph/routes.py
+++ b/taskcluster/ac_taskgraph/routes.py
@@ -9,9 +9,10 @@ import time
 from taskgraph.transforms.task import index_builder
 
 SIGNING_ROUTE_TEMPLATES = [
-    "index.{trust-domain}.{project}.v1.{variant}.{build_date}.revision.{head_rev}.{component}",
-    "index.{trust-domain}.{project}.v1.{variant}.{build_date}.{component}.latest.",
-    "index.{trust-domain}.{project}.v1.{variant}.{component}.latest",
+    "index.{trust-domain}.v2.{project}.{variant}.latest.{component}",
+    "index.{trust-domain}.v2.{project}.{variant}.{build_date}.revision.{head_rev}.{component}",
+    "index.{trust-domain}.v2.{project}.{variant}.{build_date}.latest.{component}",
+    "index.{trust-domain}.v2.{project}.{variant}.revision.{head_rev}.{component}",
 ]
 
 

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -21,7 +21,7 @@ taskgraph:
     repositories:
         mobile:
             name: android-components
-    cached-task-prefix: mobile.android-components
+    cached-task-prefix: mobile.v2.android-components
     decision-parameters: 'ac_taskgraph:get_decision_parameters'
 
 workers:


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

In #6698, I added routes, but it turns out they output something [that looks messy](https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.android-components.v1.nightly): dates and `latest` are diluted in components.

I'm seizing this opportunity to make mobile routes as similar as [the ones we have in gecko](https://searchfox.org/mozilla-central/rev/d2cec90777d573585f8477d5170892e5dcdfb0ab/taskcluster/taskgraph/transforms/task.py#248-253).

Tell me what you think @MihaiTabara!  



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
