### PR TITLE
Closes #7217: removed suspend from intentProcessor

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
@@ -52,7 +52,7 @@ class CustomTabIntentProcessor(
         }
     }
 
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         val safeIntent = SafeIntent(intent)
         val url = safeIntent.dataString
 

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
@@ -10,7 +10,6 @@ import android.provider.Browser
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
@@ -51,7 +50,7 @@ class CustomTabIntentProcessorTest {
     }
 
     @Test
-    fun processCustomTabIntentWithDefaultHandlers() = runBlockingTest {
+    fun processCustomTabIntentWithDefaultHandlers() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
@@ -80,7 +79,7 @@ class CustomTabIntentProcessorTest {
     }
 
     @Test
-    fun processCustomTabIntentWithAdditionalHeaders() = runBlockingTest {
+    fun processCustomTabIntentWithAdditionalHeaders() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
@@ -115,7 +114,7 @@ class CustomTabIntentProcessorTest {
     }
 
     @Test
-    fun processPrivateCustomTabIntentWithDefaultHandlers() = runBlockingTest {
+    fun processPrivateCustomTabIntentWithDefaultHandlers() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/IntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/IntentProcessor.kt
@@ -16,5 +16,5 @@ interface IntentProcessor {
      * @param intent The intent to process.
      * @return True if the intent was processed, otherwise false.
      */
-    suspend fun process(intent: Intent): Boolean
+    fun process(intent: Intent): Boolean
 }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -112,7 +112,7 @@ class TabIntentProcessor(
      * @param intent the intent to process
      * @return true if the intent was processed, otherwise false.
      */
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         val safeIntent = SafeIntent(intent)
         return when (safeIntent.action) {
             ACTION_VIEW, ACTION_NDEF_DISCOVERED -> processViewIntent(safeIntent)

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.nfc.NfcAdapter.ACTION_NDEF_DISCOVERED
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
@@ -56,7 +55,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun processViewIntent() = runBlockingTest {
+    fun processViewIntent() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         val useCases = SessionUseCases(sessionManager)
@@ -91,7 +90,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun processViewIntentUsingSelectedSession() = runBlockingTest {
+    fun processViewIntentUsingSelectedSession() {
         val handler = TabIntentProcessor(
             sessionManager,
             sessionUseCases.loadUrl,
@@ -107,7 +106,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun processViewIntentHavingNoSelectedSession() = runBlockingTest {
+    fun processViewIntentHavingNoSelectedSession() {
         whenever(sessionManager.selectedSession).thenReturn(null)
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
 
@@ -126,7 +125,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun processNfcIntent() = runBlockingTest {
+    fun processNfcIntent() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         val useCases = SessionUseCases(sessionManager)
@@ -153,7 +152,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun processNfcIntentUsingSelectedSession() = runBlockingTest {
+    fun processNfcIntentUsingSelectedSession() {
         val handler = TabIntentProcessor(
             sessionManager,
             sessionUseCases.loadUrl,
@@ -169,7 +168,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun processNfcIntentHavingNoSelectedSession() = runBlockingTest {
+    fun processNfcIntentHavingNoSelectedSession() {
         whenever(sessionManager.selectedSession).thenReturn(null)
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
 
@@ -188,7 +187,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `load URL on ACTION_SEND if text contains URL`() = runBlockingTest {
+    fun `load URL on ACTION_SEND if text contains URL`() {
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
 
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
@@ -218,7 +217,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `perform search on ACTION_SEND if text (no URL) provided`() = runBlockingTest {
+    fun `perform search on ACTION_SEND if text (no URL) provided`() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
@@ -246,7 +245,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `processor handles ACTION_SEND with empty text`() = runBlockingTest {
+    fun `processor handles ACTION_SEND with empty text`() {
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
 
         val intent = mock<Intent>()
@@ -258,7 +257,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `processor handles ACTION_SEARCH with empty text`() = runBlockingTest {
+    fun `processor handles ACTION_SEARCH with empty text`() {
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
 
         val intent = mock<Intent>()
@@ -270,7 +269,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `load URL on ACTION_SEARCH if text is an URL`() = runBlockingTest {
+    fun `load URL on ACTION_SEARCH if text is an URL`() {
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
 
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
@@ -284,7 +283,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `perform search on ACTION_SEARCH if text (no URL) provided`() = runBlockingTest {
+    fun `perform search on ACTION_SEARCH if text (no URL) provided`() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
@@ -312,7 +311,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `processor handles ACTION_WEB_SEARCH with empty text`() = runBlockingTest {
+    fun `processor handles ACTION_WEB_SEARCH with empty text`() {
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
 
         val intent = mock<Intent>()
@@ -324,7 +323,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `load URL on ACTION_WEB_SEARCH if text is an URL`() = runBlockingTest {
+    fun `load URL on ACTION_WEB_SEARCH if text is an URL`() {
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())
 
         val handler = TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch)
@@ -338,7 +337,7 @@ class TabIntentProcessorTest {
     }
 
     @Test
-    fun `perform search on ACTION_WEB_SEARCH if text (no URL) provided`() = runBlockingTest {
+    fun `perform search on ACTION_WEB_SEARCH if text (no URL) provided`() {
         val engine = mock<Engine>()
         val sessionManager = spy(SessionManager(engine))
         doReturn(engineSession).`when`(sessionManager).getOrCreateEngineSession(anySession(), anyBoolean())

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessor.kt
@@ -51,7 +51,7 @@ class TrustedWebActivityIntentProcessor(
         return safeIntent.action == ACTION_VIEW && isTrustedWebActivityIntent(safeIntent)
     }
 
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         val safeIntent = SafeIntent(intent)
         val url = safeIntent.dataString
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.pwa.intent
 
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_DOCUMENT
+import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
@@ -39,11 +40,11 @@ class WebAppIntentProcessor(
      * A custom tab config is also set so a custom tab toolbar can be shown when the user leaves
      * the scope defined in the manifest.
      */
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         val url = intent.toSafeIntent().dataString
 
         return if (!url.isNullOrEmpty() && matches(intent)) {
-            val webAppManifest = storage.loadManifest(url) ?: return false
+            val webAppManifest = runBlocking { storage.loadManifest(url) } ?: return false
 
             val session = Session(url, private = false, source = Source.HOME_SCREEN)
             session.webAppManifest = webAppManifest

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt
@@ -12,7 +12,6 @@ import androidx.browser.customtabs.TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_A
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.browser.state.store.BrowserStore
@@ -47,7 +46,7 @@ class TrustedWebActivityIntentProcessorTest {
     }
 
     @Test
-    fun `process checks if intent action is not valid`() = runBlockingTest {
+    fun `process checks if intent action is not valid`() {
         val processor = TrustedWebActivityIntentProcessor(mock(), mock(), mock(), mock(), mock())
 
         assertFalse(processor.process(Intent(ACTION_VIEW_PWA)))
@@ -76,7 +75,7 @@ class TrustedWebActivityIntentProcessorTest {
     }
 
     @Test
-    fun `process adds custom tab config`() = runBlockingTest {
+    fun `process adds custom tab config`() {
         val intent = Intent(ACTION_VIEW, "https://example.com".toUri()).apply {
             putExtra(EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true)
             putExtra(EXTRA_SESSION, null as Bundle?)

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessorTest.kt
@@ -31,7 +31,7 @@ import org.mockito.Mockito.`when`
 @ExperimentalCoroutinesApi
 class WebAppIntentProcessorTest {
     @Test
-    fun `process checks if intent action is not valid`() = runBlockingTest {
+    fun `process checks if intent action is not valid`() {
         val processor = WebAppIntentProcessor(mock(), mock(), mock())
 
         assertFalse(processor.process(Intent(ACTION_VIEW)))

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationIntentProcessor.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/MigrationIntentProcessor.kt
@@ -20,7 +20,7 @@ class MigrationIntentProcessor(private val store: MigrationStore) : IntentProces
      *
      * If this is true, we should show an instance of AbstractMigrationProgressActivity.
      */
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         return when (store.state.progress) {
             MigrationProgress.COMPLETED, MigrationProgress.NONE -> false
             MigrationProgress.MIGRATING -> true

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationIntentProcessorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/MigrationIntentProcessorTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.support.migration
 
 import android.content.Intent
-import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.support.migration.state.MigrationAction
 import mozilla.components.support.migration.state.MigrationStore
 import mozilla.components.support.test.ext.joinBlocking
@@ -16,7 +15,7 @@ import org.junit.Test
 
 class MigrationIntentProcessorTest {
     @Test
-    fun `process updates intent`() = runBlockingTest {
+    fun `process updates intent`() {
         val store = MigrationStore()
         val processor = MigrationIntentProcessor(store)
         val intent: Intent = mock()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-intent**
+   * ⚠️ **This is a breaking change**: `IntentProcessor.process` is not a suspend function anymore.
+
 * **feature-contextmenu**
   * Add "Share image" to context menu.
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Removing the `suspend` from the `process` gives us a 50ms win on low end devices when using the `IntentReceiverActivity` since we can now remove the `MainScope.launch` from the `IntentReceiverActivity`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
