### PR TITLE
For #7422 - Handles case where synced devices exist but have no open tabs

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -147,7 +147,7 @@ data class Tab(
 }
 
 /**
- * A synced device and the list of tabs.
+ * A synced device and its list of tabs.
  */
 data class SyncedDeviceTabs(
     val device: Device,

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
@@ -30,7 +30,7 @@ class SyncedTabsStorageSuggestionProvider(
         }
 
         val results = mutableListOf<ClientTabPair>()
-        for ((client, tabs) in syncedTabs.getSyncedTabs()) {
+        for ((client, tabs) in syncedTabs.getSyncedDeviceTabs()) {
             for (tab in tabs) {
                 val activeTabEntry = tab.active()
                 // This is a fairly naive match implementation, but this is what we do on Desktop 🤷.

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/controller/DefaultController.kt
@@ -32,14 +32,16 @@ internal class DefaultController(
 
         scope.launch {
             accountManager.withConstellation {
-                val syncedTabs = provider.getSyncedTabs()
+                val syncedDeviceTabs = provider.getSyncedDeviceTabs()
                 val otherDevices = state()?.otherDevices
 
                 scope.launch(Dispatchers.Main) {
-                    if (syncedTabs.isEmpty() && otherDevices?.isEmpty() == true) {
+                    if (syncedDeviceTabs.isEmpty() && otherDevices?.isEmpty() == true) {
                         view.onError(ErrorType.MULTIPLE_DEVICES_UNAVAILABLE)
+                    } else if (!syncedDeviceTabs.any { it.tabs.isNotEmpty() }) {
+                        view.onError(ErrorType.NO_TABS_AVAILABLE)
                     } else {
-                        view.displaySyncedTabs(syncedTabs)
+                        view.displaySyncedTabs(syncedDeviceTabs)
                     }
                 }
             }

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsProvider.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsProvider.kt
@@ -12,7 +12,7 @@ import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 interface SyncedTabsProvider {
 
     /**
-     * A list of [SyncedDeviceTabs] containing the tabs of the remote devices for the account.
+     * A list of [SyncedDeviceTabs], each containing a synced device and its current tabs.
      */
-    suspend fun getSyncedTabs(): List<SyncedDeviceTabs>
+    suspend fun getSyncedDeviceTabs(): List<SyncedDeviceTabs>
 }

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
@@ -60,9 +60,9 @@ class SyncedTabsStorage(
     }
 
     /**
-     * See [SyncedTabsProvider.getSyncedTabs].
+     * See [SyncedTabsProvider.getSyncedDeviceTabs].
      */
-    override suspend fun getSyncedTabs(): List<SyncedDeviceTabs> {
+    override suspend fun getSyncedDeviceTabs(): List<SyncedDeviceTabs> {
         val otherDevices = syncClients() ?: return emptyList()
         return tabsStorage.getAll()
             .mapNotNull { (client, tabs) ->

--- a/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/view/SyncedTabsView.kt
+++ b/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/view/SyncedTabsView.kt
@@ -61,6 +61,11 @@ interface SyncedTabsView {
     enum class ErrorType {
 
         /**
+         * Other devices found but there are no tabs to sync.
+         * */
+        NO_TABS_AVAILABLE,
+
+        /**
          * There are no other devices found with this account and therefore no tabs to sync.
          */
         MULTIPLE_DEVICES_UNAVAILABLE,

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
@@ -82,7 +82,7 @@ class SyncedTabsStorageSuggestionProviderTest {
                 )
             )
         )
-        whenever(syncedTabs.getSyncedTabs()).thenReturn(listOf(deviceTabs1, deviceTabs2))
+        whenever(syncedTabs.getSyncedDeviceTabs()).thenReturn(listOf(deviceTabs1, deviceTabs2))
 
         val suggestions = provider.onInputChanged("bobo")
         assertEquals(3, suggestions.size)

--- a/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -134,7 +134,7 @@ class SyncedTabsStorageTest {
             SyncClient("client-unknown") to listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0))
         ))
 
-        val result = feature.getSyncedTabs()
+        val result = feature.getSyncedDeviceTabs()
         assertEquals(device1, result[0].device)
         assertEquals(device2, result[1].device)
         assertEquals(tabsClient1, result[0].tabs)
@@ -151,7 +151,7 @@ class SyncedTabsStorageTest {
             )
         )
         doReturn(null).`when`(feature).syncClients()
-        assertEquals(emptyList<SyncedDeviceTabs>(), feature.getSyncedTabs())
+        assertEquals(emptyList<SyncedDeviceTabs>(), feature.getSyncedDeviceTabs())
     }
 
     @Test


### PR DESCRIPTION
Also renames two methods to provide additional clarity, and fixes a DefaultController test.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

For https://github.com/mozilla-mobile/android-components/issues/7422
**Note:** This PR needs landing before https://github.com/mozilla-mobile/fenix/pull/11634

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint check.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features≥

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
