### PR TITLE
Add firefox profiler marker API to the GeckoEngine

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -27,6 +27,7 @@ import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
@@ -495,6 +496,11 @@ class GeckoEngine(
             GeckoResult<Void>()
         })
     }
+
+    /**
+     * See [Engine.profiler].
+     */
+    override val profiler: Profiler? = null
 
     override fun name(): String = "Gecko"
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.engine.gecko.integration.LocaleSettingUpdater
 import mozilla.components.browser.engine.gecko.mediaquery.from
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
+import mozilla.components.browser.engine.gecko.profiler.Profiler
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
 import mozilla.components.browser.engine.gecko.webnotifications.GeckoWebNotificationDelegate
 import mozilla.components.browser.engine.gecko.webpush.GeckoWebPushDelegate
@@ -495,6 +496,11 @@ class GeckoEngine(
             GeckoResult<Void>()
         })
     }
+
+    /**
+     * See [Engine.profiler].
+     */
+    override val profiler: Profiler? = Profiler(runtime)
 
     override fun name(): String = "Gecko"
 

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/profiler/Profiler.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/profiler/Profiler.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.profiler
+
+import mozilla.components.concept.engine.profiler.Profiler
+import org.mozilla.geckoview.GeckoRuntime
+
+/**
+ * Gecko-based implementation of [Profiler], wrapping the
+ * ProfilerController object provided by GeckoView.
+ */
+class Profiler(
+    private val runtime: GeckoRuntime
+) : Profiler {
+
+    /**
+     * See [Profiler.isProfilerActive].
+     */
+    override fun isProfilerActive(): Boolean {
+        return runtime.profilerController.isProfilerActive
+    }
+
+    /**
+     * See [Profiler.getProfilerTime].
+     */
+    override fun getProfilerTime(): Double? {
+        return runtime.profilerController.profilerTime
+    }
+
+    /**
+     * See [Profiler.addMarker].
+     */
+    override fun addMarker(markerName: String, startTime: Double?, endTime: Double?, text: String?) {
+        runtime.profilerController.addMarker(markerName, startTime, endTime, text)
+    }
+
+    /**
+     * See [Profiler.addMarker].
+     */
+    override fun addMarker(markerName: String, startTime: Double?, text: String?) {
+        runtime.profilerController.addMarker(markerName, startTime, text)
+    }
+
+    /**
+     * See [Profiler.addMarker].
+     */
+    override fun addMarker(markerName: String, startTime: Double) {
+        runtime.profilerController.addMarker(markerName, startTime)
+    }
+
+    /**
+     * See [Profiler.addMarker].
+     */
+    override fun addMarker(markerName: String, text: String?) {
+        runtime.profilerController.addMarker(markerName, text)
+    }
+
+    /**
+     * See [Profiler.addMarker].
+     */
+    override fun addMarker(markerName: String) {
+        runtime.profilerController.addMarker(markerName)
+    }
+}

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -27,6 +27,7 @@ import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
@@ -495,6 +496,11 @@ class GeckoEngine(
             GeckoResult<Void>()
         })
     }
+
+    /**
+     * See [Engine.profiler].
+     */
+    override val profiler: Profiler? = null
 
     override fun name(): String = "Gecko"
 

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import org.json.JSONObject
 import java.lang.IllegalStateException
@@ -60,6 +61,11 @@ class SystemEngine(
      * Note: This implementation is a no-op.
      */
     override fun speculativeConnect(url: String) = Unit
+
+    /**
+     * See [Engine.profiler].
+     */
+    override val profiler: Profiler? = null
 
     /**
      * See [Engine.name]

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 import androidx.annotation.MainThread
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -176,6 +177,12 @@ interface Engine : WebExtensionRuntime, DataCleanable {
      */
     val trackingProtectionExceptionStore: TrackingProtectionExceptionStorage
         get() = throw UnsupportedOperationException("TrackingProtectionExceptionStorage not supported by this engine.")
+
+    /**
+     * Provides access to Firefox Profiler features.
+     * See [Profiler] for more information.
+     */
+    val profiler: Profiler?
 
     /**
      * Provides access to the settings of this engine.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/profiler/Profiler.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/profiler/Profiler.kt
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.profiler
+
+/**
+ * [Profiler] is being used to manage Firefox Profiler related features.
+ *
+ * If you want to add a profiler marker to mark a point in time (without a duration)
+ * you can directly use `engine.profiler?.addMarker("marker name")`.
+ * Or if you want to provide more information, you can use
+ * `engine.profiler?.addMarker("marker name", "extra information")`.
+ *
+ * If you want to add a profiler marker with a duration (with start and end time)
+ * you can use it like this, it will automatically get the end time inside the addMarker:
+ * ```
+ *     val startTime = engine.profiler?.getProfilerTime()
+ *     ...some code you want to measure...
+ *     engine.profiler?.addMarker("name", startTime)
+ * ```
+ *
+ * Or you can capture start and end time in somewhere, then add the marker in somewhere else:
+ * ```
+ *     val startTime = engine.profiler?.getProfilerTime()
+ *     ...some code you want to measure (or end time can be collected in a callback)...
+ *     val endTime = engine.profiler?.getProfilerTime()
+ *
+ *     ...somewhere else in the codebase...
+ *     engine.profiler?.addMarker("name", startTime, endTime)
+ * ```
+ *
+ * Here's an [Profiler.addMarker] example with all the possible parameters:
+ * ```
+ *     val startTime = engine.profiler?.getProfilerTime()
+ *     ...some code you want to measure...
+ *     val endTime = engine.profiler?.getProfilerTime()
+ *
+ *     ...somewhere else in the codebase...
+ *     engine.profiler?.addMarker("name", startTime, endTime, "extra information")
+ * ```
+ *
+ * [Profiler.isProfilerActive] method is handy when you want to get more information to
+ * add inside the marker, but you think it's going to be computationally heavy (and useless)
+ * when profiler is not running:
+ * ```
+ *     val startTime = engine.profiler?.getProfilerTime()
+ *     ...some code you want to measure...
+ *     if (engine.profiler?.isProfilerActive()) {
+ *         val info = aFunctionYouDoNotWantToCallWhenProfilerIsNotActive()
+ *         engine.profiler?.addMarker("name", startTime, info)
+ *     }
+ * ```
+ */
+interface Profiler {
+    /**
+     * Returns true if profiler is active and it's allowed the add markers.
+     * It's useful when it's computationally heavy to get startTime or the
+     * additional text for the marker. That code can be wrapped with
+     * isProfilerActive if check to reduce the overhead of it.
+     *
+     * @return true if profiler is active and safe to add a new marker.
+     */
+    fun isProfilerActive(): Boolean
+
+    /**
+     * Get the profiler time to be able to mark the start of the marker events.
+     * can be used like this:
+     *
+     * <code>
+     *     val startTime = engine.profiler?.getProfilerTime()
+     *     ...some code you want to measure...
+     *     engine.profiler?.addMarker("name", startTime)
+     * </code>
+     *
+     * @return profiler time as Double or null if the profiler is not active.
+     */
+    fun getProfilerTime(): Double?
+
+    /**
+     * Add a profiler marker to Gecko Profiler with the given arguments.
+     * It can be used for either adding a point-in-time marker or a duration marker.
+     * No-op if profiler is not active.
+     *
+     * @param markerName Name of the event as a string.
+     * @param startTime Start time as Double. It can be null if you want to mark a point of time.
+     * @param endTime End time as Double. If it's null, this function implicitly gets the end time.
+     * @param text An optional string field for more information about the marker.
+     */
+    fun addMarker(markerName: String, startTime: Double?, endTime: Double?, text: String?)
+
+    /**
+     * Add a profiler marker to Gecko Profiler with the given arguments.
+     * End time will be added automatically with the current profiler time when the function is called.
+     * No-op if profiler is not active.
+     * This is an overload of [Profiler.addMarker] for convenience.
+     *
+     * @param aMarkerName Name of the event as a string.
+     * @param aStartTime Start time as Double. It can be null if you want to mark a point of time.
+     * @param aText An optional string field for more information about the marker.
+     */
+    fun addMarker(markerName: String, startTime: Double?, text: String?)
+
+    /**
+     * Add a profiler marker to Gecko Profiler with the given arguments.
+     * End time will be added automatically with the current profiler time when the function is called.
+     * No-op if profiler is not active.
+     * This is an overload of [Profiler.addMarker] for convenience.
+     *
+     * @param markerName Name of the event as a string.
+     * @param startTime Start time as Double. It can be null if you want to mark a point of time.
+     */
+    fun addMarker(markerName: String, startTime: Double)
+
+    /**
+     * Add a profiler marker to Gecko Profiler with the given arguments.
+     * Time will be added automatically with the current profiler time when the function is called.
+     * No-op if profiler is not active.
+     * This is an overload of [Profiler.addMarker] for convenience.
+     *
+     * @param markerName Name of the event as a string.
+     * @param text An optional string field for more information about the marker.
+     */
+    fun addMarker(markerName: String, text: String?)
+
+    /**
+     * Add a profiler marker to Gecko Profiler with the given arguments.
+     * Time will be added automatically with the current profiler time when the function is called.
+     * No-op if profiler is not active.
+     * This is an overload of [Profiler.addMarker] for convenience.
+     *
+     * @param markerName Name of the event as a string.
+     */
+    fun addMarker(markerName: String)
+}

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.concept.engine
 import android.content.Context
 import android.util.AttributeSet
 import mozilla.components.concept.engine.Engine.BrowsingData
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -41,6 +42,9 @@ class EngineTest {
         override fun speculativeConnect(url: String) {
             throw NotImplementedError("Not needed for test")
         }
+
+        override val profiler: Profiler?
+            get() = throw NotImplementedError("Not needed for test")
 
         override val settings: Settings
             get() = throw NotImplementedError("Not needed for test")

--- a/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
+++ b/components/feature/tab-collections/src/androidTest/java/mozilla/components/feature/tab/collections/TabCollectionStorageTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.feature.tab.collections.db.TabCollectionDatabase
 import mozilla.components.feature.tab.collections.db.TabEntity
@@ -364,6 +365,9 @@ class FakeEngine : Engine {
 
     override fun speculativeConnect(url: String) =
         throw UnsupportedOperationException()
+
+    override val profiler: Profiler?
+        get() = throw NotImplementedError("Not needed for test")
 
     override val settings: Settings = DefaultSettings()
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,6 +65,9 @@ permalink: /changelog/
   * `WebNotificationFeature` checks the site permissions first before showing a notification.
   * Notifications with a long text body are now expandable to show the full text.
 
+* **concept-engine**
+  * Adds `profiler` property with `isProfilerActive`, `getProfilerTime` and `addMarker` Firefox Profiler APIs. These will allow to add profiler markers.
+
 # 47.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v46.0.0...v47.0.0)


### PR DESCRIPTION
Hi all, I'm on the Firefox Profiler team and I was working on the geckoview API for the Firefox and just landed the GeckoView part in [Bug 1624993](https://bugzilla.mozilla.org/show_bug.cgi?id=1624993). I also want to add this API to android-components so we can use that API in the consumers like Fenix. This is still not exactly complete but I wanted to get some early feedback from you. It would be great if you can take a look at it.

- I added a `ProfilerRuntime` interface and added that interface to `GeckoEngine`. These ProfilerRuntime methods calls the geckoview APIs. I'm not exactly sure about the place. I added it to GeckoEngine class but I can move it to somewhere else too if you think it's not great.
- Also currently I didn't add any tests and I would like to get your feedback on how to write this as well. This feels like a bit tricky, because when the profiler is not running, these methods are no-op. And currently there is no way to enable profiler from geckoview. It's only possible with[ remote profiling via `about:debugging`](https://profiler.firefox.com/docs/#/./guide-remote-profiling). So I'm not sure what to test here. Maybe if we have some devtools tests in the codebase, I can try to do some things like these.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
