### PR TITLE
Close #7496: Fix intermittent failing test in BrowserThumbnails

### DIFF
--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/storage/ThumbnailStorageTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.createTestCoroutinesDispatcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -24,6 +25,8 @@ import org.mockito.Mockito.spy
 @RunWith(AndroidJUnit4::class)
 class ThumbnailStorageTest {
 
+    val testDispatcher = createTestCoroutinesDispatcher()
+
     @Before
     @After
     fun cleanUp() {
@@ -33,7 +36,7 @@ class ThumbnailStorageTest {
     @Test
     fun `clearThumbnails`() = runBlocking {
         val bitmap: Bitmap = mock()
-        val thumbnailStorage = spy(ThumbnailStorage(testContext))
+        val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
         thumbnailStorage.saveThumbnail("test-tab1", bitmap).joinBlocking()
         thumbnailStorage.saveThumbnail("test-tab2", bitmap).joinBlocking()
@@ -53,7 +56,7 @@ class ThumbnailStorageTest {
     fun `deleteThumbnail`() = runBlocking {
         val sessionIdOrUrl = "test-tab1"
         val bitmap: Bitmap = mock()
-        val thumbnailStorage = spy(ThumbnailStorage(testContext))
+        val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
         thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap).joinBlocking()
         var thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
@@ -68,7 +71,7 @@ class ThumbnailStorageTest {
     fun `saveThumbnail`() = runBlocking {
         val sessionIdOrUrl = "test-tab1"
         val bitmap: Bitmap = mock()
-        val thumbnailStorage = spy(ThumbnailStorage(testContext))
+        val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
         var thumbnail = thumbnailStorage.loadThumbnail(sessionIdOrUrl).await()
 
         assertNull(thumbnail)
@@ -82,7 +85,7 @@ class ThumbnailStorageTest {
     fun `loadThumbnail`() = runBlocking {
         val sessionIdOrUrl = "test-tab1"
         val bitmap: Bitmap = mock()
-        val thumbnailStorage = spy(ThumbnailStorage(testContext))
+        val thumbnailStorage = spy(ThumbnailStorage(testContext, testDispatcher))
 
         thumbnailStorage.saveThumbnail(sessionIdOrUrl, bitmap)
         `when`(thumbnailStorage.loadThumbnail(sessionIdOrUrl)).thenReturn(CompletableDeferred(bitmap))


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Since we're using a different dispatcher for the storage from the test runner, we run into async problems in the test. Using a single thread executor, we can ensure we're running them synchronously and `runBlocking` waits for it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
