### PR TITLE
Let EngineSessions request release from their EngineView

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -314,6 +314,13 @@ class GeckoEngineSession(
         }
     }
 
+    @Synchronized
+    override fun releaseFromView() {
+        notifyObservers {
+            onReleaseFromView()
+        }
+    }
+
     /**
      * See [EngineSession.markActiveForWebExtensions].
      */

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -72,6 +72,10 @@ class GeckoEngineView @JvmOverloads constructor(
             visibility = View.VISIBLE
         }
 
+        override fun onReleaseFromView() {
+            release()
+        }
+
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
         override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
     }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -2527,6 +2527,24 @@ class GeckoEngineSessionTest {
         engineSession.goBack()
         assertFalse(observedOnNavigateBack)
     }
+
+    @Test
+    fun `releaseFromView notifies observers`() {
+        var observerCalled = false
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onReleaseFromView() {
+                observerCalled = true
+            }
+        })
+
+        engineSession.releaseFromView()
+
+        assertTrue(observerCalled)
+    }
+
     private fun mockGeckoSession(): GeckoSession {
         val session = mock<GeckoSession>()
         whenever(session.settings).thenReturn(

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -314,6 +314,13 @@ class GeckoEngineSession(
         }
     }
 
+    @Synchronized
+    override fun releaseFromView() {
+        notifyObservers {
+            onReleaseFromView()
+        }
+    }
+
     /**
      * See [EngineSession.markActiveForWebExtensions].
      */

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -72,6 +72,10 @@ class GeckoEngineView @JvmOverloads constructor(
             visibility = View.VISIBLE
         }
 
+        override fun onReleaseFromView() {
+            release()
+        }
+
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
         override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
     }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -2527,6 +2527,24 @@ class GeckoEngineSessionTest {
         engineSession.goBack()
         assertFalse(observedOnNavigateBack)
     }
+
+    @Test
+    fun `releaseFromView notifies observers`() {
+        var observerCalled = false
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onReleaseFromView() {
+                observerCalled = true
+            }
+        })
+
+        engineSession.releaseFromView()
+
+        assertTrue(observerCalled)
+    }
+
     private fun mockGeckoSession(): GeckoSession {
         val session = mock<GeckoSession>()
         whenever(session.settings).thenReturn(

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -313,6 +313,13 @@ class GeckoEngineSession(
         }
     }
 
+    @Synchronized
+    override fun releaseFromView() {
+        notifyObservers {
+            onReleaseFromView()
+        }
+    }
+
     /**
      * See [EngineSession.markActiveForWebExtensions].
      */

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -72,6 +72,10 @@ class GeckoEngineView @JvmOverloads constructor(
             visibility = View.VISIBLE
         }
 
+        override fun onReleaseFromView() {
+            release()
+        }
+
         override fun onAppPermissionRequest(permissionRequest: PermissionRequest) = Unit
         override fun onContentPermissionRequest(permissionRequest: PermissionRequest) = Unit
     }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -2447,6 +2447,24 @@ class GeckoEngineSessionTest {
         engineSession.goBack()
         assertFalse(observedOnNavigateBack)
     }
+
+    @Test
+    fun `releaseFromView notifies observers`() {
+        var observerCalled = false
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onReleaseFromView() {
+                observerCalled = true
+            }
+        })
+
+        engineSession.releaseFromView()
+
+        assertTrue(observerCalled)
+    }
+
     private fun mockGeckoSession(): GeckoSession {
         val session = mock<GeckoSession>()
         whenever(session.settings).thenReturn(

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -387,6 +387,12 @@ class SystemEngineSession(
         fullScreenCallback?.onCustomViewHidden()
     }
 
+    override fun releaseFromView() {
+        notifyObservers {
+            onReleaseFromView()
+        }
+    }
+
     internal fun toggleDesktopUA(userAgent: String, requestDesktop: Boolean): String {
         return if (requestDesktop) {
             userAgent.replace("Mobile", "eliboM").replace("Android", "diordnA")

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -986,4 +986,20 @@ class SystemEngineSessionTest {
         engineSession.goBack()
         assertTrue(observedOnNavigateBack)
     }
+
+    @Test
+    fun `releaseFromView notifies observers`() {
+        var observerCalled = false
+        val engineSession = SystemEngineSession(testContext)
+
+        engineSession.register(object : EngineSession.Observer {
+            override fun onReleaseFromView() {
+                observerCalled = true
+            }
+        })
+
+        engineSession.releaseFromView()
+
+        assertTrue(observerCalled)
+    }
 }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -131,6 +131,11 @@ abstract class EngineSession(
          * @param currentIndex Index of the current page in the history list.
          */
         fun onHistoryStateChanged(historyList: List<HistoryItem>, currentIndex: Int) = Unit
+
+        /**
+         * The session want's to be released from it's current view.
+         */
+        fun onReleaseFromView() = Unit
     }
 
     /**
@@ -532,6 +537,11 @@ abstract class EngineSession(
      * Returns true if a last known state was restored, otherwise false.
      */
     abstract fun recoverFromCrash(): Boolean
+
+    /**
+     * Requests from all observers to be released from its current view.
+     */
+    abstract fun releaseFromView()
 
     /**
      * Marks this session active/inactive for web extensions to support

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -95,6 +95,7 @@ class EngineSessionTest {
         verify(observer).onMediaAdded(mediaAdded)
         verify(observer).onMediaRemoved(mediaRemoved)
         verify(observer).onCrash()
+        verify(observer).onReleaseFromView()
         verify(observer).onLoadRequest("https://www.mozilla.org", true, true)
         verify(observer).onLaunchIntentRequest("https://www.mozilla.org", null)
         verify(observer).onProcessKilled()
@@ -133,6 +134,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onWindowRequest(windowRequest) }
         session.notifyInternalObservers { onCrash() }
+        session.notifyInternalObservers { onReleaseFromView() }
         session.notifyInternalObservers { onLoadRequest("https://www.mozilla.org", true, true) }
         session.notifyInternalObservers { onLaunchIntentRequest("https://www.mozilla.org", null) }
         session.unregister(observer)
@@ -160,6 +162,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaAdded(mediaAdded) }
         session.notifyInternalObservers { onMediaRemoved(mediaRemoved) }
         session.notifyInternalObservers { onCrash() }
+        session.notifyInternalObservers { onReleaseFromView() }
         session.notifyInternalObservers { onLoadRequest("https://www.mozilla.org", true, true) }
         session.notifyInternalObservers { onLaunchIntentRequest("https://www.firefox.com", null) }
 
@@ -181,6 +184,7 @@ class EngineSessionTest {
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
         verify(observer).onWindowRequest(windowRequest)
         verify(observer).onCrash()
+        verify(observer).onReleaseFromView()
         verify(observer).onLoadRequest("https://www.mozilla.org", true, true)
         verify(observer).onLaunchIntentRequest("https://www.mozilla.org", null)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
@@ -240,6 +244,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onReleaseFromView() }
 
         session.unregisterObservers()
 
@@ -260,6 +265,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onReleaseFromView() }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -278,6 +284,7 @@ class EngineSessionTest {
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
         verify(observer).onWindowRequest(windowRequest)
+        verify(observer).onReleaseFromView()
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -295,6 +302,7 @@ class EngineSessionTest {
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onWindowRequest(otherWindowRequest)
+        verify(observer, never()).onReleaseFromView()
         verify(otherObserver, never()).onLocationChange("https://www.firefox.com")
         verify(otherObserver, never()).onProgress(100)
         verify(otherObserver, never()).onLoadingStateChange(false)
@@ -312,6 +320,7 @@ class EngineSessionTest {
         verify(otherObserver, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(otherObserver, never()).onCancelContentPermissionRequest(otherPermissionRequest)
         verify(otherObserver, never()).onWindowRequest(otherWindowRequest)
+        verify(otherObserver, never()).onReleaseFromView()
     }
 
     @Test
@@ -345,6 +354,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onReleaseFromView() }
 
         session.close()
 
@@ -365,6 +375,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onWindowRequest(otherWindowRequest) }
+        session.notifyInternalObservers { onReleaseFromView() }
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
@@ -383,6 +394,7 @@ class EngineSessionTest {
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
         verify(observer).onWindowRequest(windowRequest)
+        verify(observer).onReleaseFromView()
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -400,6 +412,7 @@ class EngineSessionTest {
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onWindowRequest(otherWindowRequest)
+        verify(observer, never()).onReleaseFromView()
         verifyNoMoreInteractions(observer)
     }
 
@@ -432,6 +445,7 @@ class EngineSessionTest {
         otherSession.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         otherSession.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
         otherSession.notifyInternalObservers { onWindowRequest(windowRequest) }
+        otherSession.notifyInternalObservers { onReleaseFromView() }
         verify(observer, never()).onLocationChange("https://www.mozilla.org")
         verify(observer, never()).onProgress(25)
         verify(observer, never()).onLoadingStateChange(true)
@@ -449,6 +463,7 @@ class EngineSessionTest {
         verify(observer, never()).onContentPermissionRequest(permissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(permissionRequest)
         verify(observer, never()).onWindowRequest(windowRequest)
+        verify(observer, never()).onReleaseFromView()
 
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
@@ -467,6 +482,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onWindowRequest(windowRequest) }
+        session.notifyInternalObservers { onReleaseFromView() }
         verify(observer, times(1)).onLocationChange("https://www.mozilla.org")
         verify(observer, times(1)).onProgress(25)
         verify(observer, times(1)).onLoadingStateChange(true)
@@ -484,6 +500,7 @@ class EngineSessionTest {
         verify(observer, times(1)).onContentPermissionRequest(permissionRequest)
         verify(observer, times(1)).onCancelContentPermissionRequest(permissionRequest)
         verify(observer, times(1)).onWindowRequest(windowRequest)
+        verify(observer, times(1)).onReleaseFromView()
         verifyNoMoreInteractions(observer)
     }
 
@@ -699,6 +716,7 @@ class EngineSessionTest {
         defaultObserver.onMediaAdded(mock())
         defaultObserver.onMediaRemoved(mock())
         defaultObserver.onCrash()
+        defaultObserver.onReleaseFromView()
     }
 
     @Test
@@ -805,6 +823,7 @@ class EngineSessionTest {
         observer.onLoadRequest("https://www.mozilla.org", true, true)
         observer.onLaunchIntentRequest("https://www.mozilla.org", null)
         observer.onProcessKilled()
+        observer.onReleaseFromView()
     }
 }
 
@@ -850,6 +869,8 @@ open class DummyEngineSession : EngineSession() {
     override fun recoverFromCrash(): Boolean {
         return false
     }
+
+    override fun releaseFromView() {}
 
     // Helper method to access the protected method from test cases.
     fun notifyInternalObservers(block: Observer.() -> Unit) {

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/ExternalAppBrowserActivity.kt
@@ -6,6 +6,7 @@ package org.mozilla.samples.browser
 
 import androidx.fragment.app.Fragment
 import mozilla.components.feature.pwa.ext.getWebAppManifest
+import org.mozilla.samples.browser.ext.components
 
 /**
  * Activity that holds the [BrowserFragment] that is launched within an external app,
@@ -17,6 +18,8 @@ class ExternalAppBrowserActivity : BrowserActivity() {
         return if (sessionId != null) {
             val manifest = intent.getWebAppManifest()
 
+            ensureSessionIsReleased(sessionId)
+
             ExternalAppBrowserFragment.create(
                 sessionId,
                 manifest = manifest
@@ -25,5 +28,12 @@ class ExternalAppBrowserActivity : BrowserActivity() {
             // Fall back to browser fragment
             super.createBrowserFragment(sessionId)
         }
+    }
+
+    private fun ensureSessionIsReleased(sessionId: String) {
+        val session = components.sessionManager.findSessionById(sessionId) ?: return
+        val engineSession = components.sessionManager.getOrCreateEngineSession(session)
+
+        engineSession.releaseFromView()
     }
 }


### PR DESCRIPTION
For #7380 and mozilla-mobile/fenix#5772

`EngineSession`s should be able to notifiy observers that they want to be
releasd from their current `EngineView`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
