### PR TITLE
Make sure the bottom toolbar is never stuck invisible

### DIFF
--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
@@ -153,6 +153,8 @@ class BrowserToolbarBottomBehaviorTest {
     fun `Behavior will apply translation to toolbar only for vertical scrolls`() {
         val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
         behavior.initGesturesDetector(behavior.createGestureDetector())
+        val child = spy(BrowserToolbar(testContext, null, 0))
+        behavior.browserToolbar = child
         val downEvent = TestUtils.getMotionEvent(ACTION_DOWN, 0f, 0f)
         val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, 0f, 100f, downEvent)
 
@@ -316,5 +318,29 @@ class BrowserToolbarBottomBehaviorTest {
         behavior.forceExpand(toolbar)
 
         verify(behavior).animateSnap(toolbar, SnapDirection.UP)
+    }
+
+    @Test
+    fun `Behavior will forceExpand when scrolling up and !shouldScroll`() {
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        behavior.initGesturesDetector(behavior.createGestureDetector())
+        doReturn(false).`when`(behavior).shouldScroll
+        val toolbar: BrowserToolbar = spy(BrowserToolbar(testContext, null, 0))
+        behavior.browserToolbar = toolbar
+        val animator: ValueAnimator = mock()
+        behavior.snapAnimator = animator
+        doReturn(false).`when`(animator).isStarted
+
+        doReturn(100).`when`(toolbar).height
+        doReturn(100f).`when`(toolbar).translationY
+
+        val downEvent = TestUtils.getMotionEvent(ACTION_DOWN, 0f, 0f)
+        val moveEvent = TestUtils.getMotionEvent(ACTION_MOVE, 0f, 30f, downEvent)
+
+        behavior.onInterceptTouchEvent(mock(), mock(), downEvent)
+        behavior.onInterceptTouchEvent(mock(), mock(), moveEvent)
+
+        verify(behavior).tryToScrollVertically(-30f)
+        verify(behavior).forceExpand(toolbar)
     }
 }


### PR DESCRIPTION
Closes #7101. This is my attempt to solve this issue. Essentially, if the user is scrolling upwards, but the toolbar is not being scrolled and not already showing or animating up, just forceExpand it.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
