### PR TITLE
Closes #6754: Intent.asForegroundServicePendingIntent: Set PendingIntent.FLAG_UPDATE_CURRENT by default.

### DIFF
--- a/components/support/utils/src/main/java/mozilla/components/support/utils/intents.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/intents.kt
@@ -21,9 +21,13 @@ import android.os.Build
  * @param context an [Intent] to start a service.
  */
 @JvmName("createForegroundServicePendingIntent")
-fun Intent.asForegroundServicePendingIntent(context: Context, requestCode: Int): PendingIntent =
+fun Intent.asForegroundServicePendingIntent(
+    context: Context,
+    requestCode: Int,
+    flags: Int = PendingIntent.FLAG_UPDATE_CURRENT
+): PendingIntent =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        PendingIntent.getForegroundService(context, requestCode, this, 0)
+        PendingIntent.getForegroundService(context, requestCode, this, flags)
     } else {
-        PendingIntent.getService(context, requestCode, this, 0)
+        PendingIntent.getService(context, requestCode, this, flags)
     }


### PR DESCRIPTION
While testing with the crash sample app I noticed that sometimes we'd report an older crash via the notification. We need to set `PendingIntent.FLAG_UPDATE_CURRENT` so that we will always dispatch the latest intent.