### PR TITLE
Update to App Services 61.0.7

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "61.0.6"
+    const val mozilla_appservices = "61.0.7"
 
     const val mozilla_glean = "31.2.3"
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/fenix/issues/11294

# v61.0.7 (_2020-06-29_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.6...v61.0.7)

## Synced Tabs

- JSON is used instead of protocol buffers for sending data over the FFI in `remote_tabs_update_local`. ([#3285](https://github.com/mozilla/application-services/pull/3285))

## General

- The default branch has been renamed from `master` to `main`.

