### PR TITLE
Set overflow item only visible for ParentBrowserMenuItem

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
@@ -66,6 +66,7 @@ class ParentBrowserMenuItem(
         }
         val overflowView = view.findViewById<AppCompatImageView>(R.id.overflowImage)
         with(overflowView) {
+            visibility = View.VISIBLE
             setTintResource(iconTintColorResource)
         }
     }

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_text.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_image_text.xml
@@ -41,6 +41,7 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:clickable="false"
+        android:visibility="gone"
         android:background="@android:color/transparent"
         android:importantForAccessibility="no"
         app:srcCompat="@drawable/mozac_ic_arrowhead_right"/>


### PR DESCRIPTION
To address https://github.com/mozilla-mobile/android-components/pull/7159#issuecomment-635958410.