### PR TITLE
Closes #6356: Install built-in extensions using GV extension controller

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -38,6 +38,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
+import mozilla.components.support.ktx.kotlin.isResourceUrl
 import mozilla.components.support.utils.ThreadUtils
 import org.json.JSONObject
 import org.mozilla.geckoview.AllowOrDeny
@@ -199,53 +200,32 @@ class GeckoEngine(
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ): CancellableOperation {
-        val ext = GeckoWebExtension(id, url, runtime, allowContentMessaging, supportActions)
-        return installWebExtension(ext, onSuccess, onError)
-    }
 
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    internal fun installWebExtension(
-        ext: GeckoWebExtension,
-        onSuccess: ((WebExtension) -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): CancellableOperation {
-        val geckoResult = if (ext.isBuiltIn()) {
-            if (ext.supportActions) {
-                // We currently have to install the global action handler before we
-                // install the extension which is why this is done here directly.
-                // This code can be removed from the engine once the new GV addon
-                // management API (specifically installBuiltIn) lands. Then the
-                // global handlers will be invoked with the latest state whenever
-                // they are registered:
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1599897
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1582185
-                ext.registerActionHandler(webExtensionActionHandler)
-                ext.registerTabHandler(webExtensionTabHandler)
-            }
+        val onInstallSuccess: ((org.mozilla.geckoview.WebExtension) -> Unit) = {
+            val installedExtension = GeckoWebExtension(it, runtime)
+            webExtensionDelegate?.onInstalled(installedExtension)
+            installedExtension.registerActionHandler(webExtensionActionHandler)
+            installedExtension.registerTabHandler(webExtensionTabHandler)
+            onSuccess(installedExtension)
+        }
 
-            // For now we have to use registerWebExtension for builtin extensions until we get the
-            // new installBuiltIn call on the controller: https://bugzilla.mozilla.org/show_bug.cgi?id=1601067
-            runtime.registerWebExtension(ext.nativeExtension).apply {
+        val geckoResult = if (url.isResourceUrl()) {
+            runtime.webExtensionController.installBuiltIn(url).apply {
                 then({
-                    webExtensionDelegate?.onInstalled(ext)
-                    onSuccess(ext)
+                    onInstallSuccess(it!!)
                     GeckoResult<Void>()
                 }, { throwable ->
-                    onError(ext.id, throwable)
+                    onError(id, throwable)
                     GeckoResult<Void>()
                 })
             }
         } else {
-            runtime.webExtensionController.install(ext.url).apply {
+            runtime.webExtensionController.install(url).apply {
                 then({
-                    val installedExtension = GeckoWebExtension(it!!, runtime)
-                    webExtensionDelegate?.onInstalled(installedExtension)
-                    installedExtension.registerActionHandler(webExtensionActionHandler)
-                    installedExtension.registerTabHandler(webExtensionTabHandler)
-                    onSuccess(installedExtension)
+                    onInstallSuccess(it!!)
                     GeckoResult<Void>()
                 }, { throwable ->
-                    onError(ext.id, throwable)
+                    onError(id, throwable)
                     GeckoResult<Void>()
                 })
             }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -31,25 +31,12 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
  */
 @Suppress("TooManyFunctions")
 class GeckoWebExtension(
-    id: String,
-    url: String,
-    val runtime: GeckoRuntime,
-    allowContentMessaging: Boolean = true,
-    supportActions: Boolean = false,
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
-        url,
-        id,
-        createWebExtensionFlags(allowContentMessaging),
-        runtime.webExtensionController
-    ),
+    val nativeExtension: GeckoNativeWebExtension,
+    val runtime: GeckoRuntime
+) : WebExtension(nativeExtension.id, nativeExtension.location, true) {
+
     private val connectedPorts: MutableMap<PortId, Port> = mutableMapOf()
-) : WebExtension(id, url, supportActions) {
-
     private val logger = Logger("GeckoWebExtension")
-
-    constructor(native: GeckoNativeWebExtension, runtime: GeckoRuntime) :
-        this(native.id, native.location, runtime, true, true, native)
 
     /**
      * Uniquely identifies a port using its name and the session it
@@ -352,6 +339,10 @@ class GeckoWebExtension(
         }
     }
 
+    override fun isBuiltIn(): Boolean {
+        return nativeExtension.isBuiltIn
+    }
+
     override fun isEnabled(): Boolean {
         return nativeExtension.metaData?.enabled ?: true
     }
@@ -383,14 +374,6 @@ class GeckoPort(
 
     override fun disconnect() {
         nativePort.disconnect()
-    }
-}
-
-private fun createWebExtensionFlags(allowContentMessaging: Boolean): Long {
-    return if (allowContentMessaging) {
-        GeckoNativeWebExtension.Flags.ALLOW_CONTENT_MESSAGING
-    } else {
-        GeckoNativeWebExtension.Flags.NONE
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -10,7 +10,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
 import mozilla.components.concept.engine.EngineSession.SafeBrowsingPolicy
@@ -19,9 +18,7 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
-import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.Action
-import mozilla.components.concept.engine.webextension.TabHandler
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
 import mozilla.components.support.test.any
@@ -476,68 +473,36 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `install built-in web extension successfully`() {
         val runtime = mock<GeckoRuntime>()
-        val engine = GeckoEngine(context, runtime = runtime)
-        var onSuccessCalled = false
-        var onErrorCalled = false
-        val result = GeckoResult<Void>()
+        val extId = "test-webext"
+        val extUrl = "resource://android/assets/extensions/test"
 
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
+        val engine = GeckoEngine(context, runtime = runtime)
+        var onSuccessCalled = false
+        var onErrorCalled = false
+        val result = GeckoResult<GeckoWebExtension>()
+
+        whenever(extensionController.installBuiltIn(any())).thenReturn(result)
         engine.installWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
+            extId,
+            extUrl,
             onSuccess = { onSuccessCalled = true },
             onError = { _, _ -> onErrorCalled = true }
         )
-        result.complete(null)
+        result.complete(mockNativeExtension(extId, extUrl))
 
-        val extCaptor = argumentCaptor<GeckoWebExtension>()
-        verify(runtime).registerWebExtension(extCaptor.capture())
-        assertEquals("test-webext", extCaptor.value.id)
-        assertEquals("resource://android/assets/extensions/test", extCaptor.value.location)
-        assertEquals(GeckoWebExtension.Flags.ALLOW_CONTENT_MESSAGING, extCaptor.value.flags)
+        val extCaptor = argumentCaptor<String>()
+        verify(extensionController).installBuiltIn(extCaptor.capture())
+        assertEquals(extUrl, extCaptor.value)
         assertTrue(onSuccessCalled)
         assertFalse(onErrorCalled)
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    fun `install built-in web extension successfully but do not allow content messaging`() {
-        val runtime = mock<GeckoRuntime>()
-        val engine = GeckoEngine(context, runtime = runtime)
-        var onSuccessCalled = false
-        var onErrorCalled = false
-        val result = GeckoResult<Void>()
-
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
-        val extensionController: WebExtensionController = mock()
-        whenever(runtime.webExtensionController).thenReturn(extensionController)
-
-        engine.installWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            allowContentMessaging = false,
-            onSuccess = { onSuccessCalled = true },
-            onError = { _, _ -> onErrorCalled = true }
-        )
-        result.complete(null)
-
-        val extCaptor = argumentCaptor<GeckoWebExtension>()
-        verify(runtime).registerWebExtension(extCaptor.capture())
-        assertEquals("test-webext", extCaptor.value.id)
-        assertEquals("resource://android/assets/extensions/test", extCaptor.value.location)
-        assertEquals(GeckoWebExtension.Flags.NONE, extCaptor.value.flags)
-        assertTrue(onSuccessCalled)
-        assertFalse(onErrorCalled)
-    }
-
-    @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `install external web extension successfully`() {
         val runtime = mock<GeckoRuntime>()
         val extId = "test-webext"
@@ -558,14 +523,7 @@ class GeckoEngineTest {
             onSuccess = { onSuccessCalled = true },
             onError = { _, _ -> onErrorCalled = true }
         )
-        result.complete(
-            GeckoWebExtension(
-                extUrl,
-                extId,
-                org.mozilla.geckoview.WebExtension.Flags.NONE,
-                runtime.webExtensionController
-            )
-        )
+        result.complete(mockNativeExtension(extId, extUrl))
 
         val extCaptor = argumentCaptor<String>()
         verify(extensionController).install(extCaptor.capture())
@@ -575,20 +533,22 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation")
     fun `install built-in web extension failure`() {
         val runtime = mock<GeckoRuntime>()
-        val engine = GeckoEngine(context, runtime = runtime)
-        var onErrorCalled = false
-        val expected = IOException()
-        val result = GeckoResult<Void>()
+        val extId = "test-webext"
+        val extUrl = "resource://android/assets/extensions/test"
 
-        var throwable: Throwable? = null
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
-        engine.installWebExtension("test-webext-error", "resource://android/assets/extensions/error") { _, e ->
+        val engine = GeckoEngine(context, runtime = runtime)
+        var onErrorCalled = false
+        val expected = IOException()
+        val result = GeckoResult<GeckoWebExtension>()
+
+        var throwable: Throwable? = null
+        whenever(extensionController.installBuiltIn(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl) { _, e ->
             onErrorCalled = true
             throwable = e
         }
@@ -599,7 +559,6 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `install external web extension failure`() {
         val runtime = mock<GeckoRuntime>()
         val extId = "test-webext"
@@ -626,18 +585,12 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `uninstall web extension successfully`() {
         val runtime = mock<GeckoRuntime>()
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
-        val nativeExtension = GeckoWebExtension(
-            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi",
-            "test-webext",
-            org.mozilla.geckoview.WebExtension.Flags.NONE,
-            runtime.webExtensionController
-        )
+        val nativeExtension = mockNativeExtension("test-webext", "https://addons.mozilla.org/1/some_web_ext.xpi")
         val ext = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
             nativeExtension,
             runtime
@@ -668,17 +621,14 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `uninstall web extension failure`() {
         val runtime = mock<GeckoRuntime>()
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
-        val nativeExtension = GeckoWebExtension(
-            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi",
+        val nativeExtension = mockNativeExtension(
             "test-webext",
-            org.mozilla.geckoview.WebExtension.Flags.NONE,
-            runtime.webExtensionController
+            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
         )
         val ext = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
             nativeExtension,
@@ -707,8 +657,7 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation")
-    fun `web extension delegate handles installation`() {
+    fun `web extension delegate handles installation of built-in extensions`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
@@ -717,25 +666,49 @@ class GeckoEngineTest {
         val engine = GeckoEngine(context, runtime = runtime)
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
-        val result = GeckoResult<Void>()
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
-        engine.installWebExtension("test-webext", "resource://android/assets/extensions/test")
-        result.complete(null)
+        val extId = "test-webext"
+        val extUrl = "resource://android/assets/extensions/test"
+        val result = GeckoResult<GeckoWebExtension>()
+        whenever(webExtensionController.installBuiltIn(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl)
+        result.complete(mockNativeExtension(extId, extUrl))
 
         val extCaptor = argumentCaptor<WebExtension>()
         verify(webExtensionsDelegate).onInstalled(extCaptor.capture())
-        assertEquals("test-webext", extCaptor.value.id)
-        assertEquals("resource://android/assets/extensions/test", extCaptor.value.url)
+        assertEquals(extId, extCaptor.value.id)
+        assertEquals(extUrl, extCaptor.value.url)
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
+    fun `web extension delegate handles installation of external extensions`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val extId = "test-webext"
+        val extUrl = "https://addons.mozilla.org/firefox/downloads/123/some_web_ext.xpi"
+        val result = GeckoResult<GeckoWebExtension>()
+        whenever(webExtensionController.install(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl)
+        result.complete(mockNativeExtension(extId, extUrl))
+
+        val extCaptor = argumentCaptor<WebExtension>()
+        verify(webExtensionsDelegate).onInstalled(extCaptor.capture())
+        assertEquals(extId, extCaptor.value.id)
+        assertEquals(extUrl, extCaptor.value.url)
+    }
+
+    @Test
     fun `web extension delegate handles install prompt`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
-        val extension = GeckoWebExtension("test", runtime.webExtensionController)
+        val extension = mockNativeExtension("test", "uri")
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
@@ -755,14 +728,13 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `web extension delegate handles update prompt`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
 
-        val currentExtension = GeckoWebExtension("test", runtime.webExtensionController)
-        val updatedExtension = GeckoWebExtension("testUpdated", runtime.webExtensionController)
+        val currentExtension = mockNativeExtension("test", "uri")
+        val updatedExtension = mockNativeExtension("testUpdated", "uri")
         val updatedPermissions = arrayOf("p1", "p2")
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         val engine = GeckoEngine(context, runtime = runtime)
@@ -797,114 +769,10 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `web extension delegate notified of browser actions from built-in extensions`() {
-        val webExtensionController: WebExtensionController = mock()
-        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
-
-        val webExtensionsDelegate: WebExtensionDelegate = mock()
-        val engine = GeckoEngine(context, runtime = runtime)
-        engine.registerWebExtensionDelegate(webExtensionsDelegate)
-
-        val result = GeckoResult<Void>()
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
-
-        val extension = spy(mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
-        ))
-        engine.installWebExtension(extension)
-        result.complete(null)
-
-        val actionHandlerCaptor = argumentCaptor<ActionHandler>()
-        verify(extension).registerActionHandler(actionHandlerCaptor.capture())
-
-        val browserAction: Action = mock()
-        actionHandlerCaptor.value.onBrowserAction(extension, null, browserAction)
-        verify(webExtensionsDelegate).onBrowserActionDefined(eq(extension), eq(browserAction))
-        assertNull(actionHandlerCaptor.value.onToggleActionPopup(extension, browserAction))
-        verify(webExtensionsDelegate).onToggleActionPopup(eq(extension), any(), eq(browserAction))
-
-        whenever(webExtensionsDelegate.onToggleActionPopup(any(), any(), any())).thenReturn(mock())
-        assertNotNull(actionHandlerCaptor.value.onToggleActionPopup(extension, browserAction))
-    }
-
-    @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    fun `web extension delegate notified of page actions from built-in extensions`() {
-        val webExtensionController: WebExtensionController = mock()
-        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
-
-        val webExtensionsDelegate: WebExtensionDelegate = mock()
-        val engine = GeckoEngine(context, runtime = runtime)
-        engine.registerWebExtensionDelegate(webExtensionsDelegate)
-
-        val result = GeckoResult<Void>()
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
-
-        val extension = spy(mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
-        ))
-        engine.installWebExtension(extension)
-        result.complete(null)
-
-        val actionHandlerCaptor = argumentCaptor<ActionHandler>()
-        verify(extension).registerActionHandler(actionHandlerCaptor.capture())
-
-        val pageAction: Action = mock()
-        actionHandlerCaptor.value.onPageAction(extension, null, pageAction)
-        verify(webExtensionsDelegate).onPageActionDefined(eq(extension), eq(pageAction))
-        assertNull(actionHandlerCaptor.value.onToggleActionPopup(extension, pageAction))
-        verify(webExtensionsDelegate).onToggleActionPopup(eq(extension), any(), eq(pageAction))
-
-        whenever(webExtensionsDelegate.onToggleActionPopup(any(), any(), any())).thenReturn(mock())
-        assertNotNull(actionHandlerCaptor.value.onToggleActionPopup(extension, pageAction))
-    }
-
-    @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    fun `web extension delegate notified when built-in extension wants to open tab`() {
-        val webExtensionController: WebExtensionController = mock()
-        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
-
-        val webExtensionsDelegate: WebExtensionDelegate = mock()
-        val engine = GeckoEngine(context, runtime = runtime)
-        engine.registerWebExtensionDelegate(webExtensionsDelegate)
-
-        val result = GeckoResult<Void>()
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
-
-        val extension = spy(mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
-        ))
-        engine.installWebExtension(extension)
-        result.complete(null)
-
-        val tabHandlerCaptor = argumentCaptor<TabHandler>()
-        verify(extension).registerTabHandler(tabHandlerCaptor.capture())
-
-        val engineSession: EngineSession = mock()
-        tabHandlerCaptor.value.onNewTab(extension, engineSession, true, "https://mozilla.org")
-        verify(webExtensionsDelegate).onNewTab(extension, engineSession, true, "https://mozilla.org")
-    }
-
-    @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    fun `web extension delegate notified of browser actions from external extensions`() {
         val runtime = mock<GeckoRuntime>()
         val extId = "test-webext"
-        val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
+        val extUrl = "resource://android/assets/extensions/test"
 
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
@@ -914,16 +782,9 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val result = GeckoResult<GeckoWebExtension>()
-        whenever(extensionController.install(any())).thenReturn(result)
+        whenever(extensionController.installBuiltIn(any())).thenReturn(result)
         engine.installWebExtension(extId, extUrl)
-        val extension = spy(
-            GeckoWebExtension(
-                extUrl,
-                extId,
-                org.mozilla.geckoview.WebExtension.Flags.NONE,
-                runtime.webExtensionController
-            )
-        )
+        val extension = mockNativeExtension(extId, extUrl)
         result.complete(extension)
 
         val actionDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.ActionDelegate>()
@@ -942,11 +803,10 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    fun `web extension delegate notified of page actions from external extensions`() {
+    fun `web extension delegate notified of page actions from built-in extensions`() {
         val runtime = mock<GeckoRuntime>()
         val extId = "test-webext"
-        val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
+        val extUrl = "resource://android/assets/extensions/test"
 
         val extensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(extensionController)
@@ -956,16 +816,9 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val result = GeckoResult<GeckoWebExtension>()
-        whenever(extensionController.install(any())).thenReturn(result)
+        whenever(extensionController.installBuiltIn(any())).thenReturn(result)
         engine.installWebExtension(extId, extUrl)
-        val extension = spy(
-            GeckoWebExtension(
-                extUrl,
-                extId,
-                org.mozilla.geckoview.WebExtension.Flags.NONE,
-                runtime.webExtensionController
-            )
-        )
+        val extension = mockNativeExtension(extId, extUrl)
         result.complete(extension)
 
         val actionDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.ActionDelegate>()
@@ -984,7 +837,104 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
+    fun `web extension delegate notified when built-in extension wants to open tab`() {
+        val runtime = mock<GeckoRuntime>()
+        val extId = "test-webext"
+        val extUrl = "resource://android/assets/extensions/test"
+
+        val extensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(extensionController)
+
+        val engine = GeckoEngine(context, runtime = runtime)
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val result = GeckoResult<GeckoWebExtension>()
+        whenever(extensionController.installBuiltIn(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl)
+        val extension = mockNativeExtension(extId, extUrl)
+        result.complete(extension)
+
+        val tabDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.TabDelegate>()
+        verify(extension).tabDelegate = tabDelegateCaptor.capture()
+
+        val createTabDetails: org.mozilla.geckoview.WebExtension.CreateTabDetails = mock()
+        tabDelegateCaptor.value.onNewTab(extension, createTabDetails)
+
+        val extensionCaptor = argumentCaptor<WebExtension>()
+        verify(webExtensionsDelegate).onNewTab(extensionCaptor.capture(), any(), eq(false), eq(""))
+        assertEquals(extId, extensionCaptor.value.id)
+    }
+
+    @Test
+    fun `web extension delegate notified of browser actions from external extensions`() {
+        val runtime = mock<GeckoRuntime>()
+        val extId = "test-webext"
+        val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
+
+        val extensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(extensionController)
+
+        val engine = GeckoEngine(context, runtime = runtime)
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val result = GeckoResult<GeckoWebExtension>()
+        whenever(extensionController.install(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl)
+        val extension = mockNativeExtension(extId, extUrl)
+        result.complete(extension)
+
+        val actionDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.ActionDelegate>()
+        verify(extension).setActionDelegate(actionDelegateCaptor.capture())
+
+        val browserAction: org.mozilla.geckoview.WebExtension.Action = mock()
+        actionDelegateCaptor.value.onBrowserAction(extension, null, browserAction)
+
+        val extensionCaptor = argumentCaptor<WebExtension>()
+        val actionCaptor = argumentCaptor<Action>()
+        verify(webExtensionsDelegate).onBrowserActionDefined(extensionCaptor.capture(), actionCaptor.capture())
+        assertEquals(extId, extensionCaptor.value.id)
+
+        actionCaptor.value.onClick()
+        verify(browserAction).click()
+    }
+
+    @Test
+    fun `web extension delegate notified of page actions from external extensions`() {
+        val runtime = mock<GeckoRuntime>()
+        val extId = "test-webext"
+        val extUrl = "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi"
+
+        val extensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(extensionController)
+
+        val engine = GeckoEngine(context, runtime = runtime)
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val result = GeckoResult<GeckoWebExtension>()
+        whenever(extensionController.install(any())).thenReturn(result)
+        engine.installWebExtension(extId, extUrl)
+        val extension = mockNativeExtension(extId, extUrl)
+        result.complete(extension)
+
+        val actionDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.ActionDelegate>()
+        verify(extension).setActionDelegate(actionDelegateCaptor.capture())
+
+        val pageAction: org.mozilla.geckoview.WebExtension.Action = mock()
+        actionDelegateCaptor.value.onPageAction(extension, null, pageAction)
+
+        val extensionCaptor = argumentCaptor<WebExtension>()
+        val actionCaptor = argumentCaptor<Action>()
+        verify(webExtensionsDelegate).onPageActionDefined(extensionCaptor.capture(), actionCaptor.capture())
+        assertEquals(extId, extensionCaptor.value.id)
+
+        actionCaptor.value.onClick()
+        verify(pageAction).click()
+    }
+
+    @Test
     fun `web extension delegate notified when external extension wants to open tab`() {
         val runtime = mock<GeckoRuntime>()
         val extId = "test-webext"
@@ -1000,14 +950,7 @@ class GeckoEngineTest {
         val result = GeckoResult<GeckoWebExtension>()
         whenever(extensionController.install(any())).thenReturn(result)
         engine.installWebExtension(extId, extUrl)
-        val extension = spy(
-            GeckoWebExtension(
-                extUrl,
-                extId,
-                org.mozilla.geckoview.WebExtension.Flags.NONE,
-                runtime.webExtensionController
-            )
-        )
+        val extension = mockNativeExtension(extId, extUrl)
         result.complete(extension)
 
         val tabDelegateCaptor = argumentCaptor<org.mozilla.geckoview.WebExtension.TabDelegate>()
@@ -1039,7 +982,6 @@ class GeckoEngineTest {
     }
 
     @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `update web extension successfully`() {
         val runtime = mock<GeckoRuntime>()
         val extensionController: WebExtensionController = mock()
@@ -1057,11 +999,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         var onErrorCalled = false
@@ -1094,19 +1033,16 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-                "test-webext",
-                "resource://android/assets/extensions/test",
-                runtime,
-                true,
-                true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         var onErrorCalled = false
 
         engine.updateWebExtension(
-                extension,
-                onSuccess = { result = it },
-                onError = { _, _ -> onErrorCalled = true }
+            extension,
+            onSuccess = { result = it },
+            onError = { _, _ -> onErrorCalled = true }
         )
         updateExtensionResult.complete(null)
 
@@ -1128,11 +1064,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         val expected = IOException()
@@ -1258,17 +1191,14 @@ class GeckoEngineTest {
         whenever(extensionController.enable(any(), anyInt())).thenReturn(enableExtensionResult)
         whenever(runtime.webExtensionController).thenReturn(extensionController)
 
+        val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
+            mockNativeExtension(),
+            runtime
+        )
         val engine = GeckoEngine(context, runtime = runtime)
         val webExtensionsDelegate: WebExtensionDelegate = mock()
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
-        val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
-        )
         var result: WebExtension? = null
         var onErrorCalled = false
 
@@ -1298,11 +1228,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         val expected = IOException()
@@ -1338,11 +1265,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         var onErrorCalled = false
@@ -1373,11 +1297,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         val expected = IOException()
@@ -1413,11 +1334,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         var onErrorCalled = false
@@ -1452,11 +1370,8 @@ class GeckoEngineTest {
         engine.registerWebExtensionDelegate(webExtensionsDelegate)
 
         val extension = mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            runtime,
-            true,
-            true
+            mockNativeExtension(),
+            runtime
         )
         var result: WebExtension? = null
         val expected = IOException()
@@ -1849,5 +1764,21 @@ class GeckoEngineTest {
         val blockingData = object : ContentBlockingController.LogEntry.BlockingData() {}
         ReflectionUtils.setField(blockingData, "category", category)
         return blockingData
+    }
+
+    private fun mockNativeExtension(useBundle: GeckoBundle? = null): GeckoWebExtension {
+        val bundle = useBundle ?: GeckoBundle().apply {
+            putString("webExtensionId", "id")
+            putString("locationURI", "uri")
+        }
+        return spy(MockWebExtension(bundle))
+    }
+
+    private fun mockNativeExtension(id: String, location: String): GeckoWebExtension {
+        val bundle = GeckoBundle().apply {
+            putString("webExtensionId", id)
+            putString("locationURI", location)
+        }
+        return spy(MockWebExtension(bundle))
     }
 }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -26,7 +26,6 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -40,23 +39,18 @@ import org.mozilla.geckoview.WebExtension
 import org.mozilla.geckoview.WebExtensionController
 
 @RunWith(AndroidJUnit4::class)
-@Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
 class GeckoWebExtensionTest {
 
     @Test
     fun `register background message handler`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -102,7 +96,7 @@ class GeckoWebExtensionTest {
     fun `register content message handler`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionSessionController: WebExtension.SessionController = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
@@ -114,10 +108,6 @@ class GeckoWebExtensionTest {
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -166,7 +156,7 @@ class GeckoWebExtensionTest {
     fun `disconnect port from content script`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionSessionController: WebExtension.SessionController = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
@@ -176,10 +166,6 @@ class GeckoWebExtensionTest {
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -200,14 +186,10 @@ class GeckoWebExtensionTest {
     @Test
     fun `disconnect port from background script`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -229,7 +211,7 @@ class GeckoWebExtensionTest {
     @Test
     fun `register global default action handler`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
         val browserActionCaptor = argumentCaptor<Action>()
@@ -237,24 +219,8 @@ class GeckoWebExtensionTest {
         val nativeBrowserAction: WebExtension.Action = mock()
         val nativePageAction: WebExtension.Action = mock()
 
-        // Verify actions will not be acted on when not supported
-        val extensionWithActions = GeckoWebExtension(
-            "mozacTest",
-            "url",
-            runtime,
-            false,
-            false,
-            nativeGeckoWebExt
-        )
-        extensionWithActions.registerActionHandler(actionHandler)
-        verify(nativeGeckoWebExt, never()).setActionDelegate(actionDelegateCaptor.capture())
-
         // Create extension and register global default action handler
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -291,7 +257,7 @@ class GeckoWebExtensionTest {
         whenever(geckoSession.webExtensionController).thenReturn(webExtensionSessionController)
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
         val browserActionCaptor = argumentCaptor<Action>()
@@ -301,10 +267,6 @@ class GeckoWebExtensionTest {
 
         // Create extension and register action handler for session
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -339,18 +301,9 @@ class GeckoWebExtensionTest {
         val tabDelegateCaptor = argumentCaptor<WebExtension.TabDelegate>()
         val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
 
-        val nativeGeckoWebExt = spy(WebExtension(
-            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi",
-            "test-webext",
-            WebExtension.Flags.NONE,
-            runtime.webExtensionController
-        ))
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         // Create extension and register global tab handler
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -380,18 +333,9 @@ class GeckoWebExtensionTest {
         val tabHandler: TabHandler = mock()
         val tabDelegateCaptor = argumentCaptor<WebExtension.SessionTabDelegate>()
 
-        val nativeGeckoWebExt = spy(WebExtension(
-            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi",
-            "test-webext",
-            WebExtension.Flags.NONE,
-            runtime.webExtensionController
-        ))
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         // Create extension and register tab handler for session
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -415,7 +359,7 @@ class GeckoWebExtensionTest {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
         val extensionWithoutMetadata = GeckoWebExtension(
-            WebExtension("url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(),
             runtime
         )
         assertNull(extensionWithoutMetadata.getMetadata())
@@ -464,7 +408,7 @@ class GeckoWebExtensionTest {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
         val extensionWithoutMetadata = GeckoWebExtension(
-            WebExtension("url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(),
             runtime
         )
         assertNull(extensionWithoutMetadata.getMetadata())
@@ -497,17 +441,25 @@ class GeckoWebExtensionTest {
     }
 
     @Test
-    fun `isBuiltIn depends on URI scheme`() {
+    fun `isBuiltIn depends on native state`() {
         val runtime: GeckoRuntime = mock()
-        val webExtensionController: WebExtensionController = mock()
+
+        val builtInBundle = GeckoBundle()
+        builtInBundle.putBoolean("isBuiltIn", true)
+        builtInBundle.putString("webExtensionId", "id")
+        builtInBundle.putString("locationURI", "uri")
         val builtInExtension = GeckoWebExtension(
-            WebExtension("resource://url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(builtInBundle),
             runtime
         )
         assertTrue(builtInExtension.isBuiltIn())
 
+        val externalBundle = GeckoBundle()
+        externalBundle.putBoolean("isBuiltIn", false)
+        externalBundle.putString("webExtensionId", "id")
+        externalBundle.putString("locationURI", "uri")
         val externalExtension = GeckoWebExtension(
-            WebExtension("https://url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(externalBundle),
             runtime
         )
         assertFalse(externalExtension.isBuiltIn())
@@ -544,9 +496,14 @@ class GeckoWebExtensionTest {
     fun `isAllowedInPrivateBrowsing depends on native state and defaults to false if state unknown`() {
         val runtime: GeckoRuntime = mock()
         whenever(runtime.webExtensionController).thenReturn(mock())
+
+        val builtInBundle = GeckoBundle()
+        builtInBundle.putBoolean("isBuiltIn", true)
+        builtInBundle.putString("webExtensionId", "id")
+        builtInBundle.putString("locationURI", "uri")
         val builtInExtension = GeckoWebExtension(
-                WebExtension("resource://url", "id", WebExtension.Flags.NONE, mock()),
-                runtime
+            mockNativeExtension(builtInBundle),
+            runtime
         )
         assertTrue(builtInExtension.isAllowedInPrivateBrowsing())
 
@@ -571,5 +528,13 @@ class GeckoWebExtensionTest {
         val nativeWebExtensionWithoutPrivateBrowsing = MockWebExtension(bundle)
         val webExtensionWithoutPrivateBrowsing = GeckoWebExtension(nativeWebExtensionWithoutPrivateBrowsing, runtime)
         assertFalse(webExtensionWithoutPrivateBrowsing.isAllowedInPrivateBrowsing())
+    }
+
+    private fun mockNativeExtension(useBundle: GeckoBundle? = null): WebExtension {
+        val bundle = useBundle ?: GeckoBundle().apply {
+            putString("webExtensionId", "id")
+            putString("locationURI", "uri")
+        }
+        return spy(MockWebExtension(bundle))
     }
 }

--- a/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.json
+++ b/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "icons@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Browser Icons",
   "version": "1.0",
   "content_scripts": [
@@ -11,6 +16,7 @@
   ],
   "permissions": [
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -137,7 +137,7 @@ class BrowserIcons(
      */
     fun install(engine: Engine, store: BrowserStore) {
         engine.installWebExtension(
-            id = "mozacBrowserIcons",
+            id = "icons@mozac.org",
             url = "resource://android/assets/extensions/browser-icons/",
             allowContentMessaging = true,
             onSuccess = { extension ->

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -150,7 +150,7 @@ abstract class WebExtension(
      * Checks whether or not this extension is built-in (packaged with the
      * APK file) or coming from an external source.
      */
-    fun isBuiltIn(): Boolean = Uri.parse(url).scheme == "resource"
+    open fun isBuiltIn(): Boolean = Uri.parse(url).scheme == "resource"
 
     /**
      * Checks whether or not this extension is enabled.

--- a/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
+++ b/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "fxa@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Firefox Accounts WebChannel",
   "version": "1.0",
   "content_scripts": [
@@ -18,6 +23,7 @@
   "permissions": [
     "mozillaAddons",
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FxaWebChannelFeature.kt
+++ b/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FxaWebChannelFeature.kt
@@ -69,7 +69,11 @@ class FxaWebChannelFeature(
 
     @VisibleForTesting
     // This is an internal var to make it mutable for unit testing purposes only
-    internal var extensionController = WebExtensionController(WEB_CHANNEL_EXTENSION_ID, WEB_CHANNEL_EXTENSION_URL)
+    internal var extensionController = WebExtensionController(
+        WEB_CHANNEL_EXTENSION_ID,
+        WEB_CHANNEL_EXTENSION_URL,
+        WEB_CHANNEL_MESSAGING_ID
+    )
 
     override fun start() {
         extensionController.install(runtime)
@@ -165,7 +169,8 @@ class FxaWebChannelFeature(
     companion object {
         private val logger = Logger("mozac-fxawebchannel")
 
-        internal const val WEB_CHANNEL_EXTENSION_ID = "mozacWebchannel"
+        internal const val WEB_CHANNEL_EXTENSION_ID = "fxa@mozac.org"
+        internal const val WEB_CHANNEL_MESSAGING_ID = "mozacWebchannel"
         internal const val WEB_CHANNEL_EXTENSION_URL = "resource://android/assets/extensions/fxawebchannel/"
 
         // Constants for incoming messages from the WebExtension.

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
@@ -120,7 +120,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -153,7 +153,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -185,7 +185,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -223,7 +223,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -274,7 +274,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -328,7 +328,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -378,7 +378,7 @@ class FxaWebChannelFeatureTest {
         webchannelFeature.start()
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -422,7 +422,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -465,7 +465,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -504,7 +504,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -536,7 +536,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -570,7 +570,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)

--- a/components/feature/p2p/src/main/assets/extensions/p2p/manifest.json
+++ b/components/feature/p2p/src/main/assets/extensions/p2p/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "p2p@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - P2P",
   "version": "1.0",
   "content_scripts": [
@@ -11,6 +16,7 @@
   ],
   "permissions": [
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/components/feature/p2p/src/main/java/mozilla/components/feature/p2p/P2PFeature.kt
+++ b/components/feature/p2p/src/main/java/mozilla/components/feature/p2p/P2PFeature.kt
@@ -108,7 +108,7 @@ class P2PFeature(
     private fun startExtension() {
         observeSelected() // this sets actionSession
 
-        extensionController = WebExtensionController(P2P_EXTENSION_ID, P2P_EXTENSION_URL)
+        extensionController = WebExtensionController(P2P_EXTENSION_ID, P2P_EXTENSION_URL, P2P_MESSAGING_ID)
         registerP2PContentMessageHandler()
         extensionController?.install(engine)
 
@@ -172,7 +172,10 @@ class P2PFeature(
     @VisibleForTesting
     companion object {
         @VisibleForTesting
-        internal const val P2P_EXTENSION_ID = "mozacP2P"
+        internal const val P2P_EXTENSION_ID = "p2p@mozac.org"
+
+        @VisibleForTesting
+        internal const val P2P_MESSAGING_ID = "mozacP2P"
 
         @VisibleForTesting
         internal const val P2P_EXTENSION_URL = "resource://android/assets/extensions/p2p/"

--- a/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "readerview@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - ReaderView",
   "version": "1.0",
   "content_scripts": [
@@ -15,6 +20,7 @@
   "permissions": [
     "geckoViewAddons",
     "nativeMessaging",
+    "nativeMessagingFromContent",
     "tabs",
     "<all_urls>"
   ]

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -62,7 +62,11 @@ class ReaderViewFeature(
 
     @VisibleForTesting
     // This is an internal var to make it mutable for unit testing purposes only
-    internal var extensionController = WebExtensionController(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL)
+    internal var extensionController = WebExtensionController(
+        READER_VIEW_EXTENSION_ID,
+        READER_VIEW_EXTENSION_URL,
+        READER_VIEW_MESSAGING_ID
+    )
 
     @VisibleForTesting
     internal val config = Config(context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE))
@@ -273,7 +277,8 @@ class ReaderViewFeature(
 
     @VisibleForTesting
     companion object {
-        internal const val READER_VIEW_EXTENSION_ID = "mozacReaderview"
+        internal const val READER_VIEW_EXTENSION_ID = "readerview@mozac.org"
+        internal const val READER_VIEW_MESSAGING_ID = "mozacReaderview"
         internal const val READER_VIEW_EXTENSION_URL = "resource://android/assets/extensions/readerview/"
 
         // Constants for building messages sent to the web extension:

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_URL
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_MESSAGING_ID
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareStore
 import mozilla.components.support.webextensions.WebExtensionController
@@ -27,7 +28,11 @@ import mozilla.components.support.webextensions.WebExtensionController
 class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
 
     @VisibleForTesting
-    internal var extensionController = WebExtensionController(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL)
+    internal var extensionController = WebExtensionController(
+        READER_VIEW_EXTENSION_ID,
+        READER_VIEW_EXTENSION_URL,
+        READER_VIEW_MESSAGING_ID
+    )
 
     override fun invoke(
         store: MiddlewareStore<BrowserState, BrowserAction>,

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -531,7 +531,7 @@ class ReaderViewFeatureTest {
         store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
 
         val ext: WebExtension = mock()
-        whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID), any())).thenReturn(port)
+        whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_MESSAGING_ID), any())).thenReturn(port)
         WebExtensionController.installedExtensions[ReaderViewFeature.READER_VIEW_EXTENSION_ID] = ext
 
         val feature = ReaderViewFeature(testContext, engine, store, mock())

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -35,6 +35,11 @@ fun String.isUrl() = URLStringUtils.isURLLike(this)
  */
 fun String.isExtensionUrl() = this.startsWith("moz-extension://")
 
+/**
+ * Checks if this String is a URL of a resource.
+ */
+fun String.isResourceUrl() = this.startsWith("resource://")
+
 fun String.toNormalizedUrl() = URLStringUtils.toNormalizedURL(this)
 
 fun String.isPhone() = re.phoneish.matches(this)

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -155,4 +155,12 @@ class StringTest {
         assertFalse("https://mozilla.org".isExtensionUrl())
         assertFalse("http://mozilla.org".isExtensionUrl())
     }
+
+    @Test
+    fun isResourceUrl() {
+        assertTrue("resource://1232-abcd".isResourceUrl())
+        assertFalse("mozilla.org".isResourceUrl())
+        assertFalse("https://mozilla.org".isResourceUrl())
+        assertFalse("http://mozilla.org".isResourceUrl())
+    }
 }

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
@@ -19,10 +19,13 @@ import java.util.concurrent.ConcurrentHashMap
  * @property extensionId the unique ID of the web extension e.g. mozacReaderview.
  * @property extensionUrl the url pointing to a resources path for locating the
  * extension within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ * @property messagingId the unique ID used to exchange messages between extension
+ * scripts and the application.
  */
 class WebExtensionController(
     private val extensionId: String,
-    private val extensionUrl: String
+    private val extensionUrl: String,
+    private val messagingId: String
 ) {
     private val logger = Logger("mozac-webextensions")
     private var registerContentMessageHandler: (WebExtension) -> Unit? = { }
@@ -70,12 +73,12 @@ class WebExtensionController(
      *
      * @param engineSession the session the content message handler should be registered with.
      * @param messageHandler the message handler to register.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided messagingId.
      */
     fun registerContentMessageHandler(
         engineSession: EngineSession,
         messageHandler: MessageHandler,
-        name: String = extensionId
+        name: String = messagingId
     ) {
         synchronized(this) {
             registerContentMessageHandler = {
@@ -91,11 +94,11 @@ class WebExtensionController(
      * will be replaced and there is no need to unregister.
      *
      * @param messageHandler the message handler to register.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided messagingId.
      * */
     fun registerBackgroundMessageHandler(
         messageHandler: MessageHandler,
-        name: String = extensionId
+        name: String = messagingId
     ) {
         synchronized(this) {
             registerBackgroundMessageHandler = {
@@ -111,9 +114,9 @@ class WebExtensionController(
      *
      * @param msg the message to send
      * @param engineSession the session to send the content message to.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
-    fun sendContentMessage(msg: JSONObject, engineSession: EngineSession?, name: String = extensionId) {
+    fun sendContentMessage(msg: JSONObject, engineSession: EngineSession?, name: String = messagingId) {
         engineSession?.let { session ->
             installedExtensions[extensionId]?.let { ext ->
                 val port = ext.getConnectedPort(name, session)
@@ -127,11 +130,11 @@ class WebExtensionController(
      * Sends a background message to the provided extension.
      *
      * @param msg the message to send
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
     fun sendBackgroundMessage(
         msg: JSONObject,
-        name: String = extensionId
+        name: String = messagingId
     ) {
         installedExtensions[extensionId]?.let { ext ->
             val port = ext.getConnectedPort(name)
@@ -144,9 +147,9 @@ class WebExtensionController(
      * Checks whether or not a port is connected for the provided session.
      *
      * @param engineSession the session the port should be connected to or null for a port to a background script.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
-    fun portConnected(engineSession: EngineSession?, name: String = extensionId): Boolean {
+    fun portConnected(engineSession: EngineSession?, name: String = messagingId): Boolean {
         return installedExtensions[extensionId]?.let { ext ->
             ext.getConnectedPort(name, engineSession) != null
         } ?: false
@@ -156,9 +159,9 @@ class WebExtensionController(
      * Disconnects the port of the provided session.
      *
      * @param engineSession the session the port is connected to or null for a port to a background script.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
-    fun disconnectPort(engineSession: EngineSession?, name: String = extensionId) {
+    fun disconnectPort(engineSession: EngineSession?, name: String = messagingId) {
         installedExtensions[extensionId]?.disconnectPort(name, engineSession)
     }
 

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -158,6 +158,7 @@ object WebExtensionSupport {
      * the updated extension will not be installed, until the user grants the new permissions.
      * @param onExtensionsLoaded (optional) callback invoked when the extensions are loaded by the
      * engine. Note that the UI (browser/page actions etc.) may not be initialized at this point.
+     * System add-ons (built-in) extension will not be passed along.
      */
     @Suppress("LongParameterList")
     fun initialize(
@@ -290,7 +291,7 @@ object WebExtensionSupport {
                 extensions -> extensions.forEach { registerInstalledExtension(store, it) }
                 emitWebExtensionsInitializedFact(extensions)
                 initializationResult.complete(Unit)
-                onExtensionsLoaded?.invoke(extensions)
+                onExtensionsLoaded?.invoke(extensions.filter { !it.isBuiltIn() })
             },
             onError = {
                 throwable -> logger.error("Failed to query installed extension", throwable)

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionControllerTest.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito.verify
 
 class WebExtensionControllerTest {
     private val extensionId = "test-id"
+    private val messagingId = "test-messaging-id"
     private val extensionUrl = "test-url"
 
     @Before
@@ -35,7 +36,7 @@ class WebExtensionControllerTest {
     @Test
     fun `install webextension`() {
         val engine: Engine = mock()
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
 
         var onSuccessInvoked = false
         var onErrorInvoked = false
@@ -75,19 +76,19 @@ class WebExtensionControllerTest {
     @Test
     fun `register content message handler if extension installed`() {
         val extension: WebExtension = mock()
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
         WebExtensionController.installedExtensions[extensionId] = extension
 
         val session: EngineSession = mock()
         val messageHandler: MessageHandler = mock()
         controller.registerContentMessageHandler(session, messageHandler)
-        verify(extension).registerContentMessageHandler(session, extensionId, messageHandler)
+        verify(extension).registerContentMessageHandler(session, messagingId, messageHandler)
     }
 
     @Test
     fun `register content message handler before extension is installed`() {
         val engine: Engine = mock()
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
         controller.install(engine)
 
         val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
@@ -107,18 +108,18 @@ class WebExtensionControllerTest {
 
         val extension: WebExtension = mock()
         onSuccess.value.invoke(extension)
-        verify(extension).registerContentMessageHandler(session, extensionId, messageHandler)
+        verify(extension).registerContentMessageHandler(session, messagingId, messageHandler)
     }
 
     @Test
     fun `send content message`() {
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
 
         val message: JSONObject = mock()
         val extension: WebExtension = mock()
         val session: EngineSession = mock()
         val port: Port = mock()
-        whenever(extension.getConnectedPort(extensionId, session)).thenReturn(port)
+        whenever(extension.getConnectedPort(messagingId, session)).thenReturn(port)
 
         controller.sendContentMessage(message, null)
         verify(port, never()).postMessage(message)
@@ -135,18 +136,18 @@ class WebExtensionControllerTest {
     @Test
     fun `register background message handler if extension installed`() {
         val extension: WebExtension = mock()
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
         WebExtensionController.installedExtensions[extensionId] = extension
 
         val messageHandler: MessageHandler = mock()
         controller.registerBackgroundMessageHandler(messageHandler)
-        verify(extension).registerBackgroundMessageHandler(extensionId, messageHandler)
+        verify(extension).registerBackgroundMessageHandler(messagingId, messageHandler)
     }
 
     @Test
     fun `register background message handler before extension is installed`() {
         val engine: Engine = mock()
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
         controller.install(engine)
 
         val onSuccess = argumentCaptor<((WebExtension) -> Unit)>()
@@ -165,17 +166,17 @@ class WebExtensionControllerTest {
 
         val extension: WebExtension = mock()
         onSuccess.value.invoke(extension)
-        verify(extension).registerBackgroundMessageHandler(extensionId, messageHandler)
+        verify(extension).registerBackgroundMessageHandler(messagingId, messageHandler)
     }
 
     @Test
     fun `send background message`() {
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
 
         val message: JSONObject = mock()
         val extension: WebExtension = mock()
         val port: Port = mock()
-        whenever(extension.getConnectedPort(extensionId)).thenReturn(port)
+        whenever(extension.getConnectedPort(messagingId)).thenReturn(port)
 
         controller.sendBackgroundMessage(message)
         verify(port, never()).postMessage(message)
@@ -188,11 +189,11 @@ class WebExtensionControllerTest {
 
     @Test
     fun `check if port connected`() {
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
 
         val extension: WebExtension = mock()
         val session: EngineSession = mock()
-        whenever(extension.getConnectedPort(extensionId, session)).thenReturn(mock())
+        whenever(extension.getConnectedPort(messagingId, session)).thenReturn(mock())
 
         assertFalse(controller.portConnected(null))
         assertFalse(controller.portConnected(mock()))
@@ -207,17 +208,17 @@ class WebExtensionControllerTest {
     @Test
     fun `disconnect port`() {
         val extension: WebExtension = mock()
-        val controller = WebExtensionController(extensionId, extensionUrl)
+        val controller = WebExtensionController(extensionId, extensionUrl, messagingId)
 
         controller.disconnectPort(null)
-        verify(extension, never()).disconnectPort(eq(extensionId), any())
+        verify(extension, never()).disconnectPort(eq(messagingId), any())
 
         val session: EngineSession = mock()
         controller.disconnectPort(session)
-        verify(extension, never()).disconnectPort(eq(extensionId), eq(session))
+        verify(extension, never()).disconnectPort(eq(messagingId), eq(session))
 
         WebExtensionController.installedExtensions[extensionId] = extension
         controller.disconnectPort(session)
-        verify(extension, times(1)).disconnectPort(eq(extensionId), eq(session))
+        verify(extension, times(1)).disconnectPort(eq(messagingId), eq(session))
     }
 }

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -614,18 +614,28 @@ class WebExtensionSupportTest {
     fun `invokes onExtensionsLoaded callback`() {
         var executed = false
         val engine: Engine = mock()
+
         val ext: WebExtension = mock()
         whenever(ext.id).thenReturn("test")
+        whenever(ext.isBuiltIn()).thenReturn(false)
+
+        val builtInExt: WebExtension = mock()
+        whenever(builtInExt.id).thenReturn("test2")
+        whenever(builtInExt.isBuiltIn()).thenReturn(true)
+
         val store = spy(BrowserStore(BrowserState(extensions = mapOf(ext.id to WebExtensionState(ext.id)))))
 
         val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
-            callbackCaptor.value.invoke(listOf())
+            callbackCaptor.value.invoke(listOf(ext, builtInExt))
         }
 
-        val onExtensionsLoaded: ((List<WebExtension>) -> Unit) = { executed = true }
+        val onExtensionsLoaded: ((List<WebExtension>) -> Unit) = {
+            assertEquals(1, it.size)
+            assertEquals(ext, it[0])
+            executed = true
+        }
         WebExtensionSupport.initialize(runtime = engine, store = store, onExtensionsLoaded = onExtensionsLoaded)
-
         assertTrue(executed)
     }
 

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -27,10 +27,10 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
 
     override val engine: Engine by lazy {
         GeckoEngine(applicationContext, engineSettings, runtime).also {
-            it.installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
+            it.installWebExtension("borderify@mozac.org", "resource://android/assets/extensions/borderify/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }
-            it.installWebExtension("mozacTest", "resource://android/assets/extensions/test/", supportActions = true) {
+            it.installWebExtension("testext@mozac.org", "resource://android/assets/extensions/test/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }
             WebCompatFeature.install(it)

--- a/samples/browser/src/main/assets/extensions/borderify/manifest.json
+++ b/samples/browser/src/main/assets/extensions/borderify/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "borderify@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Borderify",
   "version": "1.0",
   "content_scripts": [

--- a/samples/browser/src/main/assets/extensions/test/manifest.json
+++ b/samples/browser/src/main/assets/extensions/test/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "testext@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Test extension",
   "description": "This extension is used for testing web extension functionality in Android Components",
   "version": "1.0",


### PR DESCRIPTION
**DO NOT LAND** - We're first making sure this doesn't regress performance.

This is replacing the deprecated `runtime.registerWebExtension` with the new `webExtensionController.installBuiltIn` for installing built-in extensions. 

I've described the required steps here: https://github.com/mozilla-mobile/android-components/issues/6356#issuecomment-638387500

This is best reviewed by collapsing the tests. The actual changeset is pretty small and cleaned up the engine logic nicely (net negative lines of code). 🎉 
