### PR TITLE
Add maven central repository.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,15 @@ buildscript {
             google()
         }
 
+        if (project.hasProperty("centralRepo")) {
+            maven {
+                name "MavenCentral"
+                url project.property("centralRepo")
+            }
+        } else {
+            mavenCentral()
+        }
+
         if (project.hasProperty("jcenterRepo")) {
             maven {
                 name "BintrayJCenter"
@@ -46,6 +55,15 @@ allprojects {
             }
         } else {
             google()
+        }
+
+        if (project.hasProperty("centralRepo")) {
+            maven {
+                name "MavenCentral"
+                url project.property("centralRepo")
+            }
+        } else {
+            mavenCentral()
         }
 
         if (project.hasProperty("jcenterRepo")) {

--- a/taskcluster/ac_taskgraph/job.py
+++ b/taskcluster/ac_taskgraph/job.py
@@ -67,7 +67,7 @@ def _extract_command(run, fetches_dir):
         "-P{repo_name}Repo=file://{dir}/{repo_name}".format(
             dir=maven_dependencies_dir, repo_name=repo_name
         )
-        for repo_name in ("google", "jcenter")
+        for repo_name in ("google", "jcenter", "central")
     ]
     gradle_command = ["./gradlew"] + gradle_repos_args + ["listRepositories"] + run.pop("gradlew")
     post_gradle_commands = run.pop("post-gradlew", [])

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -30,7 +30,7 @@ TEST_COMMANDS=$(echo "$FIRST_PASS_COMPONENTS" | sed "s/$/:test/g")
 LINT_COMMANDS=$(echo "$FIRST_PASS_COMPONENTS" | sed "s/$/:lintRelease/g")
 
 NEXUS_PREFIX='http://localhost:8081/nexus/content/repositories'
-GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PjcenterRepo=$NEXUS_PREFIX/jcenter/"
+GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PjcenterRepo=$NEXUS_PREFIX/jcenter/ -PcentralRepo=$NEXUS_PREFIX/central/"
 
 # First pass. We build everything to be sure to fetch all dependencies
 ./gradlew $GRADLE_ARGS $ASSEMBLE_COMMANDS $ASSEMBLE_TEST_COMMANDS ktlint detekt $LINT_COMMANDS

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
@@ -22,6 +22,7 @@ mkdir -p android-gradle-dependencies /builds/worker/artifacts
 
 cp -R ${NEXUS_WORK}/storage/jcenter android-gradle-dependencies
 cp -R ${NEXUS_WORK}/storage/google android-gradle-dependencies
+cp -R ${NEXUS_WORK}/storage/central android-gradle-dependencies
 
 tar cf - android-gradle-dependencies | xz > /builds/worker/artifacts/android-gradle-dependencies.tar.xz
 


### PR DESCRIPTION
Let's add maven central in front of jcenter in our list of external dependency repositories. Maven central seems to be less error-prone and more strict when validating dependencies and ownership.