### PR TITLE
Issue #7011: Correctly evaluate memory trimming levels.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -401,8 +401,8 @@ class SessionManager(
     @Synchronized
     @Suppress("NestedBlockDepth")
     override fun onTrimMemory(level: Int) {
-        val clearThumbnails = level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
-        val closeEngineSessions = level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
+        val clearThumbnails = shouldClearThumbnails(level)
+        val closeEngineSessions = shouldCloseEngineSessions(level)
 
         logger.debug("onTrimMemory($level): clearThumbnails=$clearThumbnails, closeEngineSessions=$closeEngineSessions")
 
@@ -540,4 +540,41 @@ fun SessionManager.runWithSessionIdOrSelected(
     }
 
     return false
+}
+
+private fun shouldClearThumbnails(level: Int): Boolean {
+    return when (level) {
+        // Foreground: The device is running much lower on memory. The app is running and not killable, but the
+        // system wants us to release unused resources to improve system performance.
+        ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW,
+        // Foreground: The device is running extremely low on memory. The app is not yet considered a killable
+        // process, but the system will begin killing background processes if apps do not release resources.
+        ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> true
+
+        // Background: The system is running low on memory and our process is near the middle of the LRU list.
+        // If the system becomes further constrained for memory, there's a chance our process will be killed.
+        ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+        // Background: The system is running low on memory and our process is one of the first to be killed
+        // if the system does not recover memory now.
+        ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> true
+
+        else -> false
+    }
+}
+
+private fun shouldCloseEngineSessions(level: Int): Boolean {
+    return when (level) {
+        // Foreground: The device is running extremely low on memory. The app is not yet considered a killable
+        // process, but the system will begin killing background processes if apps do not release resources.
+        ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> true
+
+        // Background: The system is running low on memory and our process is near the middle of the LRU list.
+        // If the system becomes further constrained for memory, there's a chance our process will be killed.
+        ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+        // Background: The system is running low on memory and our process is one of the first to be killed
+        // if the system does not recover memory now.
+        ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> true
+
+        else -> false
+    }
 }


### PR DESCRIPTION
Previously we assumed the value passed to onTrimMemory() represents a single linear progression of memory limits. But this
is not the case. We need to look at the values individually.

See:
https://developer.android.com/reference/android/content/ComponentCallbacks2
