### PR TITLE
Read EXTRA_HEADERS in TabIntentProcessor

### DIFF
--- a/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
+++ b/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabIntentProcessor.kt
@@ -7,11 +7,10 @@ package mozilla.components.feature.customtabs
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
 import android.content.res.Resources
-import android.provider.Browser
-import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.feature.intent.ext.getExtraHeaders
 import mozilla.components.feature.intent.ext.putSessionId
 import mozilla.components.feature.intent.processing.IntentProcessor
 import mozilla.components.feature.session.SessionUseCases
@@ -33,25 +32,6 @@ class CustomTabIntentProcessor(
         return safeIntent.action == ACTION_VIEW && isCustomTabIntent(safeIntent)
     }
 
-    @VisibleForTesting
-    internal fun getAdditionalHeaders(intent: SafeIntent): Map<String, String>? {
-        val pairs = intent.getBundleExtra(Browser.EXTRA_HEADERS)
-        val headers = mutableMapOf<String, String>()
-        pairs?.keySet()?.forEach { key ->
-            val header = pairs.getString(key)
-            if (header != null) {
-                headers[key] = header
-            } else {
-                throw IllegalArgumentException("getAdditionalHeaders() intent bundle contains wrong key value pair")
-            }
-        }
-        return if (headers.isEmpty()) {
-            null
-        } else {
-            headers
-        }
-    }
-
     override fun process(intent: Intent): Boolean {
         val safeIntent = SafeIntent(intent)
         val url = safeIntent.dataString
@@ -61,7 +41,7 @@ class CustomTabIntentProcessor(
             session.customTabConfig = createCustomTabConfigFromIntent(intent, resources)
 
             sessionManager.add(session)
-            loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external(), getAdditionalHeaders(safeIntent))
+            loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external(), safeIntent.getExtraHeaders())
             intent.putSessionId(session.id)
 
             true

--- a/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
+++ b/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabIntentProcessorTest.kt
@@ -22,10 +22,9 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
-import mozilla.components.support.utils.toSafeIntent
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -98,7 +97,7 @@ class CustomTabIntentProcessorTest {
             putString("X-Extra-Header", "true")
         }
         whenever(intent.getBundleExtra(Browser.EXTRA_HEADERS)).thenReturn(headersBundle)
-        val headers = handler.getAdditionalHeaders(intent.toSafeIntent())
+        val headers = mapOf("X-Extra-Header" to "true")
 
         handler.process(intent)
         verify(sessionManager).add(anySession(), eq(false), eq(null), eq(null), eq(null))

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/ext/IntentExtensions.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/ext/IntentExtensions.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.intent.ext
 
 import android.content.Intent
+import android.provider.Browser
 import mozilla.components.support.utils.SafeIntent
 
 const val EXTRA_SESSION_ID = "activeSessionId"
@@ -37,4 +38,18 @@ fun SafeIntent.getSessionId(): String? = getStringExtra(EXTRA_SESSION_ID)
  */
 fun Intent.putSessionId(sessionId: String?): Intent {
     return putExtra(EXTRA_SESSION_ID, sessionId)
+}
+
+/**
+ * Retrieves headers from the given browsing intent.
+ *
+ * @return Headers to include in the HTTP request for the intent URL.
+ */
+fun SafeIntent.getExtraHeaders(): Map<String, String>? {
+    val pairs = getBundleExtra(Browser.EXTRA_HEADERS)
+    return pairs?.keySet()?.mapNotNull { key ->
+        pairs.getString(key)?.let { header ->
+            key to header
+        }
+    }?.toMap()
 }

--- a/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
+++ b/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt
@@ -6,9 +6,9 @@ package mozilla.components.feature.intent.processing
 
 import android.app.SearchManager
 import android.content.Intent
+import android.content.Intent.ACTION_SEARCH
 import android.content.Intent.ACTION_SEND
 import android.content.Intent.ACTION_VIEW
-import android.content.Intent.ACTION_SEARCH
 import android.content.Intent.ACTION_WEB_SEARCH
 import android.content.Intent.EXTRA_TEXT
 import android.nfc.NfcAdapter.ACTION_NDEF_DISCOVERED
@@ -16,6 +16,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
+import mozilla.components.feature.intent.ext.getExtraHeaders
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.ktx.kotlin.isUrl
@@ -54,8 +55,8 @@ class TabIntentProcessor(
             if (existingSession != null) {
                 sessionManager.select(existingSession)
             } else {
-                loadUrlUseCase(url, createSession(url, private = isPrivate,
-                        source = Source.ACTION_VIEW), LoadUrlFlags.external())
+                val session = createSession(url, source = Source.ACTION_VIEW)
+                loadUrlUseCase(url, session, LoadUrlFlags.external(), intent.getExtraHeaders())
             }
             true
         }
@@ -73,7 +74,7 @@ class TabIntentProcessor(
         } else {
             val url = WebURLFinder(extraText).bestWebURL()
             if (url != null) {
-                val session = createSession(url, private = isPrivate, source = Source.ACTION_SEND)
+                val session = createSession(url, source = Source.ACTION_SEND)
                 loadUrlUseCase(url, session, LoadUrlFlags.external())
             } else {
                 newTabSearchUseCase(extraText, Source.ACTION_SEND, openNewTab)
@@ -89,7 +90,7 @@ class TabIntentProcessor(
             false
         } else {
             if (searchQuery.isUrl()) {
-                val session = createSession(searchQuery, private = isPrivate, source = Source.ACTION_SEARCH)
+                val session = createSession(searchQuery, source = Source.ACTION_SEARCH)
                 loadUrlUseCase(searchQuery, session, LoadUrlFlags.external())
             } else {
                 newTabSearchUseCase(searchQuery, Source.ACTION_SEARCH, openNewTab)
@@ -98,11 +99,11 @@ class TabIntentProcessor(
         }
     }
 
-    private fun createSession(url: String, private: Boolean = false, source: Source): Session {
+    private fun createSession(url: String, source: Source): Session {
         return if (openNewTab) {
-            Session(url, private, source).also { sessionManager.add(it, selected = true) }
+            Session(url, isPrivate, source).also { sessionManager.add(it, selected = true) }
         } else {
-            sessionManager.selectedSession ?: Session(url, private, source)
+            sessionManager.selectedSession ?: Session(url, isPrivate, source)
         }
     }
 

--- a/components/feature/intent/src/test/java/mozilla/components/feature/intent/ext/IntentExtensionsTest.kt
+++ b/components/feature/intent/src/test/java/mozilla/components/feature/intent/ext/IntentExtensionsTest.kt
@@ -5,8 +5,11 @@
 package mozilla.components.feature.intent.ext
 
 import android.content.Intent
+import android.os.Bundle
+import android.provider.Browser
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.toSafeIntent
 import org.junit.Assert.assertEquals
@@ -39,5 +42,19 @@ class IntentExtensionsTest {
 
         assertEquals(id, intent.getSessionId())
         assertEquals(id, intent.toSafeIntent().getSessionId())
+    }
+
+    @Test
+    fun `getExtraHeaders returns headers map`() {
+        val intent = mock<Intent>()
+        val headersBundle = Bundle().apply {
+            putString("X-Extra-Header", "true")
+        }
+        whenever(intent.getBundleExtra(Browser.EXTRA_HEADERS)).thenReturn(headersBundle)
+
+        assertEquals(
+            mapOf("X-Extra-Header" to "true"),
+            intent.toSafeIntent().getExtraHeaders()
+        )
     }
 }


### PR DESCRIPTION
We already do this in custom tabs, but the extra is also meant to be used with `ACTION_VIEW`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
