### PR TITLE
Closes #7244: PlacesHistoryStorage crash in Sample Browser

### DIFF
--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -54,12 +54,6 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         lifecycle.addObserver(webExtensionPopupFeature)
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-
-        components.historyStorage.cleanup()
-    }
-
     override fun onBackPressed() {
         supportFragmentManager.fragments.forEach {
             if (it is UserInteractionHandler && it.onBackPressed()) {


### PR DESCRIPTION
Removes the `cleanup` call as it permanently leaves the `Connection` unusable and we're not re-initializing or creating a new instance of it. It's not clear to us how this should be used right now.

Also makes all access to `api` thread-safe.