### PR TITLE
For #7264 - Icons now use base URL instead of full URL when being cached

### DIFF
--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/DiskIconProcessor.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/processor/DiskIconProcessor.kt
@@ -17,7 +17,15 @@ class DiskIconProcessor(
     private val cache: ProcessorDiskCache
 ) : IconProcessor {
     interface ProcessorDiskCache {
-        fun put(context: Context, request: IconRequest, resource: IconRequest.Resource, icon: Icon)
+        /**
+         * Saves icon resources to cache.
+         * */
+        fun putResources(context: Context, request: IconRequest)
+
+        /**
+         * Saves icon bitmap to cache.
+         * */
+        fun putIcon(context: Context, resource: IconRequest.Resource, icon: Icon)
     }
 
     override fun process(
@@ -27,10 +35,12 @@ class DiskIconProcessor(
         icon: Icon,
         desiredSize: DesiredSize
     ): Icon {
-        if (resource != null && icon.shouldCacheOnDisk && !request.isPrivate) {
-            cache.put(context, request, resource, icon)
+        if (resource != null && !request.isPrivate) {
+            cache.putResources(context, request)
+            if (icon.shouldCacheOnDisk) {
+                cache.putIcon(context, resource, icon)
+            }
         }
-
         return icon
     }
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
@@ -34,7 +34,8 @@ private const val WEBP_QUALITY = 90
  * Caching bitmaps and resource URLs on disk.
  */
 class IconDiskCache :
-    DiskIconLoader.LoaderDiskCache, DiskIconPreparer.PreparerDiskCache, DiskIconProcessor.ProcessorDiskCache {
+    DiskIconLoader.LoaderDiskCache, DiskIconPreparer.PreparerDiskCache,
+    DiskIconProcessor.ProcessorDiskCache {
     private val logger = Logger("Icons/IconDiskCache")
     private var iconResourcesCache: DiskLruCache? = null
     private var iconDataCache: DiskLruCache? = null
@@ -61,7 +62,7 @@ class IconDiskCache :
         return emptyList()
     }
 
-    internal fun putResources(context: Context, request: IconRequest) {
+    override fun putResources(context: Context, request: IconRequest) {
         try {
             synchronized(iconResourcesCacheWriteLock) {
                 val key = createKey(request.url)
@@ -80,8 +81,7 @@ class IconDiskCache :
         }
     }
 
-    override fun put(context: Context, request: IconRequest, resource: IconRequest.Resource, icon: Icon) {
-        putResources(context, request)
+    override fun putIcon(context: Context, resource: IconRequest.Resource, icon: Icon) {
         putIconBitmap(context, resource, icon.bitmap)
     }
 

--- a/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/DiskIconProcessorTest.kt
+++ b/components/browser/icons/src/test/java/mozilla/components/browser/icons/processor/DiskIconProcessorTest.kt
@@ -23,7 +23,7 @@ class DiskIconProcessorTest {
         val processor = DiskIconProcessor(cache)
         processor.process(mock(), mock(), mock(), icon, mock())
 
-        verify(cache, never()).put(any(), any(), any(), eq(icon))
+        verify(cache, never()).putIcon(any(), any(), eq(icon))
     }
 
     @Test
@@ -34,7 +34,7 @@ class DiskIconProcessorTest {
         val processor = DiskIconProcessor(cache)
         processor.process(mock(), mock(), mock(), icon, mock())
 
-        verify(cache, never()).put(any(), any(), any(), eq(icon))
+        verify(cache, never()).putIcon(any(), any(), eq(icon))
     }
 
     @Test
@@ -45,7 +45,7 @@ class DiskIconProcessorTest {
         val processor = DiskIconProcessor(cache)
         processor.process(mock(), mock(), mock(), icon, mock())
 
-        verify(cache, never()).put(any(), any(), any(), eq(icon))
+        verify(cache, never()).putIcon(any(), any(), eq(icon))
     }
 
     @Test
@@ -58,7 +58,7 @@ class DiskIconProcessorTest {
         val resource: IconRequest.Resource = mock()
         processor.process(mock(), request, resource, icon, mock())
 
-        verify(cache).put(any(), eq(request), eq(resource), eq(icon))
+        verify(cache).putIcon(any(), eq(resource), eq(icon))
     }
 
     @Test
@@ -71,7 +71,7 @@ class DiskIconProcessorTest {
         val resource: IconRequest.Resource = mock()
         processor.process(mock(), request, resource, icon, mock())
 
-        verify(cache).put(any(), eq(request), eq(resource), eq(icon))
+        verify(cache).putIcon(any(), eq(resource), eq(icon))
     }
 
     @Test
@@ -82,7 +82,7 @@ class DiskIconProcessorTest {
         val processor = DiskIconProcessor(cache)
         processor.process(context = mock(), request = mock(), resource = null, icon = icon, desiredSize = mock())
 
-        verify(cache, never()).put(any(), any(), any(), eq(icon))
+        verify(cache, never()).putIcon(any(), any(), eq(icon))
     }
 
     @Test
@@ -97,7 +97,7 @@ class DiskIconProcessorTest {
         val resource: IconRequest.Resource = mock()
         processor.process(context = mock(), request = request, resource = resource, icon = icon, desiredSize = mock())
 
-        verify(cache, never()).put(any(), any(), any(), eq(icon))
+        verify(cache, never()).putIcon(any(), any(), eq(icon))
     }
 
     @Test
@@ -112,6 +112,6 @@ class DiskIconProcessorTest {
         val resource: IconRequest.Resource = mock()
         processor.process(context = mock(), request = request, resource = resource, icon = icon, desiredSize = mock())
 
-        verify(cache).put(any(), eq(request), eq(resource), eq(icon))
+        verify(cache).putIcon(any(), eq(resource), eq(icon))
     }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
For https://github.com/mozilla-mobile/android-components/issues/7264

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
