### PR TITLE
For #6261 - Move browser-menu2 to concept-menu2 

### DIFF
--- a/.buildconfig.yml
+++ b/.buildconfig.yml
@@ -20,6 +20,10 @@ projects:
     path: components/concept/engine
     description: 'An abstract layer hiding the actual browser engine implementation.'
     publish: true
+  concept-menu:
+    path: components/concept/menu
+    description: 'An abstract definition of a browser menu component.'
+    publish: true
   concept-push:
     path: components/concept/push
     description: 'An abstract definition of a push service component.'

--- a/components/browser/menu/build.gradle
+++ b/components/browser/menu/build.gradle
@@ -29,7 +29,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 dependencies {
     implementation project(':concept-engine')
-    implementation project(':browser-menu2')
+    implementation project(':concept-menu')
     implementation project(':browser-state')
     implementation project(':support-base')
     implementation project(':support-ktx')

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuItem.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.menu
 
 import android.content.Context
 import android.view.View
-import mozilla.components.browser.menu2.candidate.MenuCandidate
+import mozilla.components.concept.menu.candidate.MenuCandidate
 
 /**
  * Interface to be implemented by menu items to be shown in the browser menu.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCategory.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCategory.kt
@@ -13,11 +13,11 @@ import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextAlignment
-import mozilla.components.browser.menu2.candidate.TextStyle
-import mozilla.components.browser.menu2.candidate.TypefaceStyle
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextAlignment
+import mozilla.components.concept.menu.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.TypefaceStyle
 
 /**
  * A browser menu item displaying styleable text, usable for menu categories

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCheckbox.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCheckbox.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.menu.item
 
 import android.content.Context
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 
 /**
  * A simple browser menu checkbox.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButton.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButton.kt
@@ -10,8 +10,8 @@ import android.widget.CompoundButton
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
-import mozilla.components.browser.menu2.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.ContainerStyle
 import java.lang.reflect.Modifier.PRIVATE
 
 /**

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuDivider.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuDivider.kt
@@ -9,8 +9,8 @@ import android.view.View
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DividerMenuCandidate
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DividerMenuCandidate
 
 /**
  * A browser menu item to display a horizontal divider.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
@@ -15,10 +15,10 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.HighlightableMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.HighPriorityHighlightEffect
-import mozilla.components.browser.menu2.candidate.LowPriorityHighlightEffect
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.HighPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.LowPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
 
 @Suppress("Deprecation")
 private val defaultHighlight = BrowserMenuHighlightableItem.Highlight(0, 0, 0, 0)

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitch.kt
@@ -16,9 +16,9 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.HighlightableMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.LowPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.LowPriorityHighlightEffect
 
 /**
  * A browser menu switch that can show a highlighted icon.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitch.kt
@@ -12,8 +12,8 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.SwitchCompat
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
 import java.lang.reflect.Modifier
 
 /**

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
@@ -16,10 +16,10 @@ import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 
 internal const val NO_ID = -1
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -17,10 +17,10 @@ import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.RowMenuCandidate
-import mozilla.components.browser.menu2.candidate.SmallMenuCandidate
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.RowMenuCandidate
+import mozilla.components.concept.menu.candidate.SmallMenuCandidate
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 
 /**

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuSwitch.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuSwitch.kt
@@ -6,7 +6,7 @@ package mozilla.components.browser.menu.item
 
 import android.content.Context
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 
 /**
  * A simple browser menu switch.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItem.kt
@@ -14,10 +14,10 @@ import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
 import mozilla.components.browser.menu.ext.addRippleEffect
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.MenuCandidate
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.MenuCandidate
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 
 /**
  * A menu item for displaying text with a highlight state which sets the

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItem.kt
@@ -12,11 +12,11 @@ import androidx.core.content.ContextCompat.getColor
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
-import mozilla.components.browser.menu2.candidate.MenuCandidate
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
+import mozilla.components.concept.menu.candidate.MenuCandidate
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 
 /**
  * A simple browser menu item displaying text.

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
@@ -17,11 +17,11 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextMenuIcon
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextMenuIcon
+import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.support.base.log.Log
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt
@@ -10,8 +10,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCheckboxTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCheckboxTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.browser.menu.item
 
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt
@@ -10,7 +10,7 @@ import android.widget.CheckBox
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuDividerTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuDividerTest.kt
@@ -5,8 +5,8 @@
 package mozilla.components.browser.menu.item
 
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DividerMenuCandidate
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DividerMenuCandidate
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt
@@ -18,11 +18,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.HighPriorityHighlightEffect
-import mozilla.components.browser.menu2.candidate.LowPriorityHighlightEffect
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.HighPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.LowPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitchTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageSwitchTest.kt
@@ -6,8 +6,8 @@ package mozilla.components.browser.menu.item
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
@@ -14,8 +14,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -13,10 +13,10 @@ import androidx.core.content.ContextCompat.getColor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.DrawableMenuIcon
-import mozilla.components.browser.menu2.candidate.RowMenuCandidate
-import mozilla.components.browser.menu2.candidate.SmallMenuCandidate
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.RowMenuCandidate
+import mozilla.components.concept.menu.candidate.SmallMenuCandidate
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuSwitchTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuSwitchTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.browser.menu.item
 
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.CompoundMenuCandidate
+import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItemTest.kt
@@ -13,9 +13,9 @@ import androidx.core.content.ContextCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.ContainerStyle
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/SimpleBrowserMenuItemTest.kt
@@ -11,9 +11,9 @@ import androidx.core.content.ContextCompat.getColor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
-import mozilla.components.browser.menu2.candidate.DecorativeTextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextMenuCandidate
-import mozilla.components.browser.menu2.candidate.TextStyle
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/MenuController.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/MenuController.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.browser.menu2
 
+import mozilla.components.concept.menu.Side
+
 /**
  * Controls a popup menu composed of MenuCandidate objects.
  * @param visibleSide Sets the menu to open with either the start or end visible.
@@ -11,17 +13,3 @@ package mozilla.components.browser.menu2
 class MenuController(
     private val visibleSide: Side = Side.START
 )
-
-/**
- * Indicates the starting or ending side of the menu or an option.
- */
-enum class Side {
-    /**
-     * Starting side (top or left).
-     */
-    START,
-    /**
-     * Ending side (bottom or right).
-     */
-    END
-}

--- a/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/MenuControllerTest.kt
+++ b/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/MenuControllerTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu2
 
+import mozilla.components.concept.menu.Side
 import org.junit.Test
 
 class MenuControllerTest {

--- a/components/concept/menu/build.gradle
+++ b/components/concept/menu/build.gradle
@@ -22,27 +22,16 @@ android {
 }
 
 dependencies {
-    implementation project(':concept-menu')
-    implementation project(':support-base')
-    implementation project(':support-ktx')
-    implementation project(':ui-icons')
-
-    implementation Dependencies.androidx_appcompat
-    implementation Dependencies.androidx_core_ktx
-    implementation Dependencies.androidx_recyclerview
-    implementation Dependencies.androidx_cardview
-    implementation Dependencies.androidx_constraintlayout
-
     implementation Dependencies.kotlin_stdlib
 
-    testImplementation project(':support-test')
+    implementation Dependencies.androidx_annotation
+    implementation Dependencies.androidx_appcompat
+    implementation project(':support-ktx')
 
-    testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
-    testImplementation Dependencies.testing_coroutines
-
+    testImplementation project(':support-test')
 }
 
 apply from: '../../../publish.gradle'

--- a/components/concept/menu/proguard-rules.pro
+++ b/components/concept/menu/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/concept/menu/src/main/AndroidManifest.xml
+++ b/components/concept/menu/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="mozilla.components.concept.menu" />

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/Side.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/Side.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.menu
+
+/**
+ * Indicates the starting or ending side of the menu or an option.
+ */
+enum class Side {
+    /**
+     * Starting side (top or left).
+     */
+    START,
+    /**
+     * Ending side (bottom or right).
+     */
+    END
+}

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/ContainerStyle.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/ContainerStyle.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.menu2.candidate
+package mozilla.components.concept.menu.candidate
 
 /**
  * Describes styling for the menu option container.

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuCandidate.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuCandidate.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.menu2.candidate
+package mozilla.components.concept.menu.candidate
 
 /**
  * Menu option data classes to be shown in the browser menu.

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuEffect.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuEffect.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.menu2.candidate
+package mozilla.components.concept.menu.candidate
 
 import androidx.annotation.ColorInt
 

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuIcon.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuIcon.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.menu2.candidate
+package mozilla.components.concept.menu.candidate
 
 import android.content.Context
 import android.graphics.drawable.Drawable

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/SmallMenuCandidate.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/SmallMenuCandidate.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.menu2.candidate
+package mozilla.components.concept.menu.candidate
 
 /**
  * Small icon button menu option. Can only be used with [RowMenuCandidate].

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/TextStyle.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/TextStyle.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.components.browser.menu2.candidate
+package mozilla.components.concept.menu.candidate
 
 import android.graphics.Typeface
 import android.view.View


### PR DESCRIPTION
Move the current dumb data classes into a concept component. This PR just moves the files around and updates corresponding import statements.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
