### PR TITLE
For #6757 - Adds firstContentfulPaint callback to SessionState

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -65,6 +66,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
         override fun onProcessKilled() {
             rebind()
+        }
+
+        override fun onFirstContentfulPaint() {
+            visibility = View.VISIBLE
         }
 
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -600,6 +600,7 @@ class GeckoEngineSession(
 
         override fun onFirstContentfulPaint(session: GeckoSession) {
             firstContentfulPaint = true
+            notifyObservers { onFirstContentfulPaint() }
         }
 
         override fun onContextMenu(

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -65,6 +66,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
         override fun onProcessKilled() {
             rebind()
+        }
+
+        override fun onFirstContentfulPaint() {
+            visibility = View.VISIBLE
         }
 
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
@@ -65,6 +66,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
         override fun onProcessKilled() {
             rebind()
+        }
+
+        override fun onFirstContentfulPaint() {
+            visibility = View.VISIBLE
         }
 
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -46,6 +46,10 @@ internal class EngineObserver(
         session.searchTerms = ""
     }
 
+    override fun onFirstContentfulPaint() {
+        store?.dispatch(ContentAction.UpdateFirstContentfulPaintStateAction(session.id, true))
+    }
+
     override fun onLocationChange(url: String) {
         if (!isUrlSame(session.url, url)) {
             session.title = ""

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -501,6 +501,20 @@ class EngineObserverTest {
     }
 
     @Test
+    fun engineObserverHandlesFirstContentfulPaint() {
+        val session = Session("")
+        val store = mock(BrowserStore::class.java)
+        whenever(store.state).thenReturn(mock())
+        val observer = EngineObserver(session, store)
+
+        observer.onFirstContentfulPaint()
+        verify(store).dispatch(ContentAction.UpdateFirstContentfulPaintStateAction(
+            session.id,
+            true
+        ))
+    }
+
+    @Test
     fun `onMediaAdded will subscribe to media and add it to store`() {
         val store = BrowserStore()
 

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -267,6 +267,14 @@ sealed class ContentAction : BrowserAction() {
     data class UpdateBackNavigationStateAction(val sessionId: String, val canGoBack: Boolean) : ContentAction()
 
     /**
+     * Updates the [ContentState] of the given [sessionId] to indicate whether the first contentful paint has happened.
+     */
+    data class UpdateFirstContentfulPaintStateAction(
+        val sessionId: String,
+        val firstContentfulPaint: Boolean
+    ) : ContentAction()
+
+    /**
      * Updates the [ContentState] of the given [sessionId] to indicate whether or not a forward navigation is possible.
      */
     data class UpdateForwardNavigationStateAction(val sessionId: String, val canGoForward: Boolean) : ContentAction()

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -117,6 +117,9 @@ internal object ContentStateReducer {
             is ContentAction.RemoveWebAppManifestAction -> updateContentState(state, action.sessionId) {
                 it.copy(webAppManifest = null)
             }
+            is ContentAction.UpdateFirstContentfulPaintStateAction -> updateContentState(state, action.sessionId) {
+                it.copy(firstContentfulPaint = action.firstContentfulPaint)
+            }
         }
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -39,6 +39,7 @@ import mozilla.components.concept.engine.window.WindowRequest
  * @property canGoBack whether or not there's an history item to navigate back to.
  * @property canGoForward whether or not there's an history item to navigate forward to.
  * @property webAppManifest the Web App Manifest for the currently visited page (or null).
+ * @property firstContentfulPaint whether or not the first contentful paint has happened.
  */
 data class ContentState(
     val url: String,
@@ -60,5 +61,6 @@ data class ContentState(
     val layoutInDisplayCutoutMode: Int = 0,
     val canGoBack: Boolean = false,
     val canGoForward: Boolean = false,
-    val webAppManifest: WebAppManifest? = null
+    val webAppManifest: WebAppManifest? = null,
+    val firstContentfulPaint: Boolean = false
 )

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -49,6 +49,10 @@ abstract class EngineSession(
          */
         fun onExcludedOnTrackingProtectionChange(excluded: Boolean) = Unit
 
+        /**
+         * Event to indicate that this session has had it's first engine contentful paint of page content.
+         */
+        fun onFirstContentfulPaint() = Unit
         fun onLongPress(hitResult: HitResult) = Unit
         fun onDesktopModeChange(enabled: Boolean) = Unit
         fun onFind(text: String) = Unit

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-state**
+  * Adds `firstContentfulPaint` to `ContentState` to know if first contentful paint has happened.
+
 * **service-glean**
   * ⚠️ **This is a breaking change**: Glean's configuration now requires explicitly setting an http client. Users need to pass one at construction.
     A default `lib-fetch-httpurlconnection` implementation is available.


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Testing out @pocmo ['s idea](https://github.com/mozilla-mobile/android-components/issues/6757#issuecomment-619942875) from #6757 via a session callback and var.
See accompanying Fenix PR for how I've integrated this: https://github.com/mozilla-mobile/fenix/pull/10358


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
