### PR TITLE
Closes #7271 Mark downloads as failed when exception occur when fetching

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -67,6 +67,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.lang.Exception
 import java.lang.IllegalStateException
 import kotlin.random.Random
 
@@ -351,10 +352,11 @@ abstract class AbstractFetchDownloadService : Service() {
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     internal fun startDownloadJob(currentDownloadJobState: DownloadJobState) {
         try {
             performDownload(currentDownloadJobState)
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             setDownloadJobStatus(currentDownloadJobState, FAILED)
         }
     }

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -891,7 +891,7 @@ class AbstractFetchDownloadServiceTest {
     }
 
     @Test
-    fun `job status is set to failed when IOException is thrown while performDownload`() = runBlocking {
+    fun `job status is set to failed when an Exception is thrown while performDownload`() = runBlocking {
         doThrow(IOException()).`when`(client).fetch(any())
         val download = DownloadState("https://example.com/file.txt", "file.txt")
 


### PR DESCRIPTION
Instead of crashing the app let's catch any exception when fetching and mark downloads as failed

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
