### PR TITLE
Fix browser behaviour when homescreen tab is tapped - do not open new…

### DIFF
--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -50,8 +50,13 @@ class TabIntentProcessor(
         return if (url.isNullOrEmpty()) {
             false
         } else {
-            val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
-            loadUrlUseCase(url, session, LoadUrlFlags.external())
+            val existingSession = sessionManager.sessions.find { it.url == url }
+            if (existingSession != null) {
+                sessionManager.select(existingSession)
+            } else {
+                loadUrlUseCase(url, createSession(url, private = isPrivate,
+                        source = Source.ACTION_VIEW), LoadUrlFlags.external())
+            }
             true
         }
     }

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -32,6 +32,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyList
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
@@ -74,6 +75,14 @@ class TabIntentProcessorTest {
         whenever(intent.dataString).thenReturn("http://mozilla.org")
         handler.process(intent)
         verify(engineSession).loadUrl("http://mozilla.org", flags = LoadUrlFlags.external())
+
+        // try to send a request to open a tab with the same url as before
+        whenever(intent.dataString).thenReturn("http://mozilla.org")
+        handler.process(intent)
+        verify(sessionManager).select(any())
+        verify(sessionManager, never()).add(anyList())
+
+        assertEquals(sessionManager.sessions.size, 1)
 
         val session = sessionManager.all[0]
         assertNotNull(session)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-intent**
+  * Select existing tab by url when trying to open a new tab in `TabIntentProcessor`
+
 * **feature-media**
   * Adds `MediaFullscreenOrientationFeature` to autorotate activity while in fullscreen based on media aspect ratio.
 


### PR DESCRIPTION
… tab when tab is already present in the browser


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
