### PR TITLE
Custom relation checker

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/verify/OriginVerifier.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/verify/OriginVerifier.kt
@@ -18,7 +18,6 @@ import mozilla.components.service.digitalassetlinks.AssetDescriptor
 import mozilla.components.service.digitalassetlinks.Relation.HANDLE_ALL_URLS
 import mozilla.components.service.digitalassetlinks.Relation.USE_AS_ORIGIN
 import mozilla.components.service.digitalassetlinks.RelationChecker
-import mozilla.components.service.digitalassetlinks.api.DigitalAssetLinksApi
 
 /**
  * Used to verify postMessage origin for a designated package name.
@@ -27,14 +26,11 @@ import mozilla.components.service.digitalassetlinks.api.DigitalAssetLinksApi
  * It caches any origin that has been verified during the current application
  * lifecycle and reuses that without making any new network requests.
  */
-@Suppress("LongParameterList")
 class OriginVerifier(
     private val packageName: String,
     @Relation private val relation: Int,
     packageManager: PackageManager,
-    httpClient: Client,
-    apiKey: String?,
-    private val relationChecker: RelationChecker = DigitalAssetLinksApi(httpClient, apiKey)
+    private val relationChecker: RelationChecker
 ) {
 
     @VisibleForTesting

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/OriginVerifierFeatureTest.kt
@@ -36,18 +36,16 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 class OriginVerifierFeatureTest {
 
-    private val apiKey = "XXXXXXXXX"
-
     @Test
     fun `verify fails if no creatorPackageName is saved`() = runBlockingTest {
-        val feature = OriginVerifierFeature(mock(), mock(), apiKey, mock())
+        val feature = OriginVerifierFeature(mock(), mock(), mock())
 
         assertFalse(feature.verify(CustomTabState(), mock(), RELATION_HANDLE_ALL_URLS, mock()))
     }
 
     @Test
     fun `verify returns existing relationship`() = runBlockingTest {
-        val feature = OriginVerifierFeature(mock(), mock(), apiKey, mock())
+        val feature = OriginVerifierFeature(mock(), mock(), mock())
         val origin = "https://example.com".toUri()
         val state = CustomTabState(
             creatorPackageName = "com.example.twa",
@@ -66,7 +64,7 @@ class OriginVerifierFeatureTest {
     fun `verify checks new relationships`() = runBlockingTest {
         val store: CustomTabsServiceStore = mock()
         val verifier: OriginVerifier = mock()
-        val feature = spy(OriginVerifierFeature(mock(), mock(), apiKey) { store.dispatch(it) })
+        val feature = spy(OriginVerifierFeature(mock(), mock()) { store.dispatch(it) })
         doReturn(verifier).`when`(feature).getVerifier(anyString(), anyInt())
         doReturn(true).`when`(verifier).verifyOrigin(any())
 

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/OriginVerifierTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/verify/OriginVerifierTest.kt
@@ -11,12 +11,10 @@ import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Response
 import mozilla.components.service.digitalassetlinks.AssetDescriptor
 import mozilla.components.service.digitalassetlinks.Relation
 import mozilla.components.service.digitalassetlinks.RelationChecker
-import mozilla.components.support.test.any
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -31,12 +29,10 @@ import org.mockito.MockitoAnnotations.initMocks
 @ExperimentalCoroutinesApi
 class OriginVerifierTest {
 
-    private val apiKey = "XXXXXXXXX"
     private val androidAsset = AssetDescriptor.Android(
         packageName = "com.app.name",
         sha256CertFingerprint = "AA:BB:CC:10:20:30:01:02"
     )
-    @Mock private lateinit var client: Client
     @Mock private lateinit var packageManager: PackageManager
     @Mock private lateinit var response: Response
     @Mock private lateinit var body: Response.Body
@@ -47,7 +43,6 @@ class OriginVerifierTest {
     fun setup() {
         initMocks(this)
 
-        doReturn(response).`when`(client).fetch(any())
         doReturn(body).`when`(response).body
         doReturn(200).`when`(response).status
         doReturn("{\"linked\":true}").`when`(body).string()
@@ -76,8 +71,6 @@ class OriginVerifierTest {
             "com.app.name",
             relation,
             packageManager,
-            client,
-            apiKey,
             checker
         ))
         doReturn(androidAsset).`when`(verifier).androidAsset

--- a/components/feature/pwa/build.gradle
+++ b/components/feature/pwa/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':feature-customtabs')
     implementation project(':feature-intent')
     implementation project(':feature-session')
+    implementation project(':service-digitalassetlinks')
     implementation project(':support-base')
     implementation project(':support-images')
     implementation project(':support-ktx')

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -20,7 +20,6 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent
 import mozilla.components.feature.customtabs.feature.OriginVerifierFeature
 import mozilla.components.feature.customtabs.isTrustedWebActivityIntent
@@ -29,6 +28,7 @@ import mozilla.components.feature.intent.ext.putSessionId
 import mozilla.components.feature.intent.processing.IntentProcessor
 import mozilla.components.feature.pwa.ext.toOrigin
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.service.digitalassetlinks.RelationChecker
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.toSafeIntent
 
@@ -38,13 +38,12 @@ import mozilla.components.support.utils.toSafeIntent
 class TrustedWebActivityIntentProcessor(
     private val sessionManager: SessionManager,
     private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase,
-    httpClient: Client,
     packageManager: PackageManager,
-    apiKey: String?,
+    relationChecker: RelationChecker,
     private val store: CustomTabsServiceStore
 ) : IntentProcessor {
 
-    private val verifier = OriginVerifierFeature(httpClient, packageManager, apiKey) { store.dispatch(it) }
+    private val verifier = OriginVerifierFeature(packageManager, relationChecker) { store.dispatch(it) }
     private val scope = MainScope()
 
     private fun matches(intent: Intent): Boolean {

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
@@ -37,7 +37,6 @@ import org.mockito.Mockito.verify
 @ExperimentalCoroutinesApi
 class TrustedWebActivityIntentProcessorTest {
 
-    private val apiKey = "XXXXXXXXX"
     private lateinit var store: BrowserStore
     private lateinit var sessionManager: SessionManager
 
@@ -49,7 +48,7 @@ class TrustedWebActivityIntentProcessorTest {
 
     @Test
     fun `process checks if intent action is not valid`() = runBlockingTest {
-        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), apiKey, mock())
+        val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), mock())
 
         assertFalse(processor.process(Intent(ACTION_VIEW_PWA)))
         assertFalse(processor.process(Intent(ACTION_VIEW)))
@@ -86,7 +85,7 @@ class TrustedWebActivityIntentProcessorTest {
         val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase = mock()
         val customTabsStore: CustomTabsServiceStore = mock()
 
-        val processor = TrustedWebActivityIntentProcessor(sessionManager, loadUrlUseCase, mock(), mock(), apiKey, customTabsStore)
+        val processor = TrustedWebActivityIntentProcessor(sessionManager, loadUrlUseCase, mock(), mock(), customTabsStore)
 
         assertTrue(processor.process(intent))
         val sessionState = store.state.customTabs.first()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,14 @@ permalink: /changelog/
 * **feature-contextmenu**
   * Add "Share image" to context menu.
 
+* **feature-session**
+  * ⚠️ **This is a breaking change**: `AbstractCustomTabsService` now requires `CustomTabsServiceStore`.
+  * ⚠️ **This is a breaking change**: `httpClient` and `apiKey` have been removed from `AbstractCustomTabsService`. They should be replaced with building `DigitalAssetLinksApi` and passing it to `relationChecker`.
+  * Added `relationChecker` to customize Digital Asset Links handling.
+
+* **feature-pwa**
+  * ⚠️ **This is a breaking change**: `TrustedWebActivityIntentProcessor` now requires a `RelationChecker` instead of `httpClient` and `apiKey`.
+
 # 47.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v46.0.0...v47.0.0)
@@ -22,6 +30,9 @@ permalink: /changelog/
 * [Dependencies](https://github.com/mozilla-mobile/android-components/blob/v47.0.0/buildSrc/src/main/java/Dependencies.kt)
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/v47.0.0/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v47.0.0/buildSrc/src/main/java/Config.kt)
+
+* **service-digitalassetlinks**
+  * Added new component for listing and checking Digital Asset Links. Contains a local checker and a version that uses Google's API.
 
 # 46.0.0
 

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -110,6 +110,8 @@ dependencies {
     // SDK. See bug 1592935 for more context.
     implementation project(':service-glean')
 
+    implementation project(':service-digitalassetlinks')
+
     implementation project(':support-utils')
     implementation project(':feature-downloads')
     implementation project(':support-images')

--- a/samples/browser/src/main/AndroidManifest.xml
+++ b/samples/browser/src/main/AndroidManifest.xml
@@ -126,6 +126,7 @@
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="android.support.customtabs.action.CustomTabsService" />
+                <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
                 <category android:name="androidx.browser.trusted.category.NavBarColorCustomization" />
             </intent-filter>
         </service>

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -38,10 +38,10 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
-import mozilla.components.feature.addons.update.AddonUpdater
-import mozilla.components.feature.addons.update.DefaultAddonUpdater
 import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
 import mozilla.components.feature.addons.migration.SupportedAddonsChecker
+import mozilla.components.feature.addons.update.AddonUpdater
+import mozilla.components.feature.addons.update.DefaultAddonUpdater
 import mozilla.components.feature.app.links.AppLinksInterceptor
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
@@ -65,12 +65,14 @@ import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.feature.webnotifications.WebNotificationFeature
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.lib.nearby.NearbyConnection
+import mozilla.components.service.digitalassetlinks.local.StatementApi
+import mozilla.components.service.digitalassetlinks.local.StatementRelationChecker
 import org.mozilla.samples.browser.addons.AddonsActivity
 import org.mozilla.samples.browser.downloads.DownloadService
 import org.mozilla.samples.browser.ext.components
 import org.mozilla.samples.browser.integration.FindInPageIntegration
-import org.mozilla.samples.browser.media.MediaService
 import org.mozilla.samples.browser.integration.P2PIntegration
+import org.mozilla.samples.browser.media.MediaService
 import org.mozilla.samples.browser.request.SampleRequestInterceptor
 import java.util.concurrent.TimeUnit
 
@@ -203,6 +205,11 @@ open class DefaultComponents(private val applicationContext: Context) {
         NearbyConnection(applicationContext)
     }
 
+    // Digital Asset Links checking
+    val relationChecker by lazy {
+        StatementRelationChecker(StatementApi(client))
+    }
+
     // Intent
     val tabIntentProcessor by lazy {
         TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
@@ -213,9 +220,8 @@ open class DefaultComponents(private val applicationContext: Context) {
             TrustedWebActivityIntentProcessor(
                 sessionManager,
                 sessionUseCases.loadUrl,
-                client,
                 applicationContext.packageManager,
-                null,
+                relationChecker,
                 customTabsStore
             ),
             CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, applicationContext.resources)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/customtabs/CustomTabsService.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/customtabs/CustomTabsService.kt
@@ -5,13 +5,13 @@
 package org.mozilla.samples.browser.customtabs
 
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.AbstractCustomTabsService
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
+import mozilla.components.service.digitalassetlinks.RelationChecker
 import org.mozilla.samples.browser.ext.components
 
 class CustomTabsService : AbstractCustomTabsService() {
     override val engine: Engine by lazy { components.engine }
-    override val httpClient: Client by lazy { components.client }
     override val customTabsServiceStore: CustomTabsServiceStore by lazy { components.customTabsStore }
+    override val relationChecker: RelationChecker by lazy { components.relationChecker }
 }


### PR DESCRIPTION
Builds off #7436

The Digital Asset Links relation checker is now exposed to the server, so it can be customized. Apps using A-C can choose to use the pre-existing Google API code, or switch to the new local code that fetches with our HTTP client. They can also pass null to turn off this feature.

The API Key and HTTP client properties are now passed directly to the relation checker instance.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
