### PR TITLE
Use private keyboard for find in page in private mode

### DIFF
--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/internal/FindInPagePresenter.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/internal/FindInPagePresenter.kt
@@ -47,6 +47,7 @@ internal class FindInPagePresenter(
 
     fun bind(session: SessionState) {
         this.session = session
+        view.private = session.content.private
         view.focus()
     }
 

--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.inputmethod.EditorInfoCompat
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.feature.findinpage.R
 import mozilla.components.support.ktx.android.view.hideKeyboard
@@ -32,7 +33,8 @@ class FindInPageBar @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr), FindInPageView {
     private val styling: FindInPageBarStyling = createStyling(context, attrs, defStyleAttr)
-    private val queryEditText: EditText
+    @VisibleForTesting
+    internal val queryEditText: EditText
 
     @VisibleForTesting
     internal val resultsCountTextView: TextView
@@ -46,6 +48,22 @@ class FindInPageBar @JvmOverloads constructor(
         context.getString(R.string.mozac_feature_findindpage_accessibility_result)
 
     override var listener: FindInPageView.Listener? = null
+
+    /**
+     * Sets/gets private mode.
+     *
+     * In private mode the IME should not update any personalized data such as typing history and personalized language
+     * model based on what the user typed.
+     */
+    override var private: Boolean
+        get() = (queryEditText.imeOptions and EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING) != 0
+        set(value) {
+            queryEditText.imeOptions = if (value) {
+                queryEditText.imeOptions or EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING
+            } else {
+                queryEditText.imeOptions and (EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING.inv())
+            }
+        }
 
     init {
         inflate(getContext(), R.layout.mozac_feature_findinpage_view, this)

--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageView.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageView.kt
@@ -17,6 +17,14 @@ interface FindInPageView {
     var listener: Listener?
 
     /**
+     * Sets/gets private mode.
+     *
+     * In private mode the IME should not update any personalized data such as typing history and personalized language
+     * model based on what the user typed.
+     */
+    var private: Boolean
+
+    /**
      * Displays the given [FindResultState] state in the view.
      */
     fun displayResult(result: FindResultState)

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPagePresenterTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/internal/FindInPagePresenterTest.kt
@@ -25,9 +25,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 
 class FindInPagePresenterTest {
 
@@ -97,7 +99,8 @@ class FindInPagePresenterTest {
         val view: FindInPageView = mock()
 
         val presenter = FindInPagePresenter(mock(), view)
-        val session: SessionState = mock()
+        val session = Mockito.mock(SessionState::class.java, Mockito.RETURNS_DEEP_STUBS)
+        `when`(session.content.private).thenReturn(false)
         presenter.bind(session)
 
         assertEquals(presenter.session, session)
@@ -109,7 +112,8 @@ class FindInPagePresenterTest {
         val view: FindInPageView = mock()
 
         val presenter = FindInPagePresenter(mock(), view)
-        val session: SessionState = mock()
+        val session = Mockito.mock(SessionState::class.java, Mockito.RETURNS_DEEP_STUBS)
+        `when`(session.content.private).thenReturn(false)
         presenter.bind(session)
         presenter.unbind()
 

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
@@ -6,12 +6,15 @@ package mozilla.components.feature.findinpage.view
 
 import android.widget.EditText
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.feature.findinpage.R
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
@@ -111,5 +114,28 @@ class FindInPageBarTest {
         assertEquals(textCorrectValue, view.resultsCountTextView.text)
         assertEquals(contentDesCorrectValue, view.resultsCountTextView.contentDescription)
         verify(view).announceForAccessibility(contentDesCorrectValue)
+    }
+
+    @Test
+    fun `private flag sets IME_FLAG_NO_PERSONALIZED_LEARNING on find in page bar`() {
+        val findInPageBar = spy(FindInPageBar(testContext))
+        val edit = findInPageBar.queryEditText
+
+        // By default "private mode" is off.
+        assertEquals(0, edit.imeOptions and
+                EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING)
+        assertEquals(false, findInPageBar.private)
+
+        // Turning on private mode sets flag
+        findInPageBar.private = true
+        assertNotEquals(0, edit.imeOptions and
+                EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING)
+        assertTrue(findInPageBar.private)
+
+        // Turning private mode off again - should remove flag
+        findInPageBar.private = false
+        assertEquals(0, edit.imeOptions and
+                EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING)
+        assertEquals(false, findInPageBar.private)
     }
 }


### PR DESCRIPTION
Closes #3939.
Most of the code is copied over from the toolbar component. I'm checking`session.content.private` to determine whether to use the private keyboard.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
