### PR TITLE
Issue #7295: Don't block store thread when saving thumbnail

### DIFF
--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorage.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorage.kt
@@ -10,8 +10,10 @@ import androidx.annotation.WorkerThread
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import mozilla.components.browser.thumbnails.R
 import mozilla.components.browser.thumbnails.utils.ThumbnailDiskCache
 import mozilla.components.support.base.log.logger.Logger
@@ -77,11 +79,12 @@ class ThumbnailStorage(
      * Stores the given thumbnail [Bitmap] into the disk cache with the provided session ID or url
      * as its key.
      */
-    fun saveThumbnail(sessionIdOrUrl: String, bitmap: Bitmap) {
-        logger.debug(
-            "Saved thumbnail to disk (sessionIdOrUrl = $sessionIdOrUrl, " +
-                "generationId = ${bitmap.generationId})"
-        )
-        sharedDiskCache.putThumbnailBitmap(context, sessionIdOrUrl, bitmap)
-    }
+    fun saveThumbnail(sessionIdOrUrl: String, bitmap: Bitmap): Job =
+        scope.launch {
+            logger.debug(
+                "Saved thumbnail to disk (sessionIdOrUrl = $sessionIdOrUrl, " +
+                    "generationId = ${bitmap.generationId})"
+            )
+            sharedDiskCache.putThumbnailBitmap(context, sessionIdOrUrl, bitmap)
+        }
 }

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
@@ -38,7 +39,7 @@ class ThumbnailStorageTest {
 
         assertNull(thumbnail)
 
-        thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap)
+        thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap).joinBlocking()
         thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
         assertNotNull(thumbnail)
     }


### PR DESCRIPTION
We could use separate dispatchers (separate thread pools) for saving and loading, but we discussed and didn't think it was necessary right now.

Could also think of just using an IO dispatcher instead of a custom thread pool, but that's independent of the issue here.