### PR TITLE
Issue #5217: Skip check to open about/data/js URLs in external apps

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
@@ -44,7 +44,7 @@ class AppLinksInterceptor(
     private val context: Context,
     private val interceptLinkClicks: Boolean = false,
     private val engineSupportedSchemes: Set<String> = ENGINE_SUPPORTED_SCHEMES,
-    private val alwaysDeniedSchemes: Set<String> = setOf("javascript", "about"),
+    private val alwaysDeniedSchemes: Set<String> = setOf("javascript", "about", "data"),
     private val launchInApp: () -> Boolean = { false },
     private val useCases: AppLinksUseCases = AppLinksUseCases(context, launchInApp),
     private val launchFromInterceptor: Boolean = false


### PR DESCRIPTION
This prevents looking up external apps for `data:`, `javascript:` and `about:` URLs. We don't need to look for external apps in these cases and the former actually causes crashes when the URL is too large `TransactionTooLargeException` as the intent contains the entire URL.
