### PR TITLE
Closes #7062: Add nested menu UI for web extensions actions

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -33,6 +33,8 @@ open class BrowserMenu internal constructor(
 ) {
     protected var currentPopup: PopupWindow? = null
     private var menuList: RecyclerView? = null
+    internal var currAnchor: View? = null
+    internal var isShown = false
 
     /**
      * @param anchor the view on which to pin the popup window.
@@ -79,12 +81,16 @@ open class BrowserMenu internal constructor(
             setOnDismissListener {
                 adapter.menu = null
                 currentPopup = null
+                isShown = false
                 onDismiss()
             }
 
-            displayPopup(view, anchor, orientation)
+            displayPopup(view, anchor, orientation).also {
+                currAnchor = anchor
+            }
         }.also {
             currentPopup = it
+            isShown = true
         }
     }
 

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
@@ -5,22 +5,34 @@
 package mozilla.components.browser.menu
 
 import android.content.Context
+import mozilla.components.browser.menu.item.BackPressMenuItem
+import mozilla.components.browser.menu.item.BrowserMenuDivider
+import mozilla.components.browser.menu.item.BrowserMenuImageText
+import mozilla.components.browser.menu.item.NO_ID
+import mozilla.components.browser.menu.item.ParentBrowserMenuItem
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 
 /**
  * Browser menu builder with web extension support. It allows [WebExtensionBrowserMenu] to add
- * web extension browser actions.
+ * web extension browser actions in a nested menu item. If there are no web extensions installed,
+ * the web extension menu item would return an add-on manager menu item instead.
  *
  * @param store [BrowserStore] required to render web extension browser actions
+ * @param webExtIconTintColorResource Optional ID of color resource to tint the icons of back and
+ * add-ons manager menu items.
+ * @param onAddonsManagerTapped Callback to be invoked when add-ons manager menu item is selected.
  * @param appendExtensionActionAtStart true if web extensions appear at the top (start) of the menu,
  * false if web extensions appear at the bottom of the menu. Default to false (bottom).
  */
+@Suppress("LongParameterList")
 class WebExtensionBrowserMenuBuilder(
     items: List<BrowserMenuItem>,
     extras: Map<String, Any> = emptyMap(),
     endOfMenuAlwaysVisible: Boolean = false,
     private val store: BrowserStore,
+    private val webExtIconTintColorResource: Int = NO_ID,
+    private val onAddonsManagerTapped: () -> Unit = {},
     private val appendExtensionActionAtStart: Boolean = false
 ) : BrowserMenuBuilder(items, extras, endOfMenuAlwaysVisible) {
 
@@ -31,14 +43,54 @@ class WebExtensionBrowserMenuBuilder(
         val extensionMenuItems =
             WebExtensionBrowserMenu.getOrUpdateWebExtensionMenuItems(store.state, store.state.selectedTab)
 
+        val webExtMenuItem = if (extensionMenuItems.isNotEmpty()) {
+            val backPressMenuItem = BackPressMenuItem(
+                label = context.getString(R.string.mozac_browser_menu_addons),
+                imageResource = R.drawable.mozac_ic_back,
+                iconTintColorResource = webExtIconTintColorResource
+            )
+
+            val addonsManagerMenuItem = BrowserMenuImageText(
+                label = context.getString(R.string.mozac_browser_menu_addons_manager),
+                imageResource = R.drawable.mozac_ic_extensions,
+                iconTintColorResource = webExtIconTintColorResource
+            ) {
+                onAddonsManagerTapped.invoke()
+            }
+
+            val webExtSubMenuItems =
+                listOf(backPressMenuItem) + BrowserMenuDivider() +
+                extensionMenuItems +
+                BrowserMenuDivider() + addonsManagerMenuItem
+
+            val webExtBrowserMenuAdapter = BrowserMenuAdapter(context, webExtSubMenuItems)
+            val webExtMenu = WebExtensionBrowserMenu(webExtBrowserMenuAdapter, store)
+
+            ParentBrowserMenuItem(
+                label = context.getString(R.string.mozac_browser_menu_addons),
+                imageResource = R.drawable.mozac_ic_extensions,
+                iconTintColorResource = webExtIconTintColorResource,
+                subMenu = webExtMenu,
+                endOfMenuAlwaysVisible = endOfMenuAlwaysVisible
+            )
+        } else {
+            BrowserMenuImageText(
+                label = context.getString(R.string.mozac_browser_menu_addons),
+                imageResource = R.drawable.mozac_ic_extensions,
+                iconTintColorResource = webExtIconTintColorResource
+            ) {
+                onAddonsManagerTapped.invoke()
+            }
+        }
+
         val menuItems =
             if (appendExtensionActionAtStart) {
-                extensionMenuItems + items
+                listOf(webExtMenuItem) + items
             } else {
-                items + extensionMenuItems
+                items + webExtMenuItem
             }
 
         val adapter = BrowserMenuAdapter(context, menuItems)
-        return WebExtensionBrowserMenu(adapter, store)
+        return BrowserMenu(adapter)
     }
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/AbstractParentBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/AbstractParentBrowserMenuItem.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuItem
+
+/**
+ * An abstract menu item for handling nested sub menu items on view click.
+ *
+ * @property subMenu Target sub menu to be shown when this menu item is clicked.
+ * @param endOfMenuAlwaysVisible when is set to true makes sure the bottom of the menu is always visible
+ * otherwise, the top of the menu is always visible.
+ */
+abstract class AbstractParentBrowserMenuItem(
+    private val subMenu: BrowserMenu,
+    private val endOfMenuAlwaysVisible: Boolean
+) : BrowserMenuItem {
+    /**
+     * Listener called when the sub menu is shown.
+     */
+    var onSubMenuShow: () -> Unit = {}
+    /**
+     * Listener called when the sub menu is dismissed.
+     */
+    var onSubMenuDismiss: () -> Unit = {}
+    abstract override var visible: () -> Boolean
+    abstract override fun getLayoutResource(): Int
+
+    override fun bind(menu: BrowserMenu, view: View) {
+        view.setOnClickListener {
+            menu.dismiss()
+            subMenu.show(
+                anchor = menu.currAnchor ?: view,
+                orientation = BrowserMenu.determineMenuOrientation(view.parent as? View?),
+                endOfMenuAlwaysVisible = endOfMenuAlwaysVisible
+            ) {
+                onSubMenuDismiss()
+            }
+            onSubMenuShow()
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    internal fun onBackPressed(menu: BrowserMenu, view: View) {
+        if (subMenu.isShown) {
+            subMenu.dismiss()
+            onSubMenuDismiss()
+            menu.show(
+                anchor = menu.currAnchor ?: view,
+                orientation = BrowserMenu.determineMenuOrientation(view.parent as? View?),
+                endOfMenuAlwaysVisible = endOfMenuAlwaysVisible
+            )
+        }
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BackPressMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BackPressMenuItem.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.View
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import mozilla.components.browser.menu.BrowserMenu
+
+/**
+ * A back press menu item for a nested sub menu entry.
+ *
+ * @param backPressListener Callback to be invoked when the back press menu item is clicked.
+ */
+class BackPressMenuItem(
+    label: String,
+    @DrawableRes
+    imageResource: Int,
+    @ColorRes
+    iconTintColorResource: Int = NO_ID,
+    @ColorRes
+    textColorResource: Int = NO_ID,
+    private var backPressListener: () -> Unit = {}
+) : BrowserMenuImageText(label, imageResource, iconTintColorResource, textColorResource) {
+
+    /**
+     * Binds the view according to its super, but use [backPressListener] for on view clicks.
+     */
+    override fun bind(menu: BrowserMenu, view: View) {
+        super.bind(menu, view)
+
+        view.setOnClickListener {
+            backPressListener.invoke()
+            menu.dismiss()
+        }
+    }
+    /**
+     * Sets and replaces the existing [backPressListener] for the back press item.
+     */
+    fun setListener(onClickListener: () -> Unit) {
+        backPressListener = onClickListener
+    }
+}

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.content.ContextCompat
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.R
+import mozilla.components.concept.menu.candidate.ContainerStyle
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextStyle
+
+/**
+ * A parent menu item for displaying text and an image icon with a nested sub menu.
+ * It handles back pressing if the sub menu contains a [BackPressMenuItem].
+ *
+ * @param label The visible label of this menu item.
+ * @param imageResource ID of a drawable resource to be shown as icon.
+ * @param iconTintColorResource Optional ID of color resource to tint the icon.
+ * @param textColorResource Optional ID of color resource to tint the text.
+ * @property subMenu Target sub menu to be shown when this menu item is clicked.
+ */
+@Suppress("LongParameterList")
+class ParentBrowserMenuItem(
+    private val label: String,
+    @DrawableRes
+    private val imageResource: Int,
+    @ColorRes
+    private val iconTintColorResource: Int = NO_ID,
+    @ColorRes
+    private val textColorResource: Int = NO_ID,
+    internal val subMenu: BrowserMenu,
+    endOfMenuAlwaysVisible: Boolean = false
+) : AbstractParentBrowserMenuItem(subMenu, endOfMenuAlwaysVisible) {
+
+    override var visible: () -> Boolean = { true }
+    override fun getLayoutResource() = R.layout.mozac_browser_menu_item_image_text
+
+    override fun bind(menu: BrowserMenu, view: View) {
+        bindText(view)
+        bindImage(view)
+        bindBackPress(menu, view)
+
+        super.bind(menu, view)
+    }
+
+    private fun bindText(view: View) {
+        val textView = view.findViewById<TextView>(R.id.text)
+        textView.text = label
+        textView.setColorResource(textColorResource)
+    }
+
+    private fun bindImage(view: View) {
+        val imageView = view.findViewById<AppCompatImageView>(R.id.image)
+        with(imageView) {
+            setImageResource(imageResource)
+            setTintResource(iconTintColorResource)
+        }
+    }
+
+    private fun bindBackPress(menu: BrowserMenu, view: View) {
+        val backPressMenuItem =
+            subMenu.adapter.visibleItems.find { it is BackPressMenuItem } as? BackPressMenuItem
+        backPressMenuItem?.let {
+            backPressMenuItem.setListener {
+                onBackPressed(menu, view)
+            }
+        }
+    }
+
+    override fun asCandidate(context: Context) = TextMenuCandidate(
+        label,
+        start = DrawableMenuIcon(
+            context,
+            resource = imageResource,
+            tint = if (iconTintColorResource == NO_ID) null else ContextCompat.getColor(context, iconTintColorResource)
+        ),
+        textStyle = TextStyle(
+            color = if (textColorResource == NO_ID) null else ContextCompat.getColor(context, textColorResource)
+        ),
+        containerStyle = ContainerStyle(isVisible = visible())
+    )
+}

--- a/components/browser/menu/src/main/res/values/strings.xml
+++ b/components/browser/menu/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Highlighted</string>
+    <!-- Label for add-ons submenu section -->
+    <string name="mozac_browser_menu_addons">Add-ons</string>
+    <!-- Label for add-ons sub menu item for add-ons manager -->
+    <string name="mozac_browser_menu_addons_manager">Add-ons Manager</string>
 </resources>

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt
@@ -53,6 +53,41 @@ class BrowserMenuTest {
     }
 
     @Test
+    fun `show assigns currAnchor and isShown`() {
+        val items = listOf(
+            SimpleBrowserMenuItem("Hello") {},
+            SimpleBrowserMenuItem("World") {})
+
+        val adapter = BrowserMenuAdapter(testContext, items)
+
+        val menu = BrowserMenu(adapter)
+
+        val anchor = Button(testContext)
+        val popup = menu.show(anchor)
+
+        assertNotNull(popup)
+        assertEquals(anchor, menu.currAnchor)
+        assertTrue(menu.isShown)
+    }
+
+    @Test
+    fun `dismiss sets isShown to false`() {
+        val items = listOf(
+            SimpleBrowserMenuItem("Hello") {},
+            SimpleBrowserMenuItem("World") {})
+
+        val adapter = BrowserMenuAdapter(testContext, items)
+
+        val menu = BrowserMenu(adapter)
+
+        val anchor = Button(testContext)
+        val popup = menu.show(anchor)
+        popup.dismiss()
+
+        assertFalse(menu.isShown)
+    }
+
+    @Test
     fun `recyclerview adapter will have items for every menu item`() {
         val items = listOf(
             SimpleBrowserMenuItem("Hello") {},

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -4,11 +4,15 @@
 
 package mozilla.components.browser.menu
 
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageButton
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.menu.item.BackPressMenuItem
+import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.WebExtensionBrowserMenuItem
+import mozilla.components.browser.menu.item.ParentBrowserMenuItem
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.store.BrowserStore
@@ -16,16 +20,39 @@ import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 
 @RunWith(AndroidJUnit4::class)
 class WebExtensionBrowserMenuBuilderTest {
 
     @Test
-    fun `web extension is added at the start when appendExtensionActionAtStart is true`() {
+    fun `WHEN there are no web extension actions THEN add-ons menu item invokes onAddonsManagerTapped`() {
+        var isAddonsManagerTapped = false
+        val store = BrowserStore()
+        val builder = WebExtensionBrowserMenuBuilder(
+            listOf(mockMenuItem(), mockMenuItem()),
+            store = store,
+            onAddonsManagerTapped = { isAddonsManagerTapped = true },
+            appendExtensionActionAtStart = true
+        )
+
+        val menu = builder.build(testContext)
+
+        val addonsManagerItem = menu.adapter.visibleItems[0] as? BrowserMenuImageText
+        val addonsManagerItemView =
+            LayoutInflater.from(testContext).inflate(addonsManagerItem!!.getLayoutResource(), null)
+        addonsManagerItem.bind(menu, addonsManagerItemView)
+        assertFalse(isAddonsManagerTapped)
+        addonsManagerItemView.performClick()
+        assertTrue(isAddonsManagerTapped)
+    }
+
+    @Test
+    fun `web extension sub menu add-ons manager sub menu item invokes onAddonsManagerTapped when clicked`() {
         val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
         val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
 
@@ -40,22 +67,65 @@ class WebExtensionBrowserMenuBuilderTest {
             )
         )
 
-        val store = Mockito.spy(
-            BrowserStore(
-                BrowserState(
-                    extensions = extensions
-                )
+        val store = BrowserStore(
+            BrowserState(
+                extensions = extensions
             )
         )
 
-        val builder =
-            WebExtensionBrowserMenuBuilder(
-                listOf(mockMenuItem(), mockMenuItem()),
-                store = store,
-                appendExtensionActionAtStart = true)
+        var isAddonsManagerTapped = false
+        val builder = WebExtensionBrowserMenuBuilder(
+            listOf(mockMenuItem(), mockMenuItem()),
+            store = store,
+            onAddonsManagerTapped = { isAddonsManagerTapped = true },
+            appendExtensionActionAtStart = true
+        )
 
         val menu = builder.build(testContext)
 
+        val parentMenuItem = menu.adapter.visibleItems[0] as? ParentBrowserMenuItem
+        val subMenuItemSize = parentMenuItem!!.subMenu.adapter.visibleItems.size
+        assertEquals(6, subMenuItemSize)
+        val addOnsManagerMenuItem =
+            parentMenuItem.subMenu.adapter.visibleItems[subMenuItemSize - 1] as? BrowserMenuImageText
+        val addonsManagerItemView =
+            LayoutInflater.from(testContext).inflate(addOnsManagerMenuItem!!.getLayoutResource(), null)
+        addOnsManagerMenuItem.bind(menu, addonsManagerItemView)
+        assertFalse(isAddonsManagerTapped)
+        addonsManagerItemView.performClick()
+        assertTrue(isAddonsManagerTapped)
+        assertNotNull(addOnsManagerMenuItem)
+    }
+
+    @Test
+    fun `web extension submenu is added at the start when appendExtensionActionAtStart is true`() {
+        val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
+        val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
+
+        val extensions = mapOf(
+            "id" to WebExtensionState(
+                "id",
+                "url",
+                "name",
+                true,
+                browserAction = browserAction,
+                pageAction = pageAction
+            )
+        )
+
+        val store = BrowserStore(
+            BrowserState(
+                extensions = extensions
+            )
+        )
+
+        val builder = WebExtensionBrowserMenuBuilder(
+            listOf(mockMenuItem(), mockMenuItem()),
+            store = store,
+            appendExtensionActionAtStart = true
+        )
+
+        val menu = builder.build(testContext)
         val anchor = ImageButton(testContext)
         val popup = menu.show(anchor)
 
@@ -64,17 +134,23 @@ class WebExtensionBrowserMenuBuilderTest {
 
         val recyclerAdapter = recyclerView.adapter!!
         assertNotNull(recyclerAdapter)
-        assertEquals(4, recyclerAdapter.itemCount)
+        assertEquals(3, recyclerAdapter.itemCount)
 
-        var menuItem = menu.adapter.visibleItems[0]
-        assertEquals("browser_action", (menuItem as WebExtensionBrowserMenuItem).action.title)
-
-        menuItem = menu.adapter.visibleItems[1]
-        assertEquals("page_action", (menuItem as WebExtensionBrowserMenuItem).action.title)
+        val parentMenuItem = menu.adapter.visibleItems[0] as? ParentBrowserMenuItem
+        val subMenuItemSize = parentMenuItem!!.subMenu.adapter.visibleItems.size
+        assertEquals(6, subMenuItemSize)
+        val backMenuItem = parentMenuItem.subMenu.adapter.visibleItems[0] as? BackPressMenuItem
+        val subMenuExtItemBrowserAction = parentMenuItem.subMenu.adapter.visibleItems[2] as? WebExtensionBrowserMenuItem
+        val subMenuExtItemPageAction = parentMenuItem.subMenu.adapter.visibleItems[3] as? WebExtensionBrowserMenuItem
+        val addOnsManagerMenuItem = parentMenuItem.subMenu.adapter.visibleItems[subMenuItemSize - 1] as? BrowserMenuImageText
+        assertNotNull(backMenuItem)
+        assertEquals("browser_action", subMenuExtItemBrowserAction!!.action.title)
+        assertEquals("page_action", subMenuExtItemPageAction!!.action.title)
+        assertNotNull(addOnsManagerMenuItem)
     }
 
     @Test
-    fun `web extension is added at the end when appendExtensionActionAtStart is false`() {
+    fun `web extension submenu is added at the end when appendExtensionActionAtStart is false`() {
         val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
         val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
 
@@ -89,11 +165,9 @@ class WebExtensionBrowserMenuBuilderTest {
             )
         )
 
-        val store = Mockito.spy(
-            BrowserStore(
-                BrowserState(
-                    extensions = extensions
-                )
+        val store = BrowserStore(
+            BrowserState(
+                extensions = extensions
             )
         )
 
@@ -105,7 +179,6 @@ class WebExtensionBrowserMenuBuilderTest {
             )
 
         val menu = builder.build(testContext)
-
         val anchor = ImageButton(testContext)
         val popup = menu.show(anchor)
 
@@ -114,12 +187,19 @@ class WebExtensionBrowserMenuBuilderTest {
 
         val recyclerAdapter = recyclerView.adapter!!
         assertNotNull(recyclerAdapter)
-        assertEquals(4, recyclerAdapter.itemCount)
+        assertEquals(3, recyclerAdapter.itemCount)
 
-        var menuItem = menu.adapter.visibleItems[menu.adapter.itemCount - 1]
-        assertEquals("page_action", (menuItem as WebExtensionBrowserMenuItem).action.title)
-        menuItem = menu.adapter.visibleItems[menu.adapter.itemCount - 2]
-        assertEquals("browser_action", (menuItem as WebExtensionBrowserMenuItem).action.title)
+        val parentMenuItem = menu.adapter.visibleItems[recyclerAdapter.itemCount - 1] as? ParentBrowserMenuItem
+        val subMenuItemSize = parentMenuItem!!.subMenu.adapter.visibleItems.size
+        assertEquals(6, subMenuItemSize)
+        val backMenuItem = parentMenuItem.subMenu.adapter.visibleItems[0] as? BackPressMenuItem
+        val subMenuExtItemBrowserAction = parentMenuItem.subMenu.adapter.visibleItems[2] as? WebExtensionBrowserMenuItem
+        val subMenuExtItemPageAction = parentMenuItem.subMenu.adapter.visibleItems[3] as? WebExtensionBrowserMenuItem
+        val addOnsManagerMenuItem = parentMenuItem.subMenu.adapter.visibleItems[subMenuItemSize - 1] as? BrowserMenuImageText
+        assertNotNull(backMenuItem)
+        assertEquals("browser_action", subMenuExtItemBrowserAction!!.action.title)
+        assertEquals("page_action", subMenuExtItemPageAction!!.action.title)
+        assertNotNull(addOnsManagerMenuItem)
     }
 
     private fun mockMenuItem() = object : BrowserMenuItem {

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/AbstractParentBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/AbstractParentBrowserMenuItemTest.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuAdapter
+import mozilla.components.browser.menu.R
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AbstractParentBrowserMenuItemTest {
+
+    @Test
+    fun bind() {
+        val view = View(testContext)
+        var subMenuShowCalled = false
+        var subMenuDismissCalled = false
+
+        val subMenuItem = SimpleBrowserMenuItem("test")
+        val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(subMenuItem))
+        val subMenu = BrowserMenu(subMenuAdapter)
+        val parentMenuItem = DummyParentBrowserMenuItem(subMenu)
+        val nestedMenuAdapter = BrowserMenuAdapter(testContext, listOf(parentMenuItem))
+        val nestedMenu = BrowserMenu(nestedMenuAdapter)
+
+        parentMenuItem.onSubMenuShow = {
+            subMenuShowCalled = true
+        }
+        parentMenuItem.onSubMenuDismiss = {
+            subMenuDismissCalled = true
+        }
+
+        parentMenuItem.bind(nestedMenu, view)
+        nestedMenu.show(view)
+        assertTrue(nestedMenu.isShown)
+
+        view.performClick()
+        assertFalse(nestedMenu.isShown)
+        assertTrue(subMenu.isShown)
+        assertTrue(subMenuShowCalled)
+
+        subMenu.dismiss()
+        assertTrue(subMenuDismissCalled)
+    }
+
+    @Test
+    fun onBackPressed() {
+        val view = View(testContext)
+        var subMenuDismissCalled = false
+
+        val subMenuItem = SimpleBrowserMenuItem("test")
+        val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(subMenuItem))
+        val subMenu = BrowserMenu(subMenuAdapter)
+        val parentMenuItem = DummyParentBrowserMenuItem(subMenu)
+        val nestedMenuAdapter = BrowserMenuAdapter(testContext, listOf(parentMenuItem))
+        val nestedMenu = BrowserMenu(nestedMenuAdapter)
+
+        parentMenuItem.onSubMenuDismiss = {
+            subMenuDismissCalled = true
+        }
+
+        parentMenuItem.bind(nestedMenu, view)
+        // verify onBackPressed while sub menu is not shown does nothing.
+        parentMenuItem.onBackPressed(nestedMenu, view)
+        assertFalse(subMenuDismissCalled)
+
+        nestedMenu.show(view)
+        view.performClick()
+        parentMenuItem.onBackPressed(nestedMenu, view)
+        assertTrue(nestedMenu.isShown)
+        assertFalse(subMenu.isShown)
+        assertTrue(subMenuDismissCalled)
+    }
+}
+
+class DummyParentBrowserMenuItem(
+    subMenu: BrowserMenu,
+    endOfMenuAlwaysVisible: Boolean = false
+) : AbstractParentBrowserMenuItem(subMenu, endOfMenuAlwaysVisible) {
+    override var visible: () -> Boolean = { true }
+    override fun getLayoutResource(): Int = R.layout.mozac_browser_menu_item_simple
+}

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/ParentBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/ParentBrowserMenuItemTest.kt
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu.item
+
+import android.view.LayoutInflater
+import android.widget.TextView
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.content.ContextCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuAdapter
+import mozilla.components.browser.menu.R
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ParentBrowserMenuItemTest {
+
+    @Test
+    fun `menu item ImageText should have the right text, image, and iconTintColorResource`() {
+        val subMenuItem = SimpleBrowserMenuItem("test")
+        val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(subMenuItem))
+        val subMenu = BrowserMenu(subMenuAdapter)
+        val parentMenuItem = ParentBrowserMenuItem(
+            label = "label",
+            imageResource = android.R.drawable.ic_menu_report_image,
+            iconTintColorResource = android.R.color.black,
+            textColorResource = android.R.color.black,
+            subMenu = subMenu
+        )
+        val view = LayoutInflater.from(testContext).inflate(parentMenuItem.getLayoutResource(), null)
+        val nestedMenuAdapter = BrowserMenuAdapter(testContext, listOf(parentMenuItem))
+        val nestedMenu = BrowserMenu(nestedMenuAdapter)
+
+        parentMenuItem.bind(nestedMenu, view)
+        val textView = view.findViewById<TextView>(R.id.text)
+        val imageView = view.findViewById<AppCompatImageView>(R.id.image)
+
+        assertEquals("label", textView.text)
+        assertNotNull(imageView.drawable)
+        assertNotNull(imageView.imageTintList)
+    }
+
+    @Test
+    fun `menu item ImageText with no iconTintColorResource must not have an imageTintList`() {
+        val subMenuItem = SimpleBrowserMenuItem("test")
+        val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(subMenuItem))
+        val subMenu = BrowserMenu(subMenuAdapter)
+        val parentMenuItem = ParentBrowserMenuItem(
+            label = "label",
+            imageResource = android.R.drawable.ic_menu_report_image,
+            subMenu = subMenu
+        )
+        val view = LayoutInflater.from(testContext).inflate(parentMenuItem.getLayoutResource(), null)
+        val nestedMenuAdapter = BrowserMenuAdapter(testContext, listOf(parentMenuItem))
+        val nestedMenu = BrowserMenu(nestedMenuAdapter)
+
+        parentMenuItem.bind(nestedMenu, view)
+        val imageView = view.findViewById<AppCompatImageView>(R.id.image)
+
+        assertNull(imageView.imageTintList)
+    }
+
+    @Test
+    fun `onBackPressed after sub menu is shown will dismiss the sub menu`() {
+        val backPressMenuItem = BackPressMenuItem(
+            label = "back",
+            imageResource = R.drawable.mozac_ic_back
+        )
+        val backPressView = LayoutInflater.from(testContext).inflate(backPressMenuItem.getLayoutResource(), null)
+        val subMenuItem = SimpleBrowserMenuItem("test")
+        val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(backPressMenuItem, subMenuItem))
+        val subMenu = BrowserMenu(subMenuAdapter)
+        backPressMenuItem.bind(subMenu, backPressView)
+
+        val parentMenuItem = ParentBrowserMenuItem(
+            label = "label",
+            imageResource = android.R.drawable.ic_menu_report_image,
+            subMenu = subMenu
+        )
+        val view = LayoutInflater.from(testContext).inflate(parentMenuItem.getLayoutResource(), null)
+        val nestedMenuAdapter = BrowserMenuAdapter(testContext, listOf(parentMenuItem))
+        val nestedMenu = BrowserMenu(nestedMenuAdapter)
+        parentMenuItem.bind(nestedMenu, view)
+
+        nestedMenu.show(view)
+        view.performClick()
+        assertTrue(subMenu.isShown)
+        assertFalse(nestedMenu.isShown)
+
+        backPressView.performClick()
+        assertFalse(subMenu.isShown)
+        assertTrue(nestedMenu.isShown)
+    }
+
+    @Test
+    fun `menu item image text item can be converted to candidate`() {
+        assertEquals(
+            TextMenuCandidate(
+                "label",
+                start = DrawableMenuIcon(null)
+            ),
+            ParentBrowserMenuItem(
+                "label",
+                android.R.drawable.ic_menu_report_image,
+                subMenu = mock()
+            ).asCandidate(testContext).run {
+                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
+            }
+        )
+
+        assertEquals(
+            TextMenuCandidate(
+                text = "label",
+                start = DrawableMenuIcon(
+                    drawable = null,
+                    tint = ContextCompat.getColor(testContext, android.R.color.black)
+                )
+            ),
+                ParentBrowserMenuItem(
+                "label",
+                android.R.drawable.ic_menu_report_image,
+                android.R.color.black,
+                subMenu = mock()
+            ).asCandidate(testContext).run {
+                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
+            }
+        )
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,12 @@ permalink: /changelog/
 * **service-glean**
   * BUGFIX: Fix a race condition that leads to a `ConcurrentModificationException`. [Bug 1635865](https://bugzilla.mozilla.org/1635865)
 
+* **browser-menu**
+  * Added `AbstractParentBrowserMenuItem` and `ParentBrowserMenuItem` for handling nested sub menu items on view click.
+  * ⚠️ **This is a breaking change**: `WebExtensionBrowserMenuBuilder` now returns as a sub menu entry for add-ons. The sub 
+    menu also contains an access entry for Add-ons Manager, for which `onAddonsManagerTapped` needs to be passed in the
+    constructor.
+
 # 42.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v41.0.0...42.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -214,7 +214,18 @@ open class DefaultComponents(private val applicationContext: Context) {
     }
 
     // Menu
-    val menuBuilder by lazy { WebExtensionBrowserMenuBuilder(menuItems, store = store) }
+    val menuBuilder by lazy {
+        WebExtensionBrowserMenuBuilder(
+            menuItems,
+            store = store,
+            webExtIconTintColorResource = R.color.photonGrey90,
+            onAddonsManagerTapped = {
+                val intent = Intent(applicationContext, AddonsActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                applicationContext.startActivity(intent)
+            }
+        )
+    }
 
     private val menuItems by lazy {
         val items = mutableListOf(
@@ -232,11 +243,6 @@ open class DefaultComponents(private val applicationContext: Context) {
             },
             SimpleBrowserMenuItem("Settings") {
                 Toast.makeText(applicationContext, "Settings", Toast.LENGTH_SHORT).show()
-            },
-            SimpleBrowserMenuItem("Add-ons") {
-                val intent = Intent(applicationContext, AddonsActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                applicationContext.startActivity(intent)
             },
             SimpleBrowserMenuItem("Find In Page") {
                 FindInPageIntegration.launch?.invoke()


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
