### PR TITLE
Close #7236: Fix last verification check in AutoPushFeature

### DIFF
--- a/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
+++ b/components/feature/push/src/main/java/mozilla/components/feature/push/AutoPushFeature.kt
@@ -85,7 +85,7 @@ class AutoPushFeature(
     private val prefToken: String?
         get() = preferences(context).getString(PREF_TOKEN, null)
     private var prefLastVerified: Long
-        get() = preferences(context).getLong(LAST_VERIFIED, System.currentTimeMillis())
+        get() = preferences(context).getLong(LAST_VERIFIED, 0)
         set(value) = preferences(context).edit().putLong(LAST_VERIFIED, value).apply()
 
     private val coroutineScope = CoroutineScope(coroutineContext) + SupervisorJob() + exceptionHandler { onError(it) }

--- a/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
+++ b/components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt
@@ -26,6 +26,7 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.nullable
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -54,9 +55,12 @@ class AutoPushFeatureTest {
 
     @Before
     fun setup() {
-        lastVerified = 0L
-
         whenever(connection.isInitialized()).thenReturn(true)
+    }
+
+    @After
+    fun shutdown() {
+        preference(testContext).edit().remove(LAST_VERIFIED).apply()
     }
 
     @Test
@@ -405,6 +409,23 @@ class AutoPushFeatureTest {
         feature.initialize()
 
         verify(feature, never()).verifyActiveSubscriptions()
+    }
+
+    @Test
+    fun `verification always happens on first attempt`() = runBlockingTest {
+        val feature = spy(
+            AutoPushFeature(
+                context = testContext,
+                service = mock(),
+                config = mock(),
+                coroutineContext = coroutineContext,
+                connection = mock()
+            )
+        )
+
+        feature.initialize()
+
+        verify(feature).verifyActiveSubscriptions()
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,9 @@ permalink: /changelog/
 * **support-rustlog**
   * `RustLog.enable` now takes an optional [CrashReporting] instance which is used to submit error-level log messages as `RustErrorException`s.
 
+* **feature-push**
+  * Fixed a bug where we do not verify subscriptions on first attempt.
+
 # 44.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v43.0.0...v44.0.0)


### PR DESCRIPTION
When we first access the `lastVerified` pref we do not have an value
stored so we get the value from the current time.

The first usage is where we compare the delta of the current time with
the `lastVerified` so this lead us to have a negative value which fails.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Closes #7236 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
