### PR TITLE
Closes #7359: Register WebCompat add-on with ID matching manifest

### DIFF
--- a/components/feature/webcompat/src/main/java/mozilla/components/feature/webcompat/WebCompatFeature.kt
+++ b/components/feature/webcompat/src/main/java/mozilla/components/feature/webcompat/WebCompatFeature.kt
@@ -13,7 +13,7 @@ import mozilla.components.support.base.log.logger.Logger
 object WebCompatFeature {
     private val logger = Logger("mozac-webcompat")
 
-    internal const val WEBCOMPAT_EXTENSION_ID = "webcompat@mozilla.com"
+    internal const val WEBCOMPAT_EXTENSION_ID = "webcompat@mozilla.org"
     internal const val WEBCOMPAT_EXTENSION_URL = "resource://android/assets/extensions/webcompat/"
 
     /**


### PR DESCRIPTION
The ID should match the one in the manifest. Noticed this when testing migration and found two entries with separate UUIDs in prefs.js.

Safe to change to now as we're still using the transient `registerWebExtension`, tricky later once we switch to `installBuiltIn`.

r? @denschub 