### PR TITLE
Closes #7278: Add task to generate versions for built-in extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,23 @@ subprojects {
         apply from: "${rootProject.projectDir}/${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
     }
 
+    // Define a reusable task for updating the version in manifest.json for modules that package
+    // a web extension. We automate this to make sure we never forget to update the version, either
+    // in local development or for releases. In both cases, we want to make sure the latest version
+    // of all extensions (including their latest changes) are installed on first start-up.
+    ext.updateExtensionVersion = { task, extDir ->
+        configure(task) {
+            from extDir
+            include 'manifest.template.json'
+            rename { 'manifest.json' }
+            into extDir
+
+            def values = ['version': rootProject.ext.config.componentsVersion + "." + new Date().format('MMddHHmmss')]
+            inputs.properties(values)
+            expand(values)
+        }
+    }
+
     afterEvaluate {
         if (it.hasProperty('android')) {
             jacoco {
@@ -179,6 +196,10 @@ subprojects {
 
                 packagingOptions {
                     exclude 'META-INF/atomicfu.kotlin_module'
+                }
+
+                aaptOptions {
+                    ignoreAssetsPattern "manifest.template.json"
                 }
 
                 compileOptions {

--- a/components/browser/icons/.gitignore
+++ b/components/browser/icons/.gitignore
@@ -1,2 +1,1 @@
-/build
 manifest.json

--- a/components/browser/icons/build.gradle
+++ b/components/browser/icons/build.gradle
@@ -39,6 +39,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     ]
 }
 
+tasks.register("updateBuiltInExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/browser-icons')
+}
+
 dependencies {
     implementation project(':concept-engine')
     implementation project(':concept-fetch')
@@ -71,3 +75,5 @@ dependencies {
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
+
+preBuild.dependsOn updateBuiltInExtensionVersion

--- a/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.template.json
+++ b/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.template.json
@@ -6,7 +6,7 @@
     }
   },
   "name": "Mozilla Android Components - Browser Icons",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": ["*://*/*"],

--- a/components/feature/accounts/.gitignore
+++ b/components/feature/accounts/.gitignore
@@ -1,2 +1,1 @@
-/build
 manifest.json

--- a/components/feature/accounts/build.gradle
+++ b/components/feature/accounts/build.gradle
@@ -27,6 +27,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     ]
 }
 
+tasks.register("updateBuiltInExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/fxawebchannel')
+}
+
 dependencies {
     implementation Dependencies.kotlin_coroutines
     implementation Dependencies.androidx_work_runtime
@@ -47,3 +51,5 @@ dependencies {
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
+
+preBuild.dependsOn updateBuiltInExtensionVersion

--- a/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.template.json
+++ b/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.template.json
@@ -6,7 +6,7 @@
     }
   },
   "name": "Mozilla Android Components - Firefox Accounts WebChannel",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": [

--- a/components/feature/p2p/.gitignore
+++ b/components/feature/p2p/.gitignore
@@ -1,2 +1,1 @@
-/build
 manifest.json

--- a/components/feature/p2p/build.gradle
+++ b/components/feature/p2p/build.gradle
@@ -28,6 +28,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     ]
 }
 
+tasks.register("updateBuiltInExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/p2p')
+}
+
 dependencies {
     implementation project(':browser-session')
     implementation project(':browser-state')
@@ -51,3 +55,5 @@ dependencies {
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
+
+preBuild.dependsOn updateBuiltInExtensionVersion

--- a/components/feature/p2p/src/main/assets/extensions/p2p/manifest.template.json
+++ b/components/feature/p2p/src/main/assets/extensions/p2p/manifest.template.json
@@ -6,7 +6,7 @@
     }
   },
   "name": "Mozilla Android Components - P2P",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": ["*://*/*"],

--- a/components/feature/readerview/.gitignore
+++ b/components/feature/readerview/.gitignore
@@ -1,2 +1,1 @@
-/build
 manifest.json

--- a/components/feature/readerview/build.gradle
+++ b/components/feature/readerview/build.gradle
@@ -27,6 +27,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     ]
 }
 
+tasks.register("updateBuiltInExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/readerview')
+}
+
 dependencies {
     implementation project(':browser-menu')
     implementation project(':browser-state')
@@ -53,3 +57,5 @@ dependencies {
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)
+
+preBuild.dependsOn updateBuiltInExtensionVersion

--- a/components/feature/readerview/src/main/assets/extensions/readerview/manifest.template.json
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/manifest.template.json
@@ -6,7 +6,7 @@
     }
   },
   "name": "Mozilla Android Components - ReaderView",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/samples/browser/build.gradle
+++ b/samples/browser/build.gradle
@@ -57,6 +57,14 @@ android {
     }
 }
 
+tasks.register("updateBorderifyExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/borderify')
+}
+
+tasks.register("updateTestExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/test')
+}
+
 dependencies {
     implementation project(':concept-awesomebar')
     implementation project(':concept-fetch')
@@ -150,3 +158,6 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
     ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
     apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
 }
+
+preBuild.dependsOn updateBorderifyExtensionVersion
+preBuild.dependsOn updateTestExtensionVersion

--- a/samples/browser/src/main/assets/extensions/borderify/manifest.template.json
+++ b/samples/browser/src/main/assets/extensions/borderify/manifest.template.json
@@ -6,7 +6,7 @@
     }
   },
   "name": "Mozilla Android Components - Borderify",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": ["*://www.mozilla.org/*"],

--- a/samples/browser/src/main/assets/extensions/test/manifest.template.json
+++ b/samples/browser/src/main/assets/extensions/test/manifest.template.json
@@ -7,7 +7,7 @@
   },
   "name": "Mozilla Android Components - Test extension",
   "description": "This extension is used for testing web extension functionality in Android Components",
-  "version": "1.0",
+  "version": "${version}",
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
First working version and proposal how to handle versioning once we switch to GV's`ensureBuiltIn` for installing our extension modules. `ensureBuiltIn` only installs/updates the extensions if the manifest has a newer version, so we don't pay the cost of installing on every startup.

This makes sure that
- during development extensions are always installed and we don't have to update the manifest manually on every change
- releases always get a distinct version so we don't ship extension changes that never get applied (because we forgot to update the version)

It's the simplest solution using Gradle's expand / templating functionality from the copy task. We can probably make this more generic with a re-usable task? Not sure if worth it. This is only done for browser-icons here to show the plan:
- Turn manifest.json files into templates 
- Generate the real manifest.json before we build
- gitignore it so we don't have a diff or check it in by mistake

@pocmo @grigoryk wdyt?