### PR TITLE
Closes #2985: Launch reader view in extension page

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/storage/SnapshotSerializer.kt
@@ -51,6 +51,9 @@ class SnapshotSerializer(
 
         val sessionJson = serializeSession(item.session)
         sessionJson.put(Keys.SESSION_READER_MODE_KEY, item.readerState?.active ?: false)
+        if (item.readerState?.active == true && item.readerState.activeUrl != null) {
+            sessionJson.put(Keys.SESSION_READER_MODE_ACTIVE_URL_KEY, item.readerState.activeUrl)
+        }
         itemJson.put(Keys.SESSION_KEY, sessionJson)
 
         val engineSessionState = if (item.engineSessionState != null) {
@@ -84,8 +87,10 @@ class SnapshotSerializer(
         val sessionJson = json.getJSONObject(Keys.SESSION_KEY)
         val engineSessionJson = json.getJSONObject(Keys.ENGINE_SESSION_KEY)
         val session = deserializeSession(sessionJson, restoreSessionIds, restoreParentIds)
-        val readerState =
-            ReaderState(active = sessionJson.optBoolean(Keys.SESSION_READER_MODE_KEY, false))
+        val readerState = ReaderState(
+            active = sessionJson.optBoolean(Keys.SESSION_READER_MODE_KEY, false),
+            activeUrl = sessionJson.tryGetString(Keys.SESSION_READER_MODE_ACTIVE_URL_KEY)
+        )
         val engineState = engine.createSessionState(engineSessionJson)
 
         return SessionManager.Snapshot.Item(
@@ -144,6 +149,7 @@ private object Keys {
     const val SESSION_CONTEXT_ID_KEY = "contextId"
     const val SESSION_PARENT_UUID_KEY = "parentUuid"
     const val SESSION_READER_MODE_KEY = "readerMode"
+    const val SESSION_READER_MODE_ACTIVE_URL_KEY = "readerModeArticleUrl"
     const val SESSION_TITLE = "title"
 
     const val SESSION_KEY = "session"

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -410,7 +410,10 @@ class SessionManagerMigrationTest {
         }
 
         store.dispatch(ReaderAction.UpdateReaderActiveAction(session2.id, true)).joinBlocking()
-        assertEquals(ReaderState(active = true), store.state.findTab(session2.id)?.readerState)
+        store.dispatch(ReaderAction.UpdateReaderActiveUrlAction(session2.id, "blog.mozilla.org/1")).joinBlocking()
+        assertEquals(ReaderState(active = true, activeUrl = "blog.mozilla.org/1"),
+            store.state.findTab(session2.id)?.readerState
+        )
 
         val snapshot = manager.createSnapshot()
         manager.removeAll()
@@ -419,7 +422,9 @@ class SessionManagerMigrationTest {
 
         manager.restore(snapshot)
         assertEquals(ReaderState(active = false), store.state.findTab(session1.id)?.readerState)
-        assertEquals(ReaderState(active = true), store.state.findTab(session2.id)?.readerState)
+        assertEquals(ReaderState(active = true, activeUrl = "blog.mozilla.org/1"),
+            store.state.findTab(session2.id)?.readerState
+        )
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -708,6 +708,31 @@ class SessionManagerTest {
     }
 
     @Test
+    fun `parent is not provided when linking engine session for extension page`() {
+        val engine: Engine = mock()
+
+        val parent = Session(id = "parent", initialUrl = "")
+        val parentEngineSession: EngineSession = mock()
+        val session = Session("moz-extension://test-1234")
+        session.parentId = parent.id
+        val engineSession: EngineSession = mock()
+
+        val sessionManager = SessionManager(engine)
+        sessionManager.add(parent)
+        sessionManager.add(session)
+
+        doReturn(parentEngineSession, engineSession).`when`(engine).createSession(false)
+
+        assertEquals(parentEngineSession, sessionManager.getOrCreateEngineSession(parent))
+        assertEquals(parentEngineSession, parent.engineSessionHolder.engineSession)
+
+        assertEquals(engineSession, sessionManager.getOrCreateEngineSession(session))
+        assertEquals(engineSession, session.engineSessionHolder.engineSession)
+
+        verify(engineSession).loadUrl(session.url, null, EngineSession.LoadUrlFlags.none())
+    }
+
+    @Test
     fun `removing a session unlinks the engine session`() {
         val engine: Engine = mock()
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SnapshotSerializerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/storage/SnapshotSerializerTest.kt
@@ -99,13 +99,13 @@ class SnapshotSerializerTest {
         }
 
         val serializer = SnapshotSerializer()
-        val json = serializer.itemToJSON(
+        var json = serializer.itemToJSON(
             Snapshot.Item(
                 originalSession,
                 readerState = ReaderState(active = true)
             )
         )
-        val restoredItem = serializer.itemFromJSON(engine, json)
+        var restoredItem = serializer.itemFromJSON(engine, json)
 
         assertEquals("https://www.mozilla.org", restoredItem.session.url)
         assertEquals(Session.Source.RESTORED, restoredItem.session.source)
@@ -113,6 +113,24 @@ class SnapshotSerializerTest {
         assertEquals("test-context-id", restoredItem.session.contextId)
         assertEquals("Hello World", restoredItem.session.title)
         assertEquals(ReaderState(active = true), restoredItem.readerState)
+
+        json = serializer.itemToJSON(
+            Snapshot.Item(
+                originalSession,
+                readerState = ReaderState(active = true, activeUrl = "https://blog.mozilla.org/123")
+            )
+        )
+        restoredItem = serializer.itemFromJSON(engine, json)
+        assertEquals(ReaderState(active = true, activeUrl = "https://blog.mozilla.org/123"), restoredItem.readerState)
+
+        json = serializer.itemToJSON(
+            Snapshot.Item(
+                originalSession,
+                readerState = ReaderState(active = false, activeUrl = "https://blog.mozilla.org/123")
+            )
+        )
+        restoredItem = serializer.itemFromJSON(engine, json)
+        assertEquals(ReaderState(), restoredItem.readerState)
     }
 
     @Test

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -436,6 +436,21 @@ sealed class ReaderAction : BrowserAction() {
      * Updates the [ReaderState.connectRequired] flag.
      */
     data class UpdateReaderConnectRequiredAction(val tabId: String, val connectRequired: Boolean) : ReaderAction()
+
+    /**
+    * Updates the [ReaderState.readerBaseUrl].
+    */
+    data class UpdateReaderBaseUrlAction(val tabId: String, val baseUrl: String) : ReaderAction()
+
+    /**
+     * Updates the [ReaderState.activeUrl].
+     */
+    data class UpdateReaderActiveUrlAction(val tabId: String, val activeUrl: String) : ReaderAction()
+
+    /**
+     * Clears the [ReaderState.activeUrl].
+     */
+    data class ClearReaderActiveUrlAction(val tabId: String) : ReaderAction()
 }
 
 /**

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
@@ -28,6 +28,15 @@ internal object ReaderStateReducer {
         is ReaderAction.UpdateReaderConnectRequiredAction -> state.copyWithReaderState(action.tabId) {
             it.copy(connectRequired = action.connectRequired)
         }
+        is ReaderAction.UpdateReaderBaseUrlAction -> state.copyWithReaderState(action.tabId) {
+            it.copy(baseUrl = action.baseUrl)
+        }
+        is ReaderAction.UpdateReaderActiveUrlAction -> state.copyWithReaderState(action.tabId) {
+            it.copy(activeUrl = action.activeUrl)
+        }
+        is ReaderAction.ClearReaderActiveUrlAction -> state.copyWithReaderState(action.tabId) {
+            it.copy(activeUrl = null)
+        }
     }
 }
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
@@ -14,10 +14,14 @@ package mozilla.components.browser.state.state
  * current page.
  * @property connectRequired whether or not a new connection to the reader view
  * content script is required.
+ * @property baseUrl the base URL of the reader view extension page.
+ * @property activeUrl the URL of the page currently displayed in reader view.
  */
 data class ReaderState(
     val readerable: Boolean = false,
     val active: Boolean = false,
     val checkRequired: Boolean = false,
-    val connectRequired: Boolean = false
+    val connectRequired: Boolean = false,
+    val baseUrl: String? = null,
+    val activeUrl: String? = null
 )

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
@@ -10,7 +10,9 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -91,5 +93,37 @@ class ReaderActionTest {
             .joinBlocking()
 
         assertFalse(readerState().connectRequired)
+    }
+
+    @Test
+    fun `UpdateReaderBaseUrlAction - Updates base url of ReaderState`() {
+        assertNull(readerState().baseUrl)
+
+        store.dispatch(ReaderAction.UpdateReaderBaseUrlAction(tabId = tab.id, baseUrl = "moz-extension://test"))
+            .joinBlocking()
+
+        assertEquals("moz-extension://test", readerState().baseUrl)
+    }
+
+    @Test
+    fun `UpdateReaderActiveUrlAction - Updates active url of ReaderState`() {
+        assertNull(readerState().activeUrl)
+
+        store.dispatch(ReaderAction.UpdateReaderActiveUrlAction(tabId = tab.id, activeUrl = "https://mozilla.org"))
+            .joinBlocking()
+
+        assertEquals("https://mozilla.org", readerState().activeUrl)
+    }
+
+    @Test
+    fun `ClearReaderActiveUrlAction - Clears active url of ReaderState`() {
+        assertNull(readerState().activeUrl)
+
+        store.dispatch(ReaderAction.UpdateReaderActiveUrlAction(tabId = tab.id, activeUrl = "https://mozilla.org"))
+                .joinBlocking()
+        assertEquals("https://mozilla.org", readerState().activeUrl)
+
+        store.dispatch(ReaderAction.ClearReaderActiveUrlAction(tabId = tab.id)).joinBlocking()
+        assertNull(readerState().activeUrl)
     }
 }

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/BrowserThumbnails.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/BrowserThumbnails.kt
@@ -53,6 +53,10 @@ class BrowserThumbnails(
                 requestScreenshot(session)
             }
         }
+
+        override fun onTitleChanged(session: Session, title: String) {
+            requestScreenshot(session)
+        }
     }
 
     private fun requestScreenshot(session: Session) {

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/BrowserThumbnailsTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/BrowserThumbnailsTest.kt
@@ -63,6 +63,19 @@ class BrowserThumbnailsTest {
     }
 
     @Test
+    fun `feature must capture thumbnail when title changes`() {
+        thumbnails.start()
+
+        val session = getSelectedSession()
+
+        session.notifyObservers {
+            onTitleChanged(session, "test")
+        }
+
+        verify(mockEngineView).captureThumbnail(any())
+    }
+
+    @Test
     fun `when a page is loaded and the os is in low memory condition none thumbnail should be captured`() {
         thumbnails.start()
 

--- a/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
@@ -4,14 +4,18 @@
   "version": "1.0",
   "content_scripts": [
     {
-      "matches": ["*://*/*"],
-      "js": ["readability/readability-0.2.0.js", "readability/readability-readerable-0.2.0.js", "readerview.js"],
-      "css": ["readerview.css"],
+      "matches": ["<all_urls>"],
+      "js": ["readability/readability-readerable-0.2.0.js", "readerview-content.js"],
       "run_at": "document_idle"
     }
   ],
+  "background": {
+    "scripts": ["readerview-background.js"]
+  },
   "permissions": [
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "tabs",
+    "<all_urls>"
   ]
 }

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readability/JSDOMParser-0.2.0.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readability/JSDOMParser-0.2.0.js
@@ -1,0 +1,1188 @@
+/*eslint-env es6:false*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This is a relatively lightweight DOMParser that is safe to use in a web
+ * worker. This is far from a complete DOM implementation; however, it should
+ * contain the minimal set of functionality necessary for Readability.js.
+ *
+ * Aside from not implementing the full DOM API, there are other quirks to be
+ * aware of when using the JSDOMParser:
+ *
+ *   1) Properly formed HTML/XML must be used. This means you should be extra
+ *      careful when using this parser on anything received directly from an
+ *      XMLHttpRequest. Providing a serialized string from an XMLSerializer,
+ *      however, should be safe (since the browser's XMLSerializer should
+ *      generate valid HTML/XML). Therefore, if parsing a document from an XHR,
+ *      the recommended approach is to do the XHR in the main thread, use
+ *      XMLSerializer.serializeToString() on the responseXML, and pass the
+ *      resulting string to the worker.
+ *
+ *   2) Live NodeLists are not supported. DOM methods and properties such as
+ *      getElementsByTagName() and childNodes return standard arrays. If you
+ *      want these lists to be updated when nodes are removed or added to the
+ *      document, you must take care to manually update them yourself.
+ */
+(function (global) {
+
+  // XML only defines these and the numeric ones:
+
+  var entityTable = {
+    "lt": "<",
+    "gt": ">",
+    "amp": "&",
+    "quot": '"',
+    "apos": "'",
+  };
+
+  var reverseEntityTable = {
+    "<": "&lt;",
+    ">": "&gt;",
+    "&": "&amp;",
+    '"': "&quot;",
+    "'": "&apos;",
+  };
+
+  function encodeTextContentHTML(s) {
+    return s.replace(/[&<>]/g, function(x) {
+      return reverseEntityTable[x];
+    });
+  }
+
+  function encodeHTML(s) {
+    return s.replace(/[&<>'"]/g, function(x) {
+      return reverseEntityTable[x];
+    });
+  }
+
+  function decodeHTML(str) {
+    return str.replace(/&(quot|amp|apos|lt|gt);/g, function(match, tag) {
+      return entityTable[tag];
+    }).replace(/&#(?:x([0-9a-z]{1,4})|([0-9]{1,4}));/gi, function(match, hex, numStr) {
+      var num = parseInt(hex || numStr, hex ? 16 : 10); // read num
+      return String.fromCharCode(num);
+    });
+  }
+
+  // When a style is set in JS, map it to the corresponding CSS attribute
+  var styleMap = {
+    "alignmentBaseline": "alignment-baseline",
+    "background": "background",
+    "backgroundAttachment": "background-attachment",
+    "backgroundClip": "background-clip",
+    "backgroundColor": "background-color",
+    "backgroundImage": "background-image",
+    "backgroundOrigin": "background-origin",
+    "backgroundPosition": "background-position",
+    "backgroundPositionX": "background-position-x",
+    "backgroundPositionY": "background-position-y",
+    "backgroundRepeat": "background-repeat",
+    "backgroundRepeatX": "background-repeat-x",
+    "backgroundRepeatY": "background-repeat-y",
+    "backgroundSize": "background-size",
+    "baselineShift": "baseline-shift",
+    "border": "border",
+    "borderBottom": "border-bottom",
+    "borderBottomColor": "border-bottom-color",
+    "borderBottomLeftRadius": "border-bottom-left-radius",
+    "borderBottomRightRadius": "border-bottom-right-radius",
+    "borderBottomStyle": "border-bottom-style",
+    "borderBottomWidth": "border-bottom-width",
+    "borderCollapse": "border-collapse",
+    "borderColor": "border-color",
+    "borderImage": "border-image",
+    "borderImageOutset": "border-image-outset",
+    "borderImageRepeat": "border-image-repeat",
+    "borderImageSlice": "border-image-slice",
+    "borderImageSource": "border-image-source",
+    "borderImageWidth": "border-image-width",
+    "borderLeft": "border-left",
+    "borderLeftColor": "border-left-color",
+    "borderLeftStyle": "border-left-style",
+    "borderLeftWidth": "border-left-width",
+    "borderRadius": "border-radius",
+    "borderRight": "border-right",
+    "borderRightColor": "border-right-color",
+    "borderRightStyle": "border-right-style",
+    "borderRightWidth": "border-right-width",
+    "borderSpacing": "border-spacing",
+    "borderStyle": "border-style",
+    "borderTop": "border-top",
+    "borderTopColor": "border-top-color",
+    "borderTopLeftRadius": "border-top-left-radius",
+    "borderTopRightRadius": "border-top-right-radius",
+    "borderTopStyle": "border-top-style",
+    "borderTopWidth": "border-top-width",
+    "borderWidth": "border-width",
+    "bottom": "bottom",
+    "boxShadow": "box-shadow",
+    "boxSizing": "box-sizing",
+    "captionSide": "caption-side",
+    "clear": "clear",
+    "clip": "clip",
+    "clipPath": "clip-path",
+    "clipRule": "clip-rule",
+    "color": "color",
+    "colorInterpolation": "color-interpolation",
+    "colorInterpolationFilters": "color-interpolation-filters",
+    "colorProfile": "color-profile",
+    "colorRendering": "color-rendering",
+    "content": "content",
+    "counterIncrement": "counter-increment",
+    "counterReset": "counter-reset",
+    "cursor": "cursor",
+    "direction": "direction",
+    "display": "display",
+    "dominantBaseline": "dominant-baseline",
+    "emptyCells": "empty-cells",
+    "enableBackground": "enable-background",
+    "fill": "fill",
+    "fillOpacity": "fill-opacity",
+    "fillRule": "fill-rule",
+    "filter": "filter",
+    "cssFloat": "float",
+    "floodColor": "flood-color",
+    "floodOpacity": "flood-opacity",
+    "font": "font",
+    "fontFamily": "font-family",
+    "fontSize": "font-size",
+    "fontStretch": "font-stretch",
+    "fontStyle": "font-style",
+    "fontVariant": "font-variant",
+    "fontWeight": "font-weight",
+    "glyphOrientationHorizontal": "glyph-orientation-horizontal",
+    "glyphOrientationVertical": "glyph-orientation-vertical",
+    "height": "height",
+    "imageRendering": "image-rendering",
+    "kerning": "kerning",
+    "left": "left",
+    "letterSpacing": "letter-spacing",
+    "lightingColor": "lighting-color",
+    "lineHeight": "line-height",
+    "listStyle": "list-style",
+    "listStyleImage": "list-style-image",
+    "listStylePosition": "list-style-position",
+    "listStyleType": "list-style-type",
+    "margin": "margin",
+    "marginBottom": "margin-bottom",
+    "marginLeft": "margin-left",
+    "marginRight": "margin-right",
+    "marginTop": "margin-top",
+    "marker": "marker",
+    "markerEnd": "marker-end",
+    "markerMid": "marker-mid",
+    "markerStart": "marker-start",
+    "mask": "mask",
+    "maxHeight": "max-height",
+    "maxWidth": "max-width",
+    "minHeight": "min-height",
+    "minWidth": "min-width",
+    "opacity": "opacity",
+    "orphans": "orphans",
+    "outline": "outline",
+    "outlineColor": "outline-color",
+    "outlineOffset": "outline-offset",
+    "outlineStyle": "outline-style",
+    "outlineWidth": "outline-width",
+    "overflow": "overflow",
+    "overflowX": "overflow-x",
+    "overflowY": "overflow-y",
+    "padding": "padding",
+    "paddingBottom": "padding-bottom",
+    "paddingLeft": "padding-left",
+    "paddingRight": "padding-right",
+    "paddingTop": "padding-top",
+    "page": "page",
+    "pageBreakAfter": "page-break-after",
+    "pageBreakBefore": "page-break-before",
+    "pageBreakInside": "page-break-inside",
+    "pointerEvents": "pointer-events",
+    "position": "position",
+    "quotes": "quotes",
+    "resize": "resize",
+    "right": "right",
+    "shapeRendering": "shape-rendering",
+    "size": "size",
+    "speak": "speak",
+    "src": "src",
+    "stopColor": "stop-color",
+    "stopOpacity": "stop-opacity",
+    "stroke": "stroke",
+    "strokeDasharray": "stroke-dasharray",
+    "strokeDashoffset": "stroke-dashoffset",
+    "strokeLinecap": "stroke-linecap",
+    "strokeLinejoin": "stroke-linejoin",
+    "strokeMiterlimit": "stroke-miterlimit",
+    "strokeOpacity": "stroke-opacity",
+    "strokeWidth": "stroke-width",
+    "tableLayout": "table-layout",
+    "textAlign": "text-align",
+    "textAnchor": "text-anchor",
+    "textDecoration": "text-decoration",
+    "textIndent": "text-indent",
+    "textLineThrough": "text-line-through",
+    "textLineThroughColor": "text-line-through-color",
+    "textLineThroughMode": "text-line-through-mode",
+    "textLineThroughStyle": "text-line-through-style",
+    "textLineThroughWidth": "text-line-through-width",
+    "textOverflow": "text-overflow",
+    "textOverline": "text-overline",
+    "textOverlineColor": "text-overline-color",
+    "textOverlineMode": "text-overline-mode",
+    "textOverlineStyle": "text-overline-style",
+    "textOverlineWidth": "text-overline-width",
+    "textRendering": "text-rendering",
+    "textShadow": "text-shadow",
+    "textTransform": "text-transform",
+    "textUnderline": "text-underline",
+    "textUnderlineColor": "text-underline-color",
+    "textUnderlineMode": "text-underline-mode",
+    "textUnderlineStyle": "text-underline-style",
+    "textUnderlineWidth": "text-underline-width",
+    "top": "top",
+    "unicodeBidi": "unicode-bidi",
+    "unicodeRange": "unicode-range",
+    "vectorEffect": "vector-effect",
+    "verticalAlign": "vertical-align",
+    "visibility": "visibility",
+    "whiteSpace": "white-space",
+    "widows": "widows",
+    "width": "width",
+    "wordBreak": "word-break",
+    "wordSpacing": "word-spacing",
+    "wordWrap": "word-wrap",
+    "writingMode": "writing-mode",
+    "zIndex": "z-index",
+    "zoom": "zoom",
+  };
+
+  // Elements that can be self-closing
+  var voidElems = {
+    "area": true,
+    "base": true,
+    "br": true,
+    "col": true,
+    "command": true,
+    "embed": true,
+    "hr": true,
+    "img": true,
+    "input": true,
+    "link": true,
+    "meta": true,
+    "param": true,
+    "source": true,
+    "wbr": true
+  };
+
+  var whitespace = [" ", "\t", "\n", "\r"];
+
+  // See http://www.w3schools.com/dom/dom_nodetype.asp
+  var nodeTypes = {
+    ELEMENT_NODE: 1,
+    ATTRIBUTE_NODE: 2,
+    TEXT_NODE: 3,
+    CDATA_SECTION_NODE: 4,
+    ENTITY_REFERENCE_NODE: 5,
+    ENTITY_NODE: 6,
+    PROCESSING_INSTRUCTION_NODE: 7,
+    COMMENT_NODE: 8,
+    DOCUMENT_NODE: 9,
+    DOCUMENT_TYPE_NODE: 10,
+    DOCUMENT_FRAGMENT_NODE: 11,
+    NOTATION_NODE: 12
+  };
+
+  function getElementsByTagName(tag) {
+    tag = tag.toUpperCase();
+    var elems = [];
+    var allTags = (tag === "*");
+    function getElems(node) {
+      var length = node.children.length;
+      for (var i = 0; i < length; i++) {
+        var child = node.children[i];
+        if (allTags || (child.tagName === tag))
+          elems.push(child);
+        getElems(child);
+      }
+    }
+    getElems(this);
+    return elems;
+  }
+
+  var Node = function () {};
+
+  Node.prototype = {
+    attributes: null,
+    childNodes: null,
+    localName: null,
+    nodeName: null,
+    parentNode: null,
+    textContent: null,
+    nextSibling: null,
+    previousSibling: null,
+
+    get firstChild() {
+      return this.childNodes[0] || null;
+    },
+
+    get firstElementChild() {
+      return this.children[0] || null;
+    },
+
+    get lastChild() {
+      return this.childNodes[this.childNodes.length - 1] || null;
+    },
+
+    get lastElementChild() {
+      return this.children[this.children.length - 1] || null;
+    },
+
+    appendChild: function (child) {
+      if (child.parentNode) {
+        child.parentNode.removeChild(child);
+      }
+
+      var last = this.lastChild;
+      if (last)
+        last.nextSibling = child;
+      child.previousSibling = last;
+
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        child.previousElementSibling = this.children[this.children.length - 1] || null;
+        this.children.push(child);
+        child.previousElementSibling && (child.previousElementSibling.nextElementSibling = child);
+      }
+      this.childNodes.push(child);
+      child.parentNode = this;
+    },
+
+    removeChild: function (child) {
+      var childNodes = this.childNodes;
+      var childIndex = childNodes.indexOf(child);
+      if (childIndex === -1) {
+        throw "removeChild: node not found";
+      } else {
+        child.parentNode = null;
+        var prev = child.previousSibling;
+        var next = child.nextSibling;
+        if (prev)
+          prev.nextSibling = next;
+        if (next)
+          next.previousSibling = prev;
+
+        if (child.nodeType === Node.ELEMENT_NODE) {
+          prev = child.previousElementSibling;
+          next = child.nextElementSibling;
+          if (prev)
+            prev.nextElementSibling = next;
+          if (next)
+            next.previousElementSibling = prev;
+          this.children.splice(this.children.indexOf(child), 1);
+        }
+
+        child.previousSibling = child.nextSibling = null;
+        child.previousElementSibling = child.nextElementSibling = null;
+
+        return childNodes.splice(childIndex, 1)[0];
+      }
+    },
+
+    replaceChild: function (newNode, oldNode) {
+      var childNodes = this.childNodes;
+      var childIndex = childNodes.indexOf(oldNode);
+      if (childIndex === -1) {
+        throw "replaceChild: node not found";
+      } else {
+        // This will take care of updating the new node if it was somewhere else before:
+        if (newNode.parentNode)
+          newNode.parentNode.removeChild(newNode);
+
+        childNodes[childIndex] = newNode;
+
+        // update the new node's sibling properties, and its new siblings' sibling properties
+        newNode.nextSibling = oldNode.nextSibling;
+        newNode.previousSibling = oldNode.previousSibling;
+        if (newNode.nextSibling)
+          newNode.nextSibling.previousSibling = newNode;
+        if (newNode.previousSibling)
+          newNode.previousSibling.nextSibling = newNode;
+
+        newNode.parentNode = this;
+
+        // Now deal with elements before we clear out those values for the old node,
+        // because it can help us take shortcuts here:
+        if (newNode.nodeType === Node.ELEMENT_NODE) {
+          if (oldNode.nodeType === Node.ELEMENT_NODE) {
+            // Both were elements, which makes this easier, we just swap things out:
+            newNode.previousElementSibling = oldNode.previousElementSibling;
+            newNode.nextElementSibling = oldNode.nextElementSibling;
+            if (newNode.previousElementSibling)
+              newNode.previousElementSibling.nextElementSibling = newNode;
+            if (newNode.nextElementSibling)
+              newNode.nextElementSibling.previousElementSibling = newNode;
+            this.children[this.children.indexOf(oldNode)] = newNode;
+          } else {
+            // Hard way:
+            newNode.previousElementSibling = (function() {
+              for (var i = childIndex - 1; i >= 0; i--) {
+                if (childNodes[i].nodeType === Node.ELEMENT_NODE)
+                  return childNodes[i];
+              }
+              return null;
+            })();
+            if (newNode.previousElementSibling) {
+              newNode.nextElementSibling = newNode.previousElementSibling.nextElementSibling;
+            } else {
+              newNode.nextElementSibling = (function() {
+                for (var i = childIndex + 1; i < childNodes.length; i++) {
+                  if (childNodes[i].nodeType === Node.ELEMENT_NODE)
+                    return childNodes[i];
+                }
+                return null;
+              })();
+            }
+            if (newNode.previousElementSibling)
+              newNode.previousElementSibling.nextElementSibling = newNode;
+            if (newNode.nextElementSibling)
+              newNode.nextElementSibling.previousElementSibling = newNode;
+
+            if (newNode.nextElementSibling)
+              this.children.splice(this.children.indexOf(newNode.nextElementSibling), 0, newNode);
+            else
+              this.children.push(newNode);
+          }
+        } else if (oldNode.nodeType === Node.ELEMENT_NODE) {
+          // new node is not an element node.
+          // if the old one was, update its element siblings:
+          if (oldNode.previousElementSibling)
+            oldNode.previousElementSibling.nextElementSibling = oldNode.nextElementSibling;
+          if (oldNode.nextElementSibling)
+            oldNode.nextElementSibling.previousElementSibling = oldNode.previousElementSibling;
+          this.children.splice(this.children.indexOf(oldNode), 1);
+
+          // If the old node wasn't an element, neither the new nor the old node was an element,
+          // and the children array and its members shouldn't need any updating.
+        }
+
+
+        oldNode.parentNode = null;
+        oldNode.previousSibling = null;
+        oldNode.nextSibling = null;
+        if (oldNode.nodeType === Node.ELEMENT_NODE) {
+          oldNode.previousElementSibling = null;
+          oldNode.nextElementSibling = null;
+        }
+        return oldNode;
+      }
+    },
+
+    __JSDOMParser__: true,
+  };
+
+  for (var nodeType in nodeTypes) {
+    Node[nodeType] = Node.prototype[nodeType] = nodeTypes[nodeType];
+  }
+
+  var Attribute = function (name, value) {
+    this.name = name;
+    this._value = value;
+  };
+
+  Attribute.prototype = {
+    get value() {
+      return this._value;
+    },
+    setValue: function(newValue) {
+      this._value = newValue;
+    },
+    getEncodedValue: function() {
+      return encodeHTML(this._value);
+    },
+  };
+
+  var Comment = function () {
+    this.childNodes = [];
+  };
+
+  Comment.prototype = {
+    __proto__: Node.prototype,
+
+    nodeName: "#comment",
+    nodeType: Node.COMMENT_NODE
+  };
+
+  var Text = function () {
+    this.childNodes = [];
+  };
+
+  Text.prototype = {
+    __proto__: Node.prototype,
+
+    nodeName: "#text",
+    nodeType: Node.TEXT_NODE,
+    get textContent() {
+      if (typeof this._textContent === "undefined") {
+        this._textContent = decodeHTML(this._innerHTML || "");
+      }
+      return this._textContent;
+    },
+    get innerHTML() {
+      if (typeof this._innerHTML === "undefined") {
+        this._innerHTML = encodeTextContentHTML(this._textContent || "");
+      }
+      return this._innerHTML;
+    },
+
+    set innerHTML(newHTML) {
+      this._innerHTML = newHTML;
+      delete this._textContent;
+    },
+    set textContent(newText) {
+      this._textContent = newText;
+      delete this._innerHTML;
+    },
+  };
+
+  var Document = function (url) {
+    this.documentURI = url;
+    this.styleSheets = [];
+    this.childNodes = [];
+    this.children = [];
+  };
+
+  Document.prototype = {
+    __proto__: Node.prototype,
+
+    nodeName: "#document",
+    nodeType: Node.DOCUMENT_NODE,
+    title: "",
+
+    getElementsByTagName: getElementsByTagName,
+
+    getElementById: function (id) {
+      function getElem(node) {
+        var length = node.children.length;
+        if (node.id === id)
+          return node;
+        for (var i = 0; i < length; i++) {
+          var el = getElem(node.children[i]);
+          if (el)
+            return el;
+        }
+        return null;
+      }
+      return getElem(this);
+    },
+
+    createElement: function (tag) {
+      var node = new Element(tag);
+      return node;
+    },
+
+    createTextNode: function (text) {
+      var node = new Text();
+      node.textContent = text;
+      return node;
+    },
+
+    get baseURI() {
+      if (!this.hasOwnProperty("_baseURI")) {
+        this._baseURI = this.documentURI;
+        var baseElements = this.getElementsByTagName("base");
+        var href = baseElements[0] && baseElements[0].getAttribute("href");
+        if (href) {
+          try {
+            this._baseURI = (new URL(href, this._baseURI)).href;
+          } catch (ex) {/* Just fall back to documentURI */}
+        }
+      }
+      return this._baseURI;
+    },
+  };
+
+  var Element = function (tag) {
+    // We use this to find the closing tag.
+    this._matchingTag = tag;
+    // We're explicitly a non-namespace aware parser, we just pretend it's all HTML.
+    var lastColonIndex = tag.lastIndexOf(":");
+    if (lastColonIndex != -1) {
+      tag = tag.substring(lastColonIndex + 1);
+    }
+    this.attributes = [];
+    this.childNodes = [];
+    this.children = [];
+    this.nextElementSibling = this.previousElementSibling = null;
+    this.localName = tag.toLowerCase();
+    this.tagName = tag.toUpperCase();
+    this.style = new Style(this);
+  };
+
+  Element.prototype = {
+    __proto__: Node.prototype,
+
+    nodeType: Node.ELEMENT_NODE,
+
+    getElementsByTagName: getElementsByTagName,
+
+    get className() {
+      return this.getAttribute("class") || "";
+    },
+
+    set className(str) {
+      this.setAttribute("class", str);
+    },
+
+    get id() {
+      return this.getAttribute("id") || "";
+    },
+
+    set id(str) {
+      this.setAttribute("id", str);
+    },
+
+    get href() {
+      return this.getAttribute("href") || "";
+    },
+
+    set href(str) {
+      this.setAttribute("href", str);
+    },
+
+    get src() {
+      return this.getAttribute("src") || "";
+    },
+
+    set src(str) {
+      this.setAttribute("src", str);
+    },
+
+    get srcset() {
+      return this.getAttribute("srcset") || "";
+    },
+
+    set srcset(str) {
+      this.setAttribute("srcset", str);
+    },
+
+    get nodeName() {
+      return this.tagName;
+    },
+
+    get innerHTML() {
+      function getHTML(node) {
+        var i = 0;
+        for (i = 0; i < node.childNodes.length; i++) {
+          var child = node.childNodes[i];
+          if (child.localName) {
+            arr.push("<" + child.localName);
+
+            // serialize attribute list
+            for (var j = 0; j < child.attributes.length; j++) {
+              var attr = child.attributes[j];
+              // the attribute value will be HTML escaped.
+              var val = attr.getEncodedValue();
+              var quote = (val.indexOf('"') === -1 ? '"' : "'");
+              arr.push(" " + attr.name + "=" + quote + val + quote);
+            }
+
+            if (child.localName in voidElems && !child.childNodes.length) {
+              // if this is a self-closing element, end it here
+              arr.push("/>");
+            } else {
+              // otherwise, add its children
+              arr.push(">");
+              getHTML(child);
+              arr.push("</" + child.localName + ">");
+            }
+          } else {
+            // This is a text node, so asking for innerHTML won't recurse.
+            arr.push(child.innerHTML);
+          }
+        }
+      }
+
+      // Using Array.join() avoids the overhead from lazy string concatenation.
+      // See http://blog.cdleary.com/2012/01/string-representation-in-spidermonkey/#ropes
+      var arr = [];
+      getHTML(this);
+      return arr.join("");
+    },
+
+    set innerHTML(html) {
+      var parser = new JSDOMParser();
+      var node = parser.parse(html);
+      var i;
+      for (i = this.childNodes.length; --i >= 0;) {
+        this.childNodes[i].parentNode = null;
+      }
+      this.childNodes = node.childNodes;
+      this.children = node.children;
+      for (i = this.childNodes.length; --i >= 0;) {
+        this.childNodes[i].parentNode = this;
+      }
+    },
+
+    set textContent(text) {
+      // clear parentNodes for existing children
+      for (var i = this.childNodes.length; --i >= 0;) {
+        this.childNodes[i].parentNode = null;
+      }
+
+      var node = new Text();
+      this.childNodes = [ node ];
+      this.children = [];
+      node.textContent = text;
+      node.parentNode = this;
+    },
+
+    get textContent() {
+      function getText(node) {
+        var nodes = node.childNodes;
+        for (var i = 0; i < nodes.length; i++) {
+          var child = nodes[i];
+          if (child.nodeType === 3) {
+            text.push(child.textContent);
+          } else {
+            getText(child);
+          }
+        }
+      }
+
+      // Using Array.join() avoids the overhead from lazy string concatenation.
+      // See http://blog.cdleary.com/2012/01/string-representation-in-spidermonkey/#ropes
+      var text = [];
+      getText(this);
+      return text.join("");
+    },
+
+    getAttribute: function (name) {
+      for (var i = this.attributes.length; --i >= 0;) {
+        var attr = this.attributes[i];
+        if (attr.name === name) {
+          return attr.value;
+        }
+      }
+      return undefined;
+    },
+
+    setAttribute: function (name, value) {
+      for (var i = this.attributes.length; --i >= 0;) {
+        var attr = this.attributes[i];
+        if (attr.name === name) {
+          attr.setValue(value);
+          return;
+        }
+      }
+      this.attributes.push(new Attribute(name, value));
+    },
+
+    removeAttribute: function (name) {
+      for (var i = this.attributes.length; --i >= 0;) {
+        var attr = this.attributes[i];
+        if (attr.name === name) {
+          this.attributes.splice(i, 1);
+          break;
+        }
+      }
+    },
+
+    hasAttribute: function (name) {
+      return this.attributes.some(function (attr) {
+        return attr.name == name;
+      });
+    },
+  };
+
+  var Style = function (node) {
+    this.node = node;
+  };
+
+  // getStyle() and setStyle() use the style attribute string directly. This
+  // won't be very efficient if there are a lot of style manipulations, but
+  // it's the easiest way to make sure the style attribute string and the JS
+  // style property stay in sync. Readability.js doesn't do many style
+  // manipulations, so this should be okay.
+  Style.prototype = {
+    getStyle: function (styleName) {
+      var attr = this.node.getAttribute("style");
+      if (!attr)
+        return undefined;
+
+      var styles = attr.split(";");
+      for (var i = 0; i < styles.length; i++) {
+        var style = styles[i].split(":");
+        var name = style[0].trim();
+        if (name === styleName)
+          return style[1].trim();
+      }
+
+      return undefined;
+    },
+
+    setStyle: function (styleName, styleValue) {
+      var value = this.node.getAttribute("style") || "";
+      var index = 0;
+      do {
+        var next = value.indexOf(";", index) + 1;
+        var length = next - index - 1;
+        var style = (length > 0 ? value.substr(index, length) : value.substr(index));
+        if (style.substr(0, style.indexOf(":")).trim() === styleName) {
+          value = value.substr(0, index).trim() + (next ? " " + value.substr(next).trim() : "");
+          break;
+        }
+        index = next;
+      } while (index);
+
+      value += " " + styleName + ": " + styleValue + ";";
+      this.node.setAttribute("style", value.trim());
+    }
+  };
+
+  // For each item in styleMap, define a getter and setter on the style
+  // property.
+  for (var jsName in styleMap) {
+    (function (cssName) {
+      Style.prototype.__defineGetter__(jsName, function () {
+        return this.getStyle(cssName);
+      });
+      Style.prototype.__defineSetter__(jsName, function (value) {
+        this.setStyle(cssName, value);
+      });
+    })(styleMap[jsName]);
+  }
+
+  var JSDOMParser = function () {
+    this.currentChar = 0;
+
+    // In makeElementNode() we build up many strings one char at a time. Using
+    // += for this results in lots of short-lived intermediate strings. It's
+    // better to build an array of single-char strings and then join() them
+    // together at the end. And reusing a single array (i.e. |this.strBuf|)
+    // over and over for this purpose uses less memory than using a new array
+    // for each string.
+    this.strBuf = [];
+
+    // Similarly, we reuse this array to return the two arguments from
+    // makeElementNode(), which saves us from having to allocate a new array
+    // every time.
+    this.retPair = [];
+
+    this.errorState = "";
+  };
+
+  JSDOMParser.prototype = {
+    error: function(m) {
+      dump("JSDOMParser error: " + m + "\n");
+      this.errorState += m + "\n";
+    },
+
+    /**
+     * Look at the next character without advancing the index.
+     */
+    peekNext: function () {
+      return this.html[this.currentChar];
+    },
+
+    /**
+     * Get the next character and advance the index.
+     */
+    nextChar: function () {
+      return this.html[this.currentChar++];
+    },
+
+    /**
+     * Called after a quote character is read. This finds the next quote
+     * character and returns the text string in between.
+     */
+    readString: function (quote) {
+      var str;
+      var n = this.html.indexOf(quote, this.currentChar);
+      if (n === -1) {
+        this.currentChar = this.html.length;
+        str = null;
+      } else {
+        str = this.html.substring(this.currentChar, n);
+        this.currentChar = n + 1;
+      }
+
+      return str;
+    },
+
+    /**
+     * Called when parsing a node. This finds the next name/value attribute
+     * pair and adds the result to the attributes list.
+     */
+    readAttribute: function (node) {
+      var name = "";
+
+      var n = this.html.indexOf("=", this.currentChar);
+      if (n === -1) {
+        this.currentChar = this.html.length;
+      } else {
+        // Read until a '=' character is hit; this will be the attribute key
+        name = this.html.substring(this.currentChar, n);
+        this.currentChar = n + 1;
+      }
+
+      if (!name)
+        return;
+
+      // After a '=', we should see a '"' for the attribute value
+      var c = this.nextChar();
+      if (c !== '"' && c !== "'") {
+        this.error("Error reading attribute " + name + ", expecting '\"'");
+        return;
+      }
+
+      // Read the attribute value (and consume the matching quote)
+      var value = this.readString(c);
+
+      node.attributes.push(new Attribute(name, decodeHTML(value)));
+
+      return;
+    },
+
+    /**
+     * Parses and returns an Element node. This is called after a '<' has been
+     * read.
+     *
+     * @returns an array; the first index of the array is the parsed node;
+     *          the second index is a boolean indicating whether this is a void
+     *          Element
+     */
+    makeElementNode: function (retPair) {
+      var c = this.nextChar();
+
+      // Read the Element tag name
+      var strBuf = this.strBuf;
+      strBuf.length = 0;
+      while (whitespace.indexOf(c) == -1 && c !== ">" && c !== "/") {
+        if (c === undefined)
+          return false;
+        strBuf.push(c);
+        c = this.nextChar();
+      }
+      var tag = strBuf.join("");
+
+      if (!tag)
+        return false;
+
+      var node = new Element(tag);
+
+      // Read Element attributes
+      while (c !== "/" && c !== ">") {
+        if (c === undefined)
+          return false;
+        while (whitespace.indexOf(this.html[this.currentChar++]) != -1) {
+          // Advance cursor to first non-whitespace char.
+        }
+        this.currentChar--;
+        c = this.nextChar();
+        if (c !== "/" && c !== ">") {
+          --this.currentChar;
+          this.readAttribute(node);
+        }
+      }
+
+      // If this is a self-closing tag, read '/>'
+      var closed = false;
+      if (c === "/") {
+        closed = true;
+        c = this.nextChar();
+        if (c !== ">") {
+          this.error("expected '>' to close " + tag);
+          return false;
+        }
+      }
+
+      retPair[0] = node;
+      retPair[1] = closed;
+      return true;
+    },
+
+    /**
+     * If the current input matches this string, advance the input index;
+     * otherwise, do nothing.
+     *
+     * @returns whether input matched string
+     */
+    match: function (str) {
+      var strlen = str.length;
+      if (this.html.substr(this.currentChar, strlen).toLowerCase() === str.toLowerCase()) {
+        this.currentChar += strlen;
+        return true;
+      }
+      return false;
+    },
+
+    /**
+     * Searches the input until a string is found and discards all input up to
+     * and including the matched string.
+     */
+    discardTo: function (str) {
+      var index = this.html.indexOf(str, this.currentChar) + str.length;
+      if (index === -1)
+        this.currentChar = this.html.length;
+      this.currentChar = index;
+    },
+
+    /**
+     * Reads child nodes for the given node.
+     */
+    readChildren: function (node) {
+      var child;
+      while ((child = this.readNode())) {
+        // Don't keep Comment nodes
+        if (child.nodeType !== 8) {
+          node.appendChild(child);
+        }
+      }
+    },
+
+    discardNextComment: function() {
+      if (this.match("--")) {
+        this.discardTo("-->");
+      } else {
+        var c = this.nextChar();
+        while (c !== ">") {
+          if (c === undefined)
+            return null;
+          if (c === '"' || c === "'")
+            this.readString(c);
+          c = this.nextChar();
+        }
+      }
+      return new Comment();
+    },
+
+
+    /**
+     * Reads the next child node from the input. If we're reading a closing
+     * tag, or if we've reached the end of input, return null.
+     *
+     * @returns the node
+     */
+    readNode: function () {
+      var c = this.nextChar();
+
+      if (c === undefined)
+        return null;
+
+      // Read any text as Text node
+      var textNode;
+      if (c !== "<") {
+        --this.currentChar;
+        textNode = new Text();
+        var n = this.html.indexOf("<", this.currentChar);
+        if (n === -1) {
+          textNode.innerHTML = this.html.substring(this.currentChar, this.html.length);
+          this.currentChar = this.html.length;
+        } else {
+          textNode.innerHTML = this.html.substring(this.currentChar, n);
+          this.currentChar = n;
+        }
+        return textNode;
+      }
+
+      if (this.match("![CDATA[")) {
+        var endChar = this.html.indexOf("]]>", this.currentChar);
+        if (endChar === -1) {
+          this.error("unclosed CDATA section");
+          return null;
+        }
+        textNode = new Text();
+        textNode.textContent = this.html.substring(this.currentChar, endChar);
+        this.currentChar = endChar + ("]]>").length;
+        return textNode;
+      }
+
+      c = this.peekNext();
+
+      // Read Comment node. Normally, Comment nodes know their inner
+      // textContent, but we don't really care about Comment nodes (we throw
+      // them away in readChildren()). So just returning an empty Comment node
+      // here is sufficient.
+      if (c === "!" || c === "?") {
+        // We're still before the ! or ? that is starting this comment:
+        this.currentChar++;
+        return this.discardNextComment();
+      }
+
+      // If we're reading a closing tag, return null. This means we've reached
+      // the end of this set of child nodes.
+      if (c === "/") {
+        --this.currentChar;
+        return null;
+      }
+
+      // Otherwise, we're looking at an Element node
+      var result = this.makeElementNode(this.retPair);
+      if (!result)
+        return null;
+
+      var node = this.retPair[0];
+      var closed = this.retPair[1];
+      var localName = node.localName;
+
+      // If this isn't a void Element, read its child nodes
+      if (!closed) {
+        this.readChildren(node);
+        var closingTag = "</" + node._matchingTag + ">";
+        if (!this.match(closingTag)) {
+          this.error("expected '" + closingTag + "' and got " + this.html.substr(this.currentChar, closingTag.length));
+          return null;
+        }
+      }
+
+      // Only use the first title, because SVG might have other
+      // title elements which we don't care about (medium.com
+      // does this, at least).
+      if (localName === "title" && !this.doc.title) {
+        this.doc.title = node.textContent.trim();
+      } else if (localName === "head") {
+        this.doc.head = node;
+      } else if (localName === "body") {
+        this.doc.body = node;
+      } else if (localName === "html") {
+        this.doc.documentElement = node;
+      }
+
+      return node;
+    },
+
+    /**
+     * Parses an HTML string and returns a JS implementation of the Document.
+     */
+    parse: function (html, url) {
+      this.html = html;
+      var doc = this.doc = new Document(url);
+      this.readChildren(doc);
+
+      // If this is an HTML document, remove root-level children except for the
+      // <html> node
+      if (doc.documentElement) {
+        for (var i = doc.childNodes.length; --i >= 0;) {
+          var child = doc.childNodes[i];
+          if (child !== doc.documentElement) {
+            doc.removeChild(child);
+          }
+        }
+      }
+
+      return doc;
+    }
+  };
+
+  // Attach the standard DOM types to the global scope
+  global.Node = Node;
+  global.Comment = Comment;
+  global.Document = Document;
+  global.Element = Element;
+  global.Text = Text;
+
+  // Attach JSDOMParser to the global scope
+  global.JSDOMParser = JSDOMParser;
+
+})(this);

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This background script is needed to update the current tab
+// and activate reader view.
+
+let serializedDocs = new Map();
+
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  switch (message.action) {
+     case 'show':
+       browser.tabs.update({url: `/readerview.html?url=${encodeURIComponent(message.url)}&id=${sender.contextId}`}).catch((e) => {
+         console.error("Failed to open reader view", e, e.stack);
+       });
+       break;
+     case 'addSerializedDoc':
+        serializedDocs.set(sender.contextId.toString(), message.doc);
+        break;
+     case 'getSerializedDoc':
+       let doc = serializedDocs.get(message.id);
+       if (doc) {
+         serializedDocs.delete(message.id);
+       }
+       sendResponse(doc);
+       break;
+     default:
+       console.error(`Received unsupported action ${message.action}`);
+   }
+});

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview-content.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview-content.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This script is injected into content to determine whether or not a
+// page is readerable, and to open a reader view extension page via
+// the background script.
+
+const supportedProtocols = ["http:", "https:"];
+
+// Prevent false positives for these sites. This list is taken from Fennec:
+// https://dxr.mozilla.org/mozilla-central/rev/7d47e7fa2489550ffa83aae67715c5497048923f/toolkit/components/reader/Readerable.js#45
+const blockedHosts = [
+  "amazon.com",
+  "github.com",
+  "mail.google.com",
+  "pinterest.com",
+  "reddit.com",
+  "twitter.com",
+  "youtube.com"
+];
+
+function isReaderable() {
+    if (!supportedProtocols.includes(location.protocol)) {
+      return false;
+    }
+
+    if (blockedHosts.some(blockedHost => location.hostname.endsWith(blockedHost))) {
+      return false;
+    }
+
+    if (location.pathname == "/") {
+      return false;
+    }
+
+    return isProbablyReaderable(document, _isNodeVisible);
+}
+
+function _isNodeVisible(node) {
+    return node.clientHeight > 0 && node.clientWidth > 0;
+}
+
+function connectNativePort() {
+  let port = browser.runtime.connectNative("mozacReaderview");
+  port.onMessage.addListener((message) => {
+     switch (message.action) {
+       case 'show':
+         browser.runtime.sendMessage({action: "show", options: message.value, url: location.href});
+
+         let serializedDoc = new XMLSerializer().serializeToString(document);
+         browser.runtime.sendMessage({action: "addSerializedDoc", doc: serializedDoc});
+         break;
+       case 'checkReaderState':
+         port.postMessage({baseUrl: browser.runtime.getURL("/"), readerable: isReaderable()});
+         break;
+       default:
+         console.error(`Received unsupported action ${message.action}`);
+     }
+  });
+
+  window.addEventListener("unload", (event) => { port.disconnect() }, false);
+}
+
+connectNativePort();

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.css
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.css
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Avoid adding ID selector rules in this style sheet, since they could
- * inadvertently match elements in the article content. */
-
 .mozac-readerview-body {
   padding: 20px;
   transition-property: background-color, color;
@@ -160,6 +157,7 @@
 }
 
 .mozac-readerview-body > .container > .content {
+  padding-top: 10px;
   padding-left: 0px;
   padding-right: 0px;
 }

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.html
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+      <meta content="text/html; charset=UTF-8" http-equiv="content-type" />
+      <meta name="viewport" content="width=device-width; user-scalable=0" />
+      <meta http-equiv="cache-control" content="no-store" />
+
+      <link rel="stylesheet" href="readerview.css" />
+
+      <script src="readability/JSDOMParser-0.2.0.js"></script>
+      <script src="readability/readability-0.2.0.js"></script>
+      <script src="readerview.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_URL
 import mozilla.components.lib.state.Middleware
@@ -33,25 +34,62 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
         next: (BrowserAction) -> Unit,
         action: BrowserAction
     ) {
-        preProcess(store, action)
-        next(action)
-        postProcess(store, action)
+        if (preProcess(store, action)) {
+            next(action)
+            postProcess(store, action)
+        }
     }
 
+    /**
+     * Processes the action before it is dispatched to the store.
+     *
+     * @param store a reference to the [MiddlewareStore].
+     * @param action the action to process.
+     * @return true if the original action should be processed, otherwise false.
+     */
     private fun preProcess(
         store: MiddlewareStore<BrowserState, BrowserAction>,
         action: BrowserAction
-    ) {
-        when (action) {
+    ): Boolean {
+        return when (action) {
             // We want to bind the feature instance to the lifecycle of the browser
-            // fragment so it won't necessarily be active when a tab is removed
+            // fragment. So it won't necessarily be active when a tab is removed
             // (e.g. via a tabs tray fragment). In order to disconnect the port as
             // early as possible it's best to do it here directly.
             is EngineAction.UnlinkEngineSessionAction -> {
                 store.state.findTab(action.sessionId)?.engineState?.engineSession?.let {
                     extensionController.disconnectPort(it, READER_VIEW_EXTENSION_ID)
                 }
+                true
             }
+            is ContentAction.UpdateUrlAction -> {
+                // Activate reader view when navigating to a reader page and deactivate it
+                // when navigating away. In addition, we want to mask moz-extension://
+                // URLs in the toolbar. So, if we detect the URL is coming from our
+                // extension we show the original URL instead. This is needed until
+                // we have a solution for:
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1550144
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1322304
+                // https://github.com/mozilla-mobile/android-components/issues/2879
+                val tab = store.state.findTab(action.sessionId)
+                if (isReaderUrl(tab, action.url)) {
+                    val urlReplaced = tab?.readerState?.activeUrl?.let { activeUrl ->
+                        store.dispatch(ContentAction.UpdateUrlAction(action.sessionId, activeUrl))
+                        true
+                    } ?: false
+                    store.dispatch(ReaderAction.UpdateReaderActiveAction(action.sessionId, true))
+                    !urlReplaced
+                } else {
+                    if (action.url != tab?.readerState?.activeUrl) {
+                        store.dispatch(ReaderAction.UpdateReaderActiveAction(action.sessionId, false))
+                        store.dispatch(ReaderAction.UpdateReaderableAction(action.sessionId, false))
+                        store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.sessionId, true))
+                        store.dispatch(ReaderAction.ClearReaderActiveUrlAction(action.sessionId))
+                    }
+                    true
+                }
+            }
+            else -> true
         }
     }
 
@@ -64,14 +102,24 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
                 store.dispatch(ReaderAction.UpdateReaderableAction(action.tabId, false))
                 store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.tabId, true))
             }
-            is ContentAction.UpdateUrlAction -> {
-                store.dispatch(ReaderAction.UpdateReaderActiveAction(action.sessionId, false))
-                store.dispatch(ReaderAction.UpdateReaderableAction(action.sessionId, false))
-                store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.sessionId, true))
-            }
             is EngineAction.LinkEngineSessionAction -> {
                 store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(action.sessionId, true))
             }
+            is ReaderAction.UpdateReaderActiveUrlAction -> {
+                // When a tab is restored, the reader page will connect, but we won't get a
+                // UpdateUrlAction. We still want to mask the moz-extension:// URL though
+                // so we update the URL here. See comment on handling UpdateUrlAction.
+                val tab = store.state.findTab(action.tabId)
+                val url = tab?.content?.url
+                if (url != null && isReaderUrl(tab, url)) {
+                    store.dispatch(ContentAction.UpdateUrlAction(tab.id, url))
+                }
+            }
         }
+    }
+
+    private fun isReaderUrl(tab: TabSessionState?, url: String): Boolean {
+        val readerViewBaseUrl = tab?.readerState?.baseUrl
+        return readerViewBaseUrl != null && url.startsWith(readerViewBaseUrl)
     }
 }

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/ThumbnailsFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/ThumbnailsFeature.kt
@@ -53,6 +53,10 @@ class ThumbnailsFeature(
                 requestScreenshot(session)
             }
         }
+
+        override fun onTitleChanged(session: Session, title: String) {
+            requestScreenshot(session)
+        }
     }
 
     private fun requestScreenshot(session: Session) {

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/ThumbnailsFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/ThumbnailsFeatureTest.kt
@@ -63,6 +63,19 @@ class ThumbnailsFeatureTest {
     }
 
     @Test
+    fun `feature must capture thumbnail when title changes`() {
+        feature.start()
+
+        val session = getSelectedSession()
+
+        session.notifyObservers {
+            onTitleChanged(session, "test")
+        }
+
+        verify(mockEngineView).captureThumbnail(any())
+    }
+
+    @Test
     fun `when a page is loaded and the os is in low memory condition none thumbnail should be captured`() {
         feature.start()
 

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
@@ -35,8 +35,15 @@ class WebExtensionController(
      * will happen upon successful installation.
      *
      * @param runtime the [WebExtensionRuntime] the web extension should be installed in.
+     * @param onSuccess (optional) callback invoked if the extension was installed successfully,
+     * providing access to the [WebExtension] object.
+     * @param onError (optional) callback invoked if there was an error installing the extension.
      */
-    fun install(runtime: WebExtensionRuntime) {
+    fun install(
+        runtime: WebExtensionRuntime,
+        onSuccess: ((WebExtension) -> Unit) = { },
+        onError: ((Throwable) -> Unit) = { _ -> }
+    ) {
         if (!installedExtensions.containsKey(extensionId)) {
             runtime.installWebExtension(extensionId, extensionUrl,
                 onSuccess = {
@@ -45,10 +52,12 @@ class WebExtensionController(
                         registerContentMessageHandler(it)
                         registerBackgroundMessageHandler(it)
                         installedExtensions[extensionId] = it
+                        onSuccess(it)
                     }
                 },
                 onError = { ext, throwable ->
                     logger.error("Failed to install extension: $ext", throwable)
+                    onError(throwable)
                 }
             )
         }

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
@@ -36,7 +36,10 @@ class WebExtensionControllerTest {
     fun `install webextension`() {
         val engine: Engine = mock()
         val controller = WebExtensionController(extensionId, extensionUrl)
-        controller.install(engine)
+
+        var onSuccessInvoked = false
+        var onErrorInvoked = false
+        controller.install(engine, onSuccess = { onSuccessInvoked = true }, onError = { onErrorInvoked = true })
 
         val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
         val onError = argumentCaptor<((String, Throwable) -> Unit)>()
@@ -51,6 +54,8 @@ class WebExtensionControllerTest {
         assertFalse(WebExtensionController.installedExtensions.containsKey(extensionId))
 
         onSuccess.value.invoke(mock())
+        assertTrue(onSuccessInvoked)
+        assertFalse(onErrorInvoked)
         assertTrue(WebExtensionController.installedExtensions.containsKey(extensionId))
 
         controller.install(engine)
@@ -62,6 +67,9 @@ class WebExtensionControllerTest {
             onSuccess.capture(),
             onError.capture()
         )
+
+        onError.value.invoke("", mock())
+        assertTrue(onErrorInvoked)
     }
 
     @Test


### PR DESCRIPTION
Design is as described in #2985. Instead of transforming the current DOM, we now open reader view in an extension page. We inject only a small script (instead of the whole logic) into every page to check whether or not the page is readerable. If the reader view is activated, we send a message to a background script to open the reader page which contains the rest of the logic and its dependencies.

This still requires a few workarounds, which I documented with links to the corresponding issues. However, this is now finally in a functioning and landable state. It solves many problems users reported in Fenix e.g. reader stuck in wrong zoom level, reader refreshing or reloading the original page, overlays/popups appearing etc. Also, it is now possible to navigate back and forth into reader view as we have a history entry (the extension page).