### PR TITLE
Closes #6783: Engine session state is not restored

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
@@ -82,10 +82,11 @@ class SnapshotSerializer(
 
     fun itemFromJSON(engine: Engine, json: JSONObject): SessionManager.Snapshot.Item {
         val sessionJson = json.getJSONObject(Keys.SESSION_KEY)
+        val engineSessionJson = json.getJSONObject(Keys.ENGINE_SESSION_KEY)
         val session = deserializeSession(sessionJson, restoreSessionIds, restoreParentIds)
         val readerState =
             ReaderState(active = sessionJson.optBoolean(Keys.SESSION_READER_MODE_KEY, false))
-        val engineState = engine.createSessionState(sessionJson)
+        val engineState = engine.createSessionState(engineSessionJson)
 
         return SessionManager.Snapshot.Item(
             session,


### PR DESCRIPTION
Regression is fairly recent and my mistake. 

Introduced by this change: 
https://github.com/mozilla-mobile/android-components/commit/91bc92fc5ef889e53c77981b81a54e6edb6c22b5#diff-d386a820f3dab49f970fb183c2a57201

We now use the wrong key to look up the engine session JSON object. We use `Keys.SESSION_KEY` instead of `Keys.ENGINE_SESSION_KEY`. 🤦 

I've also add a unit test here so this doesn't happen again.  