### PR TITLE
Closes #7397: Integrate GV API for runtime.openOptionsPage

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -279,6 +279,17 @@ class GeckoWebExtension(
                 )
                 return GeckoResult.fromValue(geckoEngineSession.geckoSession)
             }
+
+            override fun onOpenOptionsPage(ext: GeckoNativeWebExtension) {
+                ext.metaData?.optionsPageUrl?.let { optionsPageUrl ->
+                    tabHandler.onNewTab(
+                        this@GeckoWebExtension,
+                        GeckoEngineSession(runtime),
+                        false,
+                        optionsPageUrl
+                    )
+                }
+            }
         }
 
         nativeExtension.tabDelegate = tabDelegate

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -161,7 +161,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         AddonCollectionProvider(
             applicationContext,
             client,
-            collectionName = "16f6e5d9a40448b8955db57ced6d75",
+            collectionName = "3204bb44a6ef44d39ee34917f28055",
             maxCacheAgeInMinutes = DAY_IN_MINUTES
         )
     }


### PR DESCRIPTION
Decided to go with the simplest solution that works, similar to Fennec/Desktop, and open a new tab when the options page is triggered via JavaScript.

We may want to make this customizable in the future and support deep linking into our AddosManager/Addon/Settings UI, but this doesn't seem needed right now. It's also tricky for us as we don't use `about:addons`, but have a native UI instead. The user experience definitely feels better this way too.

Other changes:
- Use M3 add-ons so we can test decentraleyes etc.
- Make sure our action popup (in Sample Browser) responds to `window.close`