### PR TITLE
Closes #6832: Ignore initial loads of about:blank for extension pages

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -31,6 +31,11 @@ private val re = object {
 fun String.isUrl() = URLStringUtils.isURLLike(this)
 
 /**
+ * Checks if this String is a URL of an extension page.
+ */
+fun String.isExtensionUrl() = this.startsWith("moz-extension://")
+
+/**
  * Checks if this string is a URL.
  *
  * This method performs a strict check to determine whether the string is a URL. It takes longer

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -175,4 +175,12 @@ class StringTest {
         assertTrue("https://foo.bar".isSameOriginAs("https://foo.bar:443"))
         assertTrue("https://foo.bar:333".isSameOriginAs("https://foo.bar:333"))
     }
+
+    @Test
+    fun isExtensionUrl() {
+        assertTrue("moz-extension://1232-abcd".isExtensionUrl())
+        assertFalse("mozilla.org".isExtensionUrl())
+        assertFalse("https://mozilla.org".isExtensionUrl())
+        assertFalse("http://mozilla.org".isExtensionUrl())
+    }
 }


### PR DESCRIPTION
We already have a workaround to ignore initial loads of about:blank. When switching to an extension page, there's a process switch involved, which triggers the same problem. This is pretty annoying, as we always see about:blank loads before loading the actual extension page e.g. the uBlock dashboard, or a reader view page.

GV can't fix this and advised to ignore all about:blank loads (https://bugzilla.mozilla.org/show_bug.cgi?id=1634428), which also doesn't seem right to me. So, here I am only ignoring the initial loads of about:blank when switching between regular and extension pages (after a process switch).

Not pretty, but does the trick and it's in line with our existing workaround at least. @pocmo can you take a look at this one?