### PR TITLE
Separate normalTabs and privateTabs

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -54,11 +54,40 @@ internal fun BrowserState.updateTabState(
     tabId: String,
     update: (SessionState) -> SessionState
 ): BrowserState {
-    val newTabs = tabs.updateTabs(tabId, update) as List<TabSessionState>?
-    if (newTabs != null) return copy(tabs = newTabs)
+    val newState = updateTabSessionState(tabId, update as (TabSessionState) -> TabSessionState)
+    if (newState !== this) {
+        // If state was updated, the tab was found.
+        return newState
+    }
 
-    val newCustomTabs = customTabs.updateTabs(tabId, update) as List<CustomTabSessionState>?
-    if (newCustomTabs != null) return copy(customTabs = newCustomTabs)
+    val newCustomTabs = customTabs.updateTabs(tabId, update as (CustomTabSessionState) -> CustomTabSessionState)
+    if (newCustomTabs != null) {
+        return copy(customTabs = newCustomTabs)
+    }
+
+    return this
+}
+
+/**
+ * Finds the corresponding tab in the [BrowserState] and replaces it using [update].
+ * @param tabId ID of the tab to change.
+ * @param update Returns a new version of the tab state. Must be the same class,
+ * preferably using [SessionState.createCopy].
+ */
+@Suppress("Unchecked_Cast")
+internal fun BrowserState.updateTabSessionState(
+    tabId: String,
+    update: (TabSessionState) -> TabSessionState
+): BrowserState {
+    val newNormalTabs = normalTabs.updateTabs(tabId, update)
+    if (newNormalTabs != null) {
+        return copy(normalTabs = newNormalTabs)
+    }
+
+    val newPrivateTabs = privateTabs.updateTabs(tabId, update)
+    if (newPrivateTabs != null) {
+        return copy(privateTabs = newPrivateTabs)
+    }
 
     return this
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
@@ -8,6 +8,7 @@ import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.TabSessionState
 
 internal object ReaderStateReducer {
 
@@ -44,9 +45,15 @@ private fun BrowserState.copyWithReaderState(
     tabId: String,
     update: (ReaderState) -> ReaderState
 ): BrowserState {
-    return copy(
-        tabs = tabs.updateTabs(tabId) { current ->
-            current.copy(readerState = update.invoke(current.readerState))
-        } ?: tabs
-    )
+    val updater = { current: TabSessionState ->
+        current.copy(readerState = update.invoke(current.readerState))
+    }
+
+    val newNormalTabs = normalTabs.updateTabs(tabId, updater)
+    if (newNormalTabs != null) return copy(normalTabs = newNormalTabs)
+
+    val newPrivateTabs = privateTabs.updateTabs(tabId, updater)
+    if (newPrivateTabs != null) return copy(privateTabs = newPrivateTabs)
+
+    return this
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TabListReducer.kt
@@ -21,21 +21,25 @@ internal object TabListReducer {
                 // Verify that tab doesn't already exist
                 requireUniqueTab(state, action.tab)
 
+                val isPrivate = action.tab.content.private
+                val tabList = if (isPrivate) state.privateTabs else state.normalTabs
+
                 val updatedTabList = if (action.tab.parentId != null) {
-                    val parentIndex = state.tabs.indexOfFirst { it.id == action.tab.parentId }
+                    val parentIndex = tabList.indexOfFirst { it.id == action.tab.parentId }
                     if (parentIndex == -1) {
                         throw IllegalArgumentException("The parent does not exist")
                     }
 
                     // Add the child tab next to its parent
                     val childIndex = parentIndex + 1
-                    state.tabs.subList(0, childIndex) + action.tab + state.tabs.subList(childIndex, state.tabs.size)
+                    tabList.subList(0, childIndex) + action.tab + tabList.subList(childIndex, tabList.size)
                 } else {
-                    state.tabs + action.tab
+                    tabList + action.tab
                 }
 
                 state.copy(
-                    tabs = updatedTabList,
+                    normalTabs = if (isPrivate) state.normalTabs else updatedTabList,
+                    privateTabs = if (isPrivate) updatedTabList else state.privateTabs,
                     selectedTabId = if (action.select || state.selectedTabId == null) {
                         action.tab.id
                     } else {
@@ -52,12 +56,10 @@ internal object TabListReducer {
                 }
 
                 state.copy(
-                    tabs = state.tabs + action.tabs,
-                    selectedTabId = if (state.selectedTabId == null) {
-                        action.tabs.find { tab -> !tab.content.private }?.id
-                    } else {
-                        state.selectedTabId
-                    }
+                    normalTabs = state.normalTabs + action.tabs.filterNot { it.content.private },
+                    privateTabs = state.privateTabs + action.tabs.filter { it.content.private },
+                    selectedTabId = state.selectedTabId
+                        ?: action.tabs.find { tab -> !tab.content.private }?.id
                 )
             }
 
@@ -71,8 +73,11 @@ internal object TabListReducer {
                 if (tabToRemove == null) {
                     state
                 } else {
+                    val isPrivate = tabToRemove.content.private
+                    val tabList = if (isPrivate) state.privateTabs else state.normalTabs
+
                     // Remove tab and update child tabs in case their parent was removed
-                    val updatedTabList = (state.tabs - tabToRemove).map {
+                    val updatedTabList = (tabList - tabToRemove).map {
                         if (it.parentId == tabToRemove.id) it.copy(parentId = tabToRemove.parentId) else it
                     }
 
@@ -81,15 +86,20 @@ internal object TabListReducer {
                         tabToRemove.parentId
                     } else if (state.selectedTabId == tabToRemove.id) {
                         // The selected tab was removed and we need to find a new one
-                        val previousIndex = state.tabs.indexOf(tabToRemove)
-                        findNewSelectedTabId(updatedTabList, tabToRemove.content.private, previousIndex)
+                        findNewSelectedTabId(
+                            state,
+                            updatedTabList,
+                            isPrivate = tabToRemove.content.private,
+                            previousIndex = tabList.indexOf(tabToRemove)
+                        )
                     } else {
                         // The selected tab is not affected and can stay the same
                         state.selectedTabId
                     }
 
                     state.copy(
-                        tabs = updatedTabList,
+                        normalTabs = if (isPrivate) state.normalTabs else updatedTabList,
+                        privateTabs = if (isPrivate) updatedTabList else state.privateTabs,
                         selectedTabId = updatedSelection
                     )
                 }
@@ -103,7 +113,8 @@ internal object TabListReducer {
                 // happen asynchronously we may already have a tab at this point (e.g. from an `Intent`) and so we
                 // pretend we restored the list of tabs before any tab was added.
                 state.copy(
-                    tabs = action.tabs + state.tabs,
+                    normalTabs = action.tabs.filterNot { it.content.private } + state.normalTabs,
+                    privateTabs = action.tabs.filter { it.content.private } + state.privateTabs,
                     selectedTabId = if (action.selectedTabId != null && state.selectedTabId == null) {
                         // We only want to update the selected tab if none has been already selected. Otherwise we may
                         // switch to a restored tab even though the user is already looking at an existing tab (e.g.
@@ -117,19 +128,19 @@ internal object TabListReducer {
 
             is TabListAction.RemoveAllTabsAction -> {
                 state.copy(
-                    tabs = emptyList(),
+                    normalTabs = emptyList(),
+                    privateTabs = emptyList(),
                     selectedTabId = null
                 )
             }
 
             is TabListAction.RemoveAllPrivateTabsAction -> {
                 val selectionAffected = state.selectedTab?.content?.private == true
-                val updatedTabs = state.tabs.filterNot { it.content.private }
                 state.copy(
-                    tabs = updatedTabs,
-                    selectedTabId = if (selectionAffected && updatedTabs.isNotEmpty()) {
+                    privateTabs = emptyList(),
+                    selectedTabId = if (selectionAffected && state.normalTabs.isNotEmpty()) {
                         // If the selection is affected, select the last normal tab, if available.
-                        updatedTabs.last().id
+                        state.normalTabs.last().id
                     } else {
                         state.selectedTabId
                     }
@@ -138,9 +149,8 @@ internal object TabListReducer {
 
             is TabListAction.RemoveAllNormalTabsAction -> {
                 val selectionAffected = state.selectedTab?.content?.private == false
-                val updatedTabs = state.tabs.filter { it.content.private }
                 state.copy(
-                    tabs = updatedTabs,
+                    normalTabs = emptyList(),
                     selectedTabId = if (selectionAffected) {
                         // If the selection is affected, we'll set it to null as there's no
                         // normal tab left and NO private tab should get selected instead.
@@ -158,32 +168,45 @@ internal object TabListReducer {
  * Find a new selected tab and return its id after the tab at [previousIndex] was removed.
  */
 private fun findNewSelectedTabId(
-    tabs: List<TabSessionState>,
+    state: BrowserState,
+    newTabs: List<TabSessionState>,
     isPrivate: Boolean,
     previousIndex: Int
 ): String? {
-    if (tabs.isEmpty()) {
+    val allTabs: List<TabSessionState>
+    val previousIndexAll: Int
+    if (isPrivate) {
+        // Can switch from private tabs to normal tabs
+        allTabs = state.normalTabs + newTabs
+        previousIndexAll = state.normalTabs.size + previousIndex
+    } else {
+        // Cannot switch from normal tabs to private tabs
+        allTabs = newTabs
+        previousIndexAll = previousIndex
+    }
+
+    if (allTabs.isEmpty()) {
         // There's no tab left to select.
         return null
     }
 
-    val predicate: (TabSessionState) -> Boolean = { tab -> tab.content.private == isPrivate }
-
     // If the previous index is still a valid index and if this is a private/normal tab we are looking for then
     // let's use the tab at the same index.
-    if (previousIndex <= tabs.lastIndex && predicate(tabs[previousIndex])) {
-        return tabs[previousIndex].id
+    if (previousIndex in newTabs.indices) {
+        return newTabs[previousIndex].id
     }
 
     // Find a tab that matches the predicate and is nearby the tab that was selected previously
-    val nearbyTab = findNearbyTab(tabs, previousIndex, predicate)
+    val nearbyTab = findNearbyTab(allTabs, previousIndexAll) { tab ->
+        tab.content.private == isPrivate
+    }
 
     return when {
         // We found a nearby tab, let's select it.
         nearbyTab != null -> nearbyTab.id
 
         // If there's no private tab to select anymore then just select the last regular tab
-        isPrivate -> tabs.last().id
+        isPrivate -> state.normalTabs.lastOrNull()?.id
 
         // Removing the last normal tab should NOT cause a private tab to be selected
         else -> null
@@ -224,7 +247,7 @@ private fun findNearbyTab(
  * @param tab the [TabSessionState] to check.
  */
 private fun requireUniqueTab(state: BrowserState, tab: TabSessionState) {
-    require(state.tabs.find { it.id == tab.id } == null) {
+    require(state.tabs.none { it.id == tab.id }) {
         "Tab with same ID already exists"
     }
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
@@ -87,15 +87,3 @@ fun BrowserState.findTabOrCustomTabOrSelectedTab(tabId: String? = null): Session
 fun BrowserState.findTabByUrl(url: String): TabSessionState? {
     return tabs.firstOrNull { tab -> tab.content.url == url }
 }
-
-/**
- * List of private tabs.
- */
-val BrowserState.privateTabs: List<TabSessionState>
-    get() = tabs.filter { it.content.private }
-
-/**
- * List of normal (non-private) tabs.
- */
-val BrowserState.normalTabs: List<TabSessionState>
-    get() = tabs.filter { !it.content.private }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -18,9 +18,12 @@ import mozilla.components.lib.state.State
  * @property media The state of all media elements and playback states for all tabs.
  */
 data class BrowserState(
-    val tabs: List<TabSessionState> = emptyList(),
+    val normalTabs: List<TabSessionState> = emptyList(),
+    val privateTabs: List<TabSessionState> = emptyList(),
     val selectedTabId: String? = null,
     val customTabs: List<CustomTabSessionState> = emptyList(),
     val extensions: Map<String, WebExtensionState> = emptyMap(),
     val media: MediaState = MediaState()
-) : State
+) : State {
+    val tabs get() = normalTabs + privateTabs
+}

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -47,7 +47,7 @@ class ContentActionTest {
 
     @Before
     fun setUp() {
-        val state = BrowserState(tabs = listOf(
+        val state = BrowserState(normalTabs = listOf(
             createTab(url = "https://www.mozilla.org").also {
                 tabId = it.id
             },
@@ -57,6 +57,18 @@ class ContentActionTest {
         ))
 
         store = BrowserStore(state)
+    }
+
+    @Test
+    fun `nothing happens with invalid tab ID`() {
+        val newUrl = "https://www.example.org"
+        val state = store.state
+
+        store.dispatch(
+            ContentAction.UpdateUrlAction("not-an-id", newUrl)
+        ).joinBlocking()
+
+        assertEquals(state, store.state)
     }
 
     @Test

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/CustomTabListActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/CustomTabListActionTest.kt
@@ -73,7 +73,7 @@ class CustomTabListActionTest {
         val customTab2 = createCustomTab("https://www.firefox.com")
         val regularTab = createTab(url = "https://www.mozilla.org")
 
-        val state = BrowserState(customTabs = listOf(customTab1, customTab2), tabs = listOf(regularTab))
+        val state = BrowserState(customTabs = listOf(customTab1, customTab2), normalTabs = listOf(regularTab))
         val store = BrowserStore(state)
 
         assertEquals(2, store.state.customTabs.size)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/EngineActionTest.kt
@@ -29,7 +29,7 @@ class EngineActionTest {
 
         store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/MediaActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/MediaActionTest.kt
@@ -21,7 +21,7 @@ class MediaActionTest {
     @Test
     fun `AddMediaAction - Adds media for tab`() {
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             )
@@ -46,7 +46,7 @@ class MediaActionTest {
     @Test
     fun `AddMediaAction - Not existing tab`() {
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             )
@@ -73,7 +73,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -112,7 +112,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -144,7 +144,7 @@ class MediaActionTest {
         val element4 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab"),
                 createTab("https;//getpocket.com", id = "pocket-tab")
@@ -175,7 +175,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -219,7 +219,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -253,7 +253,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -287,7 +287,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -331,7 +331,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -393,7 +393,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),
@@ -441,7 +441,7 @@ class MediaActionTest {
         val element3 = createMockMediaElement()
 
         val store = BrowserStore(BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab("https://www.mozilla.org", id = "test-tab"),
                 createTab("https://www.firefox.com", id = "other-tab")
             ),

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
@@ -27,7 +27,7 @@ class ReaderActionTest {
 
         store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/SystemActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/SystemActionTest.kt
@@ -22,7 +22,7 @@ class SystemActionTest {
     @Test
     fun `LowMemoryAction removes thumbnails`() {
         val initialState = BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTab(url = "https://www.mozilla.org", id = "0"),
                 createTab(url = "https://www.firefox.com", id = "1"),
                 createTab(url = "https://www.firefox.com", id = "2")
@@ -53,7 +53,7 @@ class SystemActionTest {
     @Test
     fun `LowMemoryAction removes EngineSession references and adds state`() {
         val initialState = BrowserState(
-            tabs = listOf(
+            normalTabs = listOf(
                 createTabWithMockEngineSession(url = "https://www.mozilla.org", id = "0"),
                 createTabWithMockEngineSession(url = "https://www.firefox.com", id = "1"),
                 createTabWithMockEngineSession(url = "https://www.firefox.com", id = "2")

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/TrackingProtectionActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/TrackingProtectionActionTest.kt
@@ -27,7 +27,7 @@ class TrackingProtectionActionTest {
 
         store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
@@ -65,7 +65,7 @@ class WebExtensionActionTest {
         val tab2 = createTab("url")
         val store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab1, tab2)
+                normalTabs = listOf(tab1, tab2)
             )
         )
 
@@ -105,7 +105,7 @@ class WebExtensionActionTest {
         val tab2 = createTab("url")
         val store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab1, tab2)
+                normalTabs = listOf(tab1, tab2)
             )
         )
         assertTrue(store.state.extensions.isEmpty())
@@ -152,7 +152,7 @@ class WebExtensionActionTest {
         val tab = createTab("url")
         val store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
         val mockedBrowserAction = mock<WebExtensionBrowserAction>()
@@ -193,7 +193,7 @@ class WebExtensionActionTest {
         )
         val store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
 
@@ -234,7 +234,7 @@ class WebExtensionActionTest {
         val tab = createTab("url")
         val store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
         val mockedPageAction = mock<WebExtensionPageAction>()
@@ -275,7 +275,7 @@ class WebExtensionActionTest {
         )
         val store = BrowserStore(
             initialState = BrowserState(
-                tabs = listOf(tab)
+                normalTabs = listOf(tab)
             )
         )
 

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
@@ -61,7 +61,7 @@ class SelectorsKtTest {
         val customTab = createCustomTab("https://www.mozilla.org")
 
         val state = BrowserState(
-            tabs = listOf(tab, otherTab),
+            normalTabs = listOf(tab, otherTab),
             customTabs = listOf(customTab))
 
         assertEquals(tab, state.findTab(tab.id))
@@ -76,7 +76,7 @@ class SelectorsKtTest {
         val customTab = createCustomTab("https://www.mozilla.org")
 
         val state = BrowserState(
-            tabs = listOf(tab, otherTab),
+            normalTabs = listOf(tab, otherTab),
             customTabs = listOf(customTab))
 
         assertNull(state.findCustomTab(tab.id))
@@ -91,7 +91,7 @@ class SelectorsKtTest {
         val customTab = createCustomTab("https://www.mozilla.org")
 
         val state = BrowserState(
-            tabs = listOf(tab, otherTab),
+            normalTabs = listOf(tab, otherTab),
             customTabs = listOf(customTab),
             selectedTabId = tab.id)
 
@@ -109,9 +109,9 @@ class SelectorsKtTest {
         val customTab = createCustomTab("https://www.mozilla.org")
 
         val state = BrowserState(
-                tabs = listOf(tab, otherTab),
-                customTabs = listOf(customTab),
-                selectedTabId = tab.id)
+            normalTabs = listOf(tab, otherTab),
+            customTabs = listOf(customTab),
+            selectedTabId = tab.id)
 
         assertEquals(tab, state.findTabOrCustomTabOrSelectedTab())
         assertEquals(tab, state.findTabOrCustomTabOrSelectedTab(null))
@@ -128,7 +128,8 @@ class SelectorsKtTest {
         val privateTab2 = createTab("https://www.example.org", private = true)
 
         val state = BrowserState(
-            tabs = listOf(tab1, privateTab1, tab2, privateTab2),
+            normalTabs = listOf(tab1, tab2),
+            privateTabs = listOf(privateTab1, privateTab2),
             customTabs = listOf(createCustomTab("https://www.google.com")))
 
         assertEquals(listOf(tab1, tab2), state.normalTabs)
@@ -141,7 +142,7 @@ class SelectorsKtTest {
     @Test
     fun `findTabOrCustomTab finds regular and custom tabs`() {
         BrowserState(
-            tabs = listOf(createTab("https://www.mozilla.org", id = "test-id"))
+            normalTabs = listOf(createTab("https://www.mozilla.org", id = "test-id"))
         ).also { state ->
             assertNotNull(state.findTabOrCustomTab("test-id"))
             assertEquals(
@@ -162,7 +163,7 @@ class SelectorsKtTest {
     @Test
     fun `findTabByUrl finds a regular tab with same url or returns null`() {
         BrowserState(
-            tabs = listOf(createTab("https://www.mozilla.org", id = "test-id"))
+            normalTabs = listOf(createTab("https://www.mozilla.org", id = "test-id"))
         ).also { state ->
             assertNotNull(state.findTabByUrl("https://www.mozilla.org"))
             assertEquals(

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreExceptionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreExceptionTest.kt
@@ -58,15 +58,15 @@ class BrowserStoreExceptionTest {
     fun `AddMultipleTabsAction - Exception is thrown in tab with id already exists`() {
         unwrapStoreExceptionAndRethrow {
             val store = BrowserStore(BrowserState(
-                    tabs = listOf(
-                            createTab(id = "a", url = "https://www.mozilla.org")
-                    )
+                normalTabs = listOf(
+                    createTab(id = "a", url = "https://www.mozilla.org")
+                )
             ))
 
             store.dispatch(TabListAction.AddMultipleTabsAction(
-                    tabs = listOf(
-                            createTab(id = "a", url = "https://www.example.org")
-                    )
+                tabs = listOf(
+                    createTab(id = "a", url = "https://www.example.org")
+                )
             )).joinBlocking()
         }
     }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreTest.kt
@@ -24,7 +24,7 @@ class BrowserStoreTest {
     @Test(expected = IllegalArgumentException::class)
     fun `Initial state is validated and rejected if selected tab does not exist`() {
         val initialState = BrowserState(
-            tabs = listOf(createTab("https://www.mozilla.org")),
+            normalTabs = listOf(createTab("https://www.mozilla.org")),
             selectedTabId = "invalid"
         )
         BrowserStore(initialState)

--- a/components/feature/media/src/main/java/mozilla/components/feature/media/middleware/MediaMiddleware.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/middleware/MediaMiddleware.kt
@@ -11,8 +11,6 @@ import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.CustomTabListAction
 import mozilla.components.browser.state.action.MediaAction
 import mozilla.components.browser.state.action.TabListAction
-import mozilla.components.browser.state.selector.normalTabs
-import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.MediaState
 import mozilla.components.feature.media.middleware.sideeffects.MediaAggregateUpdater

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,11 @@ permalink: /changelog/
 * **feature-media**
   * Adds `MediaFullscreenOrientationFeature` to autorotate activity while in fullscreen based on media aspect ratio.
 
+* **browser-state**
+  * ⚠️ **This is a breaking change**: `BrowserState.tabs` has been split into two lists: `normalTabs` and `privateTabs`.
+    The `normalTabs` and `privateTabs` extension functions have been removed.
+    `tabs` is now a getter on `BrowserState` that always returns a list of normal tabs followed by private tabs.
+
 # 42.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v41.0.0...42.0.0)


### PR DESCRIPTION
It's fairly common to only want a list of normal tabs or private tabs. While this can be done using a `.filter` call, we control all the tabs inside the store and it would be more efficient to just store the two lists separately. 

To make migration as simple as possible, I've left `tabs` as a getter built into the state object rather than making an extension function. The only breaking change is that the `normalTabs`/`privateTabs` extension methods have been removed, and that `tabs` now always lists the normal tabs followed by private tabs instead of mixing them.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
