### PR TITLE
For #7392 - Material design sanity checks for BrowserMenu min/max width

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerView.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerView.kt
@@ -10,6 +10,7 @@ import android.util.AttributeSet
 import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.browser.menu.R
+import mozilla.components.support.ktx.android.util.dpToPx
 
 /**
  * [RecylerView] with automatically set width between widthMin / widthMax xml attributes.
@@ -48,18 +49,27 @@ class DynamicWidthRecyclerView @JvmOverloads constructor(
         desiredWidth: Int,
         desiredHeight: Int
     ) {
-        val minimumWidth = desiredWidth.coerceAtLeast(minWidth)
-
-        val reconciledWidth = minimumWidth
+        val reconciledWidth = desiredWidth
+            .coerceAtLeast(minWidth)
+            // Follow material guidelines where the minimum width is 112dp.
+            .coerceAtLeast(getMaterialMinimumItemWidthInPx())
             .coerceAtMost(maxWidth)
-            // Sanity check our xml set maxWidth.
-            .coerceAtMost(getScreenWidth())
+            // Leave at least 48dp as a tappable “exit area” available whenever the menu is open.
+            .coerceAtMost(getScreenWidth() - getMaterialMinimumTapAreaInPx())
 
         callSetMeasuredDimension(reconciledWidth, desiredHeight)
     }
 
     @VisibleForTesting()
     internal fun getScreenWidth(): Int = resources.displayMetrics.widthPixels
+
+    @VisibleForTesting()
+    internal fun getMaterialMinimumTapAreaInPx() =
+        MATERIAL_MINIMUM_TAP_AREA_DP.dpToPx(resources.displayMetrics)
+
+    @VisibleForTesting()
+    internal fun getMaterialMinimumItemWidthInPx() =
+        MATERIAL_MINIMUM_ITEM_WIDTH_DP.dpToPx(resources.displayMetrics)
 
     @SuppressLint("WrongCall")
     @VisibleForTesting()
@@ -72,5 +82,11 @@ class DynamicWidthRecyclerView @JvmOverloads constructor(
     // Used for testing final protected setMeasuredDimension(..) calls were executed
     internal fun callSetMeasuredDimension(width: Int, height: Int) {
         setMeasuredDimension(width, height)
+    }
+
+    @VisibleForTesting()
+    internal companion object {
+        const val MATERIAL_MINIMUM_TAP_AREA_DP = 48
+        const val MATERIAL_MINIMUM_ITEM_WIDTH_DP = 112
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -81,6 +81,11 @@ permalink: /changelog/
 * **browser-tabstray**:
   * ⚠️ **This is a breaking change**: `TabsAdapter` and `DefaultTabViewHolder` take an optional `ImageLoader` for loading browser thumbnails.
   * Fixed a bug in `TabsThumbnailView` where the `scaleFactor` was not applied all the time when expected.
+  
+* **browser-menu**:
+  * DynamicWidthRecyclerView will still be able to have a dynamic width between xml set minWidth and maxWidth attributes but we'll now enforce the following:
+    - minimum width 112 dp
+    - maximum width - screen width minus a 48dp tappable “exit area”
 
 # 44.0.0
 


### PR DESCRIPTION
DynamicWidthRecyclerView will still be able to have a dynamic width between xml
set minWidth and maxWidth attributes but we'll now enforce the following:
- minimum width 112 dp
- maximum width - screen width minus a 48dp tappable “exit area”
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).


Result in Fenix:
![DynamicWidthBrowserMenuWLimits](https://user-images.githubusercontent.com/11428869/84674063-29574700-af33-11ea-8b6f-d63f10f859f9.gif)

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
