### PR TITLE
Closes #7474: API for counting recently used PWAs

### DIFF
--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -200,14 +200,30 @@ class WebAppShortcutManager(
      * Checks if there is a currently installed web app to which this URL belongs.
      *
      * @param url url that is covered by the scope of a web app installed by the user
-     * @param currentTime the curent time in milliseconds
+     * @param currentTimeMs the current time in milliseconds, exposed for testing
      */
-    suspend fun getWebAppInstallState(url: String, currentTime: Long = System.currentTimeMillis()): WebAppInstallState {
-        if (storage.hasRecentManifest(url, currentTime = currentTime)) {
+    suspend fun getWebAppInstallState(
+        url: String,
+        @VisibleForTesting currentTimeMs: Long = System.currentTimeMillis()
+    ): WebAppInstallState {
+        if (storage.hasRecentManifest(url, currentTimeMs = currentTimeMs)) {
             return WebAppInstallState.Installed
         }
 
         return WebAppInstallState.NotInstalled
+    }
+
+    /**
+     * Counts number of recently used web apps. See [ManifestStorage.activeThresholdMs].
+     *
+     * @param activeThresholdMs defines a time window within which a web app is considered recently used.
+     * Defaults to [ManifestStorage.ACTIVE_THRESHOLD_MS].
+     * @return count of recently used web apps
+     */
+    suspend fun recentlyUsedWebAppsCount(
+        activeThresholdMs: Long = ManifestStorage.ACTIVE_THRESHOLD_MS
+    ): Int {
+        return storage.recentManifestsCount(activeThresholdMs = activeThresholdMs)
     }
 
     /**

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppShortcutManager.kt
@@ -197,20 +197,6 @@ class WebAppShortcutManager(
         }
 
     /**
-     * Uninstalls a set of PWAs from the user's device by disabling their
-     * shortcuts and removing the associated manifest data.
-     *
-     * @param startUrls List of manifest startUrls to remove.
-     * @param disabledMessage Message to display when a disable shortcut is tapped.
-     */
-    suspend fun uninstallShortcuts(context: Context, startUrls: List<String>, disabledMessage: String? = null) {
-        if (SDK_INT >= VERSION_CODES.N_MR1) {
-            context.getSystemService<ShortcutManager>()?.disableShortcuts(startUrls, disabledMessage)
-        }
-        storage.removeManifests(startUrls)
-    }
-
-    /**
      * Checks if there is a currently installed web app to which this URL belongs.
      *
      * @param url url that is covered by the scope of a web app installed by the user

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppUseCases.kt
@@ -90,13 +90,13 @@ class WebAppUseCases(
         private val shortcutManager: WebAppShortcutManager
     ) {
         /**
-         * @param currentTime the current time against which manifest usage timeouts will be validated
+         * @param currentTimeMs the current time against which manifest usage timeouts will be validated
          */
         suspend operator fun invoke(
-            currentTime: Long = System.currentTimeMillis()
+            currentTimeMs: Long = System.currentTimeMillis()
         ): WebAppShortcutManager.WebAppInstallState? {
             val session = sessionManager.selectedSession ?: return null
-            return shortcutManager.getWebAppInstallState(session.url, currentTime)
+            return shortcutManager.getWebAppInstallState(session.url, currentTimeMs)
         }
     }
 

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestDao.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/db/ManifestDao.kt
@@ -25,8 +25,12 @@ internal interface ManifestDao {
     fun getManifestsByScope(url: String): List<ManifestEntity>
 
     @WorkerThread
-    @Query("SELECT count(start_url) from manifests WHERE :url LIKE scope||'%' AND used_at < :deadline")
-    fun hasRecentManifest(url: String, deadline: Long): Int
+    @Query("SELECT count(start_url) from manifests WHERE :url LIKE scope||'%' AND used_at < :thresholdMs")
+    fun hasRecentManifest(url: String, thresholdMs: Long): Int
+
+    @WorkerThread
+    @Query("SELECT count(start_url) from manifests WHERE used_at < :thresholdMs")
+    fun recentManifestsCount(thresholdMs: Long): Int
 
     @WorkerThread
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppShortcutManagerTest.kt
@@ -274,31 +274,6 @@ class WebAppShortcutManagerTest {
     }
 
     @Test
-    fun `uninstallShortcuts removes shortcut`() = runBlockingTest {
-        manager.uninstallShortcuts(context, listOf("https://mozilla.org"))
-        verify(shortcutManager, never()).disableShortcuts(listOf("https://mozilla.org"), null)
-        verify(storage).removeManifests(listOf("https://mozilla.org"))
-
-        clearInvocations(shortcutManager)
-        clearInvocations(storage)
-
-        setSdkInt(Build.VERSION_CODES.N_MR1)
-        manager.uninstallShortcuts(context, listOf("https://mozilla.org"))
-        verify(shortcutManager).disableShortcuts(listOf("https://mozilla.org"), null)
-        verify(storage).removeManifests(listOf("https://mozilla.org"))
-    }
-
-    @Test
-    fun `uninstallShortcuts sets disabledMessage`() = runBlockingTest {
-        setSdkInt(Build.VERSION_CODES.N_MR1)
-        val domains = listOf("https://mozilla.org", "https://firefox.com")
-        val message = "Can't touch this - its uninstalled."
-        WebAppShortcutManager(context, httpClient, storage).uninstallShortcuts(context, domains, message)
-
-        verify(shortcutManager).disableShortcuts(domains, message)
-    }
-
-    @Test
     fun `checking unknown url returns uninstalled state`() = runBlockingTest {
         setSdkInt(Build.VERSION_CODES.N_MR1)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ permalink: /changelog/
 
 * **feature-pwa**
   * ⚠️ **This is a breaking change**: `TrustedWebActivityIntentProcessor` now requires a `RelationChecker` instead of `httpClient` and `apiKey`.
+  * ⚠️ **This is a breaking change**: Removed unused API from `WebAppShortcutManager`: uninstallShortcuts
+  * `WebAppShortcutManager` gained a new API: recentlyUsedWebAppsCount. Allows counting recently used web apps.
 
 * **browser-thumbnails**
   * Deletes the tab's thumbnail from the storage when the sessions are removed.


### PR DESCRIPTION
Skipped adding tests for the shortcut manager class, as they'd be even more useless than the manifest storage tests. Currently, we're not actually exercising a storage layer, which android docs seem to advise against due to a likely sqlite version mismatch (unless you run your tests on-device, which is rather slow).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
