### PR TITLE
Fix the signature of one of the engine.profiler.addMarker overloads

### DIFF
--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/profiler/Profiler.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/profiler/Profiler.kt
@@ -46,7 +46,7 @@ class Profiler(
     /**
      * See [Profiler.addMarker].
      */
-    override fun addMarker(markerName: String, startTime: Double) {
+    override fun addMarker(markerName: String, startTime: Double?) {
         runtime.profilerController.addMarker(markerName, startTime)
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/profiler/Profiler.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/profiler/Profiler.kt
@@ -110,7 +110,7 @@ interface Profiler {
      * @param markerName Name of the event as a string.
      * @param startTime Start time as Double. It can be null if you want to mark a point of time.
      */
-    fun addMarker(markerName: String, startTime: Double)
+    fun addMarker(markerName: String, startTime: Double?)
 
     /**
      * Add a profiler marker to Gecko Profiler with the given arguments.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,9 @@ permalink: /changelog/
 * **service-sync-logins**
   * ⚠️ **This is a breaking change**: removed `isAutofillEnabled` lambda from `GeckoLoginStorageDelegate` because setting has been exposed through GV
 
+* **concept-engine**
+  * Adds `profiler` property with `isProfilerActive`, `getProfilerTime` and `addMarker` Firefox Profiler APIs. These will allow to add profiler markers.
+
 # 48.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v47.0.0...v48.0.0)
@@ -67,9 +70,6 @@ permalink: /changelog/
 * **feature-webnotifications**
   * `WebNotificationFeature` checks the site permissions first before showing a notification.
   * Notifications with a long text body are now expandable to show the full text.
-
-* **concept-engine**
-  * Adds `profiler` property with `isProfilerActive`, `getProfilerTime` and `addMarker` Firefox Profiler APIs. These will allow to add profiler markers.
 
 # 47.0.0
 


### PR DESCRIPTION
We added profiler marker API in #7510. This `addMarker` overload was accepting `Double` only but it should be `Double?` instead to be able to allow nullable values as well. `getProfilerTime` returns nullable double time as well and they should be compatible. Other overloads are correct but I miss this one.

It also moves the changelog item to 49 instead of 48 (which we missed).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
