### PR TITLE
Bug 1639405 - Remove build.gradle files from triggering toolchain task

### DIFF
--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -45,9 +45,7 @@ linux64-android-gradle-dependencies:
             - taskcluster/scripts/toolchain/android-gradle-dependencies.sh
             - taskcluster/scripts/toolchain/android-gradle-dependencies/**
             - buildSrc/src/main/java/Dependencies.kt
-            - '*.gradle'
-            - components/**/build.gradle
-            - samples/**/build.gradle
+            - build.gradle
         toolchain-artifact: public/build/android-gradle-dependencies.tar.xz
         toolchain-alias: android-gradle-dependencies
     treeherder:


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

We're already watching the `Dependencies.kt` file so the only change to do here is remove the build.gradle entries.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
