### PR TITLE
Issue #6938: CrashReporter.getCrashReporterServiceById(): Handle missing crash reporter services.

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/CrashReporter.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/CrashReporter.kt
@@ -252,8 +252,8 @@ class CrashReporter(
         }
     }
 
-    internal fun getCrashReporterServiceById(id: String): CrashReporterService {
-        return services.first { it.id == id }
+    internal fun getCrashReporterServiceById(id: String): CrashReporterService? {
+        return services.firstOrNull { it.id == id }
     }
 
     enum class Prompt {

--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/CrashListAdapter.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/CrashListAdapter.kt
@@ -91,9 +91,9 @@ private fun SpannableStringBuilder.append(
     onSelection: (String) -> Unit
 ): SpannableStringBuilder {
     services.forEachIndexed { index, entity ->
-        val name = crashReporter.getCrashReporterServiceById(entity.serviceId).name
-        val url = crashReporter.getCrashReporterServiceById(entity.serviceId)
-            .createCrashReportUrl(entity.reportId)
+        val service = crashReporter.getCrashReporterServiceById(entity.serviceId)
+        val name = service?.name ?: entity.serviceId
+        val url = service?.createCrashReportUrl(entity.reportId)
 
         if (url != null) {
             append(name, object : ClickableSpan() {


### PR DESCRIPTION
If we ever remove a `CrashReporterService` that we submitted crash reports for then we could crash showing the list of crashes since we can't find that service anymore. With this patch we are handling this situation more gracefully.