### PR TITLE
mozilla-mobile/fenix#10261: Add facts for PWAs

### DIFF
--- a/components/feature/pwa/README.md
+++ b/components/feature/pwa/README.md
@@ -59,6 +59,21 @@ When `"display": "fullscreen"` is set in the web app manifest, the web app will 
 
 `WebAppSiteControlsFeature` will display a silent notification whenever a web app is open. This notification contains controls to interact with the web app, such as a refresh button and a shortcut to copy the URL.
 
+## Facts
+
+This component emits the following [Facts](../../support/base/README.md#Facts):
+
+| Action | Item    | Extras         | Description                        |
+|--------|---------|----------------|------------------------------------|
+| CLICK  | homescreen_icon_tap  |   | The user tapped the PWA icon on the homescreen. |
+| INTERACTION | background_timing | `itemExtras` | Length of time that the app was in the background before foregrounding. |
+
+#### `itemExtras`
+
+| Key          | Type    | Value                             |
+|--------------|---------|-----------------------------------|
+| timingNs     | Long | Length of time that the app was in the background. |
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/feature/pwa/README.md
+++ b/components/feature/pwa/README.md
@@ -66,13 +66,14 @@ This component emits the following [Facts](../../support/base/README.md#Facts):
 | Action | Item    | Extras         | Description                        |
 |--------|---------|----------------|------------------------------------|
 | CLICK  | homescreen_icon_tap  |   | The user tapped the PWA icon on the homescreen. |
-| INTERACTION | background_timing | `itemExtras` | Length of time that the app was in the background before foregrounding. |
+| INTERACTION | enter_background | `itemExtras` | The current system time when the app is backgrounded. |
+| INTERACTION | enter_foreground | `itemExtras` | The current system time when the app is foregrounded. |
 
 #### `itemExtras`
 
 | Key          | Type    | Value                             |
 |--------------|---------|-----------------------------------|
-| timingNs     | Long | Length of time that the app was in the background. |
+| timingNs     | Long | The current system time when a foreground or background action is taken. |
 
 ## License
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.pwa
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+/**
+ * Facts emitted for telemetry related to [PwaFeature]
+ */
+class ProgressiveWebAppFacts {
+    /**
+     * Items that specify which portion of the [PwaFeature] was interacted with
+     */
+    object Items {
+        const val CLOSE = "close"
+        const val HOMESCREEN_ICON_TAP = "homescreen_icon_tap"
+        const val FOREGROUND_TIMING = "foreground_timing"
+    }
+
+    /**
+     * Keys used to record metadata about [Items].
+     */
+    object MetadataKeys {
+        const val BACKGROUND_DURATION = "background_duration"
+    }
+}
+
+private fun emitPwaFact(
+    action: Action,
+    item: String,
+    value: String? = null,
+    metadata: Map<String, Any>? = null
+) {
+    Fact(
+        Component.FEATURE_PWA,
+        action,
+        item,
+        value,
+        metadata
+    ).collect()
+}
+
+internal fun emitCloseFact() = emitPwaFact(Action.CLICK, ProgressiveWebAppFacts.Items.CLOSE)
+
+internal fun emitHomescreenIconTapFact() =
+    emitPwaFact(
+        Action.CLICK,
+        ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP
+    )
+
+@Suppress("MagicNumber")
+internal fun emitForegroundTimingFact(timingNs: Long) =
+    emitPwaFact(
+        Action.INTERACTION,
+        ProgressiveWebAppFacts.Items.FOREGROUND_TIMING,
+        metadata = mapOf(
+            // We only care about millisecond precision here, so convert from ns to ms before emitting.
+            ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_DURATION to (timingNs / 1_000_000L)
+        )
+    )

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
@@ -17,9 +17,8 @@ class ProgressiveWebAppFacts {
      * Items that specify which portion of the [PwaFeature] was interacted with
      */
     object Items {
-        const val CLOSE = "close"
         const val HOMESCREEN_ICON_TAP = "homescreen_icon_tap"
-        const val FOREGROUND_TIMING = "foreground_timing"
+        const val DURATION_IN_BACKGROUND = "duration_in_background"
     }
 
     /**
@@ -45,8 +44,6 @@ private fun emitPwaFact(
     ).collect()
 }
 
-internal fun emitCloseFact() = emitPwaFact(Action.CLICK, ProgressiveWebAppFacts.Items.CLOSE)
-
 internal fun emitHomescreenIconTapFact() =
     emitPwaFact(
         Action.CLICK,
@@ -57,7 +54,7 @@ internal fun emitHomescreenIconTapFact() =
 internal fun emitForegroundTimingFact(timingNs: Long) =
     emitPwaFact(
         Action.INTERACTION,
-        ProgressiveWebAppFacts.Items.FOREGROUND_TIMING,
+        ProgressiveWebAppFacts.Items.DURATION_IN_BACKGROUND,
         metadata = mapOf(
             // We only care about millisecond precision here, so convert from ns to ms before emitting.
             ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_DURATION to (timingNs / 1_000_000L)

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
@@ -18,14 +18,16 @@ class ProgressiveWebAppFacts {
      */
     object Items {
         const val HOMESCREEN_ICON_TAP = "homescreen_icon_tap"
-        const val BACKGROUND_TIMING = "background_timing"
+        const val ENTER_BACKGROUND = "enter_background"
+        const val ENTER_FOREGROUND = "enter_foreground"
     }
 
     /**
      * Keys used to record metadata about [Items].
      */
     object MetadataKeys {
-        const val BACKGROUND_DURATION = "background_duration"
+        const val BACKGROUND_TIME = "background_time"
+        const val FOREGROUND_TIME = "foreground_time"
     }
 }
 
@@ -51,12 +53,23 @@ internal fun emitHomescreenIconTapFact() =
     )
 
 @Suppress("MagicNumber")
+internal fun emitForegroundTimingFact(timingNs: Long) =
+    emitPwaFact(
+        Action.INTERACTION,
+        ProgressiveWebAppFacts.Items.ENTER_FOREGROUND,
+        metadata = mapOf(
+            // We only care about millisecond precision here, so convert from ns to ms before emitting.
+            ProgressiveWebAppFacts.MetadataKeys.FOREGROUND_TIME to (timingNs / 1_000_000L)
+        )
+    )
+
+@Suppress("MagicNumber")
 internal fun emitBackgroundTimingFact(timingNs: Long) =
     emitPwaFact(
         Action.INTERACTION,
-        ProgressiveWebAppFacts.Items.BACKGROUND_TIMING,
+        ProgressiveWebAppFacts.Items.ENTER_BACKGROUND,
         metadata = mapOf(
             // We only care about millisecond precision here, so convert from ns to ms before emitting.
-            ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_DURATION to (timingNs / 1_000_000L)
+            ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_TIME to (timingNs / 1_000_000L)
         )
     )

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
@@ -18,7 +18,7 @@ class ProgressiveWebAppFacts {
      */
     object Items {
         const val HOMESCREEN_ICON_TAP = "homescreen_icon_tap"
-        const val DURATION_IN_BACKGROUND = "duration_in_background"
+        const val BACKGROUND_TIMING = "background_timing"
     }
 
     /**
@@ -51,10 +51,10 @@ internal fun emitHomescreenIconTapFact() =
     )
 
 @Suppress("MagicNumber")
-internal fun emitForegroundTimingFact(timingNs: Long) =
+internal fun emitBackgroundTimingFact(timingNs: Long) =
     emitPwaFact(
         Action.INTERACTION,
-        ProgressiveWebAppFacts.Items.DURATION_IN_BACKGROUND,
+        ProgressiveWebAppFacts.Items.BACKGROUND_TIMING,
         metadata = mapOf(
             // We only care about millisecond precision here, so convert from ns to ms before emitting.
             ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_DURATION to (timingNs / 1_000_000L)

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/ProgressiveWebAppFacts.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.pwa
 
+import mozilla.components.feature.pwa.ProgressiveWebAppFacts.Companion.MS_PRECISION
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.Fact
@@ -29,6 +30,11 @@ class ProgressiveWebAppFacts {
         const val BACKGROUND_TIME = "background_time"
         const val FOREGROUND_TIME = "foreground_time"
     }
+
+    companion object {
+        // We only care about millisecond precision in this context
+        internal const val MS_PRECISION = 1_000_000L
+    }
 }
 
 private fun emitPwaFact(
@@ -52,24 +58,20 @@ internal fun emitHomescreenIconTapFact() =
         ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP
     )
 
-@Suppress("MagicNumber")
 internal fun emitForegroundTimingFact(timingNs: Long) =
     emitPwaFact(
         Action.INTERACTION,
         ProgressiveWebAppFacts.Items.ENTER_FOREGROUND,
         metadata = mapOf(
-            // We only care about millisecond precision here, so convert from ns to ms before emitting.
-            ProgressiveWebAppFacts.MetadataKeys.FOREGROUND_TIME to (timingNs / 1_000_000L)
+            ProgressiveWebAppFacts.MetadataKeys.FOREGROUND_TIME to (timingNs / MS_PRECISION)
         )
     )
 
-@Suppress("MagicNumber")
 internal fun emitBackgroundTimingFact(timingNs: Long) =
     emitPwaFact(
         Action.INTERACTION,
         ProgressiveWebAppFacts.Items.ENTER_BACKGROUND,
         metadata = mapOf(
-            // We only care about millisecond precision here, so convert from ns to ms before emitting.
-            ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_TIME to (timingNs / 1_000_000L)
+            ProgressiveWebAppFacts.MetadataKeys.BACKGROUND_TIME to (timingNs / MS_PRECISION)
         )
     )

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
@@ -63,7 +63,6 @@ class WebAppLauncherActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         resetBackgroundTimer()
-        emitCloseFact()
         scope.cancel()
     }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
@@ -22,8 +22,8 @@ import mozilla.components.support.base.log.logger.Logger
 /**
  * This activity is launched by Web App shortcuts on the home screen.
  *
- * Based on the Web App Manifest (display) it will decide whether the app is launched in the browser or in a
- * standalone activity.
+ * Based on the Web App Manifest (display) it will decide whether the app is launched in the
+ * browser or in a standalone activity.
  */
 class WebAppLauncherActivity : AppCompatActivity() {
 
@@ -37,9 +37,7 @@ class WebAppLauncherActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         storage = ManifestStorage(this)
 
-        if (savedInstanceState == null) {
-            setBackgroundStartTime(0L) // reset
-        }
+        backgroundStartTime = savedInstanceState?.getLong("backgroundStartTime") ?: 0L
 
         val startUrl = intent.data ?: return finish()
 
@@ -51,17 +49,24 @@ class WebAppLauncherActivity : AppCompatActivity() {
         }
     }
 
+    override fun onSaveInstanceState(bundle: Bundle) {
+        // reset background start time
+        backgroundStartTime = 0L
+        bundle.putLong("backgroundStartTime", backgroundStartTime)
+        super.onSaveInstanceState(bundle)
+    }
+
     override fun onResume() {
         super.onResume()
 
         val backgroundEndTime = SystemClock.elapsedRealtimeNanos()
         emitBackgroundTimingFact(backgroundEndTime - backgroundStartTime)
-
         setBackgroundStartTime(0L) // reset
     }
 
     override fun onPause() {
         super.onPause()
+        // record when we go into the background
         setBackgroundStartTime(SystemClock.elapsedRealtimeNanos())
     }
 
@@ -73,10 +78,6 @@ class WebAppLauncherActivity : AppCompatActivity() {
     @VisibleForTesting(otherwise = PRIVATE)
     internal fun setBackgroundStartTime(timeNs: Long) {
         backgroundStartTime = timeNs
-        val bundle = Bundle()
-        bundle.putLong("backgroundStartTime", backgroundStartTime)
-
-        onSaveInstanceState(bundle)
     }
 
     @VisibleForTesting(otherwise = PRIVATE)

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
@@ -51,7 +51,7 @@ class WebAppLauncherActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         backgroundEndTime = SystemClock.elapsedRealtimeNanos()
-        emitForegroundTimingFact(backgroundEndTime - backgroundStartTime)
+        emitBackgroundTimingFact(backgroundEndTime - backgroundStartTime)
         resetBackgroundTimer()
     }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppLauncherActivity.kt
@@ -31,13 +31,9 @@ class WebAppLauncherActivity : AppCompatActivity() {
     private val logger = Logger("WebAppLauncherActivity")
     private lateinit var storage: ManifestStorage
 
-    private var backgroundStartTime: Long = 0L
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         storage = ManifestStorage(this)
-
-        backgroundStartTime = savedInstanceState?.getLong("backgroundStartTime") ?: 0L
 
         val startUrl = intent.data ?: return finish()
 
@@ -49,35 +45,21 @@ class WebAppLauncherActivity : AppCompatActivity() {
         }
     }
 
-    override fun onSaveInstanceState(bundle: Bundle) {
-        // reset background start time
-        backgroundStartTime = 0L
-        bundle.putLong("backgroundStartTime", backgroundStartTime)
-        super.onSaveInstanceState(bundle)
-    }
-
     override fun onResume() {
         super.onResume()
-
-        val backgroundEndTime = SystemClock.elapsedRealtimeNanos()
-        emitBackgroundTimingFact(backgroundEndTime - backgroundStartTime)
-        setBackgroundStartTime(0L) // reset
+        val currTime = SystemClock.elapsedRealtimeNanos()
+        emitForegroundTimingFact(currTime)
     }
 
     override fun onPause() {
         super.onPause()
-        // record when we go into the background
-        setBackgroundStartTime(SystemClock.elapsedRealtimeNanos())
+        val currTime = SystemClock.elapsedRealtimeNanos()
+        emitBackgroundTimingFact(currTime)
     }
 
     override fun onDestroy() {
         super.onDestroy()
         scope.cancel()
-    }
-
-    @VisibleForTesting(otherwise = PRIVATE)
-    internal fun setBackgroundStartTime(timeNs: Long) {
-        backgroundStartTime = timeNs
     }
 
     @VisibleForTesting(otherwise = PRIVATE)


### PR DESCRIPTION
Add PWA Facts for https://github.com/mozilla-mobile/fenix/issues/10261
  * An event ping when putting a PWA to the foreground with a time interval from start to finish use.
    * `ProgressiveWebAppFacts.Items.DURATION_IN_BACKGROUND`
  * An event ping when tapping PWA homescreen icons.
    * `ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP`
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
