### PR TITLE
For #6996: Apply proper window flags to LoginDialogFragment

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/LoginDialogFragment.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/LoginDialogFragment.kt
@@ -81,7 +81,7 @@ internal class LoginDialogFragment : PromptDialogFragment() {
     override fun shouldDismissOnLoad(): Boolean = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return BottomSheetDialog(requireContext(), this.theme).apply {
+        return BottomSheetDialog(requireContext(), R.style.MozDialogStyle).apply {
             setCancelable(true)
             setOnShowListener {
                 val bottomSheet =

--- a/components/feature/prompts/src/main/res/values/styles.xml
+++ b/components/feature/prompts/src/main/res/values/styles.xml
@@ -4,4 +4,8 @@
         <item name="boxStrokeColor">@color/mozacBoxStrokeColor</item>
         <item name="boxStrokeWidth">2dp</item>
     </style>
+    <style name="MozDialogStyle" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
 </resources>


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This makes it so the keyboard does not obscure the login editText fragments. See:
![demo of login fragment 2020-05-15 11_04_56](https://user-images.githubusercontent.com/4400286/82081902-ee47c680-969b-11ea-81f3-25ee70ac476c.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
