### PR TITLE
Closes #5249: Long URI in the address bar will hang the UI

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -32,6 +32,11 @@ import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import mozilla.components.ui.autocomplete.OnFilterListener
 import kotlin.coroutines.CoroutineContext
 
+// This is used for truncating URLs to prevent extreme cases from
+// slowing down UI rendering e.g. in case of a bookmarklet or a data URI.
+// https://github.com/mozilla-mobile/android-components/issues/5249
+const val MAX_URI_LENGTH = 25000
+
 /**
  * A customizable toolbar for browsers.
  *
@@ -99,7 +104,7 @@ class BrowserToolbar @JvmOverloads constructor(
             // We update the display toolbar immediately. We do not do that for the edit toolbar to not
             // mess with what the user is entering. Instead we will remember the value and update the
             // edit toolbar whenever we switch to it.
-            display.url = value
+            display.url = value.take(MAX_URI_LENGTH)
         }
 
     override var siteSecure: Toolbar.SiteSecurity


### PR DESCRIPTION
We've had two cases now where this was a problem. A bookmarklet (see https://github.com/mozilla-mobile/android-components/issues/6985) and a data URI (https://github.com/mozilla-mobile/android-components/issues/5249).

This fix is similar to the one we landed last week for our Awesomebar (https://github.com/csadilek/android-components/commit/bba846d12eb12e7bb91e112aba3901c034057fde), but tapping on long URLs or copying them from the clipboard etc. would still cause the UI to hang. With data URIs I can reproduce seconds/minutes long hangs that are fixed with this.

Took this from Fennec (https://github.com/pocmo/fennec-graveyard/blob/master/mobile/android/chrome/content/browser.js#L4308), and applied to both display and edit toolbar (otherwise the UI would hang once the toolbar is in edit mode).