### PR TITLE
Revert "Closes #7483: Fix telemetry foreground service notification string"

### DIFF
--- a/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SendCrashTelemetryService.kt
+++ b/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/SendCrashTelemetryService.kt
@@ -27,7 +27,7 @@ class SendCrashTelemetryService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = CrashNotification.ensureChannelExists(this)
             val notification = NotificationCompat.Builder(this, channel)
-                .setContentTitle(getString(R.string.mozac_lib_collecting_telemetry_data_in_progress,
+                .setContentTitle(getString(R.string.mozac_lib_send_crash_report_in_progress,
                     crashReporter.promptConfiguration.organizationName))
                 .setSmallIcon(R.drawable.mozac_lib_crash_notification)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/components/lib/crash/src/main/res/values/strings.xml
+++ b/components/lib/crash/src/main/res/values/strings.xml
@@ -24,9 +24,6 @@
     <!-- Label of notification showing that the crash report service is running. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
     <string name="mozac_lib_send_crash_report_in_progress">Sending crash report to %1$s</string>
 
-    <!-- Label of notification showing that the telemetry report service is running. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
-    <string name="mozac_lib_collecting_telemetry_data_in_progress">Collecting telemetry data for %1$s</string>
-
     <!-- Title of the activity that shows the list of past crashes (similar to about:crashes)-->
     <string name="mozac_lib_crash_activity_title">Crash Reports</string>
 


### PR DESCRIPTION
Reverts mozilla-mobile/android-components#7492