### PR TITLE
For #6897 - Add dismiss property to DownloadState

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -63,7 +63,9 @@ internal object ContentStateReducer {
                 it.copy(download = action.download)
             }
             is ContentAction.ConsumeDownloadAction -> updateContentState(state, action.sessionId) {
-                if (it.download != null && it.download.id == action.downloadId) {
+                if (it.download != null && it.download.id == action.downloadId &&
+                    it.download.dismissed
+                ) {
                     it.copy(download = null)
                 } else {
                     it

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -22,6 +22,7 @@ import kotlin.random.Random
  * @property referrerUrl The site that linked to this download.
  * @property skipConfirmation Whether or not the confirmation dialog should be shown before the download begins.
  * @property id The unique identifier of this download.
+ * @property dismissed Indicates that the user has dismissed the onDownloadStopped notification tab.
  */
 @Suppress("Deprecation")
 @Parcelize
@@ -34,7 +35,8 @@ data class DownloadState(
     val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
     val referrerUrl: String? = null,
     val skipConfirmation: Boolean = false,
-    val id: Long = Random.nextLong()
+    val id: Long = Random.nextLong(),
+    val dismissed: Boolean = false
 ) : Parcelable {
     val filePath: String get() =
         Environment.getExternalStoragePublicDirectory(destinationDirectory).path + "/" + fileName

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -339,9 +339,10 @@ class ContentActionTest {
     }
 
     @Test
-    fun `ConsumeDownloadAction removes download`() {
+    fun `ConsumeDownloadAction removes download if downloadState is dismissed`() {
         val download: DownloadState = mock()
         doReturn(1337L).`when`(download).id
+        doReturn(true).`when`(download).dismissed
 
         store.dispatch(
             ContentAction.UpdateDownloadAction(tab.id, download)

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -94,7 +94,9 @@ class DownloadsFeature(
                 .ifChanged { it.content.download }
                 .collect { state ->
                     val download = state.content.download
-                    if (download != null) {
+                    // [dismissed] Indicates that the user has dismissed the onDownloadStopped
+                    // notification tab, so there is no need to process anything.
+                    if (download != null && !download.dismissed) {
                         processDownload(state, download)
                     }
                 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,11 +12,13 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-downloads**
+  * Download feature will check for new DownloadState [dismissed] to be false before processing downloads. This property will be used in Fenix to check if the user has dismissed the download notification dialog.
+  * ContentStateReducer will only consume the downloadState if it has dismissed true.
+  * Fixed issue [#6881](https://github.com/mozilla-mobile/android-components/issues/6881).
+
 * **feature-session**
   * ⚠️ **This is a breaking change**: Added optional `crashReporting` param to [PictureInPictureFeature] so we can record caught exceptions.
-
-* **feature-downloads**
-  * Fixed issue [#6881](https://github.com/mozilla-mobile/android-components/issues/6881).
 
 * **feature-addons**
   * Added optional `addonAllowPrivateBrowsingLabelDrawableRes` DrawableRes parameter to `AddonPermissionsAdapter.Style` constructor to allow the clients to add their own drawable. This is used to clearly label the WebExtensions that run in private browsing.
@@ -26,7 +28,7 @@ permalink: /changelog/
 
 * **browser-tabstray**
   * Added optional `itemDecoration` DividerItemDecoration parameter to `BrowserTabsTray` constructor to allow the clients to add their own dividers. This is used to ensure setting divider item decoration after setAdapter() is called.
-  
+
 # 40.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v39.0.0...v40.0.0)


### PR DESCRIPTION
 DownloadState.dismissed will be used to keep track of dismissed download notification dialogs in Fenix.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

For https://github.com/mozilla-mobile/android-components/issues/6897

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
