### PR TITLE
Closes #6481: Introduce api to partially update the AddonsManagerAdapter

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.addons.ui
 
+import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Typeface
 import android.graphics.drawable.BitmapDrawable
@@ -20,7 +21,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.Main
@@ -56,14 +58,20 @@ class AddonsManagerAdapter(
     private val addonsManagerDelegate: AddonsManagerAdapterDelegate,
     addons: List<Addon>,
     private val style: Style? = null
-) : RecyclerView.Adapter<CustomViewHolder>() {
+) : ListAdapter<Any, CustomViewHolder>(DifferCallback) {
     private val scope = CoroutineScope(Dispatchers.IO)
-    private val items: List<Any>
-    private val unsupportedAddons = ArrayList<Addon>()
+    private val unsupportedAddons = mutableSetOf<Addon>()
     private val logger = Logger("AddonsManagerAdapter")
+    /**
+     * Represents all the add-ons that will be distributed in multiple headers like
+     * enabled, recommended and unsupported, this help have the data source of the items,
+     * displayed in the UI.
+     */
+    @VisibleForTesting
+    internal var addonsMap: MutableMap<String, Addon> = addons.associateBy({ it.id }, { it }).toMutableMap()
 
     init {
-        items = createListWithSections(addons)
+        submitList(createListWithSections(addons))
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CustomViewHolder {
@@ -122,10 +130,8 @@ class AddonsManagerAdapter(
         )
     }
 
-    override fun getItemCount() = items.size
-
     override fun getItemViewType(position: Int): Int {
-        return when (items[position]) {
+        return when (getItem(position)) {
             is Addon -> VIEW_HOLDER_TYPE_ADDON
             is Section -> VIEW_HOLDER_TYPE_SECTION
             is NotYetSupportedSection -> VIEW_HOLDER_TYPE_NOT_YET_SUPPORTED_SECTION
@@ -134,7 +140,7 @@ class AddonsManagerAdapter(
     }
 
     override fun onBindViewHolder(holder: CustomViewHolder, position: Int) {
-        val item = items[position]
+        val item = getItem(position)
 
         when (holder) {
             is SectionViewHolder -> bindSection(holder, item as Section)
@@ -171,7 +177,7 @@ class AddonsManagerAdapter(
             }
 
         holder.itemView.setOnClickListener {
-            addonsManagerDelegate.onNotYetSupportedSectionClicked(unsupportedAddons)
+            addonsManagerDelegate.onNotYetSupportedSectionClicked(unsupportedAddons.toList())
         }
     }
 
@@ -227,14 +233,25 @@ class AddonsManagerAdapter(
         style?.maybeSetAddonSummaryTextColor(holder.summaryView)
     }
 
+    @Suppress("MagicNumber")
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun fetchIcon(addon: Addon, iconView: ImageView, scope: CoroutineScope = this.scope): Job {
         return scope.launch {
             try {
+                // We calculate how much time takes to fetch an icon,
+                // if takes less than a second, we assume it comes
+                // from a cache and we don't show any transition animation.
+                val startTime = System.currentTimeMillis()
                 val iconBitmap = addonCollectionProvider.getAddonIconBitmap(addon)
+                val timeToFetch: Double = (System.currentTimeMillis() - startTime) / 1000.0
+                val isFromCache = timeToFetch < 1
                 iconBitmap?.let {
                     scope.launch(Main) {
-                        iconView.setWithCrossFadeAnimation(it)
+                        if (isFromCache) {
+                            iconView.setImageDrawable(BitmapDrawable(iconView.resources, it))
+                        } else {
+                            setWithCrossFadeAnimation(iconView, it)
+                        }
                     }
                 }
             } catch (e: IOException) {
@@ -339,16 +356,56 @@ class AddonsManagerAdapter(
             }
         }
     }
+
+    /**
+     * Update the portion of the list that contains the provided [addon].
+     * @property addon The add-on to be updated.
+     */
+    fun updateAddon(addon: Addon) {
+        addonsMap[addon.id] = addon
+        submitList(createListWithSections(addonsMap.values.toList()))
+    }
+
+    /**
+     * Updates only the portion of the list that changes between the current list and the new provided [addons].
+     * Be aware that updating a subset of the visible list is not supported, [addons] will replace
+     * the current list, but only the add-ons that have been changed will be updated in the UI.
+     * If you provide a subset it will replace the current list.
+     * @property addons A list of add-on to replace the actual list.
+     */
+    fun updateAddons(addons: List<Addon>) {
+        addonsMap = addons.associateBy({ it.id }, { it }).toMutableMap()
+        submitList(createListWithSections(addons))
+    }
+
+    internal object DifferCallback : DiffUtil.ItemCallback<Any>() {
+        override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {
+            return when {
+                oldItem is Addon && newItem is Addon -> oldItem.id == newItem.id
+                oldItem is Section && newItem is Section -> oldItem.title == newItem.title
+                oldItem is NotYetSupportedSection && newItem is NotYetSupportedSection -> oldItem.title == newItem.title
+                else -> false
+            }
+        }
+
+        @SuppressLint("DiffUtilEquals")
+        override fun areContentsTheSame(oldItem: Any, newItem: Any): Boolean {
+            return oldItem == newItem
+        }
+    }
+
+    internal fun setWithCrossFadeAnimation(image: ImageView, bitmap: Bitmap, durationMillis: Int = 1700) {
+        with(image) {
+            val bitmapDrawable = BitmapDrawable(context.resources, bitmap)
+            val animation = TransitionDrawable(arrayOf(drawable, bitmapDrawable))
+            animation.isCrossFadeEnabled = true
+            setImageDrawable(animation)
+            animation.startTransition(durationMillis)
+        }
+    }
 }
 
 private fun Addon.inUnsupportedSection() = isInstalled() && !isSupported()
 private fun Addon.inRecommendedSection() = !isInstalled()
 private fun Addon.inInstalledSection() = isInstalled() && isSupported() && isEnabled()
 private fun Addon.inDisabledSection() = isInstalled() && isSupported() && !isEnabled()
-private fun ImageView.setWithCrossFadeAnimation(bitmap: Bitmap, durationMillis: Int = 1700) {
-    val bitmapDrawable = BitmapDrawable(context.resources, bitmap)
-    val animation = TransitionDrawable(arrayOf(drawable, bitmapDrawable))
-    animation.isCrossFadeEnabled = true
-    setImageDrawable(animation)
-    animation.startTransition(durationMillis)
-}

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
@@ -29,5 +29,5 @@ interface AddonsManagerAdapterDelegate {
      *
      * @param unsupportedAddons The list of unsupported [Addon].
      */
-    fun onNotYetSupportedSectionClicked(unsupportedAddons: ArrayList<Addon>) = Unit
+    fun onNotYetSupportedSectionClicked(unsupportedAddons: List<Addon>) = Unit
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: The `SitePermissionsFeature`'s constructor, now requires a new parameter `onShouldShowRequestPermissionRationale` a lambda to allow the feature to query [ActivityCompat.shouldShowRequestPermissionRationale](https://developer.android.com/reference/androidx/core/app/ActivityCompat#shouldShowRequestPermissionRationale(android.app.Activity,%20java.lang.String)) or [Fragment.shouldShowRequestPermissionRationale](https://developer.android.com/reference/androidx/fragment/app/Fragment#shouldShowRequestPermissionRationale(java.lang.String)). This allows the `SitePermissionsFeature` to handle when a user clicks "Deny & don't ask again" button in a system permission dialog, for more information see [issue #6565](https://github.com/mozilla-mobile/android-components/issues/6565).
 
 * **feature-addons**
+  * Added `AddonsManagerAdapter.updateAddon` and `AddonsManagerAdapter.updateAddons` to allow partial updates.
+  * ⚠️ **This is a breaking change**: `AddonsManagerAdapterDelegate.onNotYetSupportedSectionClicked(unsupportedAddons: ArrayList<Addon>)` is changed to `AddonsManagerAdapterDelegate.onNotYetSupportedSectionClicked(unsupportedAddons: List<Addon>)`.
   * Fixed [issue #6685](https://github.com/mozilla-mobile/android-components/issues/6685), now `DefaultSupportedAddonsChecker` will marked any newly supported add-on as enabled.
   * Added `Addon.translatedSummary` and `Addon.translatedDescription` to ease add-on translations.
   * Added `Addon.defaultLocale` Indicates which locale will be always available to display translatable fields.


### PR DESCRIPTION
I noticed that we were updating the add-on list multiple times, in this pr I'm adding APIs to just update partially the list, just the parts that had changed, see the Fenix pr https://github.com/mozilla-mobile/fenix/pull/10086 this pr could also fix https://github.com/mozilla-mobile/android-components/issues/6484

Before adding any tests, I would like to see what do you think of this approach.   

[Fenix Before](https://drive.google.com/file/d/1Mg7XJTFTIaP_qG5ZKvmUvWtNWdVnlMPj/view?usp=sharing)
[Fenix Now](https://drive.google.com/file/d/1lDANVgMAt5yETkYj3MROhj6hVWBosx3N/view?usp=sharing) 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
