### PR TITLE
Just run release tests on components

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -73,10 +73,16 @@ job-defaults:
                             - ':{component}:assembleAndroidTest'
                             - ':{component}:test'
                             - ':{component}:lint'
-                        default:
+                        # No testRelease on this job, gradle task isn't defined
+                        tooling-detekt:
                             - ':{component}:assemble'
                             - ':{component}:assembleAndroidTest'
                             - ':{component}:test'
+                            - ':{component}:lintRelease'
+                        default:
+                            - ':{component}:assemble'
+                            - ':{component}:assembleAndroidTest'
+                            - ':{component}:testRelease'
                             - ':{component}:lintRelease'
         using: gradlew
         use-caches: false


### PR DESCRIPTION
Currently we run tests on both debug and release builds. Theoretically we can half our CI times by turning off one set of tests :)