### PR TITLE
For #7080 - Makes TabsAdapter open to subclassing

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -23,7 +23,7 @@ typealias ViewHolderProvider = (ViewGroup, BrowserTabsTray) -> TabViewHolder
  * @param viewHolderProvider a function that creates a `TabViewHolder`.
  */
 @Suppress("TooManyFunctions")
-class TabsAdapter(
+open class TabsAdapter(
     delegate: Observable<TabsTray.Observer> = ObserverRegistry(),
     private val viewHolderProvider: ViewHolderProvider = { parent, tabsTray ->
         DefaultTabViewHolder(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-tabs**
+  * Makes `TabsAdapter` open to subclassing.
+
 * **feature-intent**
   * Select existing tab by url when trying to open a new tab in `TabIntentProcessor`
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
