### PR TITLE
Get addon createdAt/updatedAt as Date

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/Extensions.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/Extensions.kt
@@ -12,9 +12,19 @@ import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.AddonUpdater.Status.Error
 import mozilla.components.feature.addons.update.AddonUpdater.Status.NoUpdateAvailable
 import mozilla.components.feature.addons.update.AddonUpdater.Status.SuccessfullyUpdated
-import java.text.NumberFormat
 import java.text.DateFormat
+import java.text.NumberFormat
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Used to parse [Addon.createdAt] and [Addon.updatedAt].
+ */
+private val dateParser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT).apply {
+    timeZone = TimeZone.getTimeZone("GMT")
+}
 
 /**
  * A shortcut to get the localized name of an add-on.
@@ -30,6 +40,19 @@ val Addon.translatedSummary: String get() = translatableSummary.translate(this)
  * A shortcut to get the localized description of an add-on.
  */
 val Addon.translatedDescription: String get() = translatableDescription.translate(this)
+
+/**
+ * The date the add-on was created, as a JVM date object.
+ */
+val Addon.createdAtDate: Date get() =
+    // This method never returns null and will throw a ParseException if parsing fails
+    dateParser.parse(createdAt)!!
+
+/**
+ * The date of the last time the add-on was updated by its developer(s),
+ * as a JVM date object.
+ */
+val Addon.updatedAtDate: Date get() = dateParser.parse(updatedAt)!!
 
 /**
  * Try to find the default language on the map otherwise defaults to [Addon.DEFAULT_LOCALE].

--- a/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
+++ b/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
@@ -7,22 +7,27 @@ package mozilla.components.feature.addons.amo.mozilla.components.feature.addons.
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
+import mozilla.components.feature.addons.ui.createdAtDate
 import mozilla.components.feature.addons.ui.getFormattedAmount
 import mozilla.components.feature.addons.ui.toLocalizedString
 import mozilla.components.feature.addons.ui.translate
 import mozilla.components.feature.addons.ui.translatedName
+import mozilla.components.feature.addons.ui.updatedAtDate
 import mozilla.components.feature.addons.update.AddonUpdater
-import mozilla.components.feature.addons.update.AddonUpdater.Status.NotInstalled
-import mozilla.components.feature.addons.update.AddonUpdater.Status.SuccessfullyUpdated
 import mozilla.components.feature.addons.update.AddonUpdater.Status.Error
 import mozilla.components.feature.addons.update.AddonUpdater.Status.NoUpdateAvailable
+import mozilla.components.feature.addons.update.AddonUpdater.Status.NotInstalled
+import mozilla.components.feature.addons.update.AddonUpdater.Status.SuccessfullyUpdated
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.Calendar.MILLISECOND
 import java.util.Date
+import java.util.GregorianCalendar
 import java.util.Locale
+import java.util.TimeZone
 
 @RunWith(AndroidJUnit4::class)
 class ExtensionsTest {
@@ -71,6 +76,34 @@ class ExtensionsTest {
         Locale.setDefault(Locale.ITALIAN)
 
         assertEquals("Hello", map.translate(addon))
+    }
+
+    @Test
+    fun createdAtUpdatedAtDate() {
+        val addon = Addon(
+            id = "id",
+            createdAt = "2015-04-25T07:26:22Z",
+            updatedAt = "2020-06-28T12:45:18Z"
+        )
+
+        val expectedCreatedAt = GregorianCalendar(TimeZone.getTimeZone("GMT")).apply {
+            set(2015, 3, 25, 7, 26, 22)
+            set(MILLISECOND, 0)
+        }.time
+        val expectedUpdatedAt = GregorianCalendar(TimeZone.getTimeZone("GMT")).apply {
+            set(2020, 5, 28, 12, 45, 18)
+            set(MILLISECOND, 0)
+        }.time
+        assertEquals(expectedCreatedAt, addon.createdAtDate)
+        assertEquals(expectedUpdatedAt, addon.updatedAtDate)
+
+        Locale.setDefault(Locale.GERMAN)
+        assertEquals(expectedCreatedAt, addon.createdAtDate)
+        assertEquals(expectedUpdatedAt, addon.updatedAtDate)
+
+        Locale.setDefault(Locale.ITALIAN)
+        assertEquals(expectedCreatedAt, addon.createdAtDate)
+        assertEquals(expectedUpdatedAt, addon.updatedAtDate)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,6 +56,9 @@ permalink: /changelog/
 * **feature-webnotifications**
   * `WebNotificationFeature` checks the site permissions first before showing a notification.
 
+* **feature-addons**
+  * Add `Addon.createdAtDate` and `Addon.updatedAtDate` extensions to get `Addon.createdAt` and `Addon.updatedAt` as a `Date`.
+
 # 47.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v46.0.0...v47.0.0)


### PR DESCRIPTION
Right now Fenix has its own date parser for this, but we should provide a standard parser in A-C. Uses the ROOT locale because the date format should always be the same for addons.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
