### PR TITLE
Closes #6680: Handle exceptions thrown by capturePixels

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -72,10 +72,6 @@ class GeckoEngineSession(
     internal var currentUrl: String? = null
     internal var scrollY: Int = 0
 
-    // This is set once the first content paint has occurred and can be used to
-    // decide if it's safe to call capturePixels on the view.
-    internal var firstContentfulPaint = false
-
     internal var job: Job = Job()
     private var lastSessionState: GeckoSession.SessionState? = null
     private var stateBeforeCrash: GeckoSession.SessionState? = null
@@ -328,7 +324,6 @@ class GeckoEngineSession(
         super.close()
         job.cancel()
         geckoSession.close()
-        firstContentfulPaint = false
     }
 
     /**
@@ -616,7 +611,6 @@ class GeckoEngineSession(
         override fun onFirstComposite(session: GeckoSession) = Unit
 
         override fun onFirstContentfulPaint(session: GeckoSession) {
-            firstContentfulPaint = true
             notifyObservers { onFirstContentfulPaint() }
         }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1915,6 +1915,25 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `onFirstContentfulPaint notifies observers`() {
+        val engineSession = GeckoEngineSession(mock(),
+            geckoSessionProvider = geckoSessionProvider)
+
+        captureDelegates()
+
+        var observed = false
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onFirstContentfulPaint() {
+                observed = true
+            }
+        })
+
+        contentDelegate.value.onFirstContentfulPaint(mock())
+        assertTrue(observed)
+    }
+
+    @Test
     fun `onCrash notifies observers about crash`() {
         val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
@@ -2388,21 +2407,6 @@ class GeckoEngineSessionTest {
         assertNotNull(receivedWindowRequest)
         assertSame(engineSession, receivedWindowRequest!!.prepare())
         assertEquals(WindowRequest.Type.CLOSE, receivedWindowRequest!!.type)
-    }
-
-    @Test
-    fun managesStateOfFirstContentfulPaint() {
-        val engineSession = GeckoEngineSession(mock(),
-                geckoSessionProvider = geckoSessionProvider)
-
-        captureDelegates()
-
-        assertFalse(engineSession.firstContentfulPaint)
-        contentDelegate.value.onFirstContentfulPaint(geckoSession)
-        assertTrue(engineSession.firstContentfulPaint)
-
-        engineSession.close()
-        assertFalse(engineSession.firstContentfulPaint)
     }
 
     class MockSecurityInformation(

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -72,10 +72,6 @@ class GeckoEngineSession(
     internal var currentUrl: String? = null
     internal var scrollY: Int = 0
 
-    // This is set once the first content paint has occurred and can be used to
-    // decide if it's safe to call capturePixels on the view.
-    internal var firstContentfulPaint = false
-
     internal var job: Job = Job()
     private var lastSessionState: GeckoSession.SessionState? = null
     private var stateBeforeCrash: GeckoSession.SessionState? = null
@@ -328,7 +324,6 @@ class GeckoEngineSession(
         super.close()
         job.cancel()
         geckoSession.close()
-        firstContentfulPaint = false
     }
 
     /**
@@ -616,7 +611,6 @@ class GeckoEngineSession(
         override fun onFirstComposite(session: GeckoSession) = Unit
 
         override fun onFirstContentfulPaint(session: GeckoSession) {
-            firstContentfulPaint = true
             notifyObservers { onFirstContentfulPaint() }
         }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1915,6 +1915,25 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `onFirstContentfulPaint notifies observers`() {
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+
+        captureDelegates()
+
+        var observed = false
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onFirstContentfulPaint() {
+                observed = true
+            }
+        })
+
+        contentDelegate.value.onFirstContentfulPaint(mock())
+        assertTrue(observed)
+    }
+
+    @Test
     fun `onCrash notifies observers about crash`() {
         val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
@@ -2388,21 +2407,6 @@ class GeckoEngineSessionTest {
         assertNotNull(receivedWindowRequest)
         assertSame(engineSession, receivedWindowRequest!!.prepare())
         assertEquals(WindowRequest.Type.CLOSE, receivedWindowRequest!!.type)
-    }
-
-    @Test
-    fun managesStateOfFirstContentfulPaint() {
-        val engineSession = GeckoEngineSession(mock(),
-                geckoSessionProvider = geckoSessionProvider)
-
-        captureDelegates()
-
-        assertFalse(engineSession.firstContentfulPaint)
-        contentDelegate.value.onFirstContentfulPaint(geckoSession)
-        assertTrue(engineSession.firstContentfulPaint)
-
-        engineSession.close()
-        assertFalse(engineSession.firstContentfulPaint)
     }
 
     class MockSecurityInformation(

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -71,10 +71,6 @@ class GeckoEngineSession(
     internal var currentUrl: String? = null
     internal var scrollY: Int = 0
 
-    // This is set once the first content paint has occurred and can be used to
-    // decide if it's safe to call capturePixels on the view.
-    internal var firstContentfulPaint = false
-
     internal var job: Job = Job()
     private var lastSessionState: GeckoSession.SessionState? = null
     private var stateBeforeCrash: GeckoSession.SessionState? = null
@@ -327,7 +323,6 @@ class GeckoEngineSession(
         super.close()
         job.cancel()
         geckoSession.close()
-        firstContentfulPaint = false
     }
 
     /**
@@ -583,7 +578,7 @@ class GeckoEngineSession(
         override fun onFirstComposite(session: GeckoSession) = Unit
 
         override fun onFirstContentfulPaint(session: GeckoSession) {
-            firstContentfulPaint = true
+            notifyObservers { onFirstContentfulPaint() }
         }
 
         override fun onContextMenu(

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1884,6 +1884,25 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `onFirstContentfulPaint notifies observers`() {
+        val engineSession = GeckoEngineSession(mock(),
+            geckoSessionProvider = geckoSessionProvider)
+
+        captureDelegates()
+
+        var observed = false
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onFirstContentfulPaint() {
+                observed = true
+            }
+        })
+
+        contentDelegate.value.onFirstContentfulPaint(mock())
+        assertTrue(observed)
+    }
+
+    @Test
     fun `onCrash notifies observers about crash`() {
         val engineSession = GeckoEngineSession(mock(),
             geckoSessionProvider = geckoSessionProvider)
@@ -2308,21 +2327,6 @@ class GeckoEngineSessionTest {
         assertNotNull(receivedWindowRequest)
         assertSame(engineSession, receivedWindowRequest!!.prepare())
         assertEquals(WindowRequest.Type.CLOSE, receivedWindowRequest!!.type)
-    }
-
-    @Test
-    fun managesStateOfFirstContentfulPaint() {
-        val engineSession = GeckoEngineSession(mock(),
-                geckoSessionProvider = geckoSessionProvider)
-
-        captureDelegates()
-
-        assertFalse(engineSession.firstContentfulPaint)
-        contentDelegate.value.onFirstContentfulPaint(geckoSession)
-        assertTrue(engineSession.firstContentfulPaint)
-
-        engineSession.close()
-        assertFalse(engineSession.firstContentfulPaint)
     }
 
     class MockSecurityInformation(


### PR DESCRIPTION
We're still seeing `IllegalStateException`s (Compositor not ready) when capturing thumbnails.

We fixed this a while ago by checking if `firstContentfulPaint` has happened, but that's not working/reliable. There's currently no other way to handle this but to catch-all and return an empty/null bitmap. See https://github.com/mozilla-mobile/android-components/issues/6680.

I've also added a missing test for the `onFirstContentfulPaint` observer which was missing from https://github.com/mozilla-mobile/android-components/pull/6844/.

The internal var we can remove now.

r? @jonalmeida ticket is labelled "skittle", but this is really independent of the new tabs tray work.