### PR TITLE
[wip] Bump app services to v61.0.5

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "61.0.2"
+    const val mozilla_appservices = "61.0.5"
 
     const val mozilla_glean = "31.1.1"
 


### PR DESCRIPTION
This PR is to ensure we can consume a-s artifacts created using taskgraph. Not intended to be merged.