### PR TITLE
Issue #5680: Deprecate URLStringUtils.isURLLikeStrict.

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -37,6 +37,11 @@ fun String.isUrl() = URLStringUtils.isURLLike(this)
  * to execute than isUrl() but checks whether, e.g., the TLD is ICANN-recognized. Consider
  * using isUrl() unless these guarantees are required.
  */
+@Deprecated(
+    "Consider using the less strict isUrl or creating a new method using" +
+        ":lib-publicsuffixlist instead. This method is being removed for performance issues"
+)
+@Suppress("DEPRECATION") // this method is being removed with the deprecated method underneath it
 fun String.isUrlStrict() = URLStringUtils.isURLLikeStrict(this)
 
 fun String.toNormalizedUrl() = URLStringUtils.toNormalizedURL(this)

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -43,6 +43,7 @@ class StringTest {
         assertNotEquals("Tweet:", url)
     }
 
+    @Suppress("DEPRECATION") // the method under test is being removed so this test will be too.
     @Test
     fun isUrlStrict() {
         assertTrue("mozilla.org".isUrlStrict())

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/URLStringUtils.kt
@@ -17,6 +17,11 @@ object URLStringUtils {
      * to execute than isURLLike() but checks whether, e.g., the TLD is ICANN-recognized. Consider
      * using isURLLike() unless these guarantees are required.
      */
+    @Deprecated(
+        "Consider using the less strict isURLLike or creating a new method using" +
+            ":lib-publicsuffixlist instead. This method is being removed for performance issues"
+    )
+    @Suppress("DEPRECATION") // we've also deprecated the elements this method relies on.
     fun isURLLikeStrict(string: String, safe: Boolean = false) =
         if (safe) {
             string.matches(WebURLFinder.fuzzyUrlRegex)

--- a/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
+++ b/components/support/utils/src/main/java/mozilla/components/support/utils/WebURLFinder.kt
@@ -334,6 +334,7 @@ class WebURLFinder {
             Pattern.compile(autolinkWebUrlPattern, regexFlags)
         }
 
+        @Deprecated("This and the expensive regex it relies on are being removed for performance issues")
         internal val fuzzyUrlRegex by lazy {
             ("^" +
                     "\\s*" +
@@ -343,6 +344,7 @@ class WebURLFinder {
                     ).toRegex(RegexOption.IGNORE_CASE)
         }
 
+        @Deprecated("This and the expensive regex it relies on are being removed for performance issues")
         internal val fuzzyUrlNonWebRegex by lazy {
             ("^" +
                     "\\s*" +

--- a/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
+++ b/components/support/utils/src/test/java/mozilla/components/support/utils/URLStringUtilsTest.kt
@@ -33,6 +33,7 @@ class URLStringUtilsTest {
         assertEquals(expectedUrl, toNormalizedURL("mozilla.org"))
     }
 
+    @Suppress("DEPRECATION") // this test will be removed with the deprecated method
     @Test
     fun isURLLikeStrict() {
         assertTrue(isURLLikeStrict("mozilla.org"))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,12 @@ permalink: /changelog/
 * **feature-top-sites**
   * Added `isDefault` to the top site entity, which allows application to specify a default top site that is added by the application. This is called through `TopSiteStorage.addTopSite`.
 
+* **support-utils**
+  * `URLStringUtils.isURLLikeStrict` is now deprecated due to performance issues. Consider using the less strict `isURLLike` instead or creating a new method using `:lib-publicsuffixlist`.
+
+* **support-ktx**
+  * `String.isUrlStrict` is now deprecated due to performance issues. Consider using the less strict `isURL` instead or creating a new method using `:lib-publicsuffixlist`.
+
 # 39.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v38.0.0...v39.0.0)


### PR DESCRIPTION
I want to remove this method and the expensive regex it relies on
because:

1. unused code should generally be removed because it's more likely to
break
2. if the APIs exist and fulfill someone's needs, they'll use them.
However, if they had to write their own, they may be able to come up
with a simpler, alternative implementation that would better fit their
needs and, in this case, be much more performant.
3. On a mobile device with limited battery, we shouldn't be
unnecessarily compiling a regex for a second or more if it's not
necessary, especially if a simpler implementation is viable
4. This hard-coded list of TLDs (from 2015) is already out-of-date and
liable to cause problems: more TLDs are getting all the time so, if
keeping a hard-coded list of TLDs is actually a need, we should find an
alternative implementation that lends itself to getting frequent updates
like our public suffix list


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
