### PR TITLE
Issue 7170: Make ThumbnailsUseCases optional in TabsFeature and TabsTrayPresenter

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
@@ -24,7 +24,7 @@ class TabsFeature(
     tabsTray: TabsTray,
     private val store: BrowserStore,
     tabsUseCases: TabsUseCases,
-    thumbnailsUseCases: ThumbnailsUseCases,
+    thumbnailsUseCases: ThumbnailsUseCases? = null,
     private val defaultTabsFilter: (TabSessionState) -> Boolean = { true },
     closeTabsTray: () -> Unit
 ) : LifecycleAwareFeature {

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenter.kt
@@ -28,7 +28,7 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 class TabsTrayPresenter(
     private val tabsTray: TabsTray,
     private val store: BrowserStore,
-    private val thumbnailsUseCases: ThumbnailsUseCases,
+    private val thumbnailsUseCases: ThumbnailsUseCases? = null,
     internal var tabsFilter: (TabSessionState) -> Boolean,
     private val closeTabsTray: () -> Unit
 ) {
@@ -46,10 +46,14 @@ class TabsTrayPresenter(
     private suspend fun collect(flow: Flow<BrowserState>) {
         flow.map { it.toTabs(tabsFilter) }
             .map { tabs ->
-                // Load the tab thumbnail from the memory or disk caches.
-                tabs.copy(list = tabs.list.map { tab ->
-                    tab.copy(thumbnail = thumbnailsUseCases.loadThumbnail(tab.id))
-                })
+                if (thumbnailsUseCases != null) {
+                    // Load the tab thumbnail from the memory or disk caches.
+                    tabs.copy(list = tabs.list.map { tab ->
+                        tab.copy(thumbnail = thumbnailsUseCases.loadThumbnail(tab.id))
+                    })
+                } else {
+                    tabs
+                }
             }
             .ifChanged()
             .collect { tabs ->

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
@@ -99,7 +99,14 @@ class TabsFeatureTest {
         val filter: (TabSessionState) -> Boolean = { false }
         val sessionManager = SessionManager(engine = mock())
         val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock(), filter, mock()))
+        val tabsFeature = spy(TabsFeature(
+            mock(),
+            store,
+            useCases,
+            mock(),
+            defaultTabsFilter = filter,
+            closeTabsTray = mock()
+        ))
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
 

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsTrayPresenterTest.kt
@@ -18,15 +18,12 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.MediaState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.browser.thumbnails.ThumbnailsUseCases
-import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.concept.tabstray.Tabs
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.tabs.ext.toTabs
 import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -61,16 +58,20 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         verifyNoMoreInteractions(tabsTray)
 
@@ -93,16 +94,20 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
 
@@ -112,7 +117,7 @@ class TabsTrayPresenterTest {
 
         store.dispatch(
             TabListAction.AddTabAction(
-                createTab("https://developer.mozilla.org/", thumbnail = mock())
+                createTab("https://developer.mozilla.org/")
             )
         ).joinBlocking()
 
@@ -128,16 +133,20 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
 
@@ -165,16 +174,20 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
 
@@ -197,19 +210,23 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock()),
-                    createTab("https://developer.mozilla.org", id = "c", thumbnail = mock()),
-                    createTab("https://www.firefox.com", id = "d", thumbnail = mock()),
-                    createTab("https://www.google.com", id = "e", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b"),
+                    createTab("https://developer.mozilla.org", id = "c"),
+                    createTab("https://www.firefox.com", id = "d"),
+                    createTab("https://www.google.com", id = "e")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
         testDispatcher.advanceUntilIdle()
@@ -232,29 +249,30 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock()),
-                    createTab("https://developer.mozilla.org", id = "c", thumbnail = mock()),
-                    createTab("https://www.firefox.com", id = "d", thumbnail = mock()),
-                    createTab("https://www.google.com", id = "e", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b"),
+                    createTab("https://developer.mozilla.org", id = "c"),
+                    createTab("https://www.firefox.com", id = "d"),
+                    createTab("https://www.google.com", id = "e")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
         testDispatcher.advanceUntilIdle()
 
         store.dispatch(
             MediaAction.UpdateMediaAggregateAction(
-                store.state.media.aggregate.copy(
-                    activeTabId = "a",
-                    state = MediaState.State.PLAYING
-                )
+                store.state.media.aggregate.copy(activeTabId = "a", state = MediaState.State.PLAYING)
             )
         ).joinBlocking()
 
@@ -268,11 +286,11 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock()),
-                    createTab("https://developer.mozilla.org", id = "c", thumbnail = mock()),
-                    createTab("https://www.firefox.com", id = "d", thumbnail = mock()),
-                    createTab("https://www.google.com", id = "e", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b"),
+                    createTab("https://developer.mozilla.org", id = "c"),
+                    createTab("https://www.firefox.com", id = "d"),
+                    createTab("https://www.google.com", id = "e")
                 ),
                 selectedTabId = "a"
             )
@@ -281,11 +299,9 @@ class TabsTrayPresenterTest {
         var closed = false
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
         val presenter = TabsTrayPresenter(
             tabsTray,
             store,
-            thumbnailsUseCases,
             tabsFilter = { true },
             closeTabsTray = { closed = true })
 
@@ -307,8 +323,8 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b")
                 ),
                 selectedTabId = "a"
             )
@@ -317,11 +333,9 @@ class TabsTrayPresenterTest {
         var closed = false
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
         val presenter = TabsTrayPresenter(
             tabsTray,
             store,
-            thumbnailsUseCases,
             tabsFilter = { true },
             closeTabsTray = { closed = true })
 
@@ -348,16 +362,20 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b")
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter = TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { true }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { true },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
         testDispatcher.advanceUntilIdle()
@@ -379,17 +397,20 @@ class TabsTrayPresenterTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "a", thumbnail = mock()),
-                    createTab("https://getpocket.com", id = "b", private = true, thumbnail = mock())
+                    createTab("https://www.mozilla.org", id = "a"),
+                    createTab("https://getpocket.com", id = "b", private = true)
                 ),
                 selectedTabId = "a"
             )
         )
 
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val thumbnailsUseCases = ThumbnailsUseCases(store, ThumbnailStorage(testContext))
-        val presenter =
-            TabsTrayPresenter(tabsTray, store, thumbnailsUseCases, { it.content.private }, mock())
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { it.content.private },
+            closeTabsTray = mock()
+        )
 
         presenter.start()
         testDispatcher.advanceUntilIdle()
@@ -408,8 +429,11 @@ class TabsTrayPresenterTest {
 
         var invoked = false
         val tabsTray: MockedTabsTray = spy(MockedTabsTray())
-        val presenter =
-            TabsTrayPresenter(tabsTray, store, mock(), { it.content.private }, { invoked = true })
+        val presenter = TabsTrayPresenter(
+            tabsTray,
+            store,
+            tabsFilter = { it.content.private },
+            closeTabsTray = { invoked = true })
 
         presenter.start()
         testDispatcher.advanceUntilIdle()
@@ -447,8 +471,7 @@ private class MockedTabsTray : TabsTray {
 
     override fun notifyAtLeastOneObserver(block: TabsTray.Observer.() -> Unit) {}
 
-    override fun <R> wrapConsumers(block: TabsTray.Observer.(R) -> Boolean): List<(R) -> Boolean> =
-        emptyList()
+    override fun <R> wrapConsumers(block: TabsTray.Observer.(R) -> Boolean): List<(R) -> Boolean> = emptyList()
 
     override fun isObserved(): Boolean = false
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,8 +16,8 @@ permalink: /changelog/
   * Added support for [onbeforeunload prompt](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload)
 
 * **feature-tabs**
-  * ⚠️ **This is a breaking change**: Added a dependency on `ThumbnailsUseCases` to `TabsFeature` and `TabsTrayPresenter`
-    for loading a tab's thumbnail.
+  * Added an optional `ThumbnailsUseCases` to `TabsFeature` and `TabsTrayPresenter` for loading a
+    tab's thumbnail.
 
 * **browser-thumbnails**
   * Adds `LoadThumbnailUseCase` in `ThumbnailsUseCases` for loading the thumbnail of a tab.


### PR DESCRIPTION

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes #7170. This also rolls back the changes to the TabsTrayPresenterTest from #7021, which are not necessary if we made ThumbnailsUseCases optional.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
