### PR TITLE
For #4637 - Query manifests with share targets

### DIFF
--- a/components/feature/pwa/schemas/mozilla.components.feature.pwa.db.ManifestDatabase/3.json
+++ b/components/feature/pwa/schemas/mozilla.components.feature.pwa.db.ManifestDatabase/3.json
@@ -1,0 +1,87 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "eb8c34cf7bcaf5f84bf0c3b407c8061a",
+    "entities": [
+      {
+        "tableName": "manifests",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`manifest` TEXT NOT NULL, `start_url` TEXT NOT NULL, `scope` TEXT, `has_share_targets` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `used_at` INTEGER NOT NULL, PRIMARY KEY(`start_url`))",
+        "fields": [
+          {
+            "fieldPath": "manifest",
+            "columnName": "manifest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startUrl",
+            "columnName": "start_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasShareTargets",
+            "columnName": "has_share_targets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "start_url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_manifests_scope",
+            "unique": false,
+            "columnNames": [
+              "scope"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manifests_scope` ON `${TABLE_NAME}` (`scope`)"
+          },
+          {
+            "name": "index_manifests_has_share_targets",
+            "unique": false,
+            "columnNames": [
+              "has_share_targets"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manifests_has_share_targets` ON `${TABLE_NAME}` (`has_share_targets`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eb8c34cf7bcaf5f84bf0c3b407c8061a')"
+    ]
+  }
+}

--- a/components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt
+++ b/components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt
@@ -1,15 +1,15 @@
 package mozilla.components.feature.pwa.db
 
 import androidx.core.database.getStringOrNull
+import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import java.io.IOException
-import androidx.room.testing.MigrationTestHelper
-import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertNull
 
 class ManifestDatabaseMigrationTest {
     private val TEST_DB = "migration-test"
@@ -20,6 +20,35 @@ class ManifestDatabaseMigrationTest {
             ManifestDatabase::class.java.canonicalName,
             FrameworkSQLiteOpenHelperFactory()
     )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate2To3() {
+        helper.createDatabase(TEST_DB, 2).apply {
+            // db has schema version 2. insert some data using SQL queries.
+            // You cannot use DAO classes because they expect the latest schema.
+            execSQL("INSERT INTO manifests (start_url, created_at, updated_at, manifest, used_at, scope) VALUES ('https://mozilla.org', 1, 2, '{}', 3, 'https://mozilla.org')")
+
+            // Prepare for the next version.
+            close()
+        }
+
+        // Re-open the database with version 2 and provide
+        // MIGRATION_1_2 as the migration process.
+        helper.runMigrationsAndValidate(TEST_DB, 3, true, ManifestDatabase.MIGRATION_2_3).apply {
+            val result = query("SELECT scope, has_share_targets FROM manifests WHERE start_url = 'https://mozilla.org'")
+
+            result.moveToNext()
+
+            assertEquals(1, result.count)
+            assertTrue(result.isFirst)
+            assertTrue(result.isLast)
+            assertEquals("https://mozilla.org", result.getStringOrNull(0))
+            assertEquals(0, result.getInt(1))
+
+            close()
+        }
+    }
 
     @Test
     @Throws(IOException::class)

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestDao.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestDao.kt
@@ -33,6 +33,15 @@ internal interface ManifestDao {
     fun recentManifestsCount(thresholdMs: Long): Int
 
     @WorkerThread
+    @Query("""
+        SELECT * from manifests 
+        WHERE has_share_targets == 1 
+        AND used_at > :deadline 
+        ORDER BY used_at DESC
+    """)
+    fun getRecentShareableManifests(deadline: Long): List<ManifestEntity>
+
+    @WorkerThread
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertManifest(manifest: ManifestEntity): Long
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestEntity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestEntity.kt
@@ -18,17 +18,33 @@ internal data class ManifestEntity(
 
     @PrimaryKey
     @ColumnInfo(name = "start_url")
-    val startUrl: String = manifest.startUrl,
+    val startUrl: String,
 
     @ColumnInfo(name = "scope", index = true)
-    var scope: String? = manifest.scope,
+    val scope: String?,
+
+    @ColumnInfo(name = "has_share_targets", index = true)
+    val hasShareTargets: Int,
 
     @ColumnInfo(name = "created_at")
-    val createdAt: Long = System.currentTimeMillis(),
+    val createdAt: Long,
 
     @ColumnInfo(name = "updated_at")
-    val updatedAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long,
 
     @ColumnInfo(name = "used_at")
-    val usedAt: Long = System.currentTimeMillis()
-)
+    val usedAt: Long
+) {
+    constructor(
+        manifest: WebAppManifest,
+        currentTime: Long = System.currentTimeMillis()
+    ) : this(
+        manifest,
+        startUrl = manifest.startUrl,
+        scope = manifest.scope,
+        hasShareTargets = if (manifest.shareTarget != null) 1 else 0,
+        createdAt = currentTime,
+        updatedAt = currentTime,
+        usedAt = currentTime
+    )
+}

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt
@@ -17,8 +17,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
@@ -82,11 +82,7 @@ class ManifestStorageTest {
     fun `update replaces the manifest as JSON`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
-        val existing = ManifestEntity(
-            manifest = firefoxManifest,
-            createdAt = 0,
-            updatedAt = 0
-        )
+        val existing = ManifestEntity(firefoxManifest, currentTime = 0)
 
         `when`(dao.getManifest("https://firefox.com")).thenReturn(existing)
 
@@ -135,11 +131,38 @@ class ManifestStorageTest {
     }
 
     @Test
+    fun `loading manifests with share targets returns list of manifests`() = runBlocking {
+        val storage = spy(ManifestStorage(testContext))
+        val dao = mockDatabase(storage)
+        val manifest1 = WebAppManifest(
+            name = "Mozilla",
+            startUrl = "https://mozilla.org",
+            shareTarget = WebAppManifest.ShareTarget("https://mozilla.org/share")
+        )
+        val manifest2 = WebAppManifest(
+            name = "Firefox",
+            startUrl = "https://firefox.com",
+            shareTarget = WebAppManifest.ShareTarget("https://firefox.com/share")
+        )
+        val timeout = ManifestStorage.ACTIVE_THRESHOLD_MS
+        val currentTime = System.currentTimeMillis()
+        val deadline = currentTime - timeout
+
+        whenever(dao.getRecentShareableManifests(deadline))
+            .thenReturn(listOf(ManifestEntity(manifest1), ManifestEntity(manifest2)))
+
+        assertEquals(
+            listOf(manifest1, manifest2),
+            storage.loadShareableManifests(currentTime)
+        )
+    }
+
+    @Test
     fun `updateManifestUsedAt updates usedAt to current timestamp`() = runBlocking {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
         val manifest = WebAppManifest(name = "Mozilla", startUrl = "https://mozilla.org")
-        val entity = ManifestEntity(manifest, usedAt = 0)
+        val entity = ManifestEntity(manifest, currentTime = 0)
 
         val entityCaptor = ArgumentCaptor.forClass(ManifestEntity::class.java)
 
@@ -219,9 +242,9 @@ class ManifestStorageTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
-        val manifest1 = ManifestEntity(manifest = firefoxManifest, createdAt = 0, updatedAt = 0)
-        val manifest2 = ManifestEntity(manifest = googleMapsManifest, createdAt = 0, updatedAt = 0)
-        val manifest3 = ManifestEntity(manifest = exampleWebAppManifest, createdAt = 0, updatedAt = 0)
+        val manifest1 = ManifestEntity(manifest = firefoxManifest, currentTime = 0)
+        val manifest2 = ManifestEntity(manifest = googleMapsManifest, currentTime = 0)
+        val manifest3 = ManifestEntity(manifest = exampleWebAppManifest, currentTime = 0)
 
         whenever(dao.getInstalledScopes(0)).thenReturn(listOf(manifest1, manifest2, manifest3))
 
@@ -242,9 +265,9 @@ class ManifestStorageTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
-        val manifest1 = ManifestEntity(manifest = firefoxManifest, createdAt = 0, updatedAt = 0)
-        val manifest2 = ManifestEntity(manifest = googleMapsManifest, createdAt = 0, updatedAt = 0)
-        val manifest3 = ManifestEntity(manifest = exampleWebAppManifest, createdAt = 0, updatedAt = 0)
+        val manifest1 = ManifestEntity(manifest = firefoxManifest, currentTime = 0)
+        val manifest2 = ManifestEntity(manifest = googleMapsManifest, currentTime = 0)
+        val manifest3 = ManifestEntity(manifest = exampleWebAppManifest, currentTime = 0)
 
         whenever(dao.getInstalledScopes(0)).thenReturn(listOf(manifest1, manifest2, manifest3))
 
@@ -260,9 +283,9 @@ class ManifestStorageTest {
         val storage = spy(ManifestStorage(testContext))
         val dao = mockDatabase(storage)
 
-        val manifest1 = ManifestEntity(manifest = firefoxManifest, createdAt = 0, updatedAt = 0)
-        val manifest2 = ManifestEntity(manifest = googleMapsManifest, createdAt = 0, updatedAt = 0)
-        val manifest3 = ManifestEntity(manifest = exampleWebAppManifest, createdAt = 0, updatedAt = 0)
+        val manifest1 = ManifestEntity(manifest = firefoxManifest, currentTime = 0)
+        val manifest2 = ManifestEntity(manifest = googleMapsManifest, currentTime = 0)
+        val manifest3 = ManifestEntity(manifest = exampleWebAppManifest, currentTime = 0)
 
         whenever(dao.getInstalledScopes(0)).thenReturn(listOf(manifest1, manifest2, manifest3))
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ permalink: /changelog/
   * Added `TrackingProtectionPolicy.toContentBlockingSetting` extension methods to convert a policy to GeckoView's `ContentBlocking.Setting`.
   * Added checks to not apply the same policy twice if they are the same as already on the engine.
 
+* **feature-pwa**
+  * Added `ManifestStorage.loadShareableManifests` to get manifest with a `WebAppManifest.ShareTarget`.
+
 # 50.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v49.0.0...v50.0.0)
@@ -61,7 +64,7 @@ permalink: /changelog/
 
 * **browser-state**
   * Added map of `SessionState.contextId` and their respective `ContainerState` in `BrowserState` to track the state of a container.
-  
+
 * **browser-menu**
   * Added an optional `longClickListener` parameter to `BrowserMenuItemToolbar.Button` and `BrowserMenuItemToolbar.TwoStateButton` to handle long click events.
 


### PR DESCRIPTION
My intent is to expose this function so that we can use it with the Fenix custom share sheet.

We want to support sharing from websites to PWAs. PWAs can define a "share target" which will receive sharing data. We can expose PWAs in the custom share sheet so that other websites can send data to them.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
