### PR TITLE
Closes #6764 Clear notifications and download jobs when onTaskRemoved or onDestroy are called.

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -296,18 +296,22 @@ abstract class AbstractFetchDownloadService : Service() {
         // stop and cannot be controlled via the notification anymore (until we persist enough data
         // to resume downloads from a new process).
 
-        val notificationManager = NotificationManagerCompat.from(context)
-
-        downloadJobs.values.forEach { state ->
-            notificationManager.cancel(state.foregroundServiceId)
-        }
+        clearAllDownloadsNotificationsAndJobs()
     }
 
     override fun onDestroy() {
         super.onDestroy()
 
-        downloadJobs.values.forEach {
-            it.job?.cancel()
+        clearAllDownloadsNotificationsAndJobs()
+    }
+
+    // Cancels all running jobs and remove all notifications
+    internal fun clearAllDownloadsNotificationsAndJobs() {
+        val notificationManager = NotificationManagerCompat.from(context)
+
+        downloadJobs.values.forEach { state ->
+            notificationManager.cancel(state.foregroundServiceId)
+            state.job?.cancel()
         }
 
         notificationUpdateScope.cancel()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-downloads**
+  * Fixed issue [#6764](https://github.com/mozilla-mobile/android-components/issues/6764).
+
 * **support-locale**
   * Added fix for respecting RTL/LTR changes when activity is recreated in Android 8
 


### PR DESCRIPTION

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
