### PR TITLE
Close #6836: Refactor feature-syncedtabs to use interactor-presenter pattern

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.storage.Storage
 import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.appservices.remotetabs.RemoteTabsProvider
+import mozilla.components.concept.sync.Device
 import mozilla.appservices.remotetabs.SyncAuthInfo as RustSyncAuthInfo
 import mozilla.components.concept.sync.SyncAuthInfo
 import mozilla.components.concept.sync.SyncStatus
@@ -144,6 +145,14 @@ data class Tab(
         return history.subList(active + 1, history.lastIndex + 1)
     }
 }
+
+/**
+ * A synced device and the list of tabs.
+ */
+data class SyncedDeviceTabs(
+    val device: Device,
+    val tabs: List<Tab>
+)
 
 /**
  * A Tab history entry.

--- a/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt
+++ b/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt
@@ -191,7 +191,7 @@ internal class AutoPushObserver(
         val rawEvent = message ?: return
 
         accountManager.withConstellation {
-            it.processRawEventAsync(String(rawEvent))
+            processRawEventAsync(String(rawEvent))
         }
     }
 

--- a/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/SendTabFeatureKtTest.kt
+++ b/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/SendTabFeatureKtTest.kt
@@ -49,7 +49,7 @@ class SendTabFeatureKtTest {
     @Test
     fun `block is executed only account is available`() {
         val accountManager: FxaAccountManager = mock()
-        val block: (DeviceConstellation) -> Unit = mock()
+        val block: DeviceConstellation.() -> Unit = mock()
         val account: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
 

--- a/components/feature/syncedtabs/build.gradle
+++ b/components/feature/syncedtabs/build.gradle
@@ -27,6 +27,12 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
     implementation project(':service-firefox-accounts')
     implementation project(':browser-icons')

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsFeature.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsFeature.kt
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs
+
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.Dispatchers
+import mozilla.components.browser.storage.sync.Tab
+import mozilla.components.feature.syncedtabs.controller.DefaultController
+import mozilla.components.feature.syncedtabs.controller.SyncedTabsController
+import mozilla.components.feature.syncedtabs.interactor.DefaultInteractor
+import mozilla.components.feature.syncedtabs.interactor.SyncedTabsInteractor
+import mozilla.components.feature.syncedtabs.presenter.DefaultPresenter
+import mozilla.components.feature.syncedtabs.presenter.SyncedTabsPresenter
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Feature implementation that will keep a [SyncedTabsView] notified with other synced device tabs for
+ * the Firefox Sync account.
+ *
+ * @param storage The synced tabs storage that stores the current device's and remote device tabs.
+ * @param accountManager Firefox Account Manager that holds a Firefox Sync account.
+ * @param view An implementor of [SyncedTabsView] that will be notified of changes.
+ * @param lifecycleOwner Android Lifecycle Owner to bind observers onto.
+ * @param coroutineContext A coroutine context that can be used to perform work off the main thread.
+ * @param onTabClicked Invoked when a tab is selected by the user on the [SyncedTabsView].
+ * @param controller See [SyncedTabsController].
+ * @param presenter See [SyncedTabsPresenter].
+ * @param interactor See [SyncedTabsInteractor].
+ */
+class SyncedTabsFeature(
+    storage: SyncedTabsStorage,
+    accountManager: FxaAccountManager,
+    view: SyncedTabsView,
+    lifecycleOwner: LifecycleOwner,
+    coroutineContext: CoroutineContext = Dispatchers.IO,
+    onTabClicked: (Tab) -> Unit,
+    controller: SyncedTabsController = DefaultController(
+        storage,
+        accountManager,
+        view,
+        coroutineContext
+    ),
+    private val presenter: SyncedTabsPresenter = DefaultPresenter(
+        controller,
+        accountManager,
+        view,
+        lifecycleOwner
+    ),
+    private val interactor: SyncedTabsInteractor = DefaultInteractor(
+        accountManager,
+        view,
+        coroutineContext,
+        onTabClicked
+    )
+) : LifecycleAwareFeature {
+
+    override fun start() {
+        presenter.start()
+        interactor.start()
+    }
+
+    override fun stop() {
+        presenter.stop()
+        interactor.stop()
+    }
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsFeature.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsFeature.kt
@@ -76,8 +76,8 @@ class SyncedTabsFeature(
      */
     @VisibleForTesting
     internal fun syncClients(): List<Device>? {
-        accountManager.withConstellation { constellation ->
-            return constellation.state()?.otherDevices
+        accountManager.withConstellation {
+            return state()?.otherDevices
         }
         return null
     }

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
@@ -4,12 +4,12 @@
 
 package mozilla.components.feature.syncedtabs
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.storage.sync.TabEntry
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
 import java.util.UUID
 
 /**

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
@@ -14,11 +14,10 @@ import java.util.UUID
 
 /**
  * A [AwesomeBar.SuggestionProvider] implementation that provides suggestions for remote tabs
- * based on [SyncedTabsFeature].
+ * based on [SyncedTabsStorage].
  */
-@ExperimentalCoroutinesApi
 class SyncedTabsStorageSuggestionProvider(
-    private val syncedTabs: SyncedTabsFeature,
+    private val syncedTabs: SyncedTabsStorage,
     private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
     private val icons: BrowserIcons? = null
 ) : AwesomeBar.SuggestionProvider {

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.controller
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsProvider
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.manager.ext.withConstellation
+import kotlin.coroutines.CoroutineContext
+
+internal class DefaultController(
+    override val provider: SyncedTabsProvider,
+    override val accountManager: FxaAccountManager,
+    override val view: SyncedTabsView,
+    private val coroutineContext: CoroutineContext
+) : SyncedTabsController {
+
+    override fun syncTabs() {
+        view.startLoading()
+
+        val scope = CoroutineScope(coroutineContext)
+
+        scope.launch {
+            accountManager.withConstellation {
+                val syncedTabs = provider.getSyncedTabs()
+                val otherDevices = state()?.otherDevices
+
+                scope.launch(Dispatchers.Main) {
+                    if (syncedTabs.isEmpty() && otherDevices?.isEmpty() == true) {
+                        view.onError(ErrorType.MULTIPLE_DEVICES_UNAVAILABLE)
+                    } else {
+                        view.displaySyncedTabs(syncedTabs)
+                    }
+                }
+            }
+
+            scope.launch(Dispatchers.Main) {
+                view.stopLoading()
+            }
+        }
+    }
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/SyncedTabsController.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/SyncedTabsController.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.controller
+
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsProvider
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+
+/**
+ * A controller for making the appropriate request for remote tabs from [SyncedTabsProvider] when the
+ * [FxaAccountManager] account is in the appropriate state. The [SyncedTabsView] can then be notified.
+ */
+interface SyncedTabsController {
+    val provider: SyncedTabsProvider
+    val accountManager: FxaAccountManager
+    val view: SyncedTabsView
+
+    /**
+     * Requests for remote tabs and notifies the [SyncedTabsView] when available with [SyncedTabsView.displaySyncedTabs]
+     * otherwise notifies the appropriate error to [SyncedTabsView.onError].
+     */
+    fun syncTabs()
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/interactor/DefaultInteractor.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/interactor/DefaultInteractor.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.interactor
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import mozilla.components.browser.storage.sync.Tab
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.manager.ext.withConstellation
+import mozilla.components.service.fxa.sync.SyncReason
+import kotlin.coroutines.CoroutineContext
+
+internal class DefaultInteractor(
+    override val accountManager: FxaAccountManager,
+    override val view: SyncedTabsView,
+    private val coroutineContext: CoroutineContext,
+    override val tabClicked: (Tab) -> Unit
+) : SyncedTabsInteractor {
+
+    override fun start() {
+        view.listener = this
+    }
+
+    override fun stop() {
+        view.listener = null
+    }
+
+    override fun onTabClicked(tab: Tab) {
+        tabClicked(tab)
+    }
+
+    override fun onRefresh() {
+        CoroutineScope(coroutineContext).launch {
+            accountManager.withConstellation {
+                refreshDevicesAsync()
+            }
+            accountManager.syncNowAsync(SyncReason.User, true)
+        }
+    }
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/interactor/SyncedTabsInteractor.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/interactor/SyncedTabsInteractor.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.interactor
+
+import mozilla.components.browser.storage.sync.Tab
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+
+/**
+ * An interactor that handles events from [SyncedTabsView.Listener].
+ */
+interface SyncedTabsInteractor : SyncedTabsView.Listener, LifecycleAwareFeature {
+    val accountManager: FxaAccountManager
+    val view: SyncedTabsView
+    val tabClicked: (Tab) -> Unit
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenter.kt
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.presenter
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LifecycleOwner
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.feature.syncedtabs.controller.SyncedTabsController
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import mozilla.components.service.fxa.SyncEngine
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.manager.SyncEnginesStorage
+import mozilla.components.service.fxa.sync.SyncStatusObserver
+
+/**
+ * The tricky part in this class is to handle all possible Sync+FxA states:
+ *
+ * - No Sync account
+ * - Connected to FxA but not Sync (impossible state on mobile at the moment).
+ * - Connected to Sync, but needs reconnection.
+ * - Connected to Sync, but tabs syncing disabled.
+ * - Connected to Sync, but tabs haven't been synced yet (they stay in memory after the first sync).
+ * - Connected to Sync, but only one device in the account (us), so no other tab to show.
+ * - Connected to Sync.
+ *
+ */
+internal class DefaultPresenter(
+    override val controller: SyncedTabsController,
+    override val accountManager: FxaAccountManager,
+    override val view: SyncedTabsView,
+    private val lifecycleOwner: LifecycleOwner
+) : SyncedTabsPresenter {
+
+    @VisibleForTesting
+    internal val eventObserver = SyncedTabsSyncObserver(view, controller)
+    @VisibleForTesting
+    internal val accountObserver = SyncedTabsAccountObserver(view, controller)
+
+    override fun start() {
+
+        accountManager.registerForSyncEvents(
+            observer = eventObserver,
+            owner = lifecycleOwner,
+            autoPause = true
+        )
+
+        accountManager.register(
+            observer = accountObserver,
+            owner = lifecycleOwner,
+            autoPause = true
+        )
+
+        // No account setup
+        if (accountManager.accountProfile() == null) {
+            view.onError(ErrorType.SYNC_UNAVAILABLE)
+            return
+        }
+
+        if (accountManager.accountNeedsReauth()) {
+            view.onError(ErrorType.SYNC_NEEDS_REAUTHENTICATION)
+            return
+        }
+
+        // Synced tabs not enabled
+        if (SyncEnginesStorage(view.asView().context).getStatus()[SyncEngine.Tabs] != true) {
+            view.onError(ErrorType.SYNC_ENGINE_UNAVAILABLE)
+            return
+        }
+
+        controller.syncTabs()
+    }
+
+    override fun stop() {
+        // no-op
+    }
+
+    internal class SyncedTabsAccountObserver(
+        private val view: SyncedTabsView,
+        private val controller: SyncedTabsController
+    ) : AccountObserver {
+
+        override fun onLoggedOut() {
+            view.onError(ErrorType.SYNC_UNAVAILABLE)
+        }
+
+        override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+            controller.syncTabs()
+        }
+
+        override fun onAuthenticationProblems() {
+            view.onError(ErrorType.SYNC_NEEDS_REAUTHENTICATION)
+        }
+    }
+
+    internal class SyncedTabsSyncObserver(
+        private val view: SyncedTabsView,
+        private val controller: SyncedTabsController
+    ) : SyncStatusObserver {
+
+        override fun onIdle() {
+            controller.syncTabs()
+        }
+
+        override fun onError(error: Exception?) {
+            view.onError(ErrorType.SYNC_ENGINE_UNAVAILABLE)
+        }
+
+        override fun onStarted() {
+            view.startLoading()
+        }
+    }
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/SyncedTabsPresenter.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/presenter/SyncedTabsPresenter.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.presenter
+
+import mozilla.components.feature.syncedtabs.controller.SyncedTabsController
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+
+/**
+ * A presenter that orchestrates the [FxaAccountManager] being in the correct state to request remote tabs from the
+ * [SyncedTabsController] or notifies [SyncedTabsView.onError] otherwise.
+ */
+interface SyncedTabsPresenter : LifecycleAwareFeature {
+    val controller: SyncedTabsController
+    val accountManager: FxaAccountManager
+    val view: SyncedTabsView
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsProvider.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsProvider.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.storage
+
+import mozilla.components.browser.storage.sync.SyncedDeviceTabs
+
+/**
+ * Provides tabs from remote Firefox Sync devices.
+ */
+interface SyncedTabsProvider {
+
+    /**
+     * A list of [SyncedDeviceTabs] containing the tabs of the remote devices for the account.
+     */
+    suspend fun getSyncedTabs(): List<SyncedDeviceTabs>
+}

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.feature.syncedtabs
+package mozilla.components.feature.syncedtabs.storage
 
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
@@ -28,7 +28,7 @@ class SyncedTabsStorage(
     private val accountManager: FxaAccountManager,
     private val store: BrowserStore,
     private val tabsStorage: RemoteTabsStorage = RemoteTabsStorage()
-) {
+) : SyncedTabsProvider {
     private var scope: CoroutineScope? = null
 
     /**
@@ -62,7 +62,7 @@ class SyncedTabsStorage(
     /**
      * Get the list of synced tabs.
      */
-    suspend fun getSyncedTabs(): List<SyncedDeviceTabs> {
+    override suspend fun getSyncedTabs(): List<SyncedDeviceTabs> {
         val otherDevices = syncClients() ?: return emptyList()
         return tabsStorage.getAll()
             .mapNotNull { (client, tabs) ->

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/view/SyncedTabsView.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/view/SyncedTabsView.kt
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.view
+
+import android.view.View
+import mozilla.components.browser.storage.sync.SyncedDeviceTabs
+import mozilla.components.browser.storage.sync.Tab
+
+/**
+ * An interface for views that can display Firefox Sync "synced tabs" and related UI controls.
+ */
+interface SyncedTabsView {
+    var listener: Listener?
+
+    /**
+     * When tab syncing has started.
+     */
+    fun startLoading() = Unit
+
+    /**
+     * When tab syncing has completed.
+     */
+    fun stopLoading() = Unit
+
+    /**
+     * New tabs have been received to display.
+     */
+    fun displaySyncedTabs(syncedTabs: List<SyncedDeviceTabs>)
+
+    /**
+     * An error has occurred that may require various user-interactions based on the [ErrorType].
+     */
+    fun onError(error: ErrorType)
+
+    /**
+     * Casts this [SyncedTabsView] interface to an actual Android [View] object.
+     */
+    fun asView(): View = (this as View)
+
+    /**
+     * An interface for notifying the listener of the [SyncedTabsView].
+     */
+    interface Listener {
+
+        /**
+         * Invoked when a tab has been selected.
+         */
+        fun onTabClicked(tab: Tab)
+
+        /**
+         * Invoked when receiving a request to refresh the synced tabs.
+         */
+        fun onRefresh()
+    }
+
+    /**
+     *  The various types of errors that can occur from syncing tabs.
+     */
+    enum class ErrorType {
+
+        /**
+         * There are no other devices found with this account and therefore no tabs to sync.
+         */
+        MULTIPLE_DEVICES_UNAVAILABLE,
+
+        /**
+         * The engine for syncing tabs is unavailable. This is mostly due to a user turning off the feature on the
+         * Firefox Sync account.
+         */
+        SYNC_ENGINE_UNAVAILABLE,
+
+        /**
+         * There is no Firefox Sync account available. A user needs to sign-in before this feature.
+         */
+        SYNC_UNAVAILABLE,
+
+        /**
+         * The Firefox Sync account requires user-intervention to re-authenticate the account.
+         */
+        SYNC_NEEDS_REAUTHENTICATION
+    }
+}

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsFeatureTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsFeatureTest.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs
+
+import androidx.lifecycle.LifecycleOwner
+import mozilla.components.feature.syncedtabs.interactor.SyncedTabsInteractor
+import mozilla.components.feature.syncedtabs.presenter.SyncedTabsPresenter
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.test.mock
+import org.junit.Test
+import org.mockito.Mockito.verify
+
+class SyncedTabsFeatureTest {
+
+    private val storage: SyncedTabsStorage = mock()
+    private val accountManager: FxaAccountManager = mock()
+    private val view: SyncedTabsView = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
+
+    private val presenter: SyncedTabsPresenter = mock()
+    private val interactor: SyncedTabsInteractor = mock()
+    private val feature: SyncedTabsFeature =
+        SyncedTabsFeature(
+            storage,
+            accountManager,
+            view,
+            lifecycleOwner,
+            onTabClicked = {},
+            presenter = presenter,
+            interactor = interactor
+        )
+
+    @Test
+    fun start() {
+        feature.start()
+
+        verify(presenter).start()
+        verify(interactor).start()
+    }
+
+    @Test
+    fun stop() {
+        feature.stop()
+
+        verify(presenter).stop()
+        verify(interactor).stop()
+    }
+}

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
@@ -5,13 +5,13 @@
 package mozilla.components.feature.syncedtabs
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.browser.storage.sync.Tab
 import mozilla.components.browser.storage.sync.TabEntry
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceType
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.syncedtabs
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.browser.storage.sync.Tab
 import mozilla.components.browser.storage.sync.TabEntry
 import mozilla.components.concept.sync.Device
@@ -18,10 +19,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class SyncedTabsStorageSuggestionProviderTest {
-    private lateinit var syncedTabs: SyncedTabsFeature
+    private lateinit var syncedTabs: SyncedTabsStorage
 
     @Before
     fun setup() {
@@ -31,44 +31,58 @@ class SyncedTabsStorageSuggestionProviderTest {
     @Test
     fun `matches remote tabs`() = runBlocking {
         val provider = SyncedTabsStorageSuggestionProvider(syncedTabs, mock())
-        val deviceTabs1 = Device(
-            id = "client1",
-            displayName = "Foo Client",
-            deviceType = DeviceType.DESKTOP,
-            isCurrentDevice = false,
-            lastAccessTime = null,
-            capabilities = listOf(),
-            subscriptionExpired = false,
-            subscription = null
-        ) to listOf(
-            Tab(listOf(
-                TabEntry("Foo", "https://foo.bar", null), /* active tab */
-                TabEntry("Bobo", "https://foo.bar", null),
-                TabEntry("Foo", "https://bobo.bar", null)
-            ), 0, 1),
-            Tab(listOf(
-                TabEntry("Hello Bobo", "https://foo.bar", null) /* active tab */
-            ), 0, 5),
-            Tab(listOf(
-                TabEntry("In URL", "https://bobo.bar", null) /* active tab */
-            ), 0, 2)
+        val deviceTabs1 = SyncedDeviceTabs(
+            Device(
+                id = "client1",
+                displayName = "Foo Client",
+                deviceType = DeviceType.DESKTOP,
+                isCurrentDevice = false,
+                lastAccessTime = null,
+                capabilities = listOf(),
+                subscriptionExpired = false,
+                subscription = null
+            ),
+            listOf(
+                Tab(
+                    listOf(
+                        TabEntry("Foo", "https://foo.bar", null), /* active tab */
+                        TabEntry("Bobo", "https://foo.bar", null),
+                        TabEntry("Foo", "https://bobo.bar", null)
+                    ), 0, 1
+                ),
+                Tab(
+                    listOf(
+                        TabEntry("Hello Bobo", "https://foo.bar", null) /* active tab */
+                    ), 0, 5
+                ),
+                Tab(
+                    listOf(
+                        TabEntry("In URL", "https://bobo.bar", null) /* active tab */
+                    ), 0, 2
+                )
+            )
         )
-        val deviceTabs2 = Device(
-            id = "client2",
-            displayName = "Bar Client",
-            deviceType = DeviceType.MOBILE,
-            isCurrentDevice = false,
-            lastAccessTime = null,
-            capabilities = listOf(),
-            subscriptionExpired = false,
-            subscription = null
-        ) to listOf(
-            Tab(listOf(
-                TabEntry("Bar", "https://bar.bar", null),
-                TabEntry("BOBO in CAPS", "https://obob.bar", null) /* active tab */
-            ), 1, 1)
+        val deviceTabs2 = SyncedDeviceTabs(
+            Device(
+                id = "client2",
+                displayName = "Bar Client",
+                deviceType = DeviceType.MOBILE,
+                isCurrentDevice = false,
+                lastAccessTime = null,
+                capabilities = listOf(),
+                subscriptionExpired = false,
+                subscription = null
+            ),
+            listOf(
+                Tab(
+                    listOf(
+                        TabEntry("Bar", "https://bar.bar", null),
+                        TabEntry("BOBO in CAPS", "https://obob.bar", null) /* active tab */
+                    ), 1, 1
+                )
+            )
         )
-        whenever(syncedTabs.getSyncedTabs()).thenReturn(mapOf(deviceTabs1, deviceTabs2))
+        whenever(syncedTabs.getSyncedTabs()).thenReturn(listOf(deviceTabs1, deviceTabs2))
 
         val suggestions = provider.onInputChanged("bobo")
         assertEquals(3, suggestions.size)

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/controller/DefaultControllerTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/controller/DefaultControllerTest.kt
@@ -1,0 +1,98 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.controller
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import mozilla.components.concept.sync.ConstellationState
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+
+@RunWith(AndroidJUnit4::class)
+class DefaultControllerTest {
+    private val storage: SyncedTabsStorage = mock()
+    private val accountManager: FxaAccountManager = mock()
+    private val view: SyncedTabsView = mock()
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `update view only when no account available`() = runBlockingTest {
+        val controller = DefaultController(
+            storage,
+            accountManager,
+            view,
+            coroutineContext
+        )
+
+        controller.syncTabs()
+
+        verify(view).startLoading()
+        verify(view).stopLoading()
+
+        verifyNoMoreInteractions(view)
+    }
+
+    @Test
+    fun `notify if there is only one device synced`() = runBlockingTest {
+        val controller = DefaultController(
+            storage,
+            accountManager,
+            view,
+            coroutineContext
+        )
+        val account: OAuthAccount = mock()
+        val constellation: DeviceConstellation = mock()
+        val state: ConstellationState = mock()
+
+        `when`(accountManager.authenticatedAccount()).thenReturn(account)
+        `when`(account.deviceConstellation()).thenReturn(constellation)
+        `when`(constellation.state()).thenReturn(state)
+        `when`(state.otherDevices).thenReturn(emptyList())
+
+        `when`(storage.getSyncedTabs()).thenReturn(emptyList())
+
+        controller.syncTabs()
+
+        verify(view).onError(ErrorType.MULTIPLE_DEVICES_UNAVAILABLE)
+    }
+}

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/interactor/DefaultInteractorTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/interactor/DefaultInteractorTest.kt
@@ -1,0 +1,128 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.interactor
+
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.browser.storage.sync.SyncedDeviceTabs
+import mozilla.components.concept.sync.DeviceConstellation
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.sync.SyncReason
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+
+class DefaultInteractorTest {
+
+    private val accountManager: FxaAccountManager = mock()
+    private val view: SyncedTabsView = mock()
+
+    @Test
+    fun start() = runBlockingTest {
+        val view =
+            TestSyncedTabsView()
+        val feature = DefaultInteractor(
+            accountManager,
+            view,
+            coroutineContext
+        ) {}
+
+        assertNull(view.listener)
+
+        feature.start()
+
+        assertNotNull(view.listener)
+    }
+
+    @Test
+    fun stop() = runBlockingTest {
+        val view =
+            TestSyncedTabsView()
+        val feature = DefaultInteractor(
+            accountManager,
+            view,
+            coroutineContext
+        ) {}
+
+        assertNull(view.listener)
+
+        feature.start()
+
+        assertNotNull(view.listener)
+
+        feature.stop()
+
+        assertNull(view.listener)
+    }
+
+    @Test
+    fun `onTabClicked invokes callback`() = runBlockingTest {
+        var invoked = false
+        val feature = DefaultInteractor(
+            accountManager,
+            view,
+            coroutineContext
+        ) {
+            invoked = true
+        }
+
+        feature.onTabClicked(mock())
+
+        assertTrue(invoked)
+    }
+
+    @Test
+    fun `onRefresh does not update devices when there is no constellation`() = runBlockingTest {
+        val feature = DefaultInteractor(
+            accountManager,
+            view,
+            coroutineContext
+        ) {}
+
+        feature.onRefresh()
+
+        verify(accountManager).syncNowAsync(SyncReason.User, true)
+    }
+
+    @Test
+    fun `onRefresh updates devices when there is a constellation`() = runBlockingTest {
+        val feature = DefaultInteractor(
+            accountManager,
+            view,
+            coroutineContext
+        ) {}
+        val account: OAuthAccount = mock()
+        val constellation: DeviceConstellation = mock()
+
+        `when`(accountManager.authenticatedAccount()).thenReturn(account)
+        `when`(account.deviceConstellation()).thenReturn(constellation)
+
+        feature.onRefresh()
+
+        verify(constellation).refreshDevicesAsync()
+        verify(accountManager).syncNowAsync(SyncReason.User, true)
+    }
+
+    private class TestSyncedTabsView : SyncedTabsView {
+        override var listener: SyncedTabsView.Listener? = null
+
+        override fun onError(error: SyncedTabsView.ErrorType) {
+        }
+
+        override fun displaySyncedTabs(syncedTabs: List<SyncedDeviceTabs>) {
+        }
+    }
+}

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenterTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/presenter/DefaultPresenterTest.kt
@@ -1,0 +1,191 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.syncedtabs.presenter
+
+import android.content.Context
+import android.view.View
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runBlockingTest
+import mozilla.components.feature.syncedtabs.controller.SyncedTabsController
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.manager.SyncEnginesStorage.Companion.SYNC_ENGINES_KEY
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class DefaultPresenterTest {
+
+    private val controller: SyncedTabsController = mock()
+    private val accountManager: FxaAccountManager = mock()
+    private val view: SyncedTabsView = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
+
+    private val prefs = testContext.getSharedPreferences(SYNC_ENGINES_KEY, Context.MODE_PRIVATE)
+
+    @Before
+    fun setup() {
+        val androidView = View(testContext)
+        `when`(view.asView()).thenReturn(androidView)
+    }
+
+    @Test
+    fun `start returns when there is no profile`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.start()
+
+        verify(view).onError(ErrorType.SYNC_UNAVAILABLE)
+    }
+
+    @Test
+    fun `start returns if sync engine is not enabled`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        // disable sync storage
+        prefs.edit().putBoolean("tabs", false).apply()
+        `when`(accountManager.accountProfile()).thenReturn(mock())
+
+        presenter.start()
+
+        verify(view).onError(ErrorType.SYNC_ENGINE_UNAVAILABLE)
+    }
+
+    @Test
+    fun `start returns if sync needs reauthentication`() {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        `when`(accountManager.accountProfile()).thenReturn(mock())
+        `when`(accountManager.accountNeedsReauth()).thenReturn(true)
+
+        presenter.start()
+
+        verify(view).onError(ErrorType.SYNC_NEEDS_REAUTHENTICATION)
+    }
+
+    @Test
+    fun `start invokes syncTabs`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        prefs.edit().putBoolean("tabs", true).apply()
+        `when`(accountManager.accountProfile()).thenReturn(mock())
+        `when`(accountManager.accountNeedsReauth()).thenReturn(false)
+
+        presenter.start()
+
+        verify(controller).syncTabs()
+    }
+
+    @Test
+    fun `notify on logout`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.accountObserver.onLoggedOut()
+
+        verify(view).onError(ErrorType.SYNC_UNAVAILABLE)
+    }
+
+    @Test
+    fun `notify on authenticated`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.accountObserver.onAuthenticated(mock(), mock())
+
+        verify(controller).syncTabs()
+    }
+
+    @Test
+    fun `notify on authentication problems`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.accountObserver.onAuthenticationProblems()
+
+        verify(view).onError(ErrorType.SYNC_NEEDS_REAUTHENTICATION)
+    }
+
+    @Test
+    fun `sync tabs on idle status`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.eventObserver.onIdle()
+
+        verify(controller).syncTabs()
+    }
+
+    @Test
+    fun `show loading state on started status`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.eventObserver.onStarted()
+
+        verify(view).startLoading()
+    }
+
+    @Test
+    fun `notify on error`() = runBlockingTest {
+        val presenter = DefaultPresenter(
+            controller,
+            accountManager,
+            view,
+            lifecycleOwner
+        )
+
+        presenter.eventObserver.onError(mock())
+
+        verify(view).onError(ErrorType.SYNC_ENGINE_UNAVAILABLE)
+    }
+}

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -1,11 +1,16 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.feature.syncedtabs
+package mozilla.components.feature.syncedtabs.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
@@ -55,7 +60,11 @@ class SyncedTabsStorageTest {
 
     @Test
     fun `listens to browser store changes and stores its state`() = runBlocking {
-        val feature = SyncedTabsStorage(accountManager, store, tabsStorage)
+        val feature = SyncedTabsStorage(
+            accountManager,
+            store,
+            tabsStorage
+        )
         feature.start()
         // This action won't change the state, but will run the flow.
         store.dispatch(TabListAction.RemoveAllPrivateTabsAction)
@@ -68,7 +77,11 @@ class SyncedTabsStorageTest {
 
     @Test
     fun `stops listening to browser store changes on stop()`() = runBlocking {
-        val feature = SyncedTabsStorage(accountManager, store, tabsStorage)
+        val feature = SyncedTabsStorage(
+            accountManager,
+            store,
+            tabsStorage
+        )
         feature.start()
         // Run the flow.
         store.dispatch(TabListAction.RemoveAllPrivateTabsAction)
@@ -85,7 +98,13 @@ class SyncedTabsStorageTest {
 
     @Test
     fun `getSyncedTabs matches tabs with FxA devices`() = runBlocking {
-        val feature = spy(SyncedTabsStorage(accountManager, store, tabsStorage))
+        val feature = spy(
+            SyncedTabsStorage(
+                accountManager,
+                store,
+                tabsStorage
+            )
+        )
         val device1 = Device(
             id = "client1",
             displayName = "Foo Client",
@@ -124,14 +143,26 @@ class SyncedTabsStorageTest {
 
     @Test
     fun `getSyncedTabs returns empty list if syncClients() is null`() = runBlocking {
-        val feature = spy(SyncedTabsStorage(accountManager, store, tabsStorage))
+        val feature = spy(
+            SyncedTabsStorage(
+                accountManager,
+                store,
+                tabsStorage
+            )
+        )
         doReturn(null).`when`(feature).syncClients()
         assertEquals(emptyList<SyncedDeviceTabs>(), feature.getSyncedTabs())
     }
 
     @Test
     fun `syncClients returns clients if the account is set and constellation state is set too`() {
-        val feature = spy(SyncedTabsStorage(accountManager, store, tabsStorage))
+        val feature = spy(
+            SyncedTabsStorage(
+                accountManager,
+                store,
+                tabsStorage
+            )
+        )
         val account: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         val state: ConstellationState = mock()
@@ -154,7 +185,13 @@ class SyncedTabsStorageTest {
 
     @Test
     fun `syncClients returns null if the account is set but constellation state is null`() {
-        val feature = spy(SyncedTabsStorage(accountManager, store, tabsStorage))
+        val feature = spy(
+            SyncedTabsStorage(
+                accountManager,
+                store,
+                tabsStorage
+            )
+        )
         val account: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
         whenever(accountManager.authenticatedAccount()).thenReturn(account)
@@ -165,7 +202,13 @@ class SyncedTabsStorageTest {
 
     @Test
     fun `syncClients returns null if the account is null`() {
-        val feature = spy(SyncedTabsStorage(accountManager, store, tabsStorage))
+        val feature = spy(
+            SyncedTabsStorage(
+                accountManager,
+                store,
+                tabsStorage
+            )
+        )
         whenever(accountManager.authenticatedAccount()).thenReturn(null)
         assertEquals(null, feature.syncClients())
     }

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/ext/FxaAccountManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/ext/FxaAccountManager.kt
@@ -11,7 +11,7 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 /**
  * Executes [block] and provides the [DeviceConstellation] of an [OAuthAccount] if present.
  */
-inline fun FxaAccountManager.withConstellation(block: (DeviceConstellation) -> Unit) {
+inline fun FxaAccountManager.withConstellation(block: DeviceConstellation.() -> Unit) {
     authenticatedAccount()?.let {
         block(it.deviceConstellation())
     }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/ext/FxaAccountManagerKtTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/ext/FxaAccountManagerKtTest.kt
@@ -18,7 +18,7 @@ class FxaAccountManagerKtTest {
     @Test
     fun `block is executed only account is available`() {
         val accountManager: FxaAccountManager = mock()
-        val block: (DeviceConstellation) -> Unit = mock()
+        val block: DeviceConstellation.() -> Unit = mock()
         val account: OAuthAccount = mock()
         val constellation: DeviceConstellation = mock()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,10 @@ permalink: /changelog/
 
 * **browser-engine-gecko**, **browser-engine-gecko-beta**, **browser-engine-gecko-nightly**
   * Improve social trackers categorization see [ac#6851](https://github.com/mozilla-mobile/android-components/issues/6851) and [fenix#5921](https://github.com/mozilla-mobile/fenix/issues/5921)
+  
+* **feature-syncedtabs**
+  * Moved `SyncedTabsFeature` to `SyncedTabsStorage`.
+  * ⚠️ **This is a breaking change**: The new `SyncedTabsFeature` now orchestrates the correct state needed for consumers to handle by implementing the `SyncedTabsView`.
 
 # 39.0.0
 


### PR DESCRIPTION
We've renamed the original `SyncedTabsFeature` to `SyncedTabsStorage` since it breaks some of our conventions of how we use "feature" components.

A new `SyncedTabsFeature` moves the logic placed in Reference Browser into an interactor/presenter architecture to make it easier for other consumers to get this for free.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

@eoger you might want to take a look at this as well.

Reference Browser PR to fix breaking APIs: https://github.com/mozilla-mobile/reference-browser/pull/1164

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
