### PR TITLE
Issue #6644: Integrate UI to cancel add-on installation

### DIFF
--- a/components/feature/addons/src/main/res/values/strings.xml
+++ b/components/feature/addons/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
     <string name="mozac_feature_addons_permissions_dialog_cancel">Cancel</string>
     <!-- Accessibility content description to install add-on button. -->
     <string name="mozac_feature_addons_install_addon_content_description">Install Add-on</string>
+    <!-- This is the label of a button to cancel an ongoing add-on installation. -->
+    <string name="mozac_feature_addons_install_addon_dialog_cancel">Cancel</string>
     <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
     <string name="mozac_feature_addons_user_rating_count">Users: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->

--- a/samples/browser/src/main/res/layout/overlay_add_on_progress.xml
+++ b/samples/browser/src/main/res/layout/overlay_add_on_progress.xml
@@ -8,15 +8,34 @@
     android:layout_height="wrap_content"
     android:elevation="1dp">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:drawablePadding="8dp"
-        android:gravity="start|center_vertical"
-        android:padding="16dp"
-        android:text="@string/mozac_add_on_install_progress_caption"
-        app:drawableStartCompat="@drawable/mozac_ic_extensions_black" />
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/install_hint"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:drawablePadding="8dp"
+            android:gravity="start|center_vertical"
+            android:padding="16dp"
+            android:text="@string/mozac_add_on_install_progress_caption"
+            app:drawableStartCompat="@drawable/mozac_ic_extensions_black" />
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/install_hint"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/mozac_feature_addons_install_addon_dialog_cancel"
+            android:textAllCaps="false" />
+
+    </RelativeLayout>
 
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
This brings in the missing piece of our add-on installation UI: https://miro.com/app/board/o9J_kw8Lt8g=/?moveToWidget=3074457347043892302&cot=3

There is still one crash left (cancellation after the add-on was downloaded), but it has been fixed in GV and will be in tomorrow's Nightly. Either way, we don't need to wait with this any longer as all problems have been addressed.

Once we have this here, let's leave the ticket open and land it in Fenix as well.