### PR TITLE
Closes #7223: Clear speculative session on engine settings change

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -179,6 +179,14 @@ class GeckoEngine(
     }
 
     /**
+     * See [Engine.clearSpeculativeSession].
+     */
+    override fun clearSpeculativeSession() {
+        this.speculativeSession?.geckoSession?.close()
+        this.speculativeSession = null
+    }
+
+    /**
      * Opens a speculative connection to the host of [url].
      *
      * This is useful if an app thinks it may be making a request to that host in the near future. If no request

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -137,6 +137,20 @@ class GeckoEngineTest {
     }
 
     @Test
+    fun clearSpeculativeSession() {
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertNull(engine.speculativeSession)
+
+        val mockGeckoSession: GeckoSession = mock()
+        val mockEngineSession: GeckoEngineSession = mock()
+        whenever(mockEngineSession.geckoSession).thenReturn(mockGeckoSession)
+        engine.speculativeSession = mockEngineSession
+        engine.clearSpeculativeSession()
+        verify(mockGeckoSession).close()
+        assertNull(engine.speculativeSession)
+    }
+
+    @Test
     fun `createSession with contextId`() {
         val engine = GeckoEngine(context, runtime = runtime)
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -179,6 +179,14 @@ class GeckoEngine(
     }
 
     /**
+     * See [Engine.clearSpeculativeSession].
+     */
+    override fun clearSpeculativeSession() {
+        this.speculativeSession?.geckoSession?.close()
+        this.speculativeSession = null
+    }
+
+    /**
      * Opens a speculative connection to the host of [url].
      *
      * This is useful if an app thinks it may be making a request to that host in the near future. If no request

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -137,6 +137,20 @@ class GeckoEngineTest {
     }
 
     @Test
+    fun clearSpeculativeSession() {
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertNull(engine.speculativeSession)
+
+        val mockGeckoSession: GeckoSession = mock()
+        val mockEngineSession: GeckoEngineSession = mock()
+        whenever(mockEngineSession.geckoSession).thenReturn(mockGeckoSession)
+        engine.speculativeSession = mockEngineSession
+        engine.clearSpeculativeSession()
+        verify(mockGeckoSession).close()
+        assertNull(engine.speculativeSession)
+    }
+
+    @Test
     fun `createSession with contextId`() {
         val engine = GeckoEngine(context, runtime = runtime)
 

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -179,6 +179,14 @@ class GeckoEngine(
     }
 
     /**
+     * See [Engine.clearSpeculativeSession].
+     */
+    override fun clearSpeculativeSession() {
+        this.speculativeSession?.geckoSession?.close()
+        this.speculativeSession = null
+    }
+
+    /**
      * Opens a speculative connection to the host of [url].
      *
      * This is useful if an app thinks it may be making a request to that host in the near future. If no request

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -137,6 +137,20 @@ class GeckoEngineTest {
     }
 
     @Test
+    fun clearSpeculativeSession() {
+        val engine = GeckoEngine(context, runtime = runtime)
+        assertNull(engine.speculativeSession)
+
+        val mockGeckoSession: GeckoSession = mock()
+        val mockEngineSession: GeckoEngineSession = mock()
+        whenever(mockEngineSession.geckoSession).thenReturn(mockGeckoSession)
+        engine.speculativeSession = mockEngineSession
+        engine.clearSpeculativeSession()
+        verify(mockGeckoSession).close()
+        assertNull(engine.speculativeSession)
+    }
+
+    @Test
     fun `createSession with contextId`() {
         val engine = GeckoEngine(context, runtime = runtime)
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -128,6 +128,14 @@ interface Engine : WebExtensionRuntime, DataCleanable {
     fun speculativeCreateSession(private: Boolean = false, contextId: String? = null) = Unit
 
     /**
+     * Removes and closes a speculative session created by [speculativeCreateSession]. This is
+     * useful in case the session should no longer be used e.g. because engine settings have
+     * changed.
+     */
+    @MainThread
+    fun clearSpeculativeSession() = Unit
+
+    /**
      * Registers a [WebNotificationDelegate] to be notified of engine events
      * related to web notifications
      *

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,9 @@ permalink: /changelog/
 * **feature-push**
   * Fixed a bug where we do not verify subscriptions on first attempt.
 
+* **feature-session**
+  * ⚠️ **This is a breaking change**: `SettingsUseCases` now requires an engine reference, to clear speculative sessions if engine settings change.
+
 # 44.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v43.0.0...v44.0.0)


### PR DESCRIPTION
Since the speculative session only exists for performance reasons I think it's fine to simply clear it and take a slight performance hit in case the user changes engine settings. This only affects the first session after a settings change anyway, and then we don't have to recreate it with the previous parameters.

Similar to our `AwesomeBarFeature`, the `SettingsUseCase` now takes an optional engine reference to support clearing the speculative session.

