### PR TITLE
Remove browser-session dependency from feature-privatemode

### DIFF
--- a/components/feature/privatemode/build.gradle
+++ b/components/feature/privatemode/build.gradle
@@ -23,8 +23,8 @@ android {
 }
 
 dependencies {
-    implementation project(':browser-session')
     implementation project(':browser-state')
+    implementation project(':support-base')
     implementation project(':support-ktx')
 
     implementation Dependencies.androidx_core_ktx


### PR DESCRIPTION
This was on the browser-state board as a TODO to migrate, but the feature actually doesn't need browser-session, so ✔️ .