### PR TITLE
Closes #7288 - Only scroll the bottom toolbar if onStartNestedScroll …

### DIFF
--- a/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehavior.kt
+++ b/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehavior.kt
@@ -47,6 +47,9 @@ class BrowserToolbarBottomBehavior(
     private var lastSnapStartedWasUp = false
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal var startedScroll = false
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var snapAnimator: ValueAnimator = ValueAnimator().apply {
         interpolator = DecelerateInterpolator()
         duration = SNAP_ANIMATION_DURATION
@@ -90,6 +93,7 @@ class BrowserToolbarBottomBehavior(
         type: Int
     ): Boolean {
         return if (shouldScroll && axes == ViewCompat.SCROLL_AXIS_VERTICAL) {
+            startedScroll = true
             shouldSnapAfterScroll = type == ViewCompat.TYPE_TOUCH
             snapAnimator.cancel()
             true
@@ -110,6 +114,7 @@ class BrowserToolbarBottomBehavior(
         target: View,
         type: Int
     ) {
+        startedScroll = false
         if (shouldSnapAfterScroll || type == ViewCompat.TYPE_NON_TOUCH) {
             if (child.translationY >= (child.height / 2f)) {
                 animateSnap(child, SnapDirection.DOWN)
@@ -188,7 +193,7 @@ class BrowserToolbarBottomBehavior(
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun tryToScrollVertically(distance: Float) {
-        if (shouldScroll) {
+        if (shouldScroll && startedScroll) {
             browserToolbar.translationY =
                 max(0f, min(browserToolbar.height.toFloat(), browserToolbar.translationY + distance))
         } else {

--- a/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
+++ b/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBottomBehaviorTest.kt
@@ -202,10 +202,26 @@ class BrowserToolbarBottomBehaviorTest {
         behavior.browserToolbar = child
         doReturn(100).`when`(child).height
         doReturn(0f).`when`(child).translationY
+        behavior.startedScroll = true
 
         behavior.tryToScrollVertically(25f)
 
         verify(child).translationY = 25f
+    }
+
+    @Test
+    fun `Behavior will not scroll vertically if startedScroll is false`() {
+        val behavior = spy(BrowserToolbarBottomBehavior(testContext, attrs = null))
+        doReturn(true).`when`(behavior).shouldScroll
+        val child = spy(BrowserToolbar(testContext, null, 0))
+        behavior.browserToolbar = child
+        doReturn(100).`when`(child).height
+        doReturn(0f).`when`(child).translationY
+        behavior.startedScroll = false
+
+        behavior.tryToScrollVertically(25f)
+
+        verify(child, never()).translationY
     }
 
     @Test


### PR DESCRIPTION
…was invoked first


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
