### PR TITLE
Closes #7308: Update the store queuedDownloads when mutate the download state.

### DIFF
--- a/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -577,4 +577,9 @@ sealed class DownloadAction : BrowserAction() {
      * Updates the [BrowserState] to remove all queued downloads.
      */
     object RemoveAllQueuedDownloadsAction : DownloadAction()
+
+    /**
+     * Updates the provided [download] on the [BrowserState].
+     */
+    data class UpdateQueuedDownloadAction(val download: DownloadState) : DownloadAction()
 }

--- a/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
+++ b/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/DownloadStateReducer.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.state.reducer
 
 import mozilla.components.browser.state.action.DownloadAction
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.content.DownloadState
 
 internal object DownloadStateReducer {
 
@@ -14,8 +15,9 @@ internal object DownloadStateReducer {
      */
     fun reduce(state: BrowserState, action: DownloadAction): BrowserState {
         return when (action) {
-            is DownloadAction.QueueDownloadAction -> {
-                state.copy(queuedDownloads = state.queuedDownloads + (action.download.id to action.download))
+            is DownloadAction.QueueDownloadAction -> updateQueuedDownloads(state, action.download)
+            is DownloadAction.UpdateQueuedDownloadAction -> {
+                updateQueuedDownloads(state, action.download)
             }
             is DownloadAction.RemoveQueuedDownloadAction -> {
                 state.copy(queuedDownloads = state.queuedDownloads - action.downloadId)
@@ -25,4 +27,7 @@ internal object DownloadStateReducer {
             }
         }
     }
+
+    private fun updateQueuedDownloads(state: BrowserState, download: DownloadState) =
+            state.copy(queuedDownloads = state.queuedDownloads + (download.id to download))
 }

--- a/components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt
+++ b/components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt
@@ -58,4 +58,22 @@ class DownloadActionTest {
         store.dispatch(DownloadAction.RemoveAllQueuedDownloadsAction).joinBlocking()
         assertTrue(store.state.queuedDownloads.isEmpty())
     }
+
+    @Test
+    fun `UpdateQueuedDownloadAction updates the provided download`() {
+        val store = BrowserStore(BrowserState())
+        val download = DownloadState("https://mozilla.org/download1", destinationDirectory = "")
+        val download2 = DownloadState("https://mozilla.org/download2", destinationDirectory = "")
+
+        store.dispatch(DownloadAction.QueueDownloadAction(download)).joinBlocking()
+        store.dispatch(DownloadAction.QueueDownloadAction(download2)).joinBlocking()
+
+        val updatedDownload = download.copy(fileName = "filename.txt")
+
+        store.dispatch(DownloadAction.UpdateQueuedDownloadAction(updatedDownload)).joinBlocking()
+
+        assertFalse(store.state.queuedDownloads.isEmpty())
+        assertEquals(2, store.state.queuedDownloads.size)
+        assertEquals(updatedDownload, store.state.queuedDownloads[updatedDownload.id])
+    }
 }

--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -628,13 +628,22 @@ abstract class AbstractFetchDownloadService : Service() {
         block: (OutputStream) -> Unit
     ) {
         val downloadWithUniqueFileName = makeUniqueFileNameIfNecessary(download, append)
-        downloadJobs[download.id]?.state = downloadWithUniqueFileName
+        updateDownloadState(downloadWithUniqueFileName)
 
         if (SDK_INT >= Build.VERSION_CODES.Q) {
             useFileStreamScopedStorage(downloadWithUniqueFileName, block)
         } else {
             useFileStreamLegacy(downloadWithUniqueFileName, append, block)
         }
+    }
+
+    /**
+     * Updates the given [updatedDownload] in the store and in the [downloadJobs].
+     */
+    @VisibleForTesting
+    internal fun updateDownloadState(updatedDownload: DownloadState) {
+        downloadJobs[updatedDownload.id]?.state = updatedDownload
+        store.dispatch(DownloadAction.UpdateQueuedDownloadAction(updatedDownload))
     }
 
     /**

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt
@@ -963,6 +963,24 @@ class AbstractFetchDownloadServiceTest {
     }
 
     @Test
+    fun `updateDownloadState must update the download state in the store and in the downloadJobs`() {
+        val download = DownloadState("https://example.com/file.txt", "file1.txt")
+        val downloadJob = DownloadJobState(state = mock(), status = ACTIVE)
+        val mockStore = mock<BrowserStore>()
+        val service = spy(object : AbstractFetchDownloadService() {
+            override val httpClient = client
+            override val store = mockStore
+        })
+
+        service.downloadJobs[download.id] = downloadJob
+
+        service.updateDownloadState(download)
+
+        assertEquals(download, service.downloadJobs[download.id]!!.state)
+        verify(mockStore).dispatch(DownloadAction.UpdateQueuedDownloadAction(download))
+    }
+
+    @Test
     fun `onTaskRemoved cancels all notifications on the shadow notification manager`() = runBlocking {
         val download = DownloadState("https://example.com/file.txt", "file.txt")
         val response = Response(


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
