### PR TITLE
Add NestedMenuCandidate concept item

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/ext/BrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/ext/BrowserMenuItem.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.menu.ext
 
+import android.content.Context
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.HighlightableMenuItem
@@ -26,3 +27,9 @@ fun List<BrowserMenuItem>.getHighlight() = asSequence()
             is BrowserMenuHighlight.ClassicHighlight -> 0
         }
     }
+
+/**
+ * Converts the menu items into a menu candidate list.
+ */
+fun List<BrowserMenuItem>.asCandidateList(context: Context) =
+    mapNotNull { it.asCandidate(context) }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BackPressMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BackPressMenuItem.kt
@@ -4,10 +4,13 @@
 
 package mozilla.components.browser.menu.item
 
+import android.content.Context
 import android.view.View
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.concept.menu.candidate.NestedMenuCandidate
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
 
 /**
  * A back press menu item for a nested sub menu entry.
@@ -41,5 +44,17 @@ class BackPressMenuItem(
      */
     fun setListener(onClickListener: () -> Unit) {
         backPressListener = onClickListener
+    }
+
+    override fun asCandidate(context: Context): NestedMenuCandidate {
+        val parentCandidate = super.asCandidate(context) as TextMenuCandidate
+        return NestedMenuCandidate(
+            id = hashCode(),
+            text = parentCandidate.text,
+            start = parentCandidate.start,
+            subMenuItems = null,
+            textStyle = parentCandidate.textStyle,
+            containerStyle = parentCandidate.containerStyle
+        )
     }
 }

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItem.kt
@@ -146,7 +146,7 @@ class BrowserMenuHighlightableItem(
     }
 
     override fun asCandidate(context: Context): TextMenuCandidate {
-        val base = super.asCandidate(context)
+        val base = super.asCandidate(context) as TextMenuCandidate
         if (!isHighlighted()) return base
 
         @Suppress("Deprecation")

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuImageText.kt
@@ -18,6 +18,7 @@ import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.R
 import mozilla.components.concept.menu.candidate.ContainerStyle
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.MenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.concept.menu.candidate.TextStyle
 
@@ -84,7 +85,7 @@ open class BrowserMenuImageText(
         }
     }
 
-    override fun asCandidate(context: Context) = TextMenuCandidate(
+    override fun asCandidate(context: Context): MenuCandidate = TextMenuCandidate(
         label,
         start = DrawableMenuIcon(
             context,

--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/ParentBrowserMenuItem.kt
@@ -13,9 +13,10 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu.ext.asCandidateList
 import mozilla.components.concept.menu.candidate.ContainerStyle
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
-import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.concept.menu.candidate.NestedMenuCandidate
 import mozilla.components.concept.menu.candidate.TextStyle
 
 /**
@@ -81,13 +82,15 @@ class ParentBrowserMenuItem(
         }
     }
 
-    override fun asCandidate(context: Context) = TextMenuCandidate(
-        label,
+    override fun asCandidate(context: Context) = NestedMenuCandidate(
+        id = hashCode(),
+        text = label,
         start = DrawableMenuIcon(
             context,
             resource = imageResource,
             tint = if (iconTintColorResource == NO_ID) null else ContextCompat.getColor(context, iconTintColorResource)
         ),
+        subMenuItems = subMenu.adapter.visibleItems.asCandidateList(context),
         textStyle = TextStyle(
             color = if (textColorResource == NO_ID) null else ContextCompat.getColor(context, textColorResource)
         ),

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuImageTextTest.kt
@@ -95,8 +95,9 @@ class BrowserMenuImageTextTest {
                 "label",
                 android.R.drawable.ic_menu_report_image,
                 listener = listener
-            ).asCandidate(context).run {
-                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
+            ).asCandidate(context).let {
+                val text = it as TextMenuCandidate
+                text.copy(start = (text.start as? DrawableMenuIcon)?.copy(drawable = null))
             }
         )
 
@@ -114,8 +115,9 @@ class BrowserMenuImageTextTest {
                 android.R.drawable.ic_menu_report_image,
                 android.R.color.black,
                 listener = listener
-            ).asCandidate(context).run {
-                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
+            ).asCandidate(context).let {
+                val text = it as TextMenuCandidate
+                text.copy(start = (text.start as? DrawableMenuIcon)?.copy(drawable = null))
             }
         )
     }

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/ParentBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/ParentBrowserMenuItemTest.kt
@@ -7,14 +7,13 @@ package mozilla.components.browser.menu.item
 import android.view.LayoutInflater
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
-import androidx.core.content.ContextCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.menu.BrowserMenuAdapter
 import mozilla.components.browser.menu.R
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
-import mozilla.components.concept.menu.candidate.TextMenuCandidate
-import mozilla.components.support.test.mock
+import mozilla.components.concept.menu.candidate.NestedMenuCandidate
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -108,36 +107,41 @@ class ParentBrowserMenuItemTest {
 
     @Test
     fun `menu item image text item can be converted to candidate`() {
+        val backPressMenuItem = BackPressMenuItem(
+            label = "back",
+            imageResource = R.drawable.mozac_ic_back
+        )
+        val subMenuItem = SimpleBrowserMenuItem("test")
+        val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(backPressMenuItem, subMenuItem))
+        val subMenu = BrowserMenu(subMenuAdapter)
+        val menuItem = ParentBrowserMenuItem(
+            "label",
+            android.R.drawable.ic_menu_report_image,
+            subMenu = subMenu
+        )
+
+        val candidate = menuItem.asCandidate(testContext)
+
+        assertEquals(menuItem.hashCode(), candidate.id)
+        assertEquals("label", candidate.text)
+        assertEquals(2, candidate.subMenuItems!!.size)
+
+        val backCandidate = candidate.subMenuItems!![0] as NestedMenuCandidate
+        val testCandidate = candidate.subMenuItems!![1] as DecorativeTextMenuCandidate
         assertEquals(
-            TextMenuCandidate(
-                "label",
-                start = DrawableMenuIcon(null)
+            NestedMenuCandidate(
+                id = backPressMenuItem.hashCode(),
+                text = "back",
+                start = DrawableMenuIcon(null),
+                subMenuItems = null
             ),
-            ParentBrowserMenuItem(
-                "label",
-                android.R.drawable.ic_menu_report_image,
-                subMenu = mock()
-            ).asCandidate(testContext).run {
+            backCandidate.run {
                 copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
             }
         )
-
         assertEquals(
-            TextMenuCandidate(
-                text = "label",
-                start = DrawableMenuIcon(
-                    drawable = null,
-                    tint = ContextCompat.getColor(testContext, android.R.color.black)
-                )
-            ),
-                ParentBrowserMenuItem(
-                "label",
-                android.R.drawable.ic_menu_report_image,
-                android.R.color.black,
-                subMenu = mock()
-            ).asCandidate(testContext).run {
-                copy(start = (start as? DrawableMenuIcon)?.copy(drawable = null))
-            }
+            DecorativeTextMenuCandidate("test"),
+            testCandidate
         )
     }
 }

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/adapter/LastItemViewHolder.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/adapter/LastItemViewHolder.kt
@@ -15,7 +15,7 @@ internal abstract class LastItemViewHolder<T>(
     itemView: View
 ) : RecyclerView.ViewHolder(itemView) {
 
-    private var lastCandidate: T? = null
+    protected var lastCandidate: T? = null
 
     /**
      * Updates the held view to reflect changes in the menu option.

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/adapter/MenuCandidateListAdapter.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/adapter/MenuCandidateListAdapter.kt
@@ -13,12 +13,14 @@ import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
 import mozilla.components.concept.menu.candidate.DividerMenuCandidate
 import mozilla.components.concept.menu.candidate.MenuCandidate
+import mozilla.components.concept.menu.candidate.NestedMenuCandidate
 import mozilla.components.concept.menu.candidate.RowMenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 
 internal class MenuCandidateListAdapter(
     private val inflater: LayoutInflater,
-    private val dismiss: () -> Unit
+    private val dismiss: () -> Unit,
+    private val reopenMenu: (NestedMenuCandidate) -> Unit
 ) : ListAdapter<MenuCandidate, MenuCandidateViewHolder<out MenuCandidate>>(MenuCandidateDiffer) {
 
     @LayoutRes
@@ -26,11 +28,15 @@ internal class MenuCandidateListAdapter(
         is TextMenuCandidate -> TextMenuCandidateViewHolder.layoutResource
         is DecorativeTextMenuCandidate -> DecorativeTextMenuCandidateViewHolder.layoutResource
         is CompoundMenuCandidate -> CompoundMenuCandidateViewHolder.getLayoutResource(item)
+        is NestedMenuCandidate -> NestedMenuCandidateViewHolder.layoutResource
         is RowMenuCandidate -> RowMenuCandidateViewHolder.layoutResource
         is DividerMenuCandidate -> DividerMenuCandidateViewHolder.layoutResource
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, @LayoutRes viewType: Int): MenuCandidateViewHolder<*> {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        @LayoutRes viewType: Int
+    ): MenuCandidateViewHolder<out MenuCandidate> {
         val view = inflater.inflate(viewType, parent, false)
         return when (viewType) {
             TextMenuCandidateViewHolder.layoutResource ->
@@ -41,6 +47,8 @@ internal class MenuCandidateListAdapter(
                 CompoundCheckboxMenuCandidateViewHolder(view, inflater, dismiss)
             CompoundSwitchMenuCandidateViewHolder.layoutResource ->
                 CompoundSwitchMenuCandidateViewHolder(view, inflater, dismiss)
+            NestedMenuCandidateViewHolder.layoutResource ->
+                NestedMenuCandidateViewHolder(view, inflater, dismiss, reopenMenu)
             RowMenuCandidateViewHolder.layoutResource ->
                 RowMenuCandidateViewHolder(view, inflater, dismiss)
             DividerMenuCandidateViewHolder.layoutResource ->
@@ -49,12 +57,13 @@ internal class MenuCandidateListAdapter(
         }
     }
 
-    override fun onBindViewHolder(holder: MenuCandidateViewHolder<*>, position: Int) {
+    override fun onBindViewHolder(holder: MenuCandidateViewHolder<out MenuCandidate>, position: Int) {
         val item = getItem(position)
         when (holder) {
             is TextMenuCandidateViewHolder -> holder.bind(item as TextMenuCandidate)
             is DecorativeTextMenuCandidateViewHolder -> holder.bind(item as DecorativeTextMenuCandidate)
             is CompoundMenuCandidateViewHolder -> holder.bind(item as CompoundMenuCandidate)
+            is NestedMenuCandidateViewHolder -> holder.bind(item as NestedMenuCandidate)
             is RowMenuCandidateViewHolder -> holder.bind(item as RowMenuCandidate)
             is DividerMenuCandidateViewHolder -> holder.bind(item as DividerMenuCandidate)
         }

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/adapter/NestedMenuCandidateViewHolder.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/adapter/NestedMenuCandidateViewHolder.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.LayoutRes
+import androidx.constraintlayout.widget.ConstraintLayout
+import mozilla.components.browser.menu2.R
+import mozilla.components.browser.menu2.adapter.icons.MenuIconAdapter
+import mozilla.components.browser.menu2.ext.applyBackgroundEffect
+import mozilla.components.browser.menu2.ext.applyStyle
+import mozilla.components.concept.menu.Side
+import mozilla.components.concept.menu.candidate.NestedMenuCandidate
+
+internal class NestedMenuCandidateViewHolder(
+    itemView: View,
+    inflater: LayoutInflater,
+    dismiss: () -> Unit,
+    private val reopenMenu: (NestedMenuCandidate) -> Unit
+) : MenuCandidateViewHolder<NestedMenuCandidate>(itemView, inflater), View.OnClickListener {
+
+    private val layout = itemView as ConstraintLayout
+    private val textView: TextView get() = itemView.findViewById(R.id.label)
+    private val startIcon = MenuIconAdapter(layout, inflater, Side.START, dismiss)
+    private val endIcon = MenuIconAdapter(layout, inflater, Side.END, dismiss)
+
+    init {
+        itemView.setOnClickListener(this)
+    }
+
+    override fun bind(newCandidate: NestedMenuCandidate, oldCandidate: NestedMenuCandidate?) {
+        super.bind(newCandidate, oldCandidate)
+
+        textView.text = newCandidate.text
+        textView.applyStyle(newCandidate.textStyle, oldCandidate?.textStyle)
+        itemView.applyBackgroundEffect(newCandidate.effect, oldCandidate?.effect)
+        startIcon.bind(newCandidate.start, oldCandidate?.start)
+        endIcon.bind(newCandidate.end, oldCandidate?.end)
+    }
+
+    override fun onClick(v: View?) {
+        lastCandidate?.let { reopenMenu(it) }
+    }
+
+    companion object {
+        @LayoutRes
+        val layoutResource = R.layout.mozac_browser_menu2_candidate_nested
+    }
+}

--- a/components/browser/menu2/src/main/res/layout/mozac_browser_menu2_candidate_nested.xml
+++ b/components/browser/menu2/src/main/res/layout/mozac_browser_menu2_candidate_nested.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Mozac.Browser.Menu2.Candidate.Container"
+    android:layout_width="match_parent"
+    android:orientation="horizontal"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/label"
+        style="@style/Mozac.Browser.Menu2.Candidate.Label"
+        android:layout_width="0dp"
+        android:clickable="false"
+        android:focusable="false"
+        android:gravity="center_vertical"
+        android:background="@null"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="Item" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/MenuCandidateListAdapterTest.kt
+++ b/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/MenuCandidateListAdapterTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.concept.menu.candidate.CompoundMenuCandidate
 import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
 import mozilla.components.concept.menu.candidate.DividerMenuCandidate
+import mozilla.components.concept.menu.candidate.NestedMenuCandidate
 import mozilla.components.concept.menu.candidate.RowMenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.support.test.mock
@@ -25,13 +26,15 @@ class MenuCandidateListAdapterTest {
 
     private lateinit var layoutInflater: LayoutInflater
     private lateinit var dismiss: () -> Unit
+    private lateinit var reopenMenu: (NestedMenuCandidate) -> Unit
     private lateinit var adapter: MenuCandidateListAdapter
 
     @Before
     fun setup() {
         layoutInflater = spy(LayoutInflater.from(testContext))
         dismiss = mock()
-        adapter = MenuCandidateListAdapter(layoutInflater, dismiss)
+        reopenMenu = mock()
+        adapter = MenuCandidateListAdapter(layoutInflater, dismiss, reopenMenu)
     }
 
     @Test

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuCandidate.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/candidate/MenuCandidate.kt
@@ -79,6 +79,30 @@ data class CompoundMenuCandidate(
 }
 
 /**
+ * Menu option that opens a nested sub menu.
+ *
+ * @property id Unique ID for this nested menu. Can be a resource ID.
+ * @property text Text to display.
+ * @property start Icon to display before the text.
+ * @property end Icon to display after the text.
+ * @property subMenuItems Nested menu items to display.
+ * If null, this item will instead return to the root menu.
+ * @property textStyle Styling to apply to the text.
+ * @property containerStyle Styling to apply to the container.
+ * @property effect Effects to apply to the option.
+ */
+data class NestedMenuCandidate(
+    val id: Int,
+    val text: String,
+    val start: MenuIcon? = null,
+    val end: DrawableMenuIcon? = null,
+    val subMenuItems: List<MenuCandidate>? = emptyList(),
+    val textStyle: TextStyle = TextStyle(),
+    override val containerStyle: ContainerStyle = ContainerStyle(),
+    val effect: MenuCandidateEffect? = null
+) : MenuCandidate()
+
+/**
  * Displays a row of small menu options.
  *
  * @property items Small menu options to display.


### PR DESCRIPTION
Broken out from the main menu2 PR. Adds a new concept menu type and corresponding view holder.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
