### PR TITLE
Issue #1705: Allow CrashReporterService to return a unique identifier for reported crashes.

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/CrashReporterService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/CrashReporterService.kt
@@ -14,16 +14,25 @@ internal const val INFO_PREFIX = "[INFO]"
 interface CrashReporterService {
     /**
      * Submits a crash report for this [Crash.UncaughtExceptionCrash].
+     *
+     * @return Unique identifier that can be used by/with this crash reporter service to find this
+     * crash - or null if no identifier can be provided.
      */
-    fun report(crash: Crash.UncaughtExceptionCrash)
+    fun report(crash: Crash.UncaughtExceptionCrash): String?
 
     /**
      * Submits a crash report for this [Crash.NativeCodeCrash].
+     *
+     * @return Unique identifier that can be used by/with this crash reporter service to find this
+     * crash - or null if no identifier can be provided.
      */
-    fun report(crash: Crash.NativeCodeCrash)
+    fun report(crash: Crash.NativeCodeCrash): String?
 
     /**
      * Submits a caught exception report for this [Throwable].
+     *
+     * @return Unique identifier that can be used by/with this crash reporter service to find this
+     * crash - or null if no identifier can be provided.
      */
-    fun report(throwable: Throwable)
+    fun report(throwable: Throwable): String?
 }

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/GleanCrashReporterService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/GleanCrashReporterService.kt
@@ -173,19 +173,22 @@ class GleanCrashReporterService(
         }
     }
 
-    override fun report(crash: Crash.UncaughtExceptionCrash) {
+    override fun report(crash: Crash.UncaughtExceptionCrash): String? {
         reportCrash(UNCAUGHT_EXCEPTION_KEY)
+        return null
     }
 
-    override fun report(crash: Crash.NativeCodeCrash) {
+    override fun report(crash: Crash.NativeCodeCrash): String? {
         if (crash.isFatal) {
             reportCrash(FATAL_NATIVE_CODE_CRASH_KEY)
         } else {
             reportCrash(NONFATAL_NATIVE_CODE_CRASH_KEY)
         }
+        return null
     }
 
-    override fun report(throwable: Throwable) {
+    override fun report(throwable: Throwable): String? {
         reportCrash(CAUGHT_EXCEPTION_KEY)
+        return null
     }
 }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt
@@ -303,15 +303,14 @@ class CrashReporterTest {
         var exceptionCrash = false
 
         val service = object : CrashReporterService {
-            override fun report(crash: Crash.UncaughtExceptionCrash) {
+            override fun report(crash: Crash.UncaughtExceptionCrash): String? {
                 exceptionCrash = true
+                return null
             }
 
-            override fun report(crash: Crash.NativeCodeCrash) {
-            }
+            override fun report(crash: Crash.NativeCodeCrash): String? = null
 
-            override fun report(throwable: Throwable) {
-            }
+            override fun report(throwable: Throwable): String? = null
         }
 
         val reporter = spy(CrashReporter(
@@ -330,15 +329,14 @@ class CrashReporterTest {
         var nativeCrash = false
 
         val service = object : CrashReporterService {
-            override fun report(crash: Crash.UncaughtExceptionCrash) {
-            }
+            override fun report(crash: Crash.UncaughtExceptionCrash): String? = null
 
-            override fun report(crash: Crash.NativeCodeCrash) {
+            override fun report(crash: Crash.NativeCodeCrash): String? {
                 nativeCrash = true
+                return null
             }
 
-            override fun report(throwable: Throwable) {
-            }
+            override fun report(throwable: Throwable): String? = null
         }
 
         val reporter = spy(CrashReporter(
@@ -357,14 +355,13 @@ class CrashReporterTest {
         var exceptionCrash = false
 
         val service = object : CrashReporterService {
-            override fun report(crash: Crash.UncaughtExceptionCrash) {
-            }
+            override fun report(crash: Crash.UncaughtExceptionCrash): String? = null
 
-            override fun report(crash: Crash.NativeCodeCrash) {
-            }
+            override fun report(crash: Crash.NativeCodeCrash): String? = null
 
-            override fun report(throwable: Throwable) {
+            override fun report(throwable: Throwable): String? {
                 exceptionCrash = true
+                return null
             }
         }
 
@@ -385,15 +382,14 @@ class CrashReporterTest {
         var nativeCrash = false
 
         val telemetryService = object : CrashReporterService {
-            override fun report(crash: Crash.UncaughtExceptionCrash) {
-            }
+            override fun report(crash: Crash.UncaughtExceptionCrash): String? = null
 
-            override fun report(crash: Crash.NativeCodeCrash) {
+            override fun report(crash: Crash.NativeCodeCrash): String? {
                 nativeCrash = true
+                return null
             }
 
-            override fun report(throwable: Throwable) {
-            }
+            override fun report(throwable: Throwable): String? = null
         }
 
         val reporter = spy(CrashReporter(

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/ExceptionHandlerTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/ExceptionHandlerTest.kt
@@ -60,14 +60,11 @@ class ExceptionHandlerTest {
         val crashReporter = CrashReporter(
                 shouldPrompt = CrashReporter.Prompt.NEVER,
                 services = listOf(object : CrashReporterService {
-                    override fun report(crash: Crash.UncaughtExceptionCrash) {
-                    }
+                    override fun report(crash: Crash.UncaughtExceptionCrash): String? = null
 
-                    override fun report(crash: Crash.NativeCodeCrash) {
-                    }
+                    override fun report(crash: Crash.NativeCodeCrash): String? = null
 
-                    override fun report(throwable: Throwable) {
-                    }
+                    override fun report(throwable: Throwable): String? = null
                 }),
                 scope = scope
         ).install(testContext)

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt
@@ -57,16 +57,19 @@ class SendCrashReportServiceTest {
         val crashReporter = spy(CrashReporter(
                 shouldPrompt = CrashReporter.Prompt.NEVER,
                 services = listOf(object : CrashReporterService {
-                    override fun report(crash: Crash.UncaughtExceptionCrash) {
+                    override fun report(crash: Crash.UncaughtExceptionCrash): String? {
                         fail("Didn't expect uncaught exception crash")
+                        return null
                     }
 
-                    override fun report(crash: Crash.NativeCodeCrash) {
+                    override fun report(crash: Crash.NativeCodeCrash): String? {
                         caughtCrash = crash
+                        return null
                     }
 
-                    override fun report(throwable: Throwable) {
+                    override fun report(throwable: Throwable): String? {
                         fail("Didn't expect caught exception")
+                        return null
                     }
                 }),
                 scope = scope

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt
@@ -55,16 +55,19 @@ class SendCrashTelemetryServiceTest {
         val crashReporter = spy(CrashReporter(
             shouldPrompt = CrashReporter.Prompt.NEVER,
             telemetryServices = listOf(object : CrashReporterService {
-                override fun report(crash: Crash.UncaughtExceptionCrash) {
+                override fun report(crash: Crash.UncaughtExceptionCrash): String? {
                     fail("Didn't expect uncaught exception crash")
+                    return null
                 }
 
-                override fun report(crash: Crash.NativeCodeCrash) {
+                override fun report(crash: Crash.NativeCodeCrash): String? {
                     caughtCrash = crash
+                    return null
                 }
 
-                override fun report(throwable: Throwable) {
+                override fun report(throwable: Throwable): String? {
                     fail("Didn't expect caught exception")
+                    return null
                 }
             }),
             scope = scope

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SentryServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SentryServiceTest.kt
@@ -106,7 +106,7 @@ class SentryServiceTest {
     }
 
     @Test
-    fun `SentryService sends message for native code crashes`() {
+    fun `SentryService sends event for native code crashes`() {
         val client: SentryClient = mock()
 
         val service = SentryService(
@@ -119,11 +119,11 @@ class SentryServiceTest {
 
         service.report(Crash.NativeCodeCrash("", true, "", false, arrayListOf()))
 
-        verify(client).sendMessage(any())
+        verify(client).sendEvent(any<EventBuilder>())
     }
 
     @Test
-    fun `SentryService does not send message for native code crashes by default`() {
+    fun `SentryService does not send event for native code crashes by default`() {
         val client: SentryClient = mock()
 
         val service = SentryService(
@@ -135,7 +135,7 @@ class SentryServiceTest {
 
         service.report(Crash.NativeCodeCrash("", true, "", false, arrayListOf()))
 
-        verify(client, never()).sendMessage(any())
+        verify(client, never()).sendEvent(any<EventBuilder>())
     }
 
     @Test

--- a/samples/crash/src/main/java/org/mozilla/samples/crash/CrashApplication.kt
+++ b/samples/crash/src/main/java/org/mozilla/samples/crash/CrashApplication.kt
@@ -55,22 +55,25 @@ private fun createDummyCrashService(context: Context): CrashReporterService {
     // For this sample we create a dummy service. In a real application this would be an instance of SentryCrashService
     // or SocorroCrashService.
     return object : CrashReporterService {
-        override fun report(crash: Crash.UncaughtExceptionCrash) {
+        override fun report(crash: Crash.UncaughtExceptionCrash): String? {
             GlobalScope.launch(Dispatchers.Main) {
                 Toast.makeText(context, "Uploading uncaught exception crash...", Toast.LENGTH_SHORT).show()
             }
+            return null
         }
 
-        override fun report(crash: Crash.NativeCodeCrash) {
+        override fun report(crash: Crash.NativeCodeCrash): String? {
             GlobalScope.launch(Dispatchers.Main) {
                 Toast.makeText(context, "Uploading native crash...", Toast.LENGTH_SHORT).show()
             }
+            return null
         }
 
-        override fun report(throwable: Throwable) {
+        override fun report(throwable: Throwable): String? {
             GlobalScope.launch(Dispatchers.Main) {
                 Toast.makeText(context, "Uploading caught exception...", Toast.LENGTH_SHORT).show()
             }
+            return null
         }
     }
 }


### PR DESCRIPTION
This is one small piece of #1705. I am going to land some pieces independently to avoid ending up with a huge patch.

Here we are allowing a `CrashReporterService` to return an ID that we can later use to lookup that crash. For Socorro we return the crash ID that we get when uploading. We can later use that to create a URL pointing to this crash. For Sentry we return the UUID of the event. We can at least ask Sentry with this UUID for the actual crash URL.