### PR TITLE
Always create sync manager on UI thread

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/sync/WorkManagerSyncManager.kt
@@ -58,7 +58,7 @@ private const val SYNC_WORKER_BACKOFF_DELAY_MINUTES = 3L
  *
  * Must be initialized on the main thread.
  */
-internal class WorkManagerSyncManager(
+internal class WorkManagerSyncManager @UiThread constructor(
     private val context: Context,
     syncConfig: SyncConfig
 ) : SyncManager(syncConfig) {


### PR DESCRIPTION
Currently we have a crash where Fenix builds `FxaAccountManager` on a background thread. This change should ensure that `FxaAccountManager` can be created on any thread safely.

https://sentry.prod.mozaws.net/operations/fenix-fennec-beta/issues/8308657/?query=is%3Aunresolved

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
