### PR TITLE
For fenix#11679: submenu items order depends on appendExtensionSubMenuAtStart

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
@@ -22,8 +22,8 @@ import mozilla.components.browser.state.store.BrowserStore
  * @param webExtIconTintColorResource Optional ID of color resource to tint the icons of back and
  * add-ons manager menu items.
  * @param onAddonsManagerTapped Callback to be invoked when add-ons manager menu item is selected.
- * @param appendExtensionActionAtStart true if web extensions appear at the top (start) of the menu,
- * false if web extensions appear at the bottom of the menu. Default to false (bottom).
+ * @param appendExtensionSubMenuAtStart true if web extension sub menu appear at the top (start) of
+ * the menu, false if web extensions appear at the bottom of the menu. Default to false (bottom).
  */
 @Suppress("LongParameterList")
 class WebExtensionBrowserMenuBuilder(
@@ -33,7 +33,7 @@ class WebExtensionBrowserMenuBuilder(
     private val store: BrowserStore,
     private val webExtIconTintColorResource: Int = NO_ID,
     private val onAddonsManagerTapped: () -> Unit = {},
-    private val appendExtensionActionAtStart: Boolean = false
+    private val appendExtensionSubMenuAtStart: Boolean = false
 ) : BrowserMenuBuilder(items, extras, endOfMenuAlwaysVisible) {
 
     /**
@@ -58,10 +58,15 @@ class WebExtensionBrowserMenuBuilder(
                 onAddonsManagerTapped.invoke()
             }
 
-            val webExtSubMenuItems =
+            val webExtSubMenuItems = if (appendExtensionSubMenuAtStart) {
                 listOf(backPressMenuItem) + BrowserMenuDivider() +
                 extensionMenuItems +
                 BrowserMenuDivider() + addonsManagerMenuItem
+            } else {
+                listOf(addonsManagerMenuItem) + BrowserMenuDivider() +
+                extensionMenuItems +
+                BrowserMenuDivider() + backPressMenuItem
+            }
 
             val webExtBrowserMenuAdapter = BrowserMenuAdapter(context, webExtSubMenuItems)
             val webExtMenu = WebExtensionBrowserMenu(webExtBrowserMenuAdapter, store)
@@ -84,7 +89,7 @@ class WebExtensionBrowserMenuBuilder(
         }
 
         val menuItems =
-            if (appendExtensionActionAtStart) {
+            if (appendExtensionSubMenuAtStart) {
                 listOf(webExtMenuItem) + items
             } else {
                 items + webExtMenuItem

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -37,7 +37,7 @@ class WebExtensionBrowserMenuBuilderTest {
             listOf(mockMenuItem(), mockMenuItem()),
             store = store,
             onAddonsManagerTapped = { isAddonsManagerTapped = true },
-            appendExtensionActionAtStart = true
+            appendExtensionSubMenuAtStart = true
         )
 
         val menu = builder.build(testContext)
@@ -78,7 +78,7 @@ class WebExtensionBrowserMenuBuilderTest {
             listOf(mockMenuItem(), mockMenuItem()),
             store = store,
             onAddonsManagerTapped = { isAddonsManagerTapped = true },
-            appendExtensionActionAtStart = true
+            appendExtensionSubMenuAtStart = true
         )
 
         val menu = builder.build(testContext)
@@ -98,7 +98,7 @@ class WebExtensionBrowserMenuBuilderTest {
     }
 
     @Test
-    fun `web extension submenu is added at the start when appendExtensionActionAtStart is true`() {
+    fun `web extension submenu is added at the start when appendExtensionSubMenuAtStart is true`() {
         val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
         val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
 
@@ -122,7 +122,7 @@ class WebExtensionBrowserMenuBuilderTest {
         val builder = WebExtensionBrowserMenuBuilder(
             listOf(mockMenuItem(), mockMenuItem()),
             store = store,
-            appendExtensionActionAtStart = true
+            appendExtensionSubMenuAtStart = true
         )
 
         val menu = builder.build(testContext)
@@ -150,7 +150,7 @@ class WebExtensionBrowserMenuBuilderTest {
     }
 
     @Test
-    fun `web extension submenu is added at the end when appendExtensionActionAtStart is false`() {
+    fun `web extension submenu is added at the end when appendExtensionSubMenuAtStart is false`() {
         val browserAction = WebExtensionBrowserAction("browser_action", false, mock(), "", 0, 0) {}
         val pageAction = WebExtensionBrowserAction("page_action", false, mock(), "", 0, 0) {}
 
@@ -175,7 +175,7 @@ class WebExtensionBrowserMenuBuilderTest {
             WebExtensionBrowserMenuBuilder(
                 listOf(mockMenuItem(), mockMenuItem()),
                 store = store,
-                appendExtensionActionAtStart = false
+                appendExtensionSubMenuAtStart = false
             )
 
         val menu = builder.build(testContext)
@@ -192,10 +192,10 @@ class WebExtensionBrowserMenuBuilderTest {
         val parentMenuItem = menu.adapter.visibleItems[recyclerAdapter.itemCount - 1] as? ParentBrowserMenuItem
         val subMenuItemSize = parentMenuItem!!.subMenu.adapter.visibleItems.size
         assertEquals(6, subMenuItemSize)
-        val backMenuItem = parentMenuItem.subMenu.adapter.visibleItems[0] as? BackPressMenuItem
+        val backMenuItem = parentMenuItem.subMenu.adapter.visibleItems[subMenuItemSize - 1] as? BackPressMenuItem
         val subMenuExtItemBrowserAction = parentMenuItem.subMenu.adapter.visibleItems[2] as? WebExtensionBrowserMenuItem
         val subMenuExtItemPageAction = parentMenuItem.subMenu.adapter.visibleItems[3] as? WebExtensionBrowserMenuItem
-        val addOnsManagerMenuItem = parentMenuItem.subMenu.adapter.visibleItems[subMenuItemSize - 1] as? BrowserMenuImageText
+        val addOnsManagerMenuItem = parentMenuItem.subMenu.adapter.visibleItems[0] as? BrowserMenuImageText
         assertNotNull(backMenuItem)
         assertEquals("browser_action", subMenuExtItemBrowserAction!!.action.title)
         assertEquals("page_action", subMenuExtItemPageAction!!.action.title)


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/11679

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
