### PR TITLE
Add asEffect helper to browser menu highlight

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuHighlight.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuHighlight.kt
@@ -4,10 +4,15 @@
 
 package mozilla.components.browser.menu
 
+import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
 import mozilla.components.browser.menu.item.NO_ID
+import mozilla.components.concept.menu.candidate.HighPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.LowPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.MenuEffect
 
 /**
  * Describes how to display a [mozilla.components.browser.menu.item.BrowserMenuHighlightableItem]
@@ -16,6 +21,11 @@ import mozilla.components.browser.menu.item.NO_ID
 sealed class BrowserMenuHighlight {
     abstract val label: String?
     abstract val canPropagate: Boolean
+
+    /**
+     * Converts the highlight into a corresponding [MenuEffect] from concept-menu.
+     */
+    abstract fun asEffect(context: Context): MenuEffect
 
     /**
      * Displays a notification dot.
@@ -30,7 +40,11 @@ sealed class BrowserMenuHighlight {
         @ColorInt val notificationTint: Int,
         override val label: String? = null,
         override val canPropagate: Boolean = true
-    ) : BrowserMenuHighlight()
+    ) : BrowserMenuHighlight() {
+        override fun asEffect(context: Context) = LowPriorityHighlightEffect(
+            notificationTint = notificationTint
+        )
+    }
 
     /**
      * Changes the background of the menu item.
@@ -48,7 +62,11 @@ sealed class BrowserMenuHighlight {
         override val label: String? = null,
         val endImageResource: Int = NO_ID,
         override val canPropagate: Boolean = true
-    ) : BrowserMenuHighlight()
+    ) : BrowserMenuHighlight() {
+        override fun asEffect(context: Context) = HighPriorityHighlightEffect(
+            backgroundTint = backgroundTint
+        )
+    }
 
     /**
      * Described how to display a highlightable menu item when it is highlighted.
@@ -68,6 +86,10 @@ sealed class BrowserMenuHighlight {
         override val canPropagate: Boolean = true
     ) : BrowserMenuHighlight() {
         override val label: String? = null
+
+        override fun asEffect(context: Context) = HighPriorityHighlightEffect(
+            backgroundTint = ContextCompat.getColor(context, colorResource)
+        )
     }
 }
 

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_checkbox.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_checkbox.xml
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.appcompat.widget.AppCompatCheckBox xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/Mozac.Browser.Menu.Item.Text"
     android:layout_width="match_parent"
     android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
@@ -11,4 +12,5 @@
     android:drawablePadding="@dimen/mozac_browser_menu_checkbox_padding"
     android:gravity="center_vertical"
     android:paddingStart="16dp"
-    android:paddingEnd="16dp" />
+    android:paddingEnd="16dp"
+    tools:text="Item" />

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_simple.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_simple.xml
@@ -8,8 +8,8 @@
     style="@style/Mozac.Browser.Menu.Item.Text"
     android:layout_width="match_parent"
     android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
-    android:gravity="center_vertical"
-    android:textAlignment="viewStart"
-    android:paddingEnd="16dp"
+    android:gravity="start|center_vertical"
     android:paddingStart="16dp"
-    tools:ignore="RtlCompat" />
+    android:paddingEnd="16dp"
+    android:textAlignment="viewStart"
+    tools:text="Item" />

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_switch.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_item_switch.xml
@@ -6,6 +6,5 @@
     style="@style/Mozac.Browser.Menu.Item.Text"
     android:layout_width="match_parent"
     android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
-    android:orientation="vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"/>

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuHighlightTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuHighlightTest.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu
+
+import android.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.menu.candidate.HighPriorityHighlightEffect
+import mozilla.components.concept.menu.candidate.LowPriorityHighlightEffect
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BrowserMenuHighlightTest {
+
+    @Test
+    fun `low priority effect keeps notification tint`() {
+        val highlight = BrowserMenuHighlight.LowPriority(
+            notificationTint = Color.RED
+        )
+        assertEquals(LowPriorityHighlightEffect(Color.RED), highlight.asEffect(mock()))
+    }
+
+    @Test
+    fun `high priority effect keeps background tint`() {
+        val highlight = BrowserMenuHighlight.HighPriority(
+            backgroundTint = Color.RED
+        )
+        assertEquals(HighPriorityHighlightEffect(Color.RED), highlight.asEffect(mock()))
+    }
+
+    @Suppress("Deprecation")
+    @Test
+    fun `classic highlight effect converts background tint`() {
+        val highlight = BrowserMenuHighlight.ClassicHighlight(
+            startImageResource = 0,
+            endImageResource = 0,
+            backgroundResource = 0,
+            colorResource = R.color.photonRed50
+        )
+        assertEquals(HighPriorityHighlightEffect(0xffff0039L.toInt()), highlight.asEffect(testContext))
+    }
+}


### PR DESCRIPTION
Breaking this out from the main menu2 PR.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
