### PR TITLE
Closes #6791: Intermittent test failure in WebExtensionSupport

### DIFF
--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -324,13 +324,13 @@ class WebExtensionSupportTest {
         val actionHandlerCaptor = argumentCaptor<ActionHandler>()
         val actionCaptor = argumentCaptor<WebExtensionAction>()
         val tabHandlerCaptor = argumentCaptor<TabHandler>()
-
         verify(ext).registerActionHandler(eq(engineSession), actionHandlerCaptor.capture())
+        verify(ext).registerTabHandler(eq(engineSession), tabHandlerCaptor.capture())
+
         actionHandlerCaptor.value.onBrowserAction(ext, engineSession, mock())
         verify(store, times(3)).dispatch(actionCaptor.capture())
         assertEquals(ext.id, (actionCaptor.allValues.last() as WebExtensionAction.UpdateTabBrowserAction).extensionId)
 
-        verify(ext).registerTabHandler(eq(engineSession), tabHandlerCaptor.capture())
         tabHandlerCaptor.value.onUpdateTab(ext, engineSession, true, null)
         verify(store).dispatch(TabListAction.SelectTabAction("1"))
         tabHandlerCaptor.value.onUpdateTab(ext, engineSession, true, "url")


### PR DESCRIPTION
Basically, we dispatch a tab browser action to test that our action handler works, but that in turn changes the tab state triggering our flow again (see registerHandlersForNewSession). We can simply verify and capture the handlers first, then trigger actions to test them.