### PR TITLE
Issue #4397: Deactive reader when following link

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -65,6 +65,7 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
                 store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.tabId, true))
             }
             is ContentAction.UpdateUrlAction -> {
+                store.dispatch(ReaderAction.UpdateReaderActiveAction(action.sessionId, false))
                 store.dispatch(ReaderAction.UpdateReaderableAction(action.sessionId, false))
                 store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.sessionId, true))
             }

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewMiddlewareTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewMiddlewareTest.kt
@@ -101,4 +101,21 @@ class ReaderViewMiddlewareTest {
         store.dispatch(ContentAction.UpdateUrlAction(tab.id, "https://www.firefox.com")).joinBlocking()
         assertTrue(store.state.findTab(tab.id)!!.readerState.checkRequired)
     }
+
+    @Test
+    fun `state is updated to leave reader mode when URL changes`() {
+        val tab = createTab("https://www.mozilla.org", id = "test-tab1",
+            readerState = ReaderState(readerable = true, active = true)
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(tabs = listOf(tab)),
+            middleware = listOf(ReaderViewMiddleware())
+        )
+        assertTrue(store.state.findTab(tab.id)!!.readerState.active)
+        assertTrue(store.state.findTab(tab.id)!!.readerState.readerable)
+
+        store.dispatch(ContentAction.UpdateUrlAction(tab.id, "https://www.firefox.com")).joinBlocking()
+        assertFalse(store.state.findTab(tab.id)!!.readerState.active)
+        assertFalse(store.state.findTab(tab.id)!!.readerState.readerable)
+    }
 }


### PR DESCRIPTION
This is fallout from the refactoring to browser state. 

When following a link or loading another page we should leave reader mode as we used to do: https://github.com/mozilla-mobile/android-components/blob/a316fa48472bf82d52851a08cb945f4e0ec57c52/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt#L148

This was just an oversight.

