### PR TITLE
Close #7495: Wait for firstContentfulPaint in BrowserThumbnail

### DIFF
--- a/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/BrowserThumbnails.kt
+++ b/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/BrowserThumbnails.kt
@@ -18,7 +18,7 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.content.isOSOnLowMemory
-import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 
 /**
  * Feature implementation for automatically taking thumbnails of sites.
@@ -43,9 +43,9 @@ class BrowserThumbnails(
     override fun start() {
         scope = store.flowScoped { flow ->
             flow.map { it.selectedTab }
-                .ifChanged { it?.content?.loading }
+                .ifAnyChanged { arrayOf(it?.content?.loading, it?.content?.firstContentfulPaint) }
                 .collect { state ->
-                    if (state?.content?.loading == false) {
+                    if (state?.content?.loading == false && state.content.firstContentfulPaint) {
                         requestScreenshot()
                     }
                 }

--- a/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/BrowserThumbnailsTest.kt
+++ b/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/BrowserThumbnailsTest.kt
@@ -64,9 +64,6 @@ class BrowserThumbnailsTest {
         thumbnails.start()
         thumbnails.stop()
 
-        // Initial loading state is false
-        verify(engineView).captureThumbnail(any())
-
         store.dispatch(ContentAction.UpdateThumbnailAction(tabId, mock())).joinBlocking()
 
         verifyNoMoreInteractions(engineView)
@@ -74,7 +71,7 @@ class BrowserThumbnailsTest {
 
     @Suppress("UNCHECKED_CAST")
     @Test
-    fun `feature must capture thumbnail when a site finishes loading`() {
+    fun `feature must capture thumbnail when a site finishes loading and first paint`() {
         val bitmap: Bitmap? = mock()
 
         store.dispatch(ContentAction.UpdateLoadingStateAction(tabId, true)).joinBlocking()
@@ -89,6 +86,7 @@ class BrowserThumbnailsTest {
         verify(store, never()).dispatch(ContentAction.UpdateThumbnailAction(tabId, bitmap!!))
 
         store.dispatch(ContentAction.UpdateLoadingStateAction(tabId, false)).joinBlocking()
+        store.dispatch(ContentAction.UpdateFirstContentfulPaintStateAction(tabId, true)).joinBlocking()
 
         verify(store).dispatch(ContentAction.UpdateThumbnailAction(tabId, bitmap))
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,10 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: `TrustedWebActivityIntentProcessor` now requires a `RelationChecker` instead of `httpClient` and `apiKey`.
 
 * **browser-thumbnails**
-  * Deletes the tab's thumbnail from the storage when the sessions are removed.
+  * The `ThumbnailMiddleware` deletes the tab's thumbnail from the storage when the sessions are removed.
+  * `BrowserThumbnails` waits for the `firstContentfulPaint` before requesting a screenshot.
+
+* **feature-tabs**
   * ⚠️ **This is a breaking change**: Removes unused `ThumbnailsUseCases` since we now load thumbnails via `ThumbnailLoader`. See [#7313](https://github.com/mozilla-mobile/android-components/issues/7313).
   * ⚠️ **This is a breaking change**: Removes `ThumbnailsUseCases` as a parameter in `TabsFeature` and `TabsTrayPresenter`.
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Closes #7495 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
