### PR TITLE
Closes #7161: Check site permissions before showing web notification

### DIFF
--- a/components/feature/webnotifications/build.gradle
+++ b/components/feature/webnotifications/build.gradle
@@ -25,6 +25,7 @@ android {
 dependencies {
     implementation project(':browser-icons')
     implementation project(':concept-engine')
+    implementation project(':feature-sitepermissions')
     implementation project(':support-ktx')
 
     implementation Dependencies.androidx_core_ktx

--- a/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
+++ b/components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationFeatureTest.kt
@@ -5,39 +5,127 @@
 package mozilla.components.feature.webnotifications
 
 import android.app.NotificationManager
-import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.Icon
+import mozilla.components.browser.icons.Icon.Source
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.webnotifications.WebNotification
+import mozilla.components.feature.sitepermissions.SitePermissions
+import mozilla.components.feature.sitepermissions.SitePermissions.Status
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage
 import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class WebNotificationFeatureTest {
-    private lateinit var icons: BrowserIcons
-
+    private val context = spy(testContext)
+    private val browserIcons: BrowserIcons = mock()
+    private val icon: Icon = mock()
     private val engine: Engine = mock()
     private val notificationManager: NotificationManager = mock()
+    private val permissionsStorage: SitePermissionsStorage = mock()
+
+    private val testNotification = WebNotification(
+        "Mozilla",
+        "mozilla.org",
+        "Notification body",
+        "mozilla.org",
+        "https://mozilla.org/image.ico",
+        "rtl",
+        "en",
+        false
+    )
 
     @Before
     fun setup() {
-        icons = mock()
+        `when`(context.getSystemService(NotificationManager::class.java)).thenReturn(notificationManager)
+        `when`(icon.source).thenReturn(Source.GENERATOR) // to no-op the browser icons call.
+        `when`(browserIcons.loadIcon(any())).thenReturn(CompletableDeferred(icon))
     }
 
     @Test
     fun `register web notification delegate`() {
-        val context: Context = mock()
         doNothing().`when`(engine).registerWebNotificationDelegate(any())
-        `when`(context.getSystemService(Context.NOTIFICATION_SERVICE)).thenReturn(notificationManager)
         doNothing().`when`(notificationManager).createNotificationChannel(any())
-        WebNotificationFeature(context, engine, icons, android.R.drawable.ic_dialog_alert, null)
+
+        WebNotificationFeature(context, engine, browserIcons, android.R.drawable.ic_dialog_alert, mock(), null)
 
         verify(engine).registerWebNotificationDelegate(any())
+    }
+
+    @Test
+    fun `engine notifies to cancel notification`() {
+        val webNotification: WebNotification = mock()
+        val feature =
+            WebNotificationFeature(context, engine, browserIcons, android.R.drawable.ic_dialog_alert, mock(), null)
+
+        `when`(webNotification.tag).thenReturn("testTag")
+
+        feature.onCloseNotification(webNotification)
+
+        verify(notificationManager).cancel("testTag", NOTIFICATION_ID)
+    }
+
+    @Test
+    fun `engine notifies to show notification`() = runBlockingTest {
+        val feature = WebNotificationFeature(
+            context,
+            engine,
+            browserIcons,
+            android.R.drawable.ic_dialog_alert,
+            permissionsStorage,
+            null,
+            coroutineContext
+        )
+        val permission = SitePermissions(origin = "mozilla.org", notification = Status.ALLOWED, savedAt = 0)
+
+        `when`(permissionsStorage.findSitePermissionsBy(any())).thenReturn(permission)
+
+        feature.onShowNotification(testNotification)
+
+        verify(notificationManager).notify(eq(testNotification.tag), eq(NOTIFICATION_ID), any())
+    }
+
+    @Test
+    fun `notification ignored if permissions are not allowed`() = runBlockingTest {
+        val feature = WebNotificationFeature(
+            context,
+            engine,
+            browserIcons,
+            android.R.drawable.ic_dialog_alert,
+            permissionsStorage,
+            null,
+            coroutineContext
+        )
+
+        // No permissions found.
+
+        feature.onShowNotification(testNotification)
+
+        verify(notificationManager, never()).notify(eq(testNotification.tag), eq(NOTIFICATION_ID), any())
+
+        // When explicitly denied.
+
+        val permission = SitePermissions(origin = "mozilla.org", notification = Status.BLOCKED, savedAt = 0)
+        `when`(permissionsStorage.findSitePermissionsBy(any())).thenReturn(permission)
+
+        feature.onShowNotification(testNotification)
+
+        verify(notificationManager, never()).notify(eq(testNotification.tag), eq(NOTIFICATION_ID), any())
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,7 +46,8 @@ permalink: /changelog/
     * BUGFIX: Compile dependencies with `NDEBUG` to avoid linking unavailable symbols.
       This fixes a crash due to a missing `stderr` symbol on older Android.
 
-
+* **feature-webnotifications**
+  * `WebNotificationFeature` checks the site permissions first before showing a notification.
 
 # 47.0.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -60,6 +60,7 @@ import mozilla.components.feature.readerview.ReaderViewMiddleware
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.sitepermissions.SitePermissionsStorage
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.feature.webnotifications.WebNotificationFeature
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
@@ -115,6 +116,8 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     private val sessionStorage by lazy { SessionStorage(applicationContext, engine) }
 
+    private val permissionStorage by lazy { SitePermissionsStorage(applicationContext) }
+
     val thumbnailStorage by lazy { ThumbnailStorage(applicationContext) }
 
     val store by lazy {
@@ -147,7 +150,7 @@ open class DefaultComponents(private val applicationContext: Context) {
                 .enable()
 
             WebNotificationFeature(applicationContext, engine, icons, R.drawable.ic_notification,
-                BrowserActivity::class.java)
+                permissionStorage, BrowserActivity::class.java)
         }
     }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
We weren't checking the site permissions before delivering a web notification so you'd receive a notification whether you wanted to or not. :)

Closes #7161 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
