### PR TITLE
Closes #7286 - Hide the keyboard when the find in page bar is unfocused

### DIFF
--- a/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
+++ b/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
@@ -92,8 +92,6 @@ class FindInPageBar @JvmOverloads constructor(
     }
 
     override fun clear() {
-        queryEditText.hideKeyboard()
-
         queryEditText.text = null
         queryEditText.clearFocus()
         resultsCountTextView.text = null
@@ -177,7 +175,8 @@ class FindInPageBar @JvmOverloads constructor(
         resultsCountTextView.setTextColorIfNotDefaultValue(styling.resultCountTextColor)
     }
 
-    private fun bindQueryEditText() {
+    @VisibleForTesting
+    internal fun bindQueryEditText() {
         with(queryEditText) {
             setTextSizeIfNotDefaultValue(styling.queryTextSize)
             setTextColorIfNotDefaultValue(styling.queryTextColor)
@@ -202,7 +201,18 @@ class FindInPageBar @JvmOverloads constructor(
                     onQueryChange(newQuery)
                 }
             })
+
+            onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+                if (!hasFocus) {
+                    this@FindInPageBar.hideKeyboard()
+                }
+            }
         }
+    }
+
+    @VisibleForTesting
+    internal fun hideKeyboard() {
+        queryEditText.hideKeyboard()
     }
 }
 

--- a/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
+++ b/components/feature/findinpage/src/test/java/mozilla/components/feature/findinpage/view/FindInPageBarTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.robolectric.shadows.ShadowLooper
 
 @RunWith(AndroidJUnit4::class)
 class FindInPageBarTest {
@@ -137,5 +138,22 @@ class FindInPageBarTest {
         assertEquals(0, edit.imeOptions and
                 EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING)
         assertEquals(false, findInPageBar.private)
+    }
+
+    @Test
+    fun `clearing the focus of the find in page bar hides the keyboard`() {
+        val findInPageBar = spy(FindInPageBar(testContext))
+
+        // re-initialize the listener to use the spy
+        findInPageBar.bindQueryEditText()
+
+        // Focus the find in page bar first
+        findInPageBar.focus()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        // clearing the focus should hide the keyboard
+        findInPageBar.clear()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        verify(findInPageBar).hideKeyboard()
     }
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
I'd like to add a test for this, but I haven't found a way to check if the keyboard is opened.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
