### PR TITLE
Issue #2985: Add fallback in case Promise.any not available

### DIFF
--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -337,7 +337,16 @@ function connectNativePort() {
       case 'show':
         async function showAsync(options) {
           try {
-            let doc = await Promise.any([fetchDocument(articleUrl), getPreparedDocument(id, articleUrl)]);
+            let doc;
+            if (typeof Promise.any === "function") {
+              doc = await Promise.any([fetchDocument(articleUrl), getPreparedDocument(id, articleUrl)]);
+            } else {
+              try {
+                doc = await getPreparedDocument(id, articleUrl);
+              } catch(e) {
+                doc = await fetchDocument(articleUrl);
+              }
+            }
             readerView.show(doc, articleUrl, options);
           } catch(e) {
             console.log(e);


### PR DESCRIPTION
This is handling `promise.any` not being available (current beta). The only part we miss is the optimization to let the faster operation of fetch|cache win, but that's fine for now.