### PR TITLE
Revert "Upgrade Glean to v31.2.1"

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val mozilla_appservices = "61.0.6"
 
-    const val mozilla_glean = "31.2.1"
+    const val mozilla_glean = "31.1.1"
 
     const val material = "1.1.0"
     const val nearby = "17.0.0"

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/ConceptFetchHttpUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/ConceptFetchHttpUploaderTest.kt
@@ -39,7 +39,9 @@ import org.mockito.Mockito.verify
 class ConceptFetchHttpUploaderTest {
     private val testPath: String = "/some/random/path/not/important"
     private val testPing: String = "{ 'ping': 'test' }"
-    private val testDefaultConfig = Configuration()
+    private val testDefaultConfig = Configuration().copy(
+        userAgent = "Glean/Test 25.0.2"
+    )
 
     /**
      * Create a mock webserver that accepts all requests.
@@ -217,6 +219,7 @@ class ConceptFetchHttpUploaderTest {
         val server = getMockWebServer()
 
         val testConfig = testDefaultConfig.copy(
+            userAgent = "Telemetry/42.23",
             serverEndpoint = "http://localhost:" + server.port
         )
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,13 +28,6 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: Removes unused `ThumbnailsUseCases` since we now load thumbnails via `ThumbnailLoader`. See [#7313](https://github.com/mozilla-mobile/android-components/issues/7313).
   * ⚠️ **This is a breaking change**: Removes `ThumbnailsUseCases` as a parameter in `TabsFeature` and `TabsTrayPresenter`.
 
-* **service-glean**
-  * Glean was updated to v31.2.1
-    * BUGFIX: Correctly format the date and time in the Date header
-    * Feature: Add rate limiting capabilities to the upload manager
-    * BUGFIX: baseline pings with reason "dirty startup" are no longer sent if Glean did not full initialize in the previous run
-
-
 * **feature-privatemode**
   * Add `PrivateNotificationFeature` to display a notification when private sessions are open.
 


### PR DESCRIPTION
This reverts commit 59269364b5e29a0617542964546654317149196d.

See https://github.com/mozilla-mobile/android-components/issues/7511#issuecomment-649721732

While these failures aren't technically blocking us, they may be masking other problems. E.g. we rely on ui tests as integration tests for the A-S stack.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
