### PR TITLE
For 6922 - Scroll to selected tab when entering tab tray

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -43,7 +43,11 @@ class TabsAdapter(
     private var tabs: Tabs? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabViewHolder {
-        return viewHolderProvider.invoke(parent, tabsTray)
+        val result = viewHolderProvider.invoke(parent, tabsTray)
+        tabs?.let {
+            this.tabsTray.scrollToPosition(it.selectedIndex)
+        }
+        return result
     }
 
     override fun getItemCount() = tabs?.list?.size ?: 0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ permalink: /changelog/
 
 * **browser-tabstray**
   * Added optional `itemDecoration` DividerItemDecoration parameter to `BrowserTabsTray` constructor to allow the clients to add their own dividers. This is used to ensure setting divider item decoration after setAdapter() is called.
+  * Added functionality to scroll to selected tab when tabs tray opens.
   
 # 40.0.0
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

With my manual testing, I:

1.  Open enough tabs to make the tab tray scroll
2.  Select a tab toward the bottom of the screen
3.  Hit the tab tray button
4.  Scroll to the top of the tab tray
5.  Press / swipe back
6.  Selected tab is still scrolled down to

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
