### PR TITLE
Close #7164: Add getSubscription to AutoPushFeature if one exists

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegate.kt
@@ -22,11 +22,7 @@ internal class GeckoWebPushDelegate(private val delegate: WebPushDelegate) : Gec
         val result: GeckoResult<GeckoWebPushSubscription> = GeckoResult()
 
         delegate.onGetSubscription(scope) { subscription ->
-            if (subscription != null) {
-                result.complete(subscription.toGeckoSubscription())
-            } else {
-                result.completeExceptionally(WebPushException("Retrieving subscription failed."))
-            }
+            result.complete(subscription?.toGeckoSubscription())
         }
 
         return result
@@ -39,11 +35,7 @@ internal class GeckoWebPushDelegate(private val delegate: WebPushDelegate) : Gec
         val result: GeckoResult<GeckoWebPushSubscription> = GeckoResult()
 
         delegate.onSubscribe(scope, appServerKey) { subscription ->
-            if (subscription != null) {
-                result.complete(subscription.toGeckoSubscription())
-            } else {
-                result.completeExceptionally(WebPushException("Creating subscription failed."))
-            }
+            result.complete(subscription?.toGeckoSubscription())
         }
 
         return result

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegateTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegateTest.kt
@@ -72,9 +72,8 @@ class GeckoWebPushDelegateTest {
 
         val nullResult = geckoDelegate.onGetSubscription("test")
 
-        nullResult?.exceptionally { throwable: Throwable ->
-            assertTrue(throwable.localizedMessage == "Retrieving subscription failed.")
-            GeckoResult.fromValue(null)
+        nullResult?.accept { sub ->
+            assertNull(sub)
         }
     }
 
@@ -108,9 +107,8 @@ class GeckoWebPushDelegateTest {
         subscription = null
 
         val nullResult = geckoDelegate.onSubscribe("test", null)
-        nullResult?.exceptionally { throwable: Throwable ->
-            assertTrue(throwable.localizedMessage == "Creating subscription failed.")
-            GeckoResult.fromValue(null)
+        nullResult?.accept { sub ->
+            assertNull(sub)
         }
     }
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegate.kt
@@ -22,11 +22,7 @@ internal class GeckoWebPushDelegate(private val delegate: WebPushDelegate) : Gec
         val result: GeckoResult<GeckoWebPushSubscription> = GeckoResult()
 
         delegate.onGetSubscription(scope) { subscription ->
-            if (subscription != null) {
-                result.complete(subscription.toGeckoSubscription())
-            } else {
-                result.completeExceptionally(WebPushException("Retrieving subscription failed."))
-            }
+            result.complete(subscription?.toGeckoSubscription())
         }
 
         return result
@@ -39,11 +35,7 @@ internal class GeckoWebPushDelegate(private val delegate: WebPushDelegate) : Gec
         val result: GeckoResult<GeckoWebPushSubscription> = GeckoResult()
 
         delegate.onSubscribe(scope, appServerKey) { subscription ->
-            if (subscription != null) {
-                result.complete(subscription.toGeckoSubscription())
-            } else {
-                result.completeExceptionally(WebPushException("Creating subscription failed."))
-            }
+            result.complete(subscription?.toGeckoSubscription())
         }
 
         return result

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegateTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegateTest.kt
@@ -72,9 +72,8 @@ class GeckoWebPushDelegateTest {
 
         val nullResult = geckoDelegate.onGetSubscription("test")
 
-        nullResult?.exceptionally { throwable: Throwable ->
-            assertTrue(throwable.localizedMessage == "Retrieving subscription failed.")
-            GeckoResult.fromValue(null)
+        nullResult?.accept { sub ->
+            assertNull(sub)
         }
     }
 
@@ -108,9 +107,8 @@ class GeckoWebPushDelegateTest {
         subscription = null
 
         val nullResult = geckoDelegate.onSubscribe("test", null)
-        nullResult?.exceptionally { throwable: Throwable ->
-            assertTrue(throwable.localizedMessage == "Creating subscription failed.")
-            GeckoResult.fromValue(null)
+        nullResult?.accept { sub ->
+            assertNull(sub)
         }
     }
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegate.kt
@@ -22,11 +22,7 @@ internal class GeckoWebPushDelegate(private val delegate: WebPushDelegate) : Gec
         val result: GeckoResult<GeckoWebPushSubscription> = GeckoResult()
 
         delegate.onGetSubscription(scope) { subscription ->
-            if (subscription != null) {
-                result.complete(subscription.toGeckoSubscription())
-            } else {
-                result.completeExceptionally(WebPushException("Retrieving subscription failed."))
-            }
+            result.complete(subscription?.toGeckoSubscription())
         }
 
         return result
@@ -39,11 +35,7 @@ internal class GeckoWebPushDelegate(private val delegate: WebPushDelegate) : Gec
         val result: GeckoResult<GeckoWebPushSubscription> = GeckoResult()
 
         delegate.onSubscribe(scope, appServerKey) { subscription ->
-            if (subscription != null) {
-                result.complete(subscription.toGeckoSubscription())
-            } else {
-                result.completeExceptionally(WebPushException("Creating subscription failed."))
-            }
+            result.complete(subscription?.toGeckoSubscription())
         }
 
         return result

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegateTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webpush/GeckoWebPushDelegateTest.kt
@@ -72,9 +72,8 @@ class GeckoWebPushDelegateTest {
 
         val nullResult = geckoDelegate.onGetSubscription("test")
 
-        nullResult?.exceptionally { throwable: Throwable ->
-            assertTrue(throwable.localizedMessage == "Retrieving subscription failed.")
-            GeckoResult.fromValue(null)
+        nullResult?.accept { sub ->
+            assertNull(sub)
         }
     }
 
@@ -108,9 +107,8 @@ class GeckoWebPushDelegateTest {
         subscription = null
 
         val nullResult = geckoDelegate.onSubscribe("test", null)
-        nullResult?.exceptionally { throwable: Throwable ->
-            assertTrue(throwable.localizedMessage == "Creating subscription failed.")
-            GeckoResult.fromValue(null)
+        nullResult?.accept { sub ->
+            assertNull(sub)
         }
     }
 

--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -231,6 +231,32 @@ class AutoPushFeature(
     }
 
     /**
+     * Checks if a subscription for the [scope] already exists.
+     *
+     * @param scope The subscription identifier which usually represents the website's URI.
+     * @param appServerKey An optional key provided by the application server.
+     * @param block The callback invoked when a subscription for the [scope] is found, otherwise null. Note: this will
+     * not execute on the calls thread.
+     */
+    fun getSubscription(
+        scope: String,
+        appServerKey: String? = null,
+        block: (AutoPushSubscription?) -> Unit
+    ) {
+        connection.ifInitialized {
+            coroutineScope.launchAndTry {
+                if (containsSubscription(scope)) {
+                    // If we have a subscription, calling subscribe will give us the existing subscription.
+                    // We do this because we do not have API symmetry across the different layers in this stack.
+                    subscribe(scope, appServerKey, {}, block)
+                } else {
+                    block(null)
+                }
+            }
+        }
+    }
+
+    /**
      * Deletes the registration token locally so that it forces the service to get a new one the
      * next time hits it's messaging server.
      */

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/RustPushConnectionTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
@@ -138,6 +139,23 @@ class RustPushConnectionTest {
         }
 
         verify(api).unsubscribeAll()
+    }
+
+    @Test
+    fun `containsSubscription returns true if a subscription exists`() {
+        val connection = createConnection()
+        val api: PushAPI = mock()
+        connection.api = api
+
+        `when`(api.dispatchInfoForChid(ArgumentMatchers.anyString()))
+            .thenReturn(mock())
+            .thenReturn(null)
+
+        runBlocking {
+            assertTrue(connection.containsSubscription("validSubscription"))
+
+            assertFalse(connection.containsSubscription("invalidSubscription"))
+        }
     }
 
     @Test(expected = IllegalStateException::class)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ permalink: /changelog/
 * **feature-push**
   * Adds the `getSubscription` call to check if a subscription exists.
 
+* **browser-engine-gecko-***
+  * Fixes GeckoWebPushDelegate to gracefully return when a subscription is not available.
+
 # 43.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v42.0.0...v43.0.0)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,9 @@ permalink: /changelog/
   * Adds `ThumbnailStorage` as a storage layer for handling saving and loading a thumbnail from the
     disk cache.
 
+* **feature-push**
+  * Adds the `getSubscription` call to check if a subscription exists.
+
 # 43.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v42.0.0...v43.0.0)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

There are two parts to this fix:

First, we added the ability to check if a subscription exists first to match the
API requirement for WebPush support in GeckoView. We do this because the
call to `getSubscription` on the engine side expects it to work as a
check before creating a subscription, where-as our implementation used a
"get or create" pattern instead.

The fallout from this is that visiting sites that check for
subscriptions were immediately given one without user permission.

Second, with the previous patch, we fixed a bug where we need to check if a
subscription exists. This new (correct) behaviour broke our original
implementation of how to handle the null case in the engine.

Integration PR for Reference Browser: https://github.com/mozilla-mobile/reference-browser/pull/1208

Fenix PR will be a fast-follow.

Closes #7164 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
