### PR TITLE
Closes #6641: Treat origins as nullable in extension metadata

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -351,7 +351,8 @@ class GeckoWebExtension(
                 homePageUrl = it.homepageUrl,
                 version = it.version,
                 permissions = it.permissions.toList(),
-                hostPermissions = it.origins.toList(),
+                // Origins is marked as @NonNull but may be null: https://bugzilla.mozilla.org/show_bug.cgi?id=1629957
+                hostPermissions = it.origins.orEmpty().toList(),
                 disabledFlags = DisabledFlags.select(it.disabledFlags),
                 optionsPageUrl = it.optionsPageUrl,
                 openOptionsPageInTab = it.openOptionsPageInTab,

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -475,7 +475,6 @@ class GeckoWebExtensionTest {
 
         val metaDataBundle = GeckoBundle()
         metaDataBundle.putStringArray("promptPermissions", arrayOf("p1", "p2"))
-        metaDataBundle.putStringArray("origins", arrayOf("o1", "o2"))
         metaDataBundle.putString("version", "1.0")
         val bundle = GeckoBundle()
         bundle.putString("webExtensionId", "id")
@@ -490,7 +489,7 @@ class GeckoWebExtensionTest {
         assertNotNull(metadata!!)
         assertEquals("1.0", metadata.version)
         assertEquals(listOf("p1", "p2"), metadata.permissions)
-        assertEquals(listOf("o1", "o2"), metadata.hostPermissions)
+        assertEquals(emptyList<String>(), metadata.hostPermissions)
         assertEquals("moz-extension://123c5c5b-cd03-4bea-b23f-ac0b9ab40257/", metadata.baseUrl)
         assertNull(metadata.description)
         assertNull(metadata.developerName)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -362,7 +362,8 @@ class GeckoWebExtension(
                 homePageUrl = it.homepageUrl,
                 version = it.version,
                 permissions = it.permissions.toList(),
-                hostPermissions = it.origins.toList(),
+                // Origins is marked as @NonNull but may be null: https://bugzilla.mozilla.org/show_bug.cgi?id=1629957
+                hostPermissions = it.origins.orEmpty().toList(),
                 disabledFlags = DisabledFlags.select(it.disabledFlags),
                 optionsPageUrl = it.optionsPageUrl,
                 openOptionsPageInTab = it.openOptionsPageInTab,

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -491,7 +491,6 @@ class GeckoWebExtensionTest {
 
         val metaDataBundle = GeckoBundle()
         metaDataBundle.putStringArray("promptPermissions", arrayOf("p1", "p2"))
-        metaDataBundle.putStringArray("origins", arrayOf("o1", "o2"))
         metaDataBundle.putString("version", "1.0")
         val bundle = GeckoBundle()
         bundle.putString("webExtensionId", "id")
@@ -506,7 +505,7 @@ class GeckoWebExtensionTest {
         assertNotNull(metadata!!)
         assertEquals("1.0", metadata.version)
         assertEquals(listOf("p1", "p2"), metadata.permissions)
-        assertEquals(listOf("o1", "o2"), metadata.hostPermissions)
+        assertEquals(emptyList<String>(), metadata.hostPermissions)
         assertEquals("moz-extension://123c5c5b-cd03-4bea-b23f-ac0b9ab40257/", metadata.baseUrl)
         assertNull(metadata.description)
         assertNull(metadata.developerName)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -350,7 +350,8 @@ class GeckoWebExtension(
                 homePageUrl = it.homepageUrl,
                 version = it.version,
                 permissions = it.permissions.toList(),
-                hostPermissions = it.origins.toList(),
+                // Origins is marked as @NonNull but may be null: https://bugzilla.mozilla.org/show_bug.cgi?id=1629957
+                hostPermissions = it.origins.orEmpty().toList(),
                 disabledFlags = DisabledFlags.select(it.disabledFlags),
                 optionsPageUrl = it.optionsPageUrl,
                 openOptionsPageInTab = it.openOptionsPageInTab,

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -474,7 +474,6 @@ class GeckoWebExtensionTest {
 
         val metaDataBundle = GeckoBundle()
         metaDataBundle.putStringArray("promptPermissions", arrayOf("p1", "p2"))
-        metaDataBundle.putStringArray("origins", arrayOf("o1", "o2"))
         metaDataBundle.putString("version", "1.0")
         val bundle = GeckoBundle()
         bundle.putString("webExtensionId", "id")
@@ -489,7 +488,7 @@ class GeckoWebExtensionTest {
         assertNotNull(metadata!!)
         assertEquals("1.0", metadata.version)
         assertEquals(listOf("p1", "p2"), metadata.permissions)
-        assertEquals(listOf("o1", "o2"), metadata.hostPermissions)
+        assertEquals(emptyList<String>(), metadata.hostPermissions)
         assertEquals("moz-extension://123c5c5b-cd03-4bea-b23f-ac0b9ab40257/", metadata.baseUrl)
         assertNull(metadata.description)
         assertNull(metadata.developerName)


### PR DESCRIPTION
This is a loose end that causes crashes for a handful of users after beta migration. It's likely only gonna affect a few users in release, but there's no need to crash if an unsupported add-on (we don't know which) returns null `origins`. We don't even have a use case for the field right now.

So, let's interpret the field as `nullable`.