### PR TITLE
Closes #6985: Make sure suggestion with long title/desc doesn't freeze UI

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
@@ -9,10 +9,20 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.awesomebar.BrowserAwesomeBar
 import mozilla.components.browser.awesomebar.R
 import mozilla.components.browser.awesomebar.widget.FlowLayout
 import mozilla.components.concept.awesomebar.AwesomeBar
+
+// This is used for truncating title and description to prevent extreme cases
+// from slowing down UI rendering e.g. in case of a bookmarklet or a data URI.
+// So this is just to make the actual truncation in the view faster which
+// is already using a truncated and "ellipsized" single line for suggestions.
+// https://github.com/mozilla-mobile/android-components/issues/6985
+@VisibleForTesting
+@Suppress("MagicNumber", "TopLevelPropertyNaming")
+internal var MAX_TEXT_LENGTH = 250
 
 internal sealed class DefaultSuggestionViewHolder {
     /**
@@ -35,13 +45,13 @@ internal sealed class DefaultSuggestionViewHolder {
 
             iconView.setImageBitmap(suggestion.icon)
 
-            titleView.text = title
+            titleView.text = title?.take(MAX_TEXT_LENGTH)
 
             if (suggestion.description.isNullOrEmpty()) {
                 descriptionView.visibility = View.GONE
             } else {
                 descriptionView.visibility = View.VISIBLE
-                descriptionView.text = suggestion.description
+                descriptionView.text = suggestion.description?.take(MAX_TEXT_LENGTH)
             }
 
             view.setOnClickListener {
@@ -84,7 +94,7 @@ internal sealed class DefaultSuggestionViewHolder {
 
                     view.setTextColor(awesomeBar.styling.chipTextColor)
                     view.setBackgroundColor(awesomeBar.styling.chipBackgroundColor)
-                    view.text = chip.title
+                    view.text = chip.title.take(MAX_TEXT_LENGTH)
                     view.setOnClickListener {
                         suggestion.onChipClicked?.invoke(chip)
                         selectionListener.invoke()

--- a/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
+++ b/components/browser/awesomebar/src/test/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolderTest.kt
@@ -16,6 +16,7 @@ import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.support.ktx.android.util.dpToPx
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -24,6 +25,11 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class DefaultSuggestionViewHolderTest {
+
+    @After
+    fun tearDown() {
+        MAX_TEXT_LENGTH = 250
+    }
 
     @Test
     fun `DefaultViewHolder sets title and description`() {
@@ -177,5 +183,57 @@ class DefaultSuggestionViewHolderTest {
         DefaultSuggestionViewHolder.Chips(awesomeBar, view)
 
         assertEquals(2.dpToPx(testContext.resources.displayMetrics), flowLayout.spacing)
+    }
+
+    @Test
+    fun `DefaultViewHolder truncates title and description if needed`() {
+        val view = LayoutInflater.from(testContext).inflate(
+            R.layout.mozac_browser_awesomebar_item_generic, null, false)
+
+        MAX_TEXT_LENGTH = 5
+        val awesomeBar = BrowserAwesomeBar(testContext)
+        val viewHolder = DefaultSuggestionViewHolder.Default(awesomeBar, view)
+
+        val suggestion = AwesomeBar.Suggestion(
+            mock(),
+            title = "123456789",
+            description = "123456789")
+
+        viewHolder.bind(suggestion) {
+            // Do nothing
+        }
+
+        val titleView = view.findViewById<TextView>(R.id.mozac_browser_awesomebar_title)
+        assertEquals("12345", titleView.text)
+
+        val descriptionView = view.findViewById<TextView>(R.id.mozac_browser_awesomebar_description)
+        assertEquals("12345", descriptionView.text)
+        assertEquals(View.VISIBLE, descriptionView.visibility)
+    }
+
+    @Test
+    fun `ChipsSuggestionViewHolder truncates title if needed`() {
+        val view = LayoutInflater.from(testContext).inflate(
+            R.layout.mozac_browser_awesomebar_item_chips, null, false)
+
+        MAX_TEXT_LENGTH = 5
+        val viewHolder = DefaultSuggestionViewHolder.Chips(
+            BrowserAwesomeBar(testContext), view)
+
+        val suggestion = AwesomeBar.Suggestion(
+            mock(),
+            chips = listOf(AwesomeBar.Suggestion.Chip("123456789"))
+        )
+
+        val container = view.findViewById<ViewGroup>(R.id.mozac_browser_awesomebar_chips)
+
+        assertEquals(0, container.childCount)
+
+        viewHolder.bind(suggestion) {
+            // Do nothing.
+        }
+
+        assertEquals(1, container.childCount)
+        assertEquals("12345", (container.getChildAt(0) as TextView).text)
     }
 }


### PR DESCRIPTION
We're already truncating in the view itself, but if the string is extremely long e.g. a 30K bookmarklet the UI hangs (see #6985). So, with this, we truncate any excessive title/description to prevent this case.