### PR TITLE
Closes #7165: Handle untracked directories during auto-publish

### DIFF
--- a/automation/publish_to_maven_local_if_modified.py
+++ b/automation/publish_to_maven_local_if_modified.py
@@ -61,6 +61,8 @@ contents_hash.update(b"\x00")
 
 untracked_files = []
 
+# First, get a list of all untracked files sans standard exclusions.
+
 # -o is for getting other (i.e. untracked) files
 # --exclude-standard is to handle standard Git exclusions: .git/info/exclude, .gitignore in each directory,
 # and the user's global exclusion file.
@@ -75,20 +77,23 @@ try:
 except StopIteration:
     pass
 
+# Then, account for some excluded files that we care about.
 untracked_files.extend(GITIGNORED_FILES_THAT_AFFECT_THE_BUILD)
 
-# So, we'll need to slurp the contents of such files for ourselves.
-# We could instead pipe output of `ls-files` into `git hash-object`, but that will probably break on non-*nix machines.
-for nm in untracked_files:
-    with open(nm, "rb") as f:
-        contents_hash.update(f.read())
-    contents_hash.update(b"\x00")
+# Finally, get hashes of everything.
+# Skip files that don't exist, e.g. missing GITIGNORED_FILES_THAT_AFFECT_THE_BUILD. `hash-object` errors out if it gets
+# a non-existent file, so we hope that disk won't change between this filter and the cmd run just below.
+filtered_untracked = [nm for nm in untracked_files if os.path.isfile(nm)]
+# Reading contents of the files is quite slow when there are lots of them, so delegate to `git hash-object`.
+git_hash_object_cmd = ["git", "hash-object"]
+git_hash_object_cmd.extend(filtered_untracked)
+changes_untracked = run_cmd_checked(git_hash_object_cmd, capture_output=True).stdout
+contents_hash.update(changes_untracked)
 contents_hash.update(b"\x00")
 
 contents_hash = contents_hash.hexdigest()
 
 # If the contents hash has changed since last publish, re-publish.
-
 last_contents_hash = ""
 try:
     with open(LAST_CONTENTS_HASH_FILE) as f:


### PR DESCRIPTION
Our python script would blow up if it encountered an untracked directory. This changes how the script reads in untracked files to account for this, and switches to git's hash-object to calculate hashes of files (instead of manually reading them into memory and hashing in python).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
