### PR TITLE
Close #7297: Add support for source URL to WebNotification

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -21,6 +21,6 @@ internal class GeckoWebNotificationDelegate(
     }
 
     private fun GeckoViewWebNotification.toWebNotification(): WebNotification {
-        return WebNotification(title, tag, text, imageUrl, textDirection, lang, requireInteraction)
+        return WebNotification(title, tag, text, "", imageUrl, textDirection, lang, requireInteraction)
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -21,6 +21,6 @@ internal class GeckoWebNotificationDelegate(
     }
 
     private fun GeckoViewWebNotification.toWebNotification(): WebNotification {
-        return WebNotification(title, tag, text, imageUrl, textDirection, lang, requireInteraction)
+        return WebNotification(title, tag, text, source, imageUrl, textDirection, lang, requireInteraction)
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -21,6 +21,6 @@ internal class GeckoWebNotificationDelegate(
     }
 
     private fun GeckoViewWebNotification.toWebNotification(): WebNotification {
-        return WebNotification(title, tag, text, imageUrl, textDirection, lang, requireInteraction)
+        return WebNotification(title, tag, text, "", imageUrl, textDirection, lang, requireInteraction)
     }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -10,6 +10,7 @@ package mozilla.components.concept.engine.webnotifications
  * @property title Title of the notification to be displayed in the first row.
  * @property tag Tag used to identify the notification.
  * @property body Body of the notification to be displayed in the second row.
+ * @property sourceUrl The URL of the page or Service Worker that generated the notification.
  * @property iconUrl Large icon url to display in the notification.
  * Corresponds to [android.app.Notification.Builder.setLargeIcon].
  * @property direction Preference for text direction.
@@ -21,6 +22,7 @@ data class WebNotification(
     val title: String?,
     val tag: String,
     val body: String?,
+    val sourceUrl: String,
     val iconUrl: String?,
     val direction: String?,
     val lang: String?,

--- a/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
+++ b/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
@@ -20,6 +20,7 @@ import mozilla.components.browser.icons.Icon.Source
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.icons.IconRequest.Size
 import mozilla.components.concept.engine.webnotifications.WebNotification
+import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 
 internal class NativeNotificationBridge(
     private val icons: BrowserIcons,
@@ -59,6 +60,7 @@ internal class NativeNotificationBridge(
             }
 
             builder.setSmallIcon(smallIcon)
+                .setSubText(sourceUrl.tryGetHostFromUrl())
                 .setContentTitle(title)
                 .setContentText(body)
                 .setShowWhen(true)

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/NativeNotificationBridgeTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.webnotifications
 
+import android.app.Notification.EXTRA_SUB_TEXT
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -18,6 +19,7 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,12 +29,13 @@ import org.mockito.Mockito.verify
 private const val TEST_TITLE = "test title"
 private const val TEST_TAG = "test tag"
 private const val TEST_TEXT = "test text"
+private const val TEST_URL = "mozilla.org"
 private const val TEST_CHANNEL = "testChannel"
 
 @RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi
 class NativeNotificationBridgeTest {
-    private val blankNotification = WebNotification(TEST_TITLE, TEST_TAG, TEST_TEXT, null, null,
+    private val blankNotification = WebNotification(TEST_TITLE, TEST_TAG, TEST_TEXT, TEST_URL, null, null,
             null, true, 0)
 
     private lateinit var icons: BrowserIcons
@@ -62,6 +65,7 @@ class NativeNotificationBridgeTest {
         assertEquals(0, notification.`when`)
         assertNotNull(notification.smallIcon)
         assertNull(notification.getLargeIcon())
+        assertTrue(notification.extras.containsKey(EXTRA_SUB_TEXT))
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,9 @@ permalink: /changelog/
   * Adds a new storage component to store containers (contextual identities) in a Room database and provides the
     necessary APIs to get, add and remove containers.
 
+* **feature-webnotifications**
+  * Adds support for displaying the `source` URL the WebNotification originated from.
+
 * **feature-tabs**
   * ⚠️ **This is a breaking change**: `TabsFeature` now supports providing custom use case implementations. Therefore, an instance of `SelectTabUseCase` and `RemoveTabUseCase` have to be provided.
 
@@ -119,6 +122,7 @@ permalink: /changelog/
 
 * **feature-downloads**
   * ⚠️ **This is a breaking change**: DownloadManager and DownloadService are now using the browser store to keep track of queued downloads. Therefore, an instance of the store needs to be provided when constructing manager and service. There's also a new DownloadMiddleware which needs to be provided to the store.
+
   ```kotlin
    val store by lazy {
         BrowserStore(middleware = listOf(
@@ -153,6 +157,7 @@ permalink: /changelog/
     override val store: BrowserStore by lazy { components.core.store } // Store needs to be provided now
   }
   ```
+
   * Fixed issue [#6893](https://github.com/mozilla-mobile/android-components/issues/6893).
   * Add notification grouping to downloads Fenix issue [#4910](https://github.com/mozilla-mobile/android-components/issues/4910).
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

A small change to support showing the source of the WebNotification.

<img width="522" alt="Screen Shot 2020-06-12 at 5 41 56 AM" src="https://user-images.githubusercontent.com/1370580/84489408-aeaad500-ac6f-11ea-8670-bca63c0e15f1.png">

r? @rocketsroger

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
