### PR TITLE
Issue #7138: Add ImageRequest to ImageLoader to allow consumers to sp…

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -14,6 +14,7 @@ import mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.images.ImageRequest
 import mozilla.components.support.images.loader.ImageLoader
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 
@@ -83,7 +84,7 @@ class DefaultTabViewHolder(
 
         // In the final else case, we have no cache or fresh screenshot; do nothing instead of clearing the image.
         if (thumbnailLoader != null && tab.thumbnail == null) {
-            thumbnailLoader.loadIntoView(thumbnailView, tab.id)
+            thumbnailLoader.loadIntoView(thumbnailView, ImageRequest(tab.id))
         } else if (tab.thumbnail != null) {
             thumbnailView.setImageBitmap(tab.thumbnail)
         }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.images.ImageRequest
 import mozilla.components.support.images.loader.ImageLoader
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
@@ -161,11 +162,11 @@ class DefaultTabViewHolderTest {
 
         viewHolder.bind(tabWithThumbnail, false, mock())
 
-        verify(loader, never()).loadIntoView(any(), eq("123"), nullable(), nullable())
+        verify(loader, never()).loadIntoView(any(), eq(ImageRequest("123")), nullable(), nullable())
 
         viewHolder.bind(tab, false, mock())
 
-        verify(loader).loadIntoView(any(), eq("123"), nullable(), nullable())
+        verify(loader).loadIntoView(any(), eq(ImageRequest("123")), nullable(), nullable())
     }
 
     @Test

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ThumbnailsMiddleware.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ThumbnailsMiddleware.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareStore
+import mozilla.components.support.images.ImageRequest
 
 /**
  * [Middleware] implementation for handling [ContentAction.UpdateThumbnailAction] and storing
@@ -28,7 +29,7 @@ class ThumbnailsMiddleware(
             is ContentAction.UpdateThumbnailAction -> {
                 // Store the captured tab screenshot from the EngineView when the session's
                 // thumbnail is updated.
-                thumbnailStorage.saveThumbnail(action.sessionId, action.thumbnail)
+                thumbnailStorage.saveThumbnail(ImageRequest(action.sessionId), action.thumbnail)
             }
             is TabListAction.RemoveAllNormalTabsAction -> {
                 store.state.tabs.filterNot { it.content.private }.forEach { tab ->

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ext/ThumbnailLoader.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ext/ThumbnailLoader.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.thumbnails.ext
+
+import android.widget.ImageView
+import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
+import mozilla.components.support.images.ImageRequest
+
+/**
+ * Loads an image asynchronously and then displays it in the [ImageView].
+ * If the view is detached from the window before loading is completed, then loading is cancelled.
+ *
+ * @param view [ImageView] to load the image into.
+ * @param id Load image for this given ID.
+ */
+fun ThumbnailLoader.loadIntoView(view: ImageView, id: String) = loadIntoView(view, ImageRequest(id))

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoader.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoader.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.thumbnails.R
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.support.images.CancelOnDetach
+import mozilla.components.support.images.ImageRequest
 import mozilla.components.support.images.loader.ImageLoader
 import java.lang.ref.WeakReference
 
@@ -25,19 +26,19 @@ class ThumbnailLoader(private val storage: ThumbnailStorage) : ImageLoader {
 
     override fun loadIntoView(
         view: ImageView,
-        id: String,
+        request: ImageRequest,
         placeholder: Drawable?,
         error: Drawable?
     ) {
         CoroutineScope(Dispatchers.Main).launch {
-            loadIntoViewInternal(WeakReference(view), id, placeholder, error)
+            loadIntoViewInternal(WeakReference(view), request, placeholder, error)
         }
     }
 
     @MainThread
     private suspend fun loadIntoViewInternal(
         view: WeakReference<ImageView>,
-        id: String,
+        request: ImageRequest,
         placeholder: Drawable?,
         error: Drawable?
     ) {
@@ -48,7 +49,7 @@ class ThumbnailLoader(private val storage: ThumbnailStorage) : ImageLoader {
         view.get()?.setImageDrawable(placeholder)
 
         // Create a loading job
-        val deferredThumbnail = storage.loadThumbnail(id)
+        val deferredThumbnail = storage.loadThumbnail(request)
 
         view.get()?.setTag(R.id.mozac_browser_thumbnails_tag_job, deferredThumbnail)
         val onAttachStateChangeListener = CancelOnDetach(deferredThumbnail).also {

--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCache.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCache.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import com.jakewharton.disklrucache.DiskLruCache
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.images.ImageRequest
 import java.io.File
 import java.io.IOException
 
@@ -34,11 +35,11 @@ class ThumbnailDiskCache {
      * Retrieves the thumbnail data from the disk cache for the given session ID or URL.
      *
      * @param context the application [Context].
-     * @param sessionIdOrUrl the session ID or URL of the thumbnail to retrieve.
+     * @param request [ImageRequest] providing the session ID or URL of the thumbnail to retrieve.
      * @return the [ByteArray] of the thumbnail or null if the snapshot of the entry does not exist.
      */
-    internal fun getThumbnailData(context: Context, sessionIdOrUrl: String): ByteArray? {
-        val snapshot = getThumbnailCache(context).get(sessionIdOrUrl) ?: return null
+    internal fun getThumbnailData(context: Context, request: ImageRequest): ByteArray? {
+        val snapshot = getThumbnailCache(context).get(request.id) ?: return null
 
         return try {
             snapshot.getInputStream(0).use {
@@ -54,14 +55,14 @@ class ThumbnailDiskCache {
      * Stores the given session ID or URL's thumbnail [Bitmap] into the disk cache.
      *
      * @param context the application [Context].
-     * @param sessionIdOrUrl the session ID or URL.
+     * @param request [ImageRequest] providing the session ID or URL of the thumbnail to retrieve.
      * @param bitmap the thumbnail [Bitmap] to store.
      */
-    internal fun putThumbnailBitmap(context: Context, sessionIdOrUrl: String, bitmap: Bitmap) {
+    internal fun putThumbnailBitmap(context: Context, request: ImageRequest, bitmap: Bitmap) {
         try {
             synchronized(thumbnailCacheWriteLock) {
                 val editor = getThumbnailCache(context)
-                    .edit(sessionIdOrUrl) ?: return
+                    .edit(request.id) ?: return
 
                 editor.newOutputStream(0).use { stream ->
                     bitmap.compress(Bitmap.CompressFormat.WEBP, WEBP_QUALITY, stream)

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/ThumbnailsMiddlewareTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/ThumbnailsMiddlewareTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
+import mozilla.components.support.images.ImageRequest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import org.junit.Test
@@ -23,7 +24,7 @@ class ThumbnailsMiddlewareTest {
 
     @Test
     fun `thumbnail storage stores the provided thumbnail on update thumbnail action`() {
-        val sessionIdOrUrl = "test-tab1"
+        val request = ImageRequest("test-tab1")
         val tab = createTab("https://www.mozilla.org", id = "test-tab1")
         val thumbnailStorage: ThumbnailStorage = mock()
         val store = BrowserStore(
@@ -32,8 +33,8 @@ class ThumbnailsMiddlewareTest {
         )
 
         val bitmap: Bitmap = mock()
-        store.dispatch(ContentAction.UpdateThumbnailAction(sessionIdOrUrl, bitmap)).joinBlocking()
-        verify(thumbnailStorage).saveThumbnail(sessionIdOrUrl, bitmap)
+        store.dispatch(ContentAction.UpdateThumbnailAction(request.id, bitmap)).joinBlocking()
+        verify(thumbnailStorage).saveThumbnail(request, bitmap)
     }
 
     @Test

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoaderTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/loader/ThumbnailLoaderTest.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.thumbnails.R
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
+import mozilla.components.support.images.ImageRequest
+import mozilla.components.support.images.ImageRequest.Size
 import mozilla.components.support.test.any
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -55,10 +57,11 @@ class ThumbnailLoaderTest {
         val view: ImageView = mock()
         val storage: ThumbnailStorage = mock()
         val loader = spy(ThumbnailLoader(storage))
+        val request = ImageRequest("123", Size.DEFAULT)
 
-        doReturn(result).`when`(storage).loadThumbnail("123")
+        doReturn(result).`when`(storage).loadThumbnail(request)
 
-        loader.loadIntoView(view, "123")
+        loader.loadIntoView(view, request)
 
         verify(view).setImageDrawable(null)
         verify(view).addOnAttachStateChangeListener(any())
@@ -80,10 +83,11 @@ class ThumbnailLoaderTest {
         val error: Drawable = mock()
         val storage: ThumbnailStorage = mock()
         val loader = spy(ThumbnailLoader(storage))
+        val request = ImageRequest("123", Size.DEFAULT)
 
-        doReturn(result).`when`(storage).loadThumbnail("123")
+        doReturn(result).`when`(storage).loadThumbnail(request)
 
-        loader.loadIntoView(view, "123", placeholder = placeholder, error = error)
+        loader.loadIntoView(view, request, placeholder = placeholder, error = error)
 
         verify(view).setImageDrawable(placeholder)
 
@@ -101,11 +105,12 @@ class ThumbnailLoaderTest {
         val previousJob: Job = mock()
         val storage: ThumbnailStorage = mock()
         val loader = spy(ThumbnailLoader(storage))
+        val request = ImageRequest("123")
 
         doReturn(previousJob).`when`(view).getTag(R.id.mozac_browser_thumbnails_tag_job)
-        doReturn(result).`when`(storage).loadThumbnail("123")
+        doReturn(result).`when`(storage).loadThumbnail(request)
 
-        loader.loadIntoView(view, "123")
+        loader.loadIntoView(view, request)
 
         verify(previousJob).cancel()
 

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
@@ -8,6 +8,7 @@ import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import mozilla.components.support.images.ImageRequest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -38,59 +39,60 @@ class ThumbnailStorageTest {
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
-        thumbnailStorage.saveThumbnail("test-tab1", bitmap).joinBlocking()
-        thumbnailStorage.saveThumbnail("test-tab2", bitmap).joinBlocking()
-        var thumbnail1 = thumbnailStorage.loadThumbnail("test-tab1").await()
-        var thumbnail2 = thumbnailStorage.loadThumbnail("test-tab2").await()
+        thumbnailStorage.saveThumbnail(ImageRequest("test-tab1"), bitmap).joinBlocking()
+        thumbnailStorage.saveThumbnail(ImageRequest("test-tab2"), bitmap).joinBlocking()
+        var thumbnail1 = thumbnailStorage.loadThumbnail(ImageRequest("test-tab1")).await()
+        var thumbnail2 = thumbnailStorage.loadThumbnail(ImageRequest("test-tab2")).await()
         assertNotNull(thumbnail1)
         assertNotNull(thumbnail2)
 
         thumbnailStorage.clearThumbnails()
-        thumbnail1 = thumbnailStorage.loadThumbnail("test-tab1").await()
-        thumbnail2 = thumbnailStorage.loadThumbnail("test-tab2").await()
+        thumbnail1 = thumbnailStorage.loadThumbnail(ImageRequest("test-tab1")).await()
+        thumbnail2 = thumbnailStorage.loadThumbnail(ImageRequest("test-tab2")).await()
         assertNull(thumbnail1)
         assertNull(thumbnail2)
     }
 
     @Test
     fun `deleteThumbnail`() = runBlocking {
-        val sessionIdOrUrl = "test-tab1"
+        val id = "test-tab1"
+        val request = ImageRequest(id)
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
-        thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap).joinBlocking()
-        var thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
+        thumbnailStorage.saveThumbnail(request, bitmap).joinBlocking()
+        var thumbnail = thumbnailStorage.loadThumbnail(request).await()
         assertNotNull(thumbnail)
 
-        thumbnailStorage.deleteThumbnail(sessionIdOrUrl).joinBlocking()
-        thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
+        thumbnailStorage.deleteThumbnail(id).joinBlocking()
+        thumbnail = thumbnailStorage.loadThumbnail(request).await()
         assertNull(thumbnail)
     }
 
     @Test
     fun `saveThumbnail`() = runBlocking {
-        val sessionIdOrUrl = "test-tab1"
+        val request = ImageRequest("test-tab1")
         val bitmap: Bitmap = mock()
-        val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
-        var thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
+        val thumbnailStorage = spy(ThumbnailStorage(testContext))
+        var thumbnail = thumbnailStorage.loadThumbnail(request).await()
 
         assertNull(thumbnail)
 
-        thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap).joinBlocking()
-        thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
+        thumbnailStorage.saveThumbnail(request, bitmap).joinBlocking()
+        thumbnail = thumbnailStorage.loadThumbnail(request).await()
         assertNotNull(thumbnail)
     }
 
     @Test
     fun `loadThumbnail`() = runBlocking {
-        val sessionIdOrUrl = "test-tab1"
+        val request = ImageRequest("test-tab1")
         val bitmap: Bitmap = mock()
         val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
-        thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap)
-        `when`(thumbnailStorage.loadThumbnail(sessionIdOrUrl)).thenReturn(CompletableDeferred(bitmap))
+        thumbnailStorage.saveThumbnail(request, bitmap)
+        `when`(thumbnailStorage.loadThumbnail(request)).thenReturn(CompletableDeferred(bitmap))
 
-        val thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
+        val thumbnail = thumbnailStorage.loadThumbnail(request).await()
         assertEquals(bitmap, thumbnail)
     }
 }

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCacheTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/utils/ThumbnailDiskCacheTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.thumbnails.utils
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.images.ImageRequest
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
@@ -24,7 +25,7 @@ class ThumbnailDiskCacheTest {
     @Test
     fun `Writing and reading bitmap bytes`() {
         val cache = ThumbnailDiskCache()
-        val sessionIdOrUrl = "123"
+        val request = ImageRequest("123")
 
         val bitmap: Bitmap = mock()
         Mockito.`when`(bitmap.compress(any(), ArgumentMatchers.anyInt(), any())).thenAnswer {
@@ -39,9 +40,9 @@ class ThumbnailDiskCacheTest {
             true
         }
 
-        cache.putThumbnailBitmap(testContext, sessionIdOrUrl, bitmap)
+        cache.putThumbnailBitmap(testContext, request, bitmap)
 
-        val data = cache.getThumbnailData(testContext, sessionIdOrUrl)
+        val data = cache.getThumbnailData(testContext, request)
         assertNotNull(data!!)
         Assert.assertEquals("Hello World", String(data))
     }
@@ -49,30 +50,30 @@ class ThumbnailDiskCacheTest {
     @Test
     fun `Removing bitmap from disk cache`() {
         val cache = ThumbnailDiskCache()
-        val sessionIdOrUrl = "123"
+        val request = ImageRequest("123")
         val bitmap: Bitmap = mock()
 
-        cache.putThumbnailBitmap(testContext, sessionIdOrUrl, bitmap)
-        var data = cache.getThumbnailData(testContext, sessionIdOrUrl)
+        cache.putThumbnailBitmap(testContext, request, bitmap)
+        var data = cache.getThumbnailData(testContext, request)
         assertNotNull(data!!)
 
-        cache.removeThumbnailData(testContext, sessionIdOrUrl)
-        data = cache.getThumbnailData(testContext, sessionIdOrUrl)
+        cache.removeThumbnailData(testContext, request.id)
+        data = cache.getThumbnailData(testContext, request)
         assertNull(data)
     }
 
     @Test
     fun `Clearing bitmap from disk cache`() {
         val cache = ThumbnailDiskCache()
-        val sessionIdOrUrl = "123"
+        val request = ImageRequest("123")
         val bitmap: Bitmap = mock()
 
-        cache.putThumbnailBitmap(testContext, sessionIdOrUrl, bitmap)
-        var data = cache.getThumbnailData(testContext, sessionIdOrUrl)
+        cache.putThumbnailBitmap(testContext, request, bitmap)
+        var data = cache.getThumbnailData(testContext, request)
         assertNotNull(data!!)
 
         cache.clear(testContext)
-        data = cache.getThumbnailData(testContext, sessionIdOrUrl)
+        data = cache.getThumbnailData(testContext, request)
         assertNull(data)
     }
 }

--- a/components/support/images/src/main/java/mozilla/components/support/images/ImageRequest.kt
+++ b/components/support/images/src/main/java/mozilla/components/support/images/ImageRequest.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.images
+
+import androidx.annotation.DimenRes
+
+/**
+ * A request to load an image.
+ *
+ * @property id The id of the image to retrieve.
+ * @property size The preferred size of the image that should be loaded.
+ */
+data class ImageRequest(
+    val id: String,
+    val size: Size = Size.DEFAULT
+) {
+
+    /**
+     * Supported sizes.
+     */
+    enum class Size(@DimenRes val dimen: Int) {
+        DEFAULT(R.dimen.mozac_support_images_size_default)
+    }
+}

--- a/components/support/images/src/main/java/mozilla/components/support/images/loader/ImageLoader.kt
+++ b/components/support/images/src/main/java/mozilla/components/support/images/loader/ImageLoader.kt
@@ -7,6 +7,7 @@ package mozilla.components.support.images.loader
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.annotation.MainThread
+import mozilla.components.support.images.ImageRequest
 
 /**
  * A loader that can load an image from an ID directly into an [ImageView].
@@ -18,14 +19,14 @@ interface ImageLoader {
      * If the view is detached from the window before loading is completed, then loading is cancelled.
      *
      * @param view [ImageView] to load the image into.
-     * @param id Load image for this given ID.
+     * @param request [ImageRequest] Load image for this given request.
      * @param placeholder [Drawable] to display while image is loading.
      * @param error [Drawable] to display if loading fails.
      */
     @MainThread
     fun loadIntoView(
         view: ImageView,
-        id: String,
+        request: ImageRequest,
         placeholder: Drawable? = null,
         error: Drawable? = null
     )

--- a/components/support/images/src/main/res/values/dimens.xml
+++ b/components/support/images/src/main/res/values/dimens.xml
@@ -2,6 +2,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <dimen name="mozac_browser_thumbnails_maximum_size" tools:ignore="PxUsage">2153px</dimen>
+<resources>
+    <dimen name="mozac_support_images_size_default">102dp</dimen>
 </resources>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,8 @@ permalink: /changelog/
   * Deletes the tab's thumbnail from the storage when the sessions are removed.
   * ⚠️ **This is a breaking change**: Removes unused `ThumbnailsUseCases` since we now load thumbnails via `ThumbnailLoader`. See [#7313](https://github.com/mozilla-mobile/android-components/issues/7313).
   * ⚠️ **This is a breaking change**: Removes `ThumbnailsUseCases` as a parameter in `TabsFeature` and `TabsTrayPresenter`.
+  * ⚠️ **This is a breaking change**: Change the id parameter to accept a new `ImageRequest` in `ImageLoader`, which
+    allows consumers of `ThumbnailLoader` to specify the preferred image size along with the id when loading an image.
 
 * **feature-privatemode**
   * Add `PrivateNotificationFeature` to display a notification when private sessions are open.


### PR DESCRIPTION
…ecify the preferred image size


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes #7138. This is very similar to BrowserIcons which uses an equivalent IconRequest.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
