### PR TITLE
Close #6957: Allow nullable encoding param in push messages

### DIFF
--- a/components/concept/push/src/main/java/mozilla/components/concept/push/PushProcessor.kt
+++ b/components/concept/push/src/main/java/mozilla/components/concept/push/PushProcessor.kt
@@ -85,10 +85,10 @@ data class EncryptedPushMessage(
         operator fun invoke(
             channelId: String,
             body: String?,
-            encoding: String,
+            encoding: String?,
             salt: String? = null,
             cryptoKey: String? = null
-        ) = EncryptedPushMessage(channelId, body, encoding, salt ?: "", cryptoKey ?: "")
+        ) = EncryptedPushMessage(channelId, body, encoding ?: "aes128gcm", salt ?: "", cryptoKey ?: "")
     }
 }
 

--- a/components/concept/push/src/main/java/mozilla/components/concept/push/PushService.kt
+++ b/components/concept/push/src/main/java/mozilla/components/concept/push/PushService.kt
@@ -31,4 +31,27 @@ interface PushService {
      * If the push service is support on the device.
      */
     fun isServiceAvailable(context: Context): Boolean
+
+    companion object {
+        /**
+         * Message key for "channel ID" in a push message.
+         */
+        const val MESSAGE_KEY_CHANNEL_ID = "chid"
+        /**
+         * Message key for the body in a push message.
+         */
+        const val MESSAGE_KEY_BODY = "body"
+        /**
+         * Message key for encoding in a push message.
+         */
+        const val MESSAGE_KEY_ENCODING = "con"
+        /**
+         * Message key for encryption salt in a push message.
+         */
+        const val MESSAGE_KEY_SALT = "enc"
+        /**
+         * Message key for "cryptoKey" in a push message.
+         */
+        const val MESSAGE_KEY_CRYPTO_KEY = "cryptokey"
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,9 @@ permalink: /changelog/
 * **feature-accounts**
   *  ⚠️ **This is a breaking change**: Refactored component to use `browser-state` instead of `browser-session`. The `FxaWebChannelFeature`  now requires a `BrowserStore` instance instead of a `SessionManager`.
 
+* **lib-push-fcm**, **lib-push-adm**, **concept-push**
+  * Allow nullable encoding values in push messsages. If they are null, we attempt to use `aes128gcm` for encoding.
+
 * **browser-toolbar**
   * It will only be animated for vertical scrolls inside the EngineView. Not for horizontal scrolls. Not for zoom gestures.
 


### PR DESCRIPTION
We fall back to the "aes128gcm" encoding if the value is not provided.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Close #6957

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
