### PR TITLE
Issue #7261: Add an isPinned parameter to Top Sites

### DIFF
--- a/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/4.json
+++ b/components/feature/top-sites/schemas/mozilla.components.feature.top.sites.db.TopSiteDatabase/4.json
@@ -1,0 +1,64 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "67b4635c36f8c6c11dc45b8733686660",
+    "entities": [
+      {
+        "tableName": "top_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `is_default` INTEGER NOT NULL, `is_pinned` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "is_default",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "is_pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '67b4635c36f8c6c11dc45b8733686660')"
+    ]
+  }
+}

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSite.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSite.kt
@@ -27,4 +27,10 @@ interface TopSite {
      * Whether or not the top site is a default top site (added as a default by the application).
      */
     val isDefault: Boolean
+
+    /**
+     * Whether or not the top site is pinned by the user. This helps the application differentiate
+     * between user pinned top sites and top sites generated from frequently visited sites.
+     */
+    val isPinned: Boolean
 }

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSiteStorage.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSiteStorage.kt
@@ -27,12 +27,16 @@ class TopSiteStorage(
      * @param url The URL string.
      * @param isDefault Whether or not the top site added should be a default top site. This is
      * used to identify top sites that are added by the application.
+     * @param isPinned Whether or not the top site is pinned by the user. This helps the application
+     * differentiate between user pinned top sites and top sites generated from frequently visited
+     * sites.
      */
-    fun addTopSite(title: String, url: String, isDefault: Boolean = false) {
+    fun addTopSite(title: String, url: String, isDefault: Boolean = false, isPinned: Boolean = true) {
         TopSiteEntity(
             title = title,
             url = url,
             isDefault = isDefault,
+            isPinned = isPinned,
             createdAt = System.currentTimeMillis()
         ).also { entity ->
             entity.id = database.value.topSiteDao().insertTopSite(entity)

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/adapter/TopSiteAdapter.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/adapter/TopSiteAdapter.kt
@@ -22,6 +22,9 @@ internal class TopSiteAdapter(
     override val isDefault: Boolean
         get() = entity.isDefault
 
+    override val isPinned: Boolean
+        get() = entity.isPinned
+
     override fun equals(other: Any?): Boolean {
         if (other !is TopSiteAdapter) {
             return false

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteDatabase.kt
@@ -14,7 +14,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 /**
  * Internal database for storing top sites.
  */
-@Database(entities = [TopSiteEntity::class], version = 3)
+@Database(entities = [TopSiteEntity::class], version = 4)
 internal abstract class TopSiteDatabase : RoomDatabase() {
     abstract fun topSiteDao(): TopSiteDao
 
@@ -34,6 +34,8 @@ internal abstract class TopSiteDatabase : RoomDatabase() {
                 Migrations.migration_1_2
             ).addMigrations(
                 Migrations.migration_2_3
+            ).addMigrations(
+                Migrations.migration_3_4
             ).build().also {
                 instance = it
             }
@@ -101,6 +103,19 @@ internal object Migrations {
                     "('https://getpocket.com/fenix-top-articles', " +
                     "'https://www.wikipedia.org/', " +
                     "'https://www.youtube.com/')"
+            )
+        }
+    }
+
+    @Suppress("MagicNumber")
+    val migration_3_4 = object : Migration(3, 4) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // Add the new is_pinned column and set is_pinned to 1 (true) for every entry.
+            database.execSQL(
+                "ALTER TABLE top_sites ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 1"
+            )
+            database.execSQL(
+                "UPDATE top_sites SET is_pinned = 1"
             )
         }
     }

--- a/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteEntity.kt
+++ b/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/db/TopSiteEntity.kt
@@ -26,6 +26,9 @@ internal data class TopSiteEntity(
     @ColumnInfo(name = "is_default")
     var isDefault: Boolean = false,
 
+    @ColumnInfo(name = "is_pinned")
+    var isPinned: Boolean = false,
+
     @ColumnInfo(name = "created_at")
     var createdAt: Long = System.currentTimeMillis()
 )

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -271,7 +271,7 @@ class FennecMigratorTest {
         assertTrue(historyStore.getVisited().isEmpty())
         assertTrue(bookmarksStore.searchBookmarks("mozilla").isEmpty())
 
-        verify(topSiteStorage, never()).addTopSite(any(), any(), anyBoolean())
+        verify(topSiteStorage, never()).addTopSite(any(), any(), anyBoolean(), anyBoolean())
 
         // Can run once.
         with(migrator.migrateAsync(mock()).await()) {
@@ -299,7 +299,7 @@ class FennecMigratorTest {
 
         assertEquals(5, historyStore.getVisited().size)
         assertEquals(2, bookmarksStore.searchBookmarks("mozilla").size)
-        verify(topSiteStorage, times(2)).addTopSite(any(), any(), anyBoolean())
+        verify(topSiteStorage, times(2)).addTopSite(any(), any(), anyBoolean(), anyBoolean())
         verify(topSiteStorage).addTopSite(
             "Featured extensions for Android – Add-ons for Firefox Android (en-US)",
             "https://addons.mozilla.org/en-US/android/collections/4757633/mob/?page=1&collection_sort=-popularity"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ permalink: /changelog/
 * **browser-menu**
   * Added an optional `longClickListener` parameter to `BrowserMenuItemToolbar.Button` and `BrowserMenuItemToolbar.TwoStateButton` to handle long click events.
 
+* **feature-top-sites**
+  * ⚠️ **This is a breaking change**: Added `isPinned` to the top site entity, which allows application to specify top sites that are pinned by the user. This is called through `TopSiteStorage.addTopSite`.
+
 # 49.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v48.0.0...v49.0.0)


### PR DESCRIPTION
Fixes #7261. Adds an `isPinned` parameter to Top Sites so that we can differentiate whether or not the top site is pinned by the user or not (versus autogenerated by frequently visited sites).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
