### PR TITLE
Refactor components using SessionManager.getEngineSession().

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -103,10 +103,10 @@ internal class TrackingProtectionExceptionFileStorage(
         persist()
     }
 
-    override fun removeAll(activeSessions: List<EngineSession?>?) {
+    override fun removeAll(activeSessions: List<EngineSession>?) {
         runtime.contentBlockingController.clearExceptionList()
-        activeSessions?.forEach {
-            it?.notifyObservers {
+        activeSessions?.forEach { engineSession ->
+            engineSession.notifyObservers {
                 onExcludedOnTrackingProtectionChange(false)
             }
         }

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
@@ -118,7 +118,7 @@ class TrackingProtectionExceptionFileStorageTest {
         val mockExceptionList =
             listOf(ContentBlockingException.fromJson(JSONObject("{\"principal\":\"eyIxIjp7IjAiOiJodHRwczovL3d3dy5jbm4uY29tLyJ9fQ==\",\"uri\":\"https:\\/\\/www.cnn.com\\/\"}")))
         val engineSession: EngineSession = mock()
-        val activeSessions: List<EngineSession?> = listOf(engineSession)
+        val activeSessions: List<EngineSession> = listOf(engineSession)
 
         whenever(session.geckoSession).thenReturn(mockGeckoSession)
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlocking)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -103,10 +103,10 @@ internal class TrackingProtectionExceptionFileStorage(
         persist()
     }
 
-    override fun removeAll(activeSessions: List<EngineSession?>?) {
+    override fun removeAll(activeSessions: List<EngineSession>?) {
         runtime.contentBlockingController.clearExceptionList()
-        activeSessions?.forEach {
-            it?.notifyObservers {
+        activeSessions?.forEach { engineSession ->
+            engineSession.notifyObservers {
                 onExcludedOnTrackingProtectionChange(false)
             }
         }

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
@@ -118,7 +118,7 @@ class TrackingProtectionExceptionFileStorageTest {
         val mockExceptionList =
             listOf(ContentBlockingException.fromJson(JSONObject("{\"principal\":\"eyIxIjp7IjAiOiJodHRwczovL3d3dy5jbm4uY29tLyJ9fQ==\",\"uri\":\"https:\\/\\/www.cnn.com\\/\"}")))
         val engineSession: EngineSession = mock()
-        val activeSessions: List<EngineSession?> = listOf(engineSession)
+        val activeSessions: List<EngineSession> = listOf(engineSession)
 
         whenever(session.geckoSession).thenReturn(mockGeckoSession)
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlocking)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorage.kt
@@ -103,10 +103,10 @@ internal class TrackingProtectionExceptionFileStorage(
         persist()
     }
 
-    override fun removeAll(activeSessions: List<EngineSession?>?) {
+    override fun removeAll(activeSessions: List<EngineSession>?) {
         runtime.contentBlockingController.clearExceptionList()
-        activeSessions?.forEach {
-            it?.notifyObservers {
+        activeSessions?.forEach { engineSession ->
+            engineSession.notifyObservers {
                 onExcludedOnTrackingProtectionChange(false)
             }
         }

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/TrackingProtectionExceptionFileStorageTest.kt
@@ -118,7 +118,7 @@ class TrackingProtectionExceptionFileStorageTest {
         val mockExceptionList =
             listOf(ContentBlockingException.fromJson(JSONObject("{\"principal\":\"eyIxIjp7IjAiOiJodHRwczovL3d3dy5jbm4uY29tLyJ9fQ==\",\"uri\":\"https:\\/\\/www.cnn.com\\/\"}")))
         val engineSession: EngineSession = mock()
-        val activeSessions: List<EngineSession?> = listOf(engineSession)
+        val activeSessions: List<EngineSession> = listOf(engineSession)
 
         whenever(session.geckoSession).thenReturn(mockGeckoSession)
         whenever(runtime.contentBlockingController).thenReturn(mockContentBlocking)

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/SessionManager.kt
@@ -317,6 +317,7 @@ class SessionManager(
     /**
      * Gets the linked engine session for the provided session (if it exists).
      */
+    @Deprecated("Read EngineSession from BrowserStore instead")
     fun getEngineSession(session: Session = selectedSessionOrThrow) = delegate.getEngineSession(session)
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/usecases/EngineSessionUseCases.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/usecases/EngineSessionUseCases.kt
@@ -45,22 +45,5 @@ class EngineSessionUseCases(
         }
     }
 
-    /**
-     * Use case for getting an [EngineSession] for a tab.
-     */
-    class GetUseCase internal constructor(
-        private val sessionManager: SessionManager
-    ) {
-        /**
-         * Gets the linked engine session for a tab (if it exists).
-         */
-        operator fun invoke(tabId: String): EngineSession? {
-            return sessionManager.findSessionById(tabId)?.let {
-                sessionManager.getEngineSession(it)
-            }
-        }
-    }
-
     val getOrCreateEngineSession = GetOrCreateUseCase(sessionManager)
-    val getEngineSession = GetUseCase(sessionManager)
 }

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -840,7 +840,7 @@ class SessionManagerMigrationTest {
         val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
         sessionManager.add(session)
 
-        assertNull(sessionManager.getEngineSession(session))
+        assertNull(store.state.findTab("session")!!.engineState.engineSession)
         assertEquals(engineSession1, sessionManager.getOrCreateEngineSession(session))
         store.state.findTab("session")!!.also { tab ->
             assertEquals(engineSession1, tab.engineState.engineSession)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerTest.kt
@@ -5,7 +5,9 @@
 package mozilla.components.browser.session
 
 import android.graphics.Bitmap
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
@@ -664,20 +666,21 @@ class SessionManagerTest {
         val privateEngineSession: EngineSession = mock()
         doReturn(privateEngineSession).`when`(engine).createSession(true)
 
-        val sessionManager = SessionManager(engine)
+        val store = BrowserStore()
+        val sessionManager = SessionManager(engine, store)
 
         val session = Session("https://www.mozilla.org")
         sessionManager.add(session)
 
-        assertNull(sessionManager.getEngineSession(session))
+        assertNull(store.state.findTab(session.id)!!.engineState.engineSession)
         assertEquals(actualEngineSession, sessionManager.getOrCreateEngineSession(session))
-        assertEquals(actualEngineSession, sessionManager.getEngineSession(session))
+        assertEquals(actualEngineSession, store.state.findTab(session.id)!!.engineState.engineSession)
         assertEquals(actualEngineSession, sessionManager.getOrCreateEngineSession(session))
         assertEquals(actualEngineSession, session.engineSessionHolder.engineSession)
 
         val privateSession = Session("https://www.mozilla.org", true, Session.Source.NONE)
         sessionManager.add(privateSession)
-        assertNull(sessionManager.getEngineSession(privateSession))
+        assertNull(store.state.findTab(privateSession.id)!!.engineState.engineSession)
         assertEquals(privateEngineSession, sessionManager.getOrCreateEngineSession(privateSession))
         assertEquals(privateEngineSession, privateSession.engineSessionHolder.engineSession)
     }
@@ -758,8 +761,9 @@ class SessionManagerTest {
     fun `add will link an engine session if provided`() {
         val engine: Engine = mock()
 
+        val store = BrowserStore()
         val actualEngineSession: EngineSession = mock()
-        val sessionManager = SessionManager(engine)
+        val sessionManager = SessionManager(engine, store)
 
         val session = Session("https://www.mozilla.org")
         assertNull(session.engineSessionHolder.engineSession)
@@ -771,7 +775,7 @@ class SessionManagerTest {
         assertNotNull(session.engineSessionHolder.engineObserver)
 
         assertEquals(actualEngineSession, sessionManager.getOrCreateEngineSession(session))
-        assertEquals(actualEngineSession, sessionManager.getEngineSession(session))
+        assertEquals(actualEngineSession, store.state.findTab(session.id)!!.engineState.engineSession)
         assertEquals(actualEngineSession, sessionManager.getOrCreateEngineSession(session))
     }
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/content/blocking/TrackingProtectionExceptionStorage.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/content/blocking/TrackingProtectionExceptionStorage.kt
@@ -50,7 +50,7 @@ interface TrackingProtectionExceptionStorage {
      * @param activeSessions A list of all active sessions (including CustomTab
      * sessions) to be notified.
      */
-    fun removeAll(activeSessions: List<EngineSession?>? = null)
+    fun removeAll(activeSessions: List<EngineSession>? = null)
 
     /**
      * Restore all domains stored in the storage.

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -61,9 +61,10 @@ class ContextMenuCandidateTest {
 
     @Test
     fun `Candidate "Open Link in New Tab" showFor displayed in correct cases`() {
-        val sessionManager = spy(SessionManager(mock()))
+        val store = BrowserStore()
+        val sessionManager = spy(SessionManager(mock(), store))
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -96,7 +97,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org", contextId = "1"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -118,7 +119,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -141,7 +142,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
 
         val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
@@ -165,7 +166,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
 
         val openInNewTab = ContextMenuCandidate.createOpenInNewTabCandidate(
@@ -187,7 +188,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInPrivateTab = ContextMenuCandidate.createOpenInPrivateTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -220,7 +221,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInPrivateTab = ContextMenuCandidate.createOpenInPrivateTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -243,7 +244,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInPrivateTab = ContextMenuCandidate.createOpenInPrivateTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -266,7 +267,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
         val openInPrivateTab = ContextMenuCandidate.createOpenInPrivateTabCandidate(
             testContext, tabsUseCases, parentView, snackbarDelegate)
@@ -285,7 +286,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
 
         val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(
@@ -344,7 +345,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org", private = true))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
 
         val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(
@@ -368,7 +369,7 @@ class ContextMenuCandidateTest {
         doReturn(mock<EngineSession>()).`when`(sessionManager).getOrCreateEngineSession(any(), anyBoolean())
         sessionManager.add(Session("https://www.mozilla.org", contextId = "1"))
 
-        val tabsUseCases = TabsUseCases(sessionManager)
+        val tabsUseCases = TabsUseCases(store, sessionManager)
         val parentView = CoordinatorLayout(testContext)
 
         val openImageInTab = ContextMenuCandidate.createOpenImageInNewTabCandidate(

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/TrackingProtectionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/TrackingProtectionUseCases.kt
@@ -83,12 +83,6 @@ class TrackingProtectionUseCases(
     ) {
         /**
          * Removes all domains from the exception list.
-         *
-         * As we are applying this on all the sessions it could cause a
-         * performance hit, right now we don't have a straightforward way to
-         * avoid it, as it will required that we introduce the browser store,
-         * we are going to address this on #6283
-         * (https://github.com/mozilla-mobile/android-components/issues/6283).
          */
         operator fun invoke() {
             val engineSessions = (store.state.tabs + store.state.customTabs).mapNotNull { tab ->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,13 @@ permalink: /changelog/
 * **feature-session**
   * ⚠️ **This is a breaking change**: `FullScreenFeature`, `SettingsUseCases`, `SwipeRefreshFeature` and `SessionFeature` now require a `BrowserStore` instead of a `SessionManager`.
   * ⚠️ **This is a breaking change**: `SessionFeature` now requires an `EngineSessionUseCases` instance.
+  * ⚠️ **This is a breaking change**: `TrackingProtectionUseCases` now requires a `BrowserStore` instead of a `SessionManager`.
+
+* **feature-tabs**
+  * ⚠️ **This is a breaking change**: `TabsUseCases.AddNewTabUseCase` and `TabsUseCases.AddNewPrivateTabUseCase` now require a `BrowserStore` instead of a `SessionManager`.
+
+* **browser-session**
+  * `SessionManager.getEngineSession()` is now deprecated. From now on please read `EngineSession` instances of tabs from `BrowserState`.
 
 * **service-sync-logins**
   * ⚠️ **This is a breaking change**: removed `isAutofillEnabled` lambda from `GeckoLoginStorageDelegate` because setting has been exposed through GV

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -367,7 +367,7 @@ open class DefaultComponents(private val applicationContext: Context) {
         ShippedDomainsProvider().also { it.initialize(applicationContext) }
     }
 
-    val tabsUseCases: TabsUseCases by lazy { TabsUseCases(sessionManager) }
+    val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store, sessionManager) }
     val downloadsUseCases: DownloadsUseCases by lazy { DownloadsUseCases(store) }
     val contextMenuUseCases: ContextMenuUseCases by lazy { ContextMenuUseCases(sessionManager, store) }
 }


### PR DESCRIPTION
This refactors all code in AC accessing `SessionManager.getEngineSession()` to use the `BrowserStore` instead. And with that `SessionManager.getEngineSession()` is marked as deprecated now.