### PR TITLE
Closes #6862: Migrate feature-accounts to browser-state

### DIFF
--- a/components/feature/accounts/build.gradle
+++ b/components/feature/accounts/build.gradle
@@ -21,13 +21,19 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += [
+            "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    ]
+}
+
 dependencies {
     implementation Dependencies.kotlin_coroutines
     implementation Dependencies.androidx_work_runtime
     implementation Dependencies.androidx_lifecycle_extensions
 
     implementation project(':concept-engine')
-    implementation project(":browser-session")
+    implementation project(":browser-state")
     implementation project(':feature-tabs')
     implementation project(':service-firefox-accounts')
     implementation project(':support-ktx')

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,9 @@ permalink: /changelog/
     * ⚠️ **This is a breaking change**: glinter errors found during code generation will now return an error code.
     * The minimum and maximum values of a timing distribution can now be controlled by the `time_unit` parameter. See [bug 1630997](https://bugzilla.mozilla.org/show_bug.cgi?id=1630997) for more details.
 
+* **feature-accounts**
+  *  ⚠️ **This is a breaking change**: Refactored component to use `browser-state` instead of `browser-session`. The `FxaWebChannelFeature`  now requires a `BrowserStore` instance instead of a `SessionManager`.    
+
 * **browser-toolbar**
   * It will only be animated for vertical scrolls inside the EngineView. Not for horizontal scrolls. Not for zoom gestures.
 


### PR DESCRIPTION
For the FxA web channel, we don't need to connect to the content script if tabs are opened in the background (e.g. via long press->open in new tab) so I removed that code. The port is disconnected automatically when the window is "unloaded".

The actual change here is minimal, it's mostly the tests, which I refactored to reduce duplication.

Tested manually in Fenix as well.