### PR TITLE
Upgrade Glean to v31.2.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val mozilla_appservices = "61.0.6"
 
-    const val mozilla_glean = "31.1.1"
+    const val mozilla_glean = "31.2.2"
 
     const val material = "1.1.0"
     const val nearby = "17.0.0"

--- a/components/service/glean/src/test/java/mozilla/components/service/glean/net/ConceptFetchHttpUploaderTest.kt
+++ b/components/service/glean/src/test/java/mozilla/components/service/glean/net/ConceptFetchHttpUploaderTest.kt
@@ -39,9 +39,7 @@ import org.mockito.Mockito.verify
 class ConceptFetchHttpUploaderTest {
     private val testPath: String = "/some/random/path/not/important"
     private val testPing: String = "{ 'ping': 'test' }"
-    private val testDefaultConfig = Configuration().copy(
-        userAgent = "Glean/Test 25.0.2"
-    )
+    private val testDefaultConfig = Configuration()
 
     /**
      * Create a mock webserver that accepts all requests.
@@ -219,7 +217,6 @@ class ConceptFetchHttpUploaderTest {
         val server = getMockWebServer()
 
         val testConfig = testDefaultConfig.copy(
-            userAgent = "Telemetry/42.23",
             serverEndpoint = "http://localhost:" + server.port
         )
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,16 @@ permalink: /changelog/
 * **feature-privatemode**
   * Add `PrivateNotificationFeature` to display a notification when private sessions are open.
 
+* **service-glean**
+  * Glean was updated to v31.2.2
+    * BUGFIX: Correctly format the date and time in the Date header
+    * Feature: Add rate limiting capabilities to the upload manager
+    * BUGFIX: baseline pings with reason "dirty startup" are no longer sent if Glean did not full initialize in the previous run
+    * BUGFIX: Compile dependencies with `NDEBUG` to avoid linking unavailable symbols.
+      This fixes a crash due to a missing `stderr` symbol on older Android.
+
+
+
 # 47.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v46.0.0...v47.0.0)


### PR DESCRIPTION
Fixes #7511 
Follow-up after #7505 was backed out.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

We missed compiling our C dep with the right cflag.
That is fixed in the latest release.
I took that release and ran the `samples-glean:connectedAndroidTest` on the Android emulator, API level 21.
A previous build failed with the error from #7511 (`dlopen failed: cannot locate symbol "stderr" referenced`).
This new build doesn't fail anymore.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
