### PR TITLE
For #7107: Increase touch target height for buttons in browser toolbar.

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.menu.item
 import android.content.Context
 import android.os.Build
 import android.view.View
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.annotation.ColorRes
@@ -41,7 +42,6 @@ class BrowserMenuItemToolbar(
 
         val selectableBackground =
             layout.context.theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless)
-        val iconHeight = view.resources.getDimensionPixelSize(R.dimen.mozac_browser_menu_item_image_text_icon_height)
 
         for (item in items) {
             val button = AppCompatImageButton(layout.context)
@@ -54,7 +54,7 @@ class BrowserMenuItemToolbar(
                 menu.dismiss()
             }
 
-            layout.addView(button, LinearLayout.LayoutParams(0, iconHeight, 1f))
+            layout.addView(button, LinearLayout.LayoutParams(0, MATCH_PARENT, 1f))
         }
     }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
