### PR TITLE
Closes issue #7398: Avoid passing negative values to the download contentLength

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -182,11 +182,14 @@ internal class EngineObserver(
         cookie: String?,
         userAgent: String?
     ) {
+        // We want to avoid negative contentLength values
+        // For more info see https://bugzilla.mozilla.org/show_bug.cgi?id=1632594
+        val fileSize = if (contentLength != null && contentLength < 0) null else contentLength
         val download = DownloadState(
             url,
             fileName,
             contentType,
-            contentLength,
+            fileSize,
             userAgent,
             Environment.DIRECTORY_DOWNLOADS
         )


### PR DESCRIPTION
We are getting negative [values from GV](https://bugzilla.mozilla.org/show_bug.cgi?id=1632594#c5), I think we should avoid entering these values into AC 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
