### PR TITLE
Fix EditToolbar keyEvent handling

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -49,7 +49,7 @@ private const val AUTOCOMPLETE_QUERY_THREADS = 3
  * - actions: Optional action icons injected by other components (e.g. barcode scanner)
  * - exit: Button that switches back to display mode or invoke an app-defined callback.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 class EditToolbar internal constructor(
     context: Context,
     private val toolbar: BrowserToolbar,
@@ -111,10 +111,14 @@ class EditToolbar internal constructor(
                     context.resources.getDimensionPixelSize(R.dimen.mozac_browser_toolbar_url_gone_margin_end))
 
             setOnDispatchKeyEventPreImeListener { event ->
-                if (event?.keyCode == KeyEvent.KEYCODE_BACK && editListener?.onCancelEditing() != false) {
-                    toolbar.displayMode()
+                if (event?.keyCode == KeyEvent.KEYCODE_BACK) {
+                    if (editListener?.onCancelEditing() != false) {
+                        toolbar.displayMode()
+                    }
+                    true
+                } else {
+                    false
                 }
-                false
             }
         }
     )

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt
@@ -193,4 +193,10 @@ class EditToolbarTest {
         clearView.performClick()
         assertTrue(editToolbar.views.url.text.isBlank())
     }
+
+    @Test
+    fun `dispatchKeyEventPreIme on urlView returns true for KEYCODE_BACK`() {
+        val (_, editToolbar) = createEditToolbar()
+        assertTrue(editToolbar.views.url.dispatchKeyEventPreIme(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK)))
+    }
 }


### PR DESCRIPTION
Closes #3600.

Return true in `setOnDispatchKeyEventPreImeListener` when the back button was pressed. This prevents handling the back button press twice in the case that the keyboard has already been closed.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
