### PR TITLE
For #7337: Prevent text in <ul> tags being read twice by screen readers.

### DIFF
--- a/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -93,7 +93,7 @@ object ErrorPages {
          * Warning: When updating these params you WILL cause breaking changes that are undetected
          * by consumers. Update the README accordingly.
          */
-        return "resource://android/assets/$htmlResource?" +
+        var urlEncodedErrorPage = "resource://android/assets/$htmlResource?" +
             "&title=$title" +
             "&button=$button" +
             "&description=$description" +
@@ -103,6 +103,10 @@ object ErrorPages {
             "&badCertTechInfo=$badCertTechInfo" +
             "&badCertGoBack=$badCertGoBack" +
             "&badCertAcceptTemporary=$badCertAcceptTemporary"
+
+        urlEncodedErrorPage = urlEncodedErrorPage
+            .replace("<ul>", "<ul role=\"presentation\">")
+        return urlEncodedErrorPage
     }
 }
 

--- a/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
+++ b/components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt
@@ -129,7 +129,12 @@ class ErrorPagesTest {
 
         assertTrue(errorPage.startsWith("resource://android/assets/$htmlFilename"))
         assertTrue(errorPage.contains("&button=${context.resources.getString(errorType.refreshButtonRes)}"))
-        assertTrue(errorPage.contains("&description=${context.resources.getString(errorType.messageRes, uri)}"))
+        assertTrue(
+            errorPage.contains(
+                "&description=${context.resources.getString(errorType.messageRes, uri)}"
+                    .replace("<ul>", "<ul role=\"presentation\">")
+            )
+        )
         assertTrue(errorPage.contains("&image=$expectedImageName"))
     }
 }


### PR DESCRIPTION
See also : https://github.com/mozilla-mobile/android-components/pull/5299.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
