### PR TITLE
For #6978 - Catch reflection exceptions in BrowserGestureDetector

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetector.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserGestureDetector.kt
@@ -83,12 +83,17 @@ internal class BrowserGestureDetector(
             // The lower the values the higher the sensitivity.
             // Values of 0 here would mean all swipe events will be treated as pinch/spread to zoom gestures,
             // in our context effectively meaning no scrolling, only zooming.
-            listOf(
-                javaClass.getDeclaredField("mSpanSlop"),
-                javaClass.getDeclaredField("mMinSpan")
-            ).forEach { field ->
-                field.isAccessible = true
-                field.set(this, (field.get(this) as Int) / 2)
+            try {
+                listOf(
+                    javaClass.getDeclaredField("mSpanSlop"),
+                    javaClass.getDeclaredField("mMinSpan")
+                ).forEach { field ->
+                    field.isAccessible = true
+                    field.set(this, (field.get(this) as Int) / 2)
+                }
+            } catch (e: ReflectiveOperationException) {
+                // Seems like some OEMs made some breaking changes in the framework.
+                // no-op
             }
         }
     }


### PR DESCRIPTION
Although the fields BrowserGestureDetector want to modify through reflection
should be a stable part of the Android framework it was seen that on some
devices they do not exist.
Nothing more we can do in these cases than just prevent the reflection
exceptions bubbling up and potentially crash client apps.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: No unit tests for this.
- [x] **Changelog**: This PR includes does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

// Small video of what this would mean for Fenix - https://drive.google.com/file/d/1wWHBsf1LPfgnBFmbo3WOdhAoH5x-O8wW/view?usp=sharing

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
