### PR TITLE
Add getNormalOrPrivateTabs function to BrowserState

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
@@ -89,13 +89,22 @@ fun BrowserState.findTabByUrl(url: String): TabSessionState? {
 }
 
 /**
+ * Gets a list of normal or private tabs depending on the requested type.
+ * @param private If true, all private tabs will be returned.
+ * If false, all normal tabs will be returned.
+ */
+fun BrowserState.getNormalOrPrivateTabs(private: Boolean): List<TabSessionState> {
+    return tabs.filter { it.content.private == private }
+}
+
+/**
  * List of private tabs.
  */
 val BrowserState.privateTabs: List<TabSessionState>
-    get() = tabs.filter { it.content.private }
+    get() = getNormalOrPrivateTabs(private = true)
 
 /**
  * List of normal (non-private) tabs.
  */
 val BrowserState.normalTabs: List<TabSessionState>
-    get() = tabs.filter { !it.content.private }
+    get() = getNormalOrPrivateTabs(private = false)

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
@@ -121,6 +121,24 @@ class SelectorsKtTest {
     }
 
     @Test
+    fun `getNormalOrPrivateTabs extension function`() {
+        val tab1 = createTab("https://www.firefox.com")
+        val tab2 = createTab("https://www.mozilla.org")
+        val privateTab1 = createTab("https://getpocket.com", private = true)
+        val privateTab2 = createTab("https://www.example.org", private = true)
+
+        val state = BrowserState(
+            tabs = listOf(tab1, privateTab1, tab2, privateTab2),
+            customTabs = listOf(createCustomTab("https://www.google.com")))
+
+        assertEquals(listOf(tab1, tab2), state.getNormalOrPrivateTabs(private = false))
+        assertEquals(listOf(privateTab1, privateTab2), state.getNormalOrPrivateTabs(private = true))
+
+        assertEquals(emptyList<TabSessionState>(), BrowserState().getNormalOrPrivateTabs(private = true))
+        assertEquals(emptyList<TabSessionState>(), BrowserState().getNormalOrPrivateTabs(private = false))
+    }
+
+    @Test
     fun `privateTabs and normalTabs extension properties`() {
         val tab1 = createTab("https://www.firefox.com")
         val tab2 = createTab("https://www.mozilla.org")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,9 +4,9 @@ title: Changelog
 permalink: /changelog/
 ---
 
-# 43.0.0-SNAPSHOT (In Development)
+# 44.0.0-SNAPSHOT (In Development)
 
-* [Commits](https://github.com/mozilla-mobile/android-components/compare/v43.0.0...master)
+* [Commits](https://github.com/mozilla-mobile/android-components/compare/v44.0.0...master)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/104?closed=1)
 * [Dependencies](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Dependencies.kt)
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
@@ -33,6 +33,9 @@ permalink: /changelog/
 * **feature-session**
   * Removes unused `ThumbnailsFeature` since this has been refactored into its own browser-thumbnails component in
     [#6827](https://github.com/mozilla-mobile/android-components/issues/6827).
+
+* **browser-state**
+  * Adds `BrowserState.getNormalOrPrivateTabs(private: Boolean)` to get `normalTabs` or `privateTabs` based on a boolean condition.
 
 # 43.0.0
 


### PR DESCRIPTION
It's fairly common to have an if statement like this:
```
if (showingPrivate) {
  store.state.privateTabs
} else {
  store.state.normalTabs
}
```

This change adds a helper to simplify the above if statement into one line: `store.state.getNormalOrPrivateTabs(isPrivate = showingPrivate)`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
