### PR TITLE
Closes #7181 - Do not crash on nonimplemented select login prompt

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -112,10 +112,11 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
             geckoResult.complete(prompt.dismiss())
         }
 
+        // Currently no-op will be addressed in https://github.com/mozilla-mobile/android-components/issues/7134
         geckoEngineSession.notifyObservers {
             onPromptRequest(
                 PromptRequest.SelectLoginPrompt(
-                    logins = prompt.options.map { it.value.toLogin() },
+                    logins = listOf(),
                     onConfirm = onConfirmSave,
                     onDismiss = onDismiss
                 )


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Once I actually implement the select login prompt in #7134 (probably next week) I'll make sure this STR doesn't crash then, but for now, let's make sure we aren't crashing on this nonimplemented feature 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
