### PR TITLE
Closes #7600: Reset content message handler when selected tab changes

### DIFF
--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -99,6 +99,7 @@ class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
     ) {
         when (action) {
             is TabListAction.SelectTabAction -> {
+                store.dispatch(ReaderAction.UpdateReaderConnectRequiredAction(action.tabId, true))
                 store.dispatch(ReaderAction.UpdateReaderableAction(action.tabId, false))
                 store.dispatch(ReaderAction.UpdateReaderableCheckRequiredAction(action.tabId, true))
             }

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewMiddlewareTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewMiddlewareTest.kt
@@ -70,7 +70,7 @@ class ReaderViewMiddlewareTest {
     }
 
     @Test
-    fun `state is updated to trigger readerable check when new tab is selected`() {
+    fun `state is updated to reconnect and trigger readerable check when new tab is selected`() {
         val tab1 = createTab("https://www.mozilla.org", id = "test-tab1")
         val tab2 = createTab("https://www.firefox.com", id = "test-tab2",
             readerState = ReaderState(readerable = true)
@@ -79,16 +79,20 @@ class ReaderViewMiddlewareTest {
             initialState = BrowserState(tabs = listOf(tab1, tab2)),
             middleware = listOf(ReaderViewMiddleware())
         )
+        assertFalse(store.state.findTab(tab1.id)!!.readerState.connectRequired)
         assertFalse(store.state.findTab(tab1.id)!!.readerState.checkRequired)
         assertFalse(store.state.findTab(tab1.id)!!.readerState.readerable)
+        assertFalse(store.state.findTab(tab2.id)!!.readerState.connectRequired)
         assertFalse(store.state.findTab(tab2.id)!!.readerState.checkRequired)
         assertTrue(store.state.findTab(tab2.id)!!.readerState.readerable)
 
         store.dispatch(TabListAction.SelectTabAction(tab2.id)).joinBlocking()
         assertFalse(store.state.findTab(tab1.id)!!.readerState.readerable)
         assertFalse(store.state.findTab(tab1.id)!!.readerState.checkRequired)
+        assertFalse(store.state.findTab(tab1.id)!!.readerState.connectRequired)
         assertFalse(store.state.findTab(tab2.id)!!.readerState.readerable)
         assertTrue(store.state.findTab(tab2.id)!!.readerState.checkRequired)
+        assertTrue(store.state.findTab(tab2.id)!!.readerState.connectRequired)
     }
 
     @Test


### PR DESCRIPTION
An existing engine session can be rendered in tab using different feature instances, so we should reset the content message handler, capturing the current's feature config. We could think of a bigger change here by making the config global, but since it requires a context that's tricky and this fixes it.