### PR TITLE
Change WebAppHideToolbarFeature to use callback

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/WebAppHideToolbarFeature.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/feature/WebAppHideToolbarFeature.kt
@@ -4,9 +4,7 @@
 
 package mozilla.components.feature.pwa.feature
 
-import android.view.View
 import androidx.core.net.toUri
-import androidx.core.view.isVisible
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.MainScope
@@ -41,19 +39,19 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
  * In standard custom tabs, no scopes are trusted.
  * As a result the URL has no impact on toolbar visibility.
  *
- * @param toolbar Toolbar to show or hide.
  * @param store Reference to the browser store where tab state is located.
  * @param customTabsStore Reference to the store that communicates with the custom tabs service.
  * @param tabId ID of the tab session, or null if the selected session should be used.
  * @param manifest Reference to the cached [WebAppManifest] for the current PWA.
  * Null if this feature is not used in a PWA context.
+ * @param setToolbarVisibility Callback to show or hide the toolbar.
  */
 class WebAppHideToolbarFeature(
-    private val toolbar: View,
     private val store: BrowserStore,
     private val customTabsStore: CustomTabsServiceStore,
     private val tabId: String? = null,
-    manifest: WebAppManifest? = null
+    manifest: WebAppManifest? = null,
+    private val setToolbarVisibility: (Boolean) -> Unit
 ) : LifecycleAwareFeature {
 
     private val manifestScope = listOfNotNull(manifest?.getTrustedScope())
@@ -63,7 +61,7 @@ class WebAppHideToolbarFeature(
         // Hide the toolbar by default to prevent a flash.
         val tab = store.state.findTabOrCustomTabOrSelectedTab(tabId)
         val customTabState = customTabsStore.state.getCustomTabStateForTab(tab)
-        toolbar.isVisible = shouldToolbarBeVisible(tab, customTabState)
+        setToolbarVisibility(shouldToolbarBeVisible(tab, customTabState))
     }
 
     @ExperimentalCoroutinesApi
@@ -84,7 +82,7 @@ class WebAppHideToolbarFeature(
                     .map { (tab, customTabState) -> shouldToolbarBeVisible(tab, customTabState) }
                     .ifChanged()
                     .collect { toolbarVisible ->
-                        toolbar.isVisible = toolbarVisible
+                        setToolbarVisibility(toolbarVisible)
                     }
             }
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,7 +55,7 @@ permalink: /changelog/
   * Added `ContentState.pictureInPictureEnabled` to track if Picture in Picture mode is in use.
 
 * **feature-pwa**
-  * ⚠️ **This is a breaking change**: `WebAppHideToolbarFeature` now takes `BrowserStore` instead of `SessionManager`. `trustedScopes` is now derived from `CustomTabsServiceStore` and `WebAppManifest`.
+  * ⚠️ **This is a breaking change**: `WebAppHideToolbarFeature` now takes `BrowserStore` instead of `SessionManager`. `trustedScopes` is now derived from `CustomTabsServiceStore` and `WebAppManifest`. `setToolbarVisibility` should now be used set the visibility of the toolbar.
   * ⚠️ **This is a breaking change**: `onToolbarVisibilityChange` has been removed. You should now observe `BrowserStore` instead.
 
 # 44.0.0

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.feature.customtabs.CustomTabWindowFeature
@@ -51,12 +52,13 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
 
         hideToolbarFeature.set(
             feature = WebAppHideToolbarFeature(
-                layout.toolbar,
                 components.store,
                 components.customTabsStore,
                 sessionId,
                 manifest
-            ),
+            ) { toolbarVisible ->
+                layout.toolbar.isVisible = toolbarVisible
+            },
             owner = this,
             view = layout.toolbar)
 


### PR DESCRIPTION
One more tweak for the PWA toolbar system. This makes the Fenix integration easier.