### PR TITLE
Provide request interceptor to automatically navigate into PWAs

### DIFF
--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -269,6 +269,8 @@ class SystemEngineView @JvmOverloads constructor(
 
                                 super.shouldInterceptRequest(view, request)
                             }
+
+                            is InterceptionResponse.Deny -> super.shouldInterceptRequest(view, request)
                         }
                     }
                 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
@@ -26,6 +26,11 @@ interface RequestInterceptor {
         data class Url(val url: String) : InterceptionResponse()
 
         data class AppIntent(val appIntent: Intent, val url: String) : InterceptionResponse()
+
+        /**
+         * Deny request without further action.
+         */
+        object Deny : InterceptionResponse()
     }
 
     /**

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppInterceptor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppInterceptor.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.feature.pwa.ext.putUrlOverride
+import mozilla.components.feature.pwa.intent.WebAppIntentProcessor
+
+/**
+ * This feature will intercept requests and reopen them in the corresponding installed PWA, if any.
+ *
+ * @param shortcutManager current shortcut manager instance to lookup web app install states
+ */
+class WebAppInterceptor(
+    private val context: Context,
+    private val manifestStorage: ManifestStorage,
+    private val launchFromInterceptor: Boolean = true
+) : RequestInterceptor {
+
+    @Suppress("ReturnCount")
+    override fun onLoadRequest(
+        engineSession: EngineSession,
+        uri: String,
+        hasUserGesture: Boolean,
+        isSameDomain: Boolean,
+        isRedirect: Boolean,
+        isDirectNavigation: Boolean
+    ): RequestInterceptor.InterceptionResponse? {
+        val scope = manifestStorage.getInstalledScope(uri) ?: return null
+        val startUrl = manifestStorage.getStartUrlForInstalledScope(scope) ?: return null
+        val intent = createIntentFromUri(startUrl, uri)
+
+        if (!launchFromInterceptor) {
+            return RequestInterceptor.InterceptionResponse.AppIntent(intent, uri)
+        }
+
+        intent.flags = intent.flags or Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(intent)
+
+        return RequestInterceptor.InterceptionResponse.Deny
+    }
+
+    /**
+     * Creates a new VIEW_PWA intent for a URL.
+     *
+     * @param uri target URL for the new intent
+     */
+    private fun createIntentFromUri(startUrl: String, urlOverride: String = startUrl): Intent {
+        return Intent(WebAppIntentProcessor.ACTION_VIEW_PWA, Uri.parse(startUrl)).apply {
+            this.addCategory(Intent.CATEGORY_DEFAULT)
+            this.putUrlOverride(urlOverride)
+        }
+    }
+}

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestDao.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestDao.kt
@@ -43,4 +43,8 @@ internal interface ManifestDao {
     @WorkerThread
     @Query("DELETE FROM manifests WHERE start_url IN (:startUrls)")
     fun deleteManifests(startUrls: List<String>)
+
+    @WorkerThread
+    @Query("SELECT * from manifests WHERE used_at > :expiresAt ORDER BY LENGTH(scope)")
+    fun getInstalledScopes(expiresAt: Long): List<ManifestEntity>
 }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Intent.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ext/Intent.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.concept.engine.manifest.WebAppManifestParser
 
+internal const val EXTRA_URL_OVERRIDE = "mozilla.components.feature.pwa.EXTRA_URL_OVERRIDE"
+
 /**
  * Add extended [WebAppManifest] data to the intent.
  */
@@ -22,3 +24,25 @@ fun Intent.putWebAppManifest(webAppManifest: WebAppManifest) {
 fun Intent.getWebAppManifest(): WebAppManifest? {
     return extras?.getWebAppManifest()
 }
+
+/**
+ * Add [String] URL override to the intent.
+ *
+ * @param url The URL override value.
+ *
+ * @return Returns the same Intent object, for chaining multiple calls
+ * into a single statement.
+ *
+ * @see [getUrlOverride]
+ */
+fun Intent.putUrlOverride(url: String?): Intent {
+    return putExtra(EXTRA_URL_OVERRIDE, url)
+}
+
+/**
+ * Retrieves [String] Url override from the intent.
+ *
+ * @return The URL override previously added with [putUrlOverride],
+ * or null if no URL was found.
+ */
+fun Intent.getUrlOverride(): String? = getStringExtra(EXTRA_URL_OVERRIDE)

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppInterceptorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppInterceptorTest.kt
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.request.RequestInterceptor
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WebAppInterceptorTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockEngineSession: EngineSession
+    private lateinit var mockManifestStorage: ManifestStorage
+    private lateinit var webAppInterceptor: WebAppInterceptor
+
+    private val webUrl = "https://example.com"
+    private val webUrlWithWebApp = "https://google.com/maps/"
+    private val webUrlOutOfScope = "https://google.com/search/"
+
+    @Before
+    fun setup() {
+        mockContext = mock()
+        mockEngineSession = mock()
+        mockManifestStorage = mock()
+
+        webAppInterceptor = WebAppInterceptor(
+            context = mockContext,
+            manifestStorage = mockManifestStorage,
+            launchFromInterceptor = true
+        )
+    }
+
+    @Test
+    fun `request is intercepted when navigating to an installed web app`() {
+        whenever(mockManifestStorage.getInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
+        whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
+
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false)
+
+        assert(response is RequestInterceptor.InterceptionResponse.Deny)
+    }
+
+    @Test
+    fun `request is not intercepted when url is out of scope`() {
+        whenever(mockManifestStorage.getInstalledScope(webUrlOutOfScope)).thenReturn(null)
+        whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlOutOfScope)).thenReturn(null)
+
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlOutOfScope, true, false, false, false)
+
+        assertNull(response)
+    }
+
+    @Test
+    fun `request is not intercepted when url is not part of a web app`() {
+        whenever(mockManifestStorage.getInstalledScope(webUrl)).thenReturn(null)
+        whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrl)).thenReturn(null)
+
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrl, true, false, false, false)
+
+        assertNull(response)
+    }
+
+    @Test
+    fun `request is intercepted with app intent if not launchFromInterceptor`() {
+        webAppInterceptor = WebAppInterceptor(
+            context = mockContext,
+            manifestStorage = mockManifestStorage,
+            launchFromInterceptor = false
+        )
+
+        whenever(mockManifestStorage.getInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
+        whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
+
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false)
+
+        assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
+    }
+
+    @Test
+    fun `launchFromInterceptor is enabled by default`() {
+        webAppInterceptor = WebAppInterceptor(
+            context = mockContext,
+            manifestStorage = mockManifestStorage
+        )
+
+        whenever(mockManifestStorage.getInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
+        whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
+
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false)
+
+        assert(response is RequestInterceptor.InterceptionResponse.Deny)
+    }
+}

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -53,6 +53,7 @@ import mozilla.components.feature.intent.processing.TabIntentProcessor
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.middleware.MediaMiddleware
 import mozilla.components.feature.pwa.ManifestStorage
+import mozilla.components.feature.pwa.WebAppInterceptor
 import mozilla.components.feature.pwa.WebAppShortcutManager
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.pwa.intent.TrustedWebActivityIntentProcessor
@@ -206,6 +207,13 @@ open class DefaultComponents(private val applicationContext: Context) {
                 applicationContext.components.preferences.getBoolean(PREF_LAUNCH_EXTERNAL_APP, false)
             },
             launchFromInterceptor = true
+        )
+    }
+
+    val webAppInterceptor by lazy {
+        WebAppInterceptor(
+            applicationContext,
+            webAppManifestStorage
         )
     }
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -5,6 +5,9 @@
 package org.mozilla.samples.browser
 
 import android.app.Application
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import mozilla.appservices.Megazord
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.fetch.Client
@@ -50,6 +53,10 @@ class SampleApplication : Application() {
         Facts.registerProcessor(LogFactProcessor())
 
         components.engine.warmUp()
+
+        GlobalScope.launch(Dispatchers.IO) {
+            components.webAppManifestStorage.warmUpScopes(System.currentTimeMillis())
+        }
 
         try {
             GlobalAddonDependencyProvider.initialize(

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
@@ -27,8 +27,17 @@ class SampleRequestInterceptor(val context: Context) : RequestInterceptor {
     ): InterceptionResponse? {
         return when (uri) {
             "sample:about" -> InterceptionResponse.Content("<h1>I am the sample browser</h1>")
-            else -> context.components.appLinksInterceptor.onLoadRequest(
-                engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation)
+            else -> {
+                var response = context.components.appLinksInterceptor.onLoadRequest(
+                        engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation)
+
+                if (response == null && !isDirectNavigation) {
+                    response = context.components.webAppInterceptor.onLoadRequest(
+                        engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation)
+                }
+
+                response
+            }
         }
     }
 


### PR DESCRIPTION
For #7366 and mozilla-mobile/fenix#5772

- a WebAppInterceptor is needed to redirect to a separate WebApp
  activity
- the manifest dao currently reports a web app as installed when it was
  last used before the deadline / expiration time. This is the oposite
  of what it's supposed to do.
- The intent extension should also hold an override URL so a WebApp
  intent can be launched with a deeplink.
- The WebAppIntentProcessor currently launches new sessions for each
  intent. This will break user expectations when they start to be
  switched to a already running WebApp activity but loose their session.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
