### PR TITLE
Issue #6838: Fix top sites migration that used isDefault instead of is_default

### DIFF
--- a/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/3.json
+++ b/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/3.json
@@ -1,0 +1,58 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "4c6cae8272b2580de8cb444de31f27d5",
+    "entities": [
+      {
+        "tableName": "top_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `is_default` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "is_default",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4c6cae8272b2580de8cb444de31f27d5')"
+    ]
+  }
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
@@ -14,7 +14,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 /**
  * Internal database for storing top sites.
  */
-@Database(entities = [TopSiteEntity::class], version = 2)
+@Database(entities = [TopSiteEntity::class], version = 3)
 internal abstract class TopSiteDatabase : RoomDatabase() {
     abstract fun topSiteDao(): TopSiteDao
 
@@ -32,6 +32,8 @@ internal abstract class TopSiteDatabase : RoomDatabase() {
                 "top_sites"
             ).addMigrations(
                 Migrations.migration_1_2
+            ).addMigrations(
+                Migrations.migration_2_3
             ).build().also {
                 instance = it
             }
@@ -52,6 +54,49 @@ internal object Migrations {
             database.execSQL(
                 "UPDATE top_sites " +
                     "SET isDefault = 1 " +
+                    "WHERE url IN " +
+                    "('https://getpocket.com/fenix-top-articles', " +
+                    "'https://www.wikipedia.org/', " +
+                    "'https://www.youtube.com/')"
+            )
+        }
+    }
+
+    @Suppress("MagicNumber")
+    val migration_2_3 = object : Migration(2, 3) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // Create a temporary top sites table of version 1.
+            database.execSQL(
+                "CREATE TABLE IF NOT EXISTS `top_sites_temp` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    "`title` TEXT NOT NULL, " +
+                    "`url` TEXT NOT NULL, " +
+                    "`is_default` INTEGER NOT NULL, " +
+                    "`created_at` INTEGER NOT NULL)"
+            )
+
+            // Insert every entry from the old table into the temporary top sites table.
+            database.execSQL(
+                "INSERT INTO top_sites_temp (title, url, created_at, is_default) " +
+                    "SELECT title, url, created_at, 0 FROM top_sites"
+            )
+
+            // Assume there are consumers of version 2 with the mismatched isDefault and is_default
+            // column name. Drop the old table.
+            database.execSQL(
+                "DROP TABLE top_sites"
+            )
+
+            // Rename the temporary table to top_sites.
+            database.execSQL(
+                "ALTER TABLE top_sites_temp RENAME TO top_sites"
+            )
+
+            // Prior to version 2, pocket top sites, wikipedia and youtube were added as default
+            // sites in Fenix. Look for these entries and set isDefault to 1 (true).
+            database.execSQL(
+                "UPDATE top_sites " +
+                    "SET is_default = 1 " +
                     "WHERE url IN " +
                     "('https://getpocket.com/fenix-top-articles', " +
                     "'https://www.wikipedia.org/', " +


### PR DESCRIPTION
Fixes #6838.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
