### PR TITLE
Issue #1705: Assign UUID to every crash object.

### DIFF
--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt
@@ -20,6 +20,7 @@ class NativeCodeCrashTest {
         intent.component = ComponentName(
             "org.mozilla.samples.browser",
             "mozilla.components.lib.crash.handler.CrashHandlerService")
+        intent.putExtra("uuid", "afc91225-93d7-4328-b3eb-d26ad5af4d86")
         intent.putExtra("minidumpPath",
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp")
         intent.putExtra("fatal", false)
@@ -29,6 +30,10 @@ class NativeCodeCrashTest {
 
         val crash = Crash.NativeCodeCrash.fromBundle(intent.extras!!)
 
+        assertEquals(
+            "afc91225-93d7-4328-b3eb-d26ad5af4d86",
+            crash.uuid
+        )
         assertEquals(crash.minidumpSuccess, true)
         assertEquals(crash.isFatal, false)
         assertEquals(
@@ -39,5 +44,21 @@ class NativeCodeCrashTest {
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.extra",
             crash.extrasPath
         )
+    }
+
+    @Test
+    fun `to and from bundle`() {
+        val crash = Crash.NativeCodeCrash(
+            "minidumpPath",
+            true,
+            "extrasPath",
+            true,
+            arrayListOf()
+        )
+
+        val bundle = crash.toBundle()
+        val otherCrash = Crash.NativeCodeCrash.fromBundle(bundle)
+
+        assertEquals(crash, otherCrash)
     }
 }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/UncaughtExceptionCrashTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/UncaughtExceptionCrashTest.kt
@@ -20,4 +20,15 @@ class UncaughtExceptionCrashTest {
 
         assertEquals(exception, crash.throwable)
     }
+
+    @Test
+    fun `to and from bundle`() {
+        val exception = RuntimeException("Kaput")
+        val crash = Crash.UncaughtExceptionCrash(exception, arrayListOf())
+
+        val bundle = crash.toBundle()
+        val otherCrash = Crash.UncaughtExceptionCrash.fromBundle(bundle)
+
+        assertEquals(crash, otherCrash)
+    }
 }

--- a/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
+++ b/components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt
@@ -52,6 +52,10 @@ class CrashHandlerServiceTest {
             "mozilla.components.lib.crash.handler.CrashHandlerService"
         )
         intent?.putExtra(
+            "uuid",
+            "94f66ed7-50c7-41d1-96a7-299139a8c2af"
+        )
+        intent?.putExtra(
             "minidumpPath",
             "/data/data/org.mozilla.samples.browser/files/mozilla/Crash Reports/pending/3ba5f665-8422-dc8e-a88e-fc65c081d304.dmp"
         )


### PR DESCRIPTION
Assigning every crash a unique ID so that we can later reference this crash when saving some metadata about it to disk.