### PR TITLE
Issue #1705 - lib-crash: Add database storage for crashes.

### DIFF
--- a/components/lib/crash/build.gradle
+++ b/components/lib/crash/build.gradle
@@ -21,6 +21,7 @@ plugins {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -30,6 +31,12 @@ android {
         targetSdkVersion config.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    kapt {
+        arguments {
+            arg("room.schemaLocation", "$projectDir/schemas".toString())
+        }
     }
 
     buildTypes {
@@ -50,6 +57,9 @@ dependencies {
     implementation project(':support-base')
     implementation project(':support-ktx')
     implementation project(':support-utils')
+
+    implementation Dependencies.androidx_room_runtime
+    kapt Dependencies.androidx_room_compiler
 
     // We only compile against Sentry, GeckoView, and Glean. It's up to the app to add those dependencies if it wants to
     // send crash reports to Socorro (GV) or Sentry.

--- a/components/lib/crash/schemas/mozilla.components.lib.crash.db.CrashDatabase/1.json
+++ b/components/lib/crash/schemas/mozilla.components.lib.crash.db.CrashDatabase/1.json
@@ -1,0 +1,84 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "c82f6a8cf8fbd6509f73a7d7d5ff97cd",
+    "entities": [
+      {
+        "tableName": "crashes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `stacktrace` TEXT NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stacktrace",
+            "columnName": "stacktrace",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `crashUuid` TEXT NOT NULL, `service_id` TEXT NOT NULL, `report_id` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "crashUuid",
+            "columnName": "crashUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "report_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c82f6a8cf8fbd6509f73a7d7d5ff97cd')"
+    ]
+  }
+}

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashDao.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashDao.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.crash.db
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+
+/**
+ * Dao for saving and accessing crash related information.
+ */
+@Dao
+internal interface CrashDao {
+    /**
+     * Inserts a crash into the database.
+     */
+    @Insert
+    fun insertCrash(crash: CrashEntity): Long
+
+    /**
+     * Inserts a report to the database.
+     */
+    @Insert
+    fun insertReport(report: ReportEntity): Long
+
+    /**
+     * Returns saved crashes with their reports.
+     */
+    @Transaction
+    @Query("SELECT * FROM crashes ORDER BY created_at DESC")
+    fun getCrashesWithReports(): LiveData<List<CrashWithReports>>
+}

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashDatabase.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashDatabase.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.crash.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+/**
+ * Internal database for storing collections and their tabs.
+ */
+@Database(
+    entities = [CrashEntity::class, ReportEntity::class],
+    version = 1
+)
+internal abstract class CrashDatabase : RoomDatabase() {
+    abstract fun crashDao(): CrashDao
+
+    companion object {
+        @Volatile private var instance: CrashDatabase? = null
+
+        @Synchronized
+        fun get(context: Context): CrashDatabase {
+            instance?.let { return it }
+
+            return Room.databaseBuilder(context, CrashDatabase::class.java, "crashes")
+                // We are allowing main thread queries here since we need to write to disk blocking
+                // in a crash event before the process gets shutdown. At this point the app already
+                // crashed and temporarily blocking the UI thread is not that problematic anymore.
+                .allowMainThreadQueries()
+                .build()
+                .also {
+                    instance = it
+                }
+        }
+    }
+}

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashEntity.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashEntity.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.crash.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import mozilla.components.lib.crash.Crash
+import mozilla.components.support.base.ext.getStacktraceAsString
+
+/**
+ * Database entity modeling a crash that has happened.
+ */
+@Entity(
+    tableName = "crashes"
+)
+internal data class CrashEntity(
+    /**
+     * Generated UUID for this crash.
+     */
+    @PrimaryKey
+    @ColumnInfo(name = "uuid")
+    var uuid: String,
+
+    /**
+     * The stacktrace of the crash (if this crash was caused by an exception/throwable): otherwise
+     * a string describing the type of crash.
+     */
+    @ColumnInfo(name = "stacktrace")
+    var stacktrace: String,
+
+    /**
+     * Timestamp (in milliseconds) of when the crash happened.
+     */
+    @ColumnInfo(name = "created_at")
+    var createdAt: Long
+)
+
+internal fun Crash.toEntity(): CrashEntity {
+    return CrashEntity(
+        uuid = uuid,
+        stacktrace = getStacktrace(),
+        createdAt = System.currentTimeMillis()
+    )
+}
+
+internal fun Crash.getStacktrace(): String {
+    return when (this) {
+        is Crash.NativeCodeCrash -> "<native crash>"
+        is Crash.UncaughtExceptionCrash -> throwable.getStacktraceAsString()
+    }
+}

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashWithReports.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/CrashWithReports.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.crash.db
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+/**
+ * Data class modelling the relationship between [CrashEntity] and [ReportEntity] objects.
+ */
+internal data class CrashWithReports(
+    @Embedded
+    val crash: CrashEntity,
+
+    @Relation(
+        parentColumn = "uuid",
+        entityColumn = "crash_uuid"
+    )
+    val reports: List<ReportEntity>
+)

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/ReportEntity.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/db/ReportEntity.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.crash.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import mozilla.components.lib.crash.service.CrashReporterService
+
+/**
+ * Datanase entry describing a crash report that was sent to a crash reporting service.
+ */
+@Entity(
+    tableName = "reports"
+)
+internal data class ReportEntity(
+    /**
+     * Database internal primary key of the entry.
+     */
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    var id: Long? = null,
+
+    /**
+     * UUID of the crash that was reported.
+     */
+    @ColumnInfo(name = "crash_uuid")
+    var crashUuid: String,
+
+    /**
+     * Id of the service the crash was reported to (matching [CrashReporterService.id].
+     */
+    @ColumnInfo(name = "service_id")
+    var serviceId: String,
+
+    /**
+     * The id of the crash report as returned by [CrashReporterService.report].
+     */
+    @ColumnInfo(name = "report_id")
+    var reportId: String
+)

--- a/components/support/base/src/main/java/mozilla/components/support/base/ext/Throwable.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/ext/Throwable.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.ext
+
+import java.io.PrintWriter
+import java.io.StringWriter
+
+private const val STACK_TRACE_INITIAL_BUFFER_SIZE = 256
+
+/**
+ * Returns a formatted string of the [Throwable.stackTrace].
+ */
+fun Throwable.getStacktraceAsString(): String {
+    val sw = StringWriter(STACK_TRACE_INITIAL_BUFFER_SIZE)
+    val pw = PrintWriter(sw, false)
+    printStackTrace(pw)
+    pw.flush()
+    return sw.toString()
+}

--- a/components/support/base/src/main/java/mozilla/components/support/base/log/sink/AndroidLogSink.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/log/sink/AndroidLogSink.kt
@@ -5,12 +5,10 @@
 package mozilla.components.support.base.log.sink
 
 import android.os.Build
+import mozilla.components.support.base.ext.getStacktraceAsString
 import mozilla.components.support.base.log.Log
-import java.io.PrintWriter
-import java.io.StringWriter
 
 private const val MAX_TAG_LENGTH = 23
-private const val STACK_TRACE_INITIAL_BUFFER_SIZE = 256
 
 /**
  * <code>LogSink</code> implementation that writes to Android's log.
@@ -27,12 +25,8 @@ class AndroidLogSink(
         val logTag = tag(tag)
 
         val logMessage: String = if (message != null && throwable != null) {
-            "$message\n${stackTrace(throwable)}"
-        } else message ?: if (throwable != null) {
-            stackTrace(throwable)
-        } else {
-            "(empty)"
-        }
+            "$message\n${throwable.getStacktraceAsString()}"
+        } else message ?: (throwable?.getStacktraceAsString() ?: "(empty)")
 
         android.util.Log.println(priority.value, logTag, logMessage)
     }
@@ -43,13 +37,5 @@ class AndroidLogSink(
             return tag.substring(0, MAX_TAG_LENGTH)
         }
         return tag
-    }
-
-    private fun stackTrace(throwable: Throwable): String {
-        val sw = StringWriter(STACK_TRACE_INITIAL_BUFFER_SIZE)
-        val pw = PrintWriter(sw, false)
-        throwable.printStackTrace(pw)
-        pw.flush()
-        return sw.toString()
     }
 }


### PR DESCRIPTION
This patch adds the database classes to store information about crashes on disk. In this state it is not being used yet. Landing this separately to continue working on the UI and the integration. I'm not 100% happy with that part yet and therefore want to continue iterating. However the database piece seems to be stable enough and probably won't change.