### PR TITLE
Closes #7269: Only register extension tab handler if needed

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -331,6 +331,14 @@ class GeckoWebExtension(
     }
 
     /**
+     * See [WebExtension.hasTabHandler].
+     */
+    override fun hasTabHandler(session: EngineSession): Boolean {
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        return geckoSession.webExtensionController.getTabDelegate(nativeExtension) != null
+    }
+
+    /**
      * See [WebExtension.getMetadata].
      */
     override fun getMetadata(): Metadata? {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -398,6 +398,10 @@ class GeckoWebExtensionTest {
         extension.registerTabHandler(session, tabHandler)
         verify(webExtensionSessionController).setTabDelegate(eq(nativeGeckoWebExt), tabDelegateCaptor.capture())
 
+        assertFalse(extension.hasTabHandler(session))
+        whenever(webExtensionSessionController.getTabDelegate(nativeGeckoWebExt)).thenReturn(tabDelegateCaptor.value)
+        assertTrue(extension.hasTabHandler(session))
+
         // Verify that tab methods are forwarded to the handler
         val tabBundle = GeckoBundle()
         tabBundle.putBoolean("active", true)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -331,6 +331,14 @@ class GeckoWebExtension(
     }
 
     /**
+     * See [WebExtension.hasTabHandler].
+     */
+    override fun hasTabHandler(session: EngineSession): Boolean {
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        return geckoSession.webExtensionController.getTabDelegate(nativeExtension) != null
+    }
+
+    /**
      * See [WebExtension.getMetadata].
      */
     override fun getMetadata(): Metadata? {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -398,6 +398,10 @@ class GeckoWebExtensionTest {
         extension.registerTabHandler(session, tabHandler)
         verify(webExtensionSessionController).setTabDelegate(eq(nativeGeckoWebExt), tabDelegateCaptor.capture())
 
+        assertFalse(extension.hasTabHandler(session))
+        whenever(webExtensionSessionController.getTabDelegate(nativeGeckoWebExt)).thenReturn(tabDelegateCaptor.value)
+        assertTrue(extension.hasTabHandler(session))
+
         // Verify that tab methods are forwarded to the handler
         val tabBundle = GeckoBundle()
         tabBundle.putBoolean("active", true)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -330,6 +330,14 @@ class GeckoWebExtension(
     }
 
     /**
+     * See [WebExtension.hasTabHandler].
+     */
+    override fun hasTabHandler(session: EngineSession): Boolean {
+        val geckoSession = (session as GeckoEngineSession).geckoSession
+        return geckoSession.webExtensionController.getTabDelegate(nativeExtension) != null
+    }
+
+    /**
      * See [WebExtension.getMetadata].
      */
     override fun getMetadata(): Metadata? {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -397,6 +397,10 @@ class GeckoWebExtensionTest {
         extension.registerTabHandler(session, tabHandler)
         verify(webExtensionSessionController).setTabDelegate(eq(nativeGeckoWebExt), tabDelegateCaptor.capture())
 
+        assertFalse(extension.hasTabHandler(session))
+        whenever(webExtensionSessionController.getTabDelegate(nativeGeckoWebExt)).thenReturn(tabDelegateCaptor.value)
+        assertTrue(extension.hasTabHandler(session))
+
         // Verify that tab methods are forwarded to the handler
         val tabBundle = GeckoBundle()
         tabBundle.putBoolean("active", true)

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -139,6 +139,15 @@ abstract class WebExtension(
     abstract fun registerTabHandler(session: EngineSession, tabHandler: TabHandler)
 
     /**
+     * Checks whether there is an existing tab handler for the provided
+     * session.
+     *
+     * @param session the session the tab handler was registered for.
+     * @return true if an tab handler is registered, otherwise false.
+     */
+    abstract fun hasTabHandler(session: EngineSession): Boolean
+
+    /**
      * Returns additional information about this extension.
      *
      * @return extension [Metadata], or null if the extension isn't

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -360,21 +360,15 @@ object WebExtensionSupport {
         session: EngineSession,
         sessionId: String
     ) {
-        val actionHandler = SessionActionHandler(store, sessionId)
-        registerSessionActionHandler(extension, session, actionHandler)
-
-        val tabHandler = SessionTabHandler(store, sessionId, onCloseTabOverride, onSelectTabOverride)
-        registerSessionTabHandler(extension, session, tabHandler)
-    }
-
-    private fun registerSessionActionHandler(ext: WebExtension, session: EngineSession, handler: SessionActionHandler) {
-        if (ext.supportActions && !ext.hasActionHandler(session)) {
-            ext.registerActionHandler(session, handler)
+        if (extension.supportActions && !extension.hasActionHandler(session)) {
+            val actionHandler = SessionActionHandler(store, sessionId)
+            extension.registerActionHandler(session, actionHandler)
         }
-    }
 
-    private fun registerSessionTabHandler(ext: WebExtension, session: EngineSession, handler: TabHandler) {
-        ext.registerTabHandler(session, handler)
+        if (!extension.hasTabHandler(session)) {
+            val tabHandler = SessionTabHandler(store, sessionId, onCloseTabOverride, onSelectTabOverride)
+            extension.registerTabHandler(session, tabHandler)
+        }
     }
 
     @Suppress("LongParameterList")


### PR DESCRIPTION
See https://github.com/mozilla-mobile/android-components/issues/7269#issue-631645512.

Introduces `hasTabHandler`, similar to `hasActionHandler` so we don't re-register tab handlers every time session state changes.