### PR TITLE
Use helper to change state of tab in BrowserStore

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -124,29 +124,14 @@ internal object ContentStateReducer {
     }
 }
 
-private fun updateContentState(
+private inline fun updateContentState(
     state: BrowserState,
     tabId: String,
-    update: (ContentState) -> ContentState
+    crossinline update: (ContentState) -> ContentState
 ): BrowserState {
-    // Currently we map over both lists (tabs and customTabs). We could optimize this away later on if we know what
-    // type we want to modify.
-    return state.copy(
-        tabs = state.tabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(content = update.invoke(current.content))
-            } else {
-                current
-            }
-        },
-        customTabs = state.customTabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(content = update.invoke(current.content))
-            } else {
-                current
-            }
-        }
-    )
+    return state.updateTabState(tabId) { current ->
+        current.createCopy(content = update(current.content))
+    }
 }
 
 private fun isHostEquals(sessionUrl: String, newUrl: String): Boolean {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/CustomTabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/CustomTabListReducer.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.state.reducer
 
 import mozilla.components.browser.state.action.CustomTabListAction
-import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.state.BrowserState
 
 internal object CustomTabListReducer {
@@ -17,8 +16,7 @@ internal object CustomTabListReducer {
             is CustomTabListAction.AddCustomTabAction -> state.copy(customTabs = state.customTabs + action.tab)
 
             is CustomTabListAction.RemoveCustomTabAction -> {
-                val tab = state.findCustomTab(action.tabId) ?: return state
-                state.copy(customTabs = state.customTabs - tab)
+                state.copy(customTabs = state.customTabs.filter { it.id != action.tabId })
             }
 
             is CustomTabListAction.RemoveAllCustomTabsAction -> {

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
@@ -28,26 +28,11 @@ internal object EngineStateReducer {
     }
 }
 
-private fun BrowserState.copyWithEngineState(
+private inline fun BrowserState.copyWithEngineState(
     tabId: String,
-    update: (EngineState) -> EngineState
+    crossinline update: (EngineState) -> EngineState
 ): BrowserState {
-    // Currently we map over both lists (tabs and customTabs). We could optimize this away later on if we know what
-    // type we want to modify.
-    return copy(
-        tabs = tabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(engineState = update.invoke(current.engineState))
-            } else {
-                current
-            }
-        },
-        customTabs = customTabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(engineState = update.invoke(current.engineState))
-            } else {
-                current
-            }
-        }
-    )
+    return updateTabState(tabId) { current ->
+        current.createCopy(engineState = update(current.engineState))
+    }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
@@ -45,12 +45,8 @@ private fun BrowserState.copyWithReaderState(
     update: (ReaderState) -> ReaderState
 ): BrowserState {
     return copy(
-        tabs = tabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(readerState = update.invoke(current.readerState))
-            } else {
-                current
-            }
-        }
+        tabs = tabs.updateTabs(tabId) { current ->
+            current.copy(readerState = update.invoke(current.readerState))
+        } ?: tabs
     )
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TrackingProtectionStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TrackingProtectionStateReducer.kt
@@ -35,26 +35,11 @@ internal object TrackingProtectionStateReducer {
     }
 }
 
-private fun BrowserState.copyWithTrackingProtectionState(
+private inline fun BrowserState.copyWithTrackingProtectionState(
     tabId: String,
-    update: (TrackingProtectionState) -> TrackingProtectionState
+    crossinline update: (TrackingProtectionState) -> TrackingProtectionState
 ): BrowserState {
-    // Currently we map over both lists (tabs and customTabs). We could optimize this away later on if we know what
-    // type we want to modify.
-    return copy(
-        tabs = tabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(trackingProtection = update.invoke(current.trackingProtection))
-            } else {
-                current
-            }
-        },
-        customTabs = customTabs.map { current ->
-            if (current.id == tabId) {
-                current.copy(trackingProtection = update.invoke(current.trackingProtection))
-            } else {
-                current
-            }
-        }
-    )
+    return updateTabState(tabId) { current ->
+        current.createCopy(trackingProtection = update(current.trackingProtection))
+    }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/WebExtensionReducer.kt
@@ -89,21 +89,11 @@ internal object WebExtensionReducer {
         update: (WebExtensionState) -> WebExtensionState
     ): BrowserState {
         return copy(
-            tabs = tabs.map { current ->
-                if (current.id == tabId) {
-                    val existingExtension = current.extensionState[extensionId]
-                    val newExtension = extensionId to update(existingExtension ?: WebExtensionState(extensionId))
-                    val updatedExtensions = if (existingExtension == null) {
-                        current.extensionState + newExtension
-                    } else {
-                        val newExtensions = current.extensionState - extensionId
-                        newExtensions + newExtension
-                    }
-                    current.copy(extensionState = updatedExtensions)
-                } else {
-                    current
-                }
-            }
+            tabs = tabs.updateTabs(tabId) { current ->
+                val existingExtension = current.extensionState[extensionId]
+                val newExtension = extensionId to update(existingExtension ?: WebExtensionState(extensionId))
+                current.copy(extensionState = current.extensionState + newExtension)
+            } ?: tabs
         )
     }
 
@@ -113,7 +103,6 @@ internal object WebExtensionReducer {
     ): BrowserState {
         val existingExtension = extensions[extensionId]
         val newExtension = extensionId to update(existingExtension ?: WebExtensionState(extensionId))
-        val updatedExtensions = extensions - extensionId
-        return copy(extensions = updatedExtensions + newExtension)
+        return copy(extensions = extensions + newExtension)
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -25,7 +25,24 @@ data class CustomTabSessionState(
     override val engineState: EngineState = EngineState(),
     override val extensionState: Map<String, WebExtensionState> = emptyMap(),
     override val contextId: String? = null
-) : SessionState
+) : SessionState {
+
+    override fun createCopy(
+        id: String,
+        content: ContentState,
+        trackingProtection: TrackingProtectionState,
+        engineState: EngineState,
+        extensionState: Map<String, WebExtensionState>,
+        contextId: String?
+    ) = copy(
+        id = id,
+        content = content,
+        trackingProtection = trackingProtection,
+        engineState = engineState,
+        extensionState = extensionState,
+        contextId = contextId
+    )
+}
 
 /**
  * Convenient function for creating a custom tab.

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/SessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/SessionState.kt
@@ -24,4 +24,17 @@ interface SessionState {
     val engineState: EngineState
     val extensionState: Map<String, WebExtensionState>
     val contextId: String?
+
+    /**
+     * Copy the class and override some parameters.
+     */
+    @Suppress("LongParameterList")
+    fun createCopy(
+        id: String = this.id,
+        content: ContentState = this.content,
+        trackingProtection: TrackingProtectionState = this.trackingProtection,
+        engineState: EngineState = this.engineState,
+        extensionState: Map<String, WebExtensionState> = this.extensionState,
+        contextId: String? = this.contextId
+    ): SessionState
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -31,7 +31,24 @@ data class TabSessionState(
     override val extensionState: Map<String, WebExtensionState> = emptyMap(),
     val readerState: ReaderState = ReaderState(),
     override val contextId: String? = null
-) : SessionState
+) : SessionState {
+
+    override fun createCopy(
+        id: String,
+        content: ContentState,
+        trackingProtection: TrackingProtectionState,
+        engineState: EngineState,
+        extensionState: Map<String, WebExtensionState>,
+        contextId: String?
+    ) = copy(
+        id = id,
+        content = content,
+        trackingProtection = trackingProtection,
+        engineState = engineState,
+        extensionState = extensionState,
+        contextId = contextId
+    )
+}
 
 /**
  * Convenient function for creating a tab.


### PR DESCRIPTION
This reduces some of the repeated code in `BrowserStore`, and additionally optimizes by stopping iteration once the correct tab list is found.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
