### PR TITLE
Closes #6855: Do not use unsupportedAddon as global value

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -61,7 +61,6 @@ class AddonsManagerAdapter(
     private val style: Style? = null
 ) : ListAdapter<Any, CustomViewHolder>(DifferCallback) {
     private val scope = CoroutineScope(Dispatchers.IO)
-    private val unsupportedAddons = mutableSetOf<Addon>()
     private val logger = Logger("AddonsManagerAdapter")
     /**
      * Represents all the add-ons that will be distributed in multiple headers like
@@ -167,6 +166,7 @@ class AddonsManagerAdapter(
         holder: UnsupportedSectionViewHolder,
         section: NotYetSupportedSection
     ) {
+        val unsupportedAddons = addonsMap.values.filter { it.inUnsupportedSection() }
         val context = holder.itemView.context
         holder.titleView.setText(section.title)
         holder.descriptionView.text =
@@ -180,7 +180,7 @@ class AddonsManagerAdapter(
             }
 
         holder.itemView.setOnClickListener {
-            addonsManagerDelegate.onNotYetSupportedSectionClicked(unsupportedAddons.toList())
+            addonsManagerDelegate.onNotYetSupportedSectionClicked(unsupportedAddons)
         }
     }
 
@@ -279,6 +279,7 @@ class AddonsManagerAdapter(
         val installedAddons = ArrayList<Addon>()
         val recommendedAddons = ArrayList<Addon>()
         val disabledAddons = ArrayList<Addon>()
+        val unsupportedAddons = ArrayList<Addon>()
 
         addons.forEach { addon ->
             when {


### PR DESCRIPTION
As we updated the `AddonsManagerAdapter` for doing partial updates, we kept the `unsupportedAddon` list as a global value, this caused when we deleted items from it the list wasn't updated properly. Instead of using the `unsupportedAddon` list now we are querying `addonsMap` as now is our source of truth.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
