### PR TITLE
Closes #7310: Support custom use cases in TabsFeature

### DIFF
--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -56,9 +56,33 @@ class TabsUseCases(
         }
     }
 
-    class RemoveTabUseCase internal constructor(
+    /**
+     * Contract for use cases that remove a tab.
+     */
+    interface RemoveTabUseCase {
+        /**
+         * Removes the session with the provided ID. This method
+         * has no effect if the session doesn't exist.
+         *
+         * @param sessionId The ID of the session to remove.
+         */
+        operator fun invoke(sessionId: String)
+
+        /**
+         * Removes the provided session.
+         *
+         * @param session The session to remove.
+         */
+        operator fun invoke(session: Session)
+    }
+
+    /**
+     * Default implementation of [RemoveTabUseCase], interacting
+     * with [SessionManager].
+     */
+    class DefaultRemoveTabUseCase internal constructor(
         private val sessionManager: SessionManager
-    ) {
+    ) : RemoveTabUseCase {
 
         /**
          * Removes the session with the provided ID. This method
@@ -66,7 +90,7 @@ class TabsUseCases(
          *
          * @param sessionId The ID of the session to remove.
          */
-        operator fun invoke(sessionId: String) {
+        override operator fun invoke(sessionId: String) {
             val session = sessionManager.findSessionById(sessionId)
             if (session != null) {
                 invoke(session)
@@ -78,7 +102,7 @@ class TabsUseCases(
          *
          * @param session The session to remove.
          */
-        operator fun invoke(session: Session) {
+        override operator fun invoke(session: Session) {
             sessionManager.remove(session)
         }
     }
@@ -204,7 +228,7 @@ class TabsUseCases(
     }
 
     val selectTab: SelectTabUseCase by lazy { DefaultSelectTabUseCase(sessionManager) }
-    val removeTab: RemoveTabUseCase by lazy { RemoveTabUseCase(sessionManager) }
+    val removeTab: RemoveTabUseCase by lazy { DefaultRemoveTabUseCase(sessionManager) }
     val addTab: AddNewTabUseCase by lazy { AddNewTabUseCase(sessionManager) }
     val addPrivateTab: AddNewPrivateTabUseCase by lazy { AddNewPrivateTabUseCase(sessionManager) }
     val removeAllTabs: RemoveAllTabsUseCase by lazy { RemoveAllTabsUseCase(sessionManager) }

--- a/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
+++ b/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/TabsFeature.kt
@@ -23,7 +23,8 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 class TabsFeature(
     tabsTray: TabsTray,
     private val store: BrowserStore,
-    tabsUseCases: TabsUseCases,
+    selectTabUseCase: TabsUseCases.SelectTabUseCase,
+    removeTabUseCase: TabsUseCases.RemoveTabUseCase,
     thumbnailsUseCases: ThumbnailsUseCases? = null,
     private val defaultTabsFilter: (TabSessionState) -> Boolean = { true },
     closeTabsTray: () -> Unit
@@ -40,8 +41,8 @@ class TabsFeature(
     @VisibleForTesting
     internal var interactor = TabsTrayInteractor(
         tabsTray,
-        tabsUseCases.selectTab,
-        tabsUseCases.removeTab,
+        selectTabUseCase,
+        removeTabUseCase,
         closeTabsTray)
 
     override fun start() {

--- a/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
+++ b/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/tabstray/TabsFeatureTest.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.tabs.tabstray
 
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.tabstray.Tabs
@@ -20,12 +19,12 @@ class TabsFeatureTest {
 
     @Test
     fun `asserting getters`() {
-        val sessionManager = SessionManager(engine = mock())
         val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
-        val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock(), mock(), mock()))
+        val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
+        val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
+        val tabsFeature = spy(TabsFeature(mock(), store, selectTabUseCase, removeTabUseCase, mock(), mock(), mock()))
 
         assertNotEquals(tabsFeature.interactor, interactor)
         assertNotEquals(tabsFeature.presenter, presenter)
@@ -39,12 +38,12 @@ class TabsFeatureTest {
 
     @Test
     fun start() {
-        val sessionManager = SessionManager(engine = mock())
         val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
-        val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock(), mock(), mock()))
+        val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
+        val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
+        val tabsFeature = spy(TabsFeature(mock(), store, selectTabUseCase, removeTabUseCase, mock(), mock(), mock()))
 
         tabsFeature.presenter = presenter
         tabsFeature.interactor = interactor
@@ -57,12 +56,12 @@ class TabsFeatureTest {
 
     @Test
     fun stop() {
-        val sessionManager = SessionManager(engine = mock())
         val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
-        val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock(), mock(), mock()))
+        val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
+        val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
+        val tabsFeature = spy(TabsFeature(mock(), store, selectTabUseCase, removeTabUseCase, mock(), mock(), mock()))
 
         tabsFeature.presenter = presenter
         tabsFeature.interactor = interactor
@@ -75,12 +74,12 @@ class TabsFeatureTest {
 
     @Test
     fun filterTabs() {
-        val sessionManager = SessionManager(engine = mock())
         val store = BrowserStore()
         val presenter: TabsTrayPresenter = mock()
         val interactor: TabsTrayInteractor = mock()
-        val useCases = TabsUseCases(sessionManager)
-        val tabsFeature = spy(TabsFeature(mock(), store, useCases, mock(), mock(), mock()))
+        val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
+        val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
+        val tabsFeature = spy(TabsFeature(mock(), store, selectTabUseCase, removeTabUseCase, mock(), mock(), mock()))
 
         tabsFeature.presenter = presenter
         tabsFeature.interactor = interactor
@@ -97,12 +96,13 @@ class TabsFeatureTest {
     fun `filterTabs uses default filter if a new one is not provided`() {
         val store = BrowserStore()
         val filter: (TabSessionState) -> Boolean = { false }
-        val sessionManager = SessionManager(engine = mock())
-        val useCases = TabsUseCases(sessionManager)
+        val selectTabUseCase: TabsUseCases.SelectTabUseCase = mock()
+        val removeTabUseCase: TabsUseCases.RemoveTabUseCase = mock()
         val tabsFeature = spy(TabsFeature(
             mock(),
             store,
-            useCases,
+            selectTabUseCase,
+            removeTabUseCase,
             mock(),
             defaultTabsFilter = filter,
             closeTabsTray = mock()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,9 @@ permalink: /changelog/
   * Adds a new storage component to store containers (contextual identities) in a Room database and provides the
     necessary APIs to get, add and remove containers.
 
+* **feature-tabs**
+  * ⚠️ **This is a breaking change**: `TabsFeature` now supports providing custom use case implementations. Therefore, an instance of `SelectTabUseCase` and `RemoveTabUseCase` have to be provided.
+
 # 44.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v43.0.0...v44.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -46,7 +46,8 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
         tabsFeature = TabsFeature(
             tabsTray,
             components.store,
-            components.tabsUseCases,
+            components.tabsUseCases.selectTab,
+            components.tabsUseCases.removeTab,
             components.thumbnailsUseCases,
             closeTabsTray = ::closeTabsTray
         ).also { lifecycle.addObserver(it) }


### PR DESCRIPTION
Because `RemoveTabsUseCase` can't be customized, making undo possible in Fenix requires a workaround and an additional observer. Seems simple enough to get rid of...