### PR TITLE
Closes #6702: Upgrade to GV Nightly 77.0.20200422093542

### DIFF
--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -6,7 +6,7 @@ internal object GeckoVersions {
     /**
      * GeckoView Nightly Version.
      */
-    const val nightly_version = "77.0.20200421094220"
+    const val nightly_version = "77.0.20200422093542"
 
     /**
      * GeckoView Beta Version.


### PR DESCRIPTION
Speeding up this upgrade to bring in the fix for #6702 