### PR TITLE
For #6910 - Expose reports as artifacts

### DIFF
--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -137,10 +137,26 @@ def add_artifacts(config, tasks):
         artifact_template = task.pop("artifact-template", {})
         task["attributes"]["artifacts"] = artifacts = {}
 
-        if task.pop("expose-artifacts", False):
-            component = task["attributes"]["component"]
-            build_artifact_definitions = task.setdefault("worker", {}).setdefault("artifacts", [])
+        component = task["attributes"]["component"]
+        build_artifact_definitions = task.setdefault("worker", {}).setdefault("artifacts", [])
 
+        if "tests-artifact-template" in task:
+            tests_artifact_template = task.pop("tests-artifact-template", {})
+            build_artifact_definitions.append({
+                "type": tests_artifact_template["type"],
+                "name": tests_artifact_template["name"],
+                "path": tests_artifact_template["path"].format(component_path=get_path(component)),
+            })
+
+        if "lint-artifact-template" in task:
+            lint_artifact_template = task.pop("lint-artifact-template", {})
+            build_artifact_definitions.append({
+                "type": lint_artifact_template["type"],
+                "name": lint_artifact_template["name"],
+                "path": lint_artifact_template["path"].format(component_path=get_path(component)),
+            })
+
+        if task.pop("expose-artifacts", False):
             all_extensions = get_extensions(component)
             artifact_file_names_per_extension = {
                 extension: '{component}-{version}{timestamp}{extension}'.format(

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -22,6 +22,14 @@ job-defaults:
         type: file
         name: public/build/{artifact_file_name}
         path: '/builds/worker/checkouts/src/{component_path}/build/maven/org/mozilla/components/{component}/{version}/{artifact_file_name}'
+    tests-artifact-template:
+        type: directory
+        name: public/reports/tests
+        path: '/builds/worker/checkouts/src/{component_path}/build/reports/tests'
+    lint-artifact-template:
+        type: file
+        name: public/reports/lint-results-release.html
+        path: '/builds/worker/checkouts/src/{component_path}/build/reports/lint-results-release.html'
     attributes:
         code-review:
             by-build-type:


### PR DESCRIPTION
This exposes the HTML reports from tests, lint, & jacoco as Taskcluster build artifacts. After this change they can be accessed from the "Artifacts" menu in Taskcluster, and linked to!
