### PR TITLE
Closes #6356: Install built-in extensions using GV extension controller

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -39,6 +39,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
+import mozilla.components.support.ktx.kotlin.isResourceUrl
 import mozilla.components.support.utils.ThreadUtils
 import org.json.JSONObject
 import org.mozilla.geckoview.AllowOrDeny
@@ -203,58 +204,35 @@ class GeckoEngine(
     override fun installWebExtension(
         id: String,
         url: String,
-        allowContentMessaging: Boolean,
-        supportActions: Boolean,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ): CancellableOperation {
-        val ext = GeckoWebExtension(id, url, runtime, allowContentMessaging, supportActions)
-        return installWebExtension(ext, onSuccess, onError)
-    }
 
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    internal fun installWebExtension(
-        ext: GeckoWebExtension,
-        onSuccess: ((WebExtension) -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): CancellableOperation {
-        val geckoResult = if (ext.isBuiltIn()) {
-            if (ext.supportActions) {
-                // We currently have to install the global action handler before we
-                // install the extension which is why this is done here directly.
-                // This code can be removed from the engine once the new GV addon
-                // management API (specifically installBuiltIn) lands. Then the
-                // global handlers will be invoked with the latest state whenever
-                // they are registered:
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1599897
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1582185
-                ext.registerActionHandler(webExtensionActionHandler)
-                ext.registerTabHandler(webExtensionTabHandler)
-            }
+        val onInstallSuccess: ((org.mozilla.geckoview.WebExtension) -> Unit) = {
+            val installedExtension = GeckoWebExtension(it, runtime)
+            webExtensionDelegate?.onInstalled(installedExtension)
+            installedExtension.registerActionHandler(webExtensionActionHandler)
+            installedExtension.registerTabHandler(webExtensionTabHandler)
+            onSuccess(installedExtension)
+        }
 
-            // For now we have to use registerWebExtension for builtin extensions until we get the
-            // new installBuiltIn call on the controller: https://bugzilla.mozilla.org/show_bug.cgi?id=1601067
-            runtime.registerWebExtension(ext.nativeExtension).apply {
+        val geckoResult = if (url.isResourceUrl()) {
+            runtime.webExtensionController.ensureBuiltIn(url, id).apply {
                 then({
-                    webExtensionDelegate?.onInstalled(ext)
-                    onSuccess(ext)
+                    onInstallSuccess(it!!)
                     GeckoResult<Void>()
                 }, { throwable ->
-                    onError(ext.id, throwable)
+                    onError(id, throwable)
                     GeckoResult<Void>()
                 })
             }
         } else {
-            runtime.webExtensionController.install(ext.url).apply {
+            runtime.webExtensionController.install(url).apply {
                 then({
-                    val installedExtension = GeckoWebExtension(it!!, runtime)
-                    webExtensionDelegate?.onInstalled(installedExtension)
-                    installedExtension.registerActionHandler(webExtensionActionHandler)
-                    installedExtension.registerTabHandler(webExtensionTabHandler)
-                    onSuccess(installedExtension)
+                    onInstallSuccess(it!!)
                     GeckoResult<Void>()
                 }, { throwable ->
-                    onError(ext.id, throwable)
+                    onError(id, throwable)
                     GeckoResult<Void>()
                 })
             }

--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -31,25 +31,12 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
  */
 @Suppress("TooManyFunctions")
 class GeckoWebExtension(
-    id: String,
-    url: String,
-    val runtime: GeckoRuntime,
-    allowContentMessaging: Boolean = true,
-    supportActions: Boolean = false,
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
-        url,
-        id,
-        createWebExtensionFlags(allowContentMessaging),
-        runtime.webExtensionController
-    ),
+    val nativeExtension: GeckoNativeWebExtension,
+    val runtime: GeckoRuntime
+) : WebExtension(nativeExtension.id, nativeExtension.location, true) {
+
     private val connectedPorts: MutableMap<PortId, Port> = mutableMapOf()
-) : WebExtension(id, url, supportActions) {
-
     private val logger = Logger("GeckoWebExtension")
-
-    constructor(native: GeckoNativeWebExtension, runtime: GeckoRuntime) :
-        this(native.id, native.location, runtime, true, true, native)
 
     /**
      * Uniquely identifies a port using its name and the session it
@@ -372,6 +359,10 @@ class GeckoWebExtension(
         }
     }
 
+    override fun isBuiltIn(): Boolean {
+        return nativeExtension.isBuiltIn
+    }
+
     override fun isEnabled(): Boolean {
         return nativeExtension.metaData?.enabled ?: true
     }
@@ -403,14 +394,6 @@ class GeckoPort(
 
     override fun disconnect() {
         nativePort.disconnect()
-    }
-}
-
-private fun createWebExtensionFlags(allowContentMessaging: Boolean): Long {
-    return if (allowContentMessaging) {
-        GeckoNativeWebExtension.Flags.ALLOW_CONTENT_MESSAGING
-    } else {
-        GeckoNativeWebExtension.Flags.NONE
     }
 }
 

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -40,23 +40,18 @@ import org.mozilla.geckoview.WebExtension
 import org.mozilla.geckoview.WebExtensionController
 
 @RunWith(AndroidJUnit4::class)
-@Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
 class GeckoWebExtensionTest {
 
     @Test
     fun `register background message handler`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -102,7 +97,7 @@ class GeckoWebExtensionTest {
     fun `register content message handler`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionSessionController: WebExtension.SessionController = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
@@ -114,10 +109,6 @@ class GeckoWebExtensionTest {
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -166,7 +157,7 @@ class GeckoWebExtensionTest {
     fun `disconnect port from content script`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionSessionController: WebExtension.SessionController = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
@@ -176,10 +167,6 @@ class GeckoWebExtensionTest {
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -200,14 +187,10 @@ class GeckoWebExtensionTest {
     @Test
     fun `disconnect port from background script`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -229,7 +212,7 @@ class GeckoWebExtensionTest {
     @Test
     fun `register global default action handler`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
         val browserActionCaptor = argumentCaptor<Action>()
@@ -237,24 +220,8 @@ class GeckoWebExtensionTest {
         val nativeBrowserAction: WebExtension.Action = mock()
         val nativePageAction: WebExtension.Action = mock()
 
-        // Verify actions will not be acted on when not supported
-        val extensionWithActions = GeckoWebExtension(
-            "mozacTest",
-            "url",
-            runtime,
-            false,
-            false,
-            nativeGeckoWebExt
-        )
-        extensionWithActions.registerActionHandler(actionHandler)
-        verify(nativeGeckoWebExt, never()).setActionDelegate(actionDelegateCaptor.capture())
-
         // Create extension and register global default action handler
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -291,7 +258,7 @@ class GeckoWebExtensionTest {
         whenever(geckoSession.webExtensionController).thenReturn(webExtensionSessionController)
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
         val browserActionCaptor = argumentCaptor<Action>()
@@ -301,10 +268,6 @@ class GeckoWebExtensionTest {
 
         // Create extension and register action handler for session
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -340,19 +303,13 @@ class GeckoWebExtensionTest {
         val tabDelegateCaptor = argumentCaptor<WebExtension.TabDelegate>()
         val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
 
-        val metaDataBundle = GeckoBundle()
-        metaDataBundle.putStringArray("disabledFlags", emptyArray())
         val bundle = GeckoBundle()
-        bundle.putString("webExtensionId", "test-webext")
-        bundle.putString("locationURI", "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi")
+        bundle.putString("webExtensionId", "id")
+        bundle.putString("locationURI", "uri")
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension(bundle)
 
-        val nativeGeckoWebExt = spy(MockWebExtension(bundle))
         // Create extension and register global tab handler
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -371,6 +328,8 @@ class GeckoWebExtensionTest {
         tabDelegateCaptor.value.onOpenOptionsPage(nativeGeckoWebExt)
         verify(tabHandler, never()).onNewTab(eq(extension), any(), eq(false), eq("http://options-page.moz"))
 
+        val metaDataBundle = GeckoBundle()
+        metaDataBundle.putStringArray("disabledFlags", emptyArray())
         bundle.putBundle("metaData", metaDataBundle)
         val nativeGeckoWebExtWithMetadata = MockWebExtension(bundle)
         tabDelegateCaptor.value.onOpenOptionsPage(nativeGeckoWebExtWithMetadata)
@@ -396,18 +355,9 @@ class GeckoWebExtensionTest {
         val tabHandler: TabHandler = mock()
         val tabDelegateCaptor = argumentCaptor<WebExtension.SessionTabDelegate>()
 
-        val nativeGeckoWebExt = spy(WebExtension(
-            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi",
-            "test-webext",
-            WebExtension.Flags.NONE,
-            runtime.webExtensionController
-        ))
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         // Create extension and register tab handler for session
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -435,7 +385,7 @@ class GeckoWebExtensionTest {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
         val extensionWithoutMetadata = GeckoWebExtension(
-            WebExtension("url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(),
             runtime
         )
         assertNull(extensionWithoutMetadata.getMetadata())
@@ -484,7 +434,7 @@ class GeckoWebExtensionTest {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
         val extensionWithoutMetadata = GeckoWebExtension(
-            WebExtension("url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(),
             runtime
         )
         assertNull(extensionWithoutMetadata.getMetadata())
@@ -516,17 +466,25 @@ class GeckoWebExtensionTest {
     }
 
     @Test
-    fun `isBuiltIn depends on URI scheme`() {
+    fun `isBuiltIn depends on native state`() {
         val runtime: GeckoRuntime = mock()
-        val webExtensionController: WebExtensionController = mock()
+
+        val builtInBundle = GeckoBundle()
+        builtInBundle.putBoolean("isBuiltIn", true)
+        builtInBundle.putString("webExtensionId", "id")
+        builtInBundle.putString("locationURI", "uri")
         val builtInExtension = GeckoWebExtension(
-            WebExtension("resource://url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(builtInBundle),
             runtime
         )
         assertTrue(builtInExtension.isBuiltIn())
 
+        val externalBundle = GeckoBundle()
+        externalBundle.putBoolean("isBuiltIn", false)
+        externalBundle.putString("webExtensionId", "id")
+        externalBundle.putString("locationURI", "uri")
         val externalExtension = GeckoWebExtension(
-            WebExtension("https://url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(externalBundle),
             runtime
         )
         assertFalse(externalExtension.isBuiltIn())
@@ -563,9 +521,14 @@ class GeckoWebExtensionTest {
     fun `isAllowedInPrivateBrowsing depends on native state and defaults to false if state unknown`() {
         val runtime: GeckoRuntime = mock()
         whenever(runtime.webExtensionController).thenReturn(mock())
+
+        val builtInBundle = GeckoBundle()
+        builtInBundle.putBoolean("isBuiltIn", true)
+        builtInBundle.putString("webExtensionId", "id")
+        builtInBundle.putString("locationURI", "uri")
         val builtInExtension = GeckoWebExtension(
-                WebExtension("resource://url", "id", WebExtension.Flags.NONE, mock()),
-                runtime
+            mockNativeExtension(builtInBundle),
+            runtime
         )
         assertTrue(builtInExtension.isAllowedInPrivateBrowsing())
 
@@ -590,5 +553,13 @@ class GeckoWebExtensionTest {
         val nativeWebExtensionWithoutPrivateBrowsing = MockWebExtension(bundle)
         val webExtensionWithoutPrivateBrowsing = GeckoWebExtension(nativeWebExtensionWithoutPrivateBrowsing, runtime)
         assertFalse(webExtensionWithoutPrivateBrowsing.isAllowedInPrivateBrowsing())
+    }
+
+    private fun mockNativeExtension(useBundle: GeckoBundle? = null): WebExtension {
+        val bundle = useBundle ?: GeckoBundle().apply {
+            putString("webExtensionId", "id")
+            putString("locationURI", "uri")
+        }
+        return spy(MockWebExtension(bundle))
     }
 }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -39,6 +39,7 @@ import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
 import mozilla.components.concept.engine.webpush.WebPushDelegate
 import mozilla.components.concept.engine.webpush.WebPushHandler
+import mozilla.components.support.ktx.kotlin.isResourceUrl
 import mozilla.components.support.utils.ThreadUtils
 import org.json.JSONObject
 import org.mozilla.geckoview.AllowOrDeny
@@ -203,58 +204,35 @@ class GeckoEngine(
     override fun installWebExtension(
         id: String,
         url: String,
-        allowContentMessaging: Boolean,
-        supportActions: Boolean,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ): CancellableOperation {
-        val ext = GeckoWebExtension(id, url, runtime, allowContentMessaging, supportActions)
-        return installWebExtension(ext, onSuccess, onError)
-    }
 
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    internal fun installWebExtension(
-        ext: GeckoWebExtension,
-        onSuccess: ((WebExtension) -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> }
-    ): CancellableOperation {
-        val geckoResult = if (ext.isBuiltIn()) {
-            if (ext.supportActions) {
-                // We currently have to install the global action handler before we
-                // install the extension which is why this is done here directly.
-                // This code can be removed from the engine once the new GV addon
-                // management API (specifically installBuiltIn) lands. Then the
-                // global handlers will be invoked with the latest state whenever
-                // they are registered:
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1599897
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1582185
-                ext.registerActionHandler(webExtensionActionHandler)
-                ext.registerTabHandler(webExtensionTabHandler)
-            }
+        val onInstallSuccess: ((org.mozilla.geckoview.WebExtension) -> Unit) = {
+            val installedExtension = GeckoWebExtension(it, runtime)
+            webExtensionDelegate?.onInstalled(installedExtension)
+            installedExtension.registerActionHandler(webExtensionActionHandler)
+            installedExtension.registerTabHandler(webExtensionTabHandler)
+            onSuccess(installedExtension)
+        }
 
-            // For now we have to use registerWebExtension for builtin extensions until we get the
-            // new installBuiltIn call on the controller: https://bugzilla.mozilla.org/show_bug.cgi?id=1601067
-            runtime.registerWebExtension(ext.nativeExtension).apply {
+        val geckoResult = if (url.isResourceUrl()) {
+            runtime.webExtensionController.ensureBuiltIn(url, id).apply {
                 then({
-                    webExtensionDelegate?.onInstalled(ext)
-                    onSuccess(ext)
+                    onInstallSuccess(it!!)
                     GeckoResult<Void>()
                 }, { throwable ->
-                    onError(ext.id, throwable)
+                    onError(id, throwable)
                     GeckoResult<Void>()
                 })
             }
         } else {
-            runtime.webExtensionController.install(ext.url).apply {
+            runtime.webExtensionController.install(url).apply {
                 then({
-                    val installedExtension = GeckoWebExtension(it!!, runtime)
-                    webExtensionDelegate?.onInstalled(installedExtension)
-                    installedExtension.registerActionHandler(webExtensionActionHandler)
-                    installedExtension.registerTabHandler(webExtensionTabHandler)
-                    onSuccess(installedExtension)
+                    onInstallSuccess(it!!)
                     GeckoResult<Void>()
                 }, { throwable ->
-                    onError(ext.id, throwable)
+                    onError(id, throwable)
                     GeckoResult<Void>()
                 })
             }

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -31,25 +31,12 @@ import org.mozilla.geckoview.WebExtension.Action as GeckoNativeWebExtensionActio
  */
 @Suppress("TooManyFunctions")
 class GeckoWebExtension(
-    id: String,
-    url: String,
-    val runtime: GeckoRuntime,
-    allowContentMessaging: Boolean = true,
-    supportActions: Boolean = false,
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    val nativeExtension: GeckoNativeWebExtension = GeckoNativeWebExtension(
-        url,
-        id,
-        createWebExtensionFlags(allowContentMessaging),
-        runtime.webExtensionController
-    ),
+    val nativeExtension: GeckoNativeWebExtension,
+    val runtime: GeckoRuntime
+) : WebExtension(nativeExtension.id, nativeExtension.location, true) {
+
     private val connectedPorts: MutableMap<PortId, Port> = mutableMapOf()
-) : WebExtension(id, url, supportActions) {
-
     private val logger = Logger("GeckoWebExtension")
-
-    constructor(native: GeckoNativeWebExtension, runtime: GeckoRuntime) :
-        this(native.id, native.location, runtime, true, true, native)
 
     /**
      * Uniquely identifies a port using its name and the session it
@@ -372,6 +359,10 @@ class GeckoWebExtension(
         }
     }
 
+    override fun isBuiltIn(): Boolean {
+        return nativeExtension.isBuiltIn
+    }
+
     override fun isEnabled(): Boolean {
         return nativeExtension.metaData?.enabled ?: true
     }
@@ -403,14 +394,6 @@ class GeckoPort(
 
     override fun disconnect() {
         nativePort.disconnect()
-    }
-}
-
-private fun createWebExtensionFlags(allowContentMessaging: Boolean): Long {
-    return if (allowContentMessaging) {
-        GeckoNativeWebExtension.Flags.ALLOW_CONTENT_MESSAGING
-    } else {
-        GeckoNativeWebExtension.Flags.NONE
     }
 }
 

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -40,23 +40,18 @@ import org.mozilla.geckoview.WebExtension
 import org.mozilla.geckoview.WebExtensionController
 
 @RunWith(AndroidJUnit4::class)
-@Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
 class GeckoWebExtensionTest {
 
     @Test
     fun `register background message handler`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val portCaptor = argumentCaptor<Port>()
         val portDelegateCaptor = argumentCaptor<WebExtension.PortDelegate>()
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -102,7 +97,7 @@ class GeckoWebExtensionTest {
     fun `register content message handler`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionSessionController: WebExtension.SessionController = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
@@ -114,10 +109,6 @@ class GeckoWebExtensionTest {
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -166,7 +157,7 @@ class GeckoWebExtensionTest {
     fun `disconnect port from content script`() {
         val runtime: GeckoRuntime = mock()
         val webExtensionSessionController: WebExtension.SessionController = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val session: GeckoEngineSession = mock()
         val geckoSession: GeckoSession = mock()
@@ -176,10 +167,6 @@ class GeckoWebExtensionTest {
         whenever(session.geckoSession).thenReturn(geckoSession)
 
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -200,14 +187,10 @@ class GeckoWebExtensionTest {
     @Test
     fun `disconnect port from background script`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val messageHandler: MessageHandler = mock()
         val messageDelegateCaptor = argumentCaptor<WebExtension.MessageDelegate>()
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -229,7 +212,7 @@ class GeckoWebExtensionTest {
     @Test
     fun `register global default action handler`() {
         val runtime: GeckoRuntime = mock()
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
         val browserActionCaptor = argumentCaptor<Action>()
@@ -237,24 +220,8 @@ class GeckoWebExtensionTest {
         val nativeBrowserAction: WebExtension.Action = mock()
         val nativePageAction: WebExtension.Action = mock()
 
-        // Verify actions will not be acted on when not supported
-        val extensionWithActions = GeckoWebExtension(
-            "mozacTest",
-            "url",
-            runtime,
-            false,
-            false,
-            nativeGeckoWebExt
-        )
-        extensionWithActions.registerActionHandler(actionHandler)
-        verify(nativeGeckoWebExt, never()).setActionDelegate(actionDelegateCaptor.capture())
-
         // Create extension and register global default action handler
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -291,7 +258,7 @@ class GeckoWebExtensionTest {
         whenever(geckoSession.webExtensionController).thenReturn(webExtensionSessionController)
         whenever(session.geckoSession).thenReturn(geckoSession)
 
-        val nativeGeckoWebExt: WebExtension = mock()
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         val actionHandler: ActionHandler = mock()
         val actionDelegateCaptor = argumentCaptor<WebExtension.ActionDelegate>()
         val browserActionCaptor = argumentCaptor<Action>()
@@ -301,10 +268,6 @@ class GeckoWebExtensionTest {
 
         // Create extension and register action handler for session
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -340,19 +303,13 @@ class GeckoWebExtensionTest {
         val tabDelegateCaptor = argumentCaptor<WebExtension.TabDelegate>()
         val engineSessionCaptor = argumentCaptor<GeckoEngineSession>()
 
-        val metaDataBundle = GeckoBundle()
-        metaDataBundle.putStringArray("disabledFlags", emptyArray())
         val bundle = GeckoBundle()
-        bundle.putString("webExtensionId", "test-webext")
-        bundle.putString("locationURI", "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi")
+        bundle.putString("webExtensionId", "id")
+        bundle.putString("locationURI", "uri")
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension(bundle)
 
-        val nativeGeckoWebExt = spy(MockWebExtension(bundle))
         // Create extension and register global tab handler
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -371,6 +328,8 @@ class GeckoWebExtensionTest {
         tabDelegateCaptor.value.onOpenOptionsPage(nativeGeckoWebExt)
         verify(tabHandler, never()).onNewTab(eq(extension), any(), eq(false), eq("http://options-page.moz"))
 
+        val metaDataBundle = GeckoBundle()
+        metaDataBundle.putStringArray("disabledFlags", emptyArray())
         bundle.putBundle("metaData", metaDataBundle)
         val nativeGeckoWebExtWithMetadata = MockWebExtension(bundle)
         tabDelegateCaptor.value.onOpenOptionsPage(nativeGeckoWebExtWithMetadata)
@@ -396,18 +355,9 @@ class GeckoWebExtensionTest {
         val tabHandler: TabHandler = mock()
         val tabDelegateCaptor = argumentCaptor<WebExtension.SessionTabDelegate>()
 
-        val nativeGeckoWebExt = spy(WebExtension(
-            "https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi",
-            "test-webext",
-            WebExtension.Flags.NONE,
-            runtime.webExtensionController
-        ))
+        val nativeGeckoWebExt: WebExtension = mockNativeExtension()
         // Create extension and register tab handler for session
         val extension = GeckoWebExtension(
-            id = "mozacTest",
-            url = "url",
-            allowContentMessaging = true,
-            supportActions = true,
             runtime = runtime,
             nativeExtension = nativeGeckoWebExt
         )
@@ -435,7 +385,7 @@ class GeckoWebExtensionTest {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
         val extensionWithoutMetadata = GeckoWebExtension(
-            WebExtension("url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(),
             runtime
         )
         assertNull(extensionWithoutMetadata.getMetadata())
@@ -484,7 +434,7 @@ class GeckoWebExtensionTest {
         val webExtensionController: WebExtensionController = mock()
         whenever(runtime.webExtensionController).thenReturn(webExtensionController)
         val extensionWithoutMetadata = GeckoWebExtension(
-            WebExtension("url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(),
             runtime
         )
         assertNull(extensionWithoutMetadata.getMetadata())
@@ -516,17 +466,25 @@ class GeckoWebExtensionTest {
     }
 
     @Test
-    fun `isBuiltIn depends on URI scheme`() {
+    fun `isBuiltIn depends on native state`() {
         val runtime: GeckoRuntime = mock()
-        val webExtensionController: WebExtensionController = mock()
+
+        val builtInBundle = GeckoBundle()
+        builtInBundle.putBoolean("isBuiltIn", true)
+        builtInBundle.putString("webExtensionId", "id")
+        builtInBundle.putString("locationURI", "uri")
         val builtInExtension = GeckoWebExtension(
-            WebExtension("resource://url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(builtInBundle),
             runtime
         )
         assertTrue(builtInExtension.isBuiltIn())
 
+        val externalBundle = GeckoBundle()
+        externalBundle.putBoolean("isBuiltIn", false)
+        externalBundle.putString("webExtensionId", "id")
+        externalBundle.putString("locationURI", "uri")
         val externalExtension = GeckoWebExtension(
-            WebExtension("https://url", "id", WebExtension.Flags.NONE, webExtensionController),
+            mockNativeExtension(externalBundle),
             runtime
         )
         assertFalse(externalExtension.isBuiltIn())
@@ -563,9 +521,14 @@ class GeckoWebExtensionTest {
     fun `isAllowedInPrivateBrowsing depends on native state and defaults to false if state unknown`() {
         val runtime: GeckoRuntime = mock()
         whenever(runtime.webExtensionController).thenReturn(mock())
+
+        val builtInBundle = GeckoBundle()
+        builtInBundle.putBoolean("isBuiltIn", true)
+        builtInBundle.putString("webExtensionId", "id")
+        builtInBundle.putString("locationURI", "uri")
         val builtInExtension = GeckoWebExtension(
-                WebExtension("resource://url", "id", WebExtension.Flags.NONE, mock()),
-                runtime
+            mockNativeExtension(builtInBundle),
+            runtime
         )
         assertTrue(builtInExtension.isAllowedInPrivateBrowsing())
 
@@ -590,5 +553,13 @@ class GeckoWebExtensionTest {
         val nativeWebExtensionWithoutPrivateBrowsing = MockWebExtension(bundle)
         val webExtensionWithoutPrivateBrowsing = GeckoWebExtension(nativeWebExtensionWithoutPrivateBrowsing, runtime)
         assertFalse(webExtensionWithoutPrivateBrowsing.isAllowedInPrivateBrowsing())
+    }
+
+    private fun mockNativeExtension(useBundle: GeckoBundle? = null): WebExtension {
+        val bundle = useBundle ?: GeckoBundle().apply {
+            putString("webExtensionId", "id")
+            putString("locationURI", "uri")
+        }
+        return spy(MockWebExtension(bundle))
     }
 }

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -203,12 +203,10 @@ class GeckoEngine(
     override fun installWebExtension(
         id: String,
         url: String,
-        allowContentMessaging: Boolean,
-        supportActions: Boolean,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((String, Throwable) -> Unit)
     ): CancellableOperation {
-        val ext = GeckoWebExtension(id, url, runtime, allowContentMessaging, supportActions)
+        val ext = GeckoWebExtension(id, url, runtime, true, true)
         return installWebExtension(ext, onSuccess, onError)
     }
 

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -521,37 +521,6 @@ class GeckoEngineTest {
 
     @Test
     @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
-    fun `install built-in web extension successfully but do not allow content messaging`() {
-        val runtime = mock<GeckoRuntime>()
-        val engine = GeckoEngine(context, runtime = runtime)
-        var onSuccessCalled = false
-        var onErrorCalled = false
-        val result = GeckoResult<Void>()
-
-        whenever(runtime.registerWebExtension(any())).thenReturn(result)
-        val extensionController: WebExtensionController = mock()
-        whenever(runtime.webExtensionController).thenReturn(extensionController)
-
-        engine.installWebExtension(
-            "test-webext",
-            "resource://android/assets/extensions/test",
-            allowContentMessaging = false,
-            onSuccess = { onSuccessCalled = true },
-            onError = { _, _ -> onErrorCalled = true }
-        )
-        result.complete(null)
-
-        val extCaptor = argumentCaptor<GeckoWebExtension>()
-        verify(runtime).registerWebExtension(extCaptor.capture())
-        assertEquals("test-webext", extCaptor.value.id)
-        assertEquals("resource://android/assets/extensions/test", extCaptor.value.location)
-        assertEquals(GeckoWebExtension.Flags.NONE, extCaptor.value.flags)
-        assertTrue(onSuccessCalled)
-        assertFalse(onErrorCalled)
-    }
-
-    @Test
-    @Suppress("Deprecation") // https://github.com/mozilla-mobile/android-components/issues/6356
     fun `install external web extension successfully`() {
         val runtime = mock<GeckoRuntime>()
         val extId = "test-webext"

--- a/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.json
+++ b/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "icons@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Browser Icons",
   "version": "1.0",
   "content_scripts": [
@@ -11,6 +16,7 @@
   ],
   "permissions": [
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -137,9 +137,8 @@ class BrowserIcons(
      */
     fun install(engine: Engine, store: BrowserStore) {
         engine.installWebExtension(
-            id = "mozacBrowserIcons",
+            id = "icons@mozac.org",
             url = "resource://android/assets/extensions/browser-icons/",
-            allowContentMessaging = true,
             onSuccess = { extension ->
                 Logger.debug("Installed browser-icons extension")
 

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -159,7 +159,7 @@ abstract class WebExtension(
      * Checks whether or not this extension is built-in (packaged with the
      * APK file) or coming from an external source.
      */
-    fun isBuiltIn(): Boolean = Uri.parse(url).scheme == "resource"
+    open fun isBuiltIn(): Boolean = Uri.parse(url).scheme == "resource"
 
     /**
      * Checks whether or not this extension is enabled.

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
@@ -20,10 +20,6 @@ interface WebExtensionRuntime {
      * within the APK file (e.g. resource://android/assets/extensions/my_web_ext) or to a
      * local (e.g. resource://android/assets/extensions/my_web_ext.xpi) or remote
      * (e.g. https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi) XPI file.
-     * @param allowContentMessaging whether or not the web extension is allowed
-     * to send messages from content scripts, defaults to true.
-     * @param supportActions whether or not browser and page actions are handled when
-     * received from the web extension, defaults to false.
      * @param onSuccess (optional) callback invoked if the extension was installed successfully,
      * providing access to the [WebExtension] object for bi-directional messaging.
      * @param onError (optional) callback invoked if there was an error installing the extension.
@@ -34,8 +30,6 @@ interface WebExtensionRuntime {
     fun installWebExtension(
         id: String,
         url: String,
-        allowContentMessaging: Boolean = true,
-        supportActions: Boolean = false,
         onSuccess: ((WebExtension) -> Unit) = { },
         onError: ((String, Throwable) -> Unit) = { _, _ -> }
     ): CancellableOperation {

--- a/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
+++ b/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "fxa@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Firefox Accounts WebChannel",
   "version": "1.0",
   "content_scripts": [
@@ -18,6 +23,7 @@
   "permissions": [
     "mozillaAddons",
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FxaWebChannelFeature.kt
+++ b/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FxaWebChannelFeature.kt
@@ -69,7 +69,11 @@ class FxaWebChannelFeature(
 
     @VisibleForTesting
     // This is an internal var to make it mutable for unit testing purposes only
-    internal var extensionController = WebExtensionController(WEB_CHANNEL_EXTENSION_ID, WEB_CHANNEL_EXTENSION_URL)
+    internal var extensionController = WebExtensionController(
+        WEB_CHANNEL_EXTENSION_ID,
+        WEB_CHANNEL_EXTENSION_URL,
+        WEB_CHANNEL_MESSAGING_ID
+    )
 
     override fun start() {
         extensionController.install(runtime)
@@ -165,7 +169,8 @@ class FxaWebChannelFeature(
     companion object {
         private val logger = Logger("mozac-fxawebchannel")
 
-        internal const val WEB_CHANNEL_EXTENSION_ID = "mozacWebchannel"
+        internal const val WEB_CHANNEL_EXTENSION_ID = "fxa@mozac.org"
+        internal const val WEB_CHANNEL_MESSAGING_ID = "mozacWebchannel"
         internal const val WEB_CHANNEL_EXTENSION_URL = "resource://android/assets/extensions/fxawebchannel/"
 
         // Constants for incoming messages from the WebExtension.

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt
@@ -67,8 +67,6 @@ class FxaWebChannelFeatureTest {
         verify(engine, times(1)).installWebExtension(
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_URL),
-            eq(true),
-            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -80,8 +78,6 @@ class FxaWebChannelFeatureTest {
         verify(engine, times(1)).installWebExtension(
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
             eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_URL),
-            eq(true),
-            eq(false),
             any(),
             any()
         )
@@ -120,7 +116,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -153,7 +149,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -185,7 +181,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -223,7 +219,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -274,7 +270,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -328,7 +324,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -378,7 +374,7 @@ class FxaWebChannelFeatureTest {
         webchannelFeature.start()
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -422,7 +418,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -465,7 +461,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -504,7 +500,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -536,7 +532,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)
@@ -570,7 +566,7 @@ class FxaWebChannelFeatureTest {
 
         verify(ext).registerContentMessageHandler(
             eq(engineSession),
-            eq(FxaWebChannelFeature.WEB_CHANNEL_EXTENSION_ID),
+            eq(FxaWebChannelFeature.WEB_CHANNEL_MESSAGING_ID),
             messageHandler.capture()
         )
         messageHandler.value.onPortConnected(port)

--- a/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -405,7 +405,7 @@ class AddonManagerTest {
         })
 
         verify(engine).installWebExtension(
-            eq("ext1"), any(), anyBoolean(), anyBoolean(), onSuccessCaptor.capture(), any()
+            eq("ext1"), any(), onSuccessCaptor.capture(), any()
         )
 
         val extension: WebExtension = mock()
@@ -439,7 +439,7 @@ class AddonManagerTest {
         })
 
         verify(engine).installWebExtension(
-            eq("ext1"), any(), anyBoolean(), anyBoolean(), any(), onErrorCaptor.capture()
+            eq("ext1"), any(), any(), onErrorCaptor.capture()
         )
 
         onErrorCaptor.value.invoke(addon.id, IllegalStateException("test"))
@@ -466,7 +466,7 @@ class AddonManagerTest {
         })
 
         verify(engine, never()).installWebExtension(
-            any(), any(), anyBoolean(), anyBoolean(), any(), any()
+            any(), any(), any(), any()
         )
 
         assertNotNull(throwable!!)

--- a/components/feature/p2p/src/main/assets/extensions/p2p/manifest.json
+++ b/components/feature/p2p/src/main/assets/extensions/p2p/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "p2p@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - P2P",
   "version": "1.0",
   "content_scripts": [
@@ -11,6 +16,7 @@
   ],
   "permissions": [
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/components/feature/p2p/src/main/java/mozilla/components/feature/p2p/P2PFeature.kt
+++ b/components/feature/p2p/src/main/java/mozilla/components/feature/p2p/P2PFeature.kt
@@ -108,7 +108,7 @@ class P2PFeature(
     private fun startExtension() {
         observeSelected() // this sets actionSession
 
-        extensionController = WebExtensionController(P2P_EXTENSION_ID, P2P_EXTENSION_URL)
+        extensionController = WebExtensionController(P2P_EXTENSION_ID, P2P_EXTENSION_URL, P2P_MESSAGING_ID)
         registerP2PContentMessageHandler()
         extensionController?.install(engine)
 
@@ -172,7 +172,10 @@ class P2PFeature(
     @VisibleForTesting
     companion object {
         @VisibleForTesting
-        internal const val P2P_EXTENSION_ID = "mozacP2P"
+        internal const val P2P_EXTENSION_ID = "p2p@mozac.org"
+
+        @VisibleForTesting
+        internal const val P2P_MESSAGING_ID = "mozacP2P"
 
         @VisibleForTesting
         internal const val P2P_EXTENSION_URL = "resource://android/assets/extensions/p2p/"

--- a/components/feature/p2p/src/test/java/mozilla/components/feature/p2p/P2PFeatureTest.kt
+++ b/components/feature/p2p/src/test/java/mozilla/components/feature/p2p/P2PFeatureTest.kt
@@ -140,8 +140,6 @@ class P2PFeatureTest {
         Mockito.verify(engine, Mockito.times(1)).installWebExtension(
             eq(P2PFeature.P2P_EXTENSION_ID),
             eq(P2PFeature.P2P_EXTENSION_URL),
-            eq(true),
-            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -152,8 +150,6 @@ class P2PFeatureTest {
         Mockito.verify(engine, Mockito.times(1)).installWebExtension(
             eq(P2PFeature.P2P_EXTENSION_ID),
             eq(P2PFeature.P2P_EXTENSION_URL),
-            eq(true),
-            eq(false),
             onSuccess.capture(),
             onError.capture()
         )

--- a/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "readerview@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - ReaderView",
   "version": "1.0",
   "content_scripts": [
@@ -13,8 +18,10 @@
     "scripts": ["readerview-background.js"]
   },
   "permissions": [
+    "mozillaAddons",
     "geckoViewAddons",
     "nativeMessaging",
+    "nativeMessagingFromContent",
     "tabs",
     "<all_urls>"
   ]

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -59,7 +59,11 @@ class ReaderViewFeature(
 
     @VisibleForTesting
     // This is an internal var to make it mutable for unit testing purposes only
-    internal var extensionController = WebExtensionController(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL)
+    internal var extensionController = WebExtensionController(
+        READER_VIEW_EXTENSION_ID,
+        READER_VIEW_EXTENSION_URL,
+        READER_VIEW_MESSAGING_ID
+    )
 
     @VisibleForTesting
     internal val config = ReaderViewConfig(context) { message ->
@@ -197,9 +201,7 @@ class ReaderViewFeature(
             // In case the extension was installed while an extension page was
             // displayed (if on startup we opened directly into a
             // restored reader view page), we have to reload the extension page,
-            // as we may have missed to connect the port. This will be fixed by:
-            // https://github.com/mozilla-mobile/android-components/issues/6356
-            // (Then we don't have to install our built-in extension on startup)
+            // as we may have missed to connect the port.
             val selectedTab = store.state.selectedTab
             if (selectedTab?.readerState?.active == true) {
                 selectedTab.engineState.engineSession?.reload()
@@ -241,7 +243,8 @@ class ReaderViewFeature(
 
     @VisibleForTesting
     companion object {
-        internal const val READER_VIEW_EXTENSION_ID = "mozacReaderview"
+        internal const val READER_VIEW_EXTENSION_ID = "readerview@mozac.org"
+        internal const val READER_VIEW_MESSAGING_ID = "mozacReaderview"
         internal const val READER_VIEW_EXTENSION_URL = "resource://android/assets/extensions/readerview/"
 
         // Constants for building messages sent to the web extension:

--- a/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
+++ b/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewMiddleware.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_ID
 import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_EXTENSION_URL
+import mozilla.components.feature.readerview.ReaderViewFeature.Companion.READER_VIEW_MESSAGING_ID
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareStore
 import mozilla.components.support.webextensions.WebExtensionController
@@ -27,7 +28,11 @@ import mozilla.components.support.webextensions.WebExtensionController
 class ReaderViewMiddleware : Middleware<BrowserState, BrowserAction> {
 
     @VisibleForTesting
-    internal var extensionController = WebExtensionController(READER_VIEW_EXTENSION_ID, READER_VIEW_EXTENSION_URL)
+    internal var extensionController = WebExtensionController(
+        READER_VIEW_EXTENSION_ID,
+        READER_VIEW_EXTENSION_URL,
+        READER_VIEW_MESSAGING_ID
+    )
 
     override fun invoke(
         store: MiddlewareStore<BrowserState, BrowserAction>,

--- a/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -76,8 +76,6 @@ class ReaderViewFeatureTest {
         verify(engine, times(1)).installWebExtension(
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID),
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_URL),
-            eq(true),
-            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -89,8 +87,6 @@ class ReaderViewFeatureTest {
         verify(engine, times(1)).installWebExtension(
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID),
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_URL),
-            eq(true),
-            eq(false),
             any(),
             any()
         )
@@ -115,8 +111,6 @@ class ReaderViewFeatureTest {
         verify(engine, times(1)).installWebExtension(
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID),
             eq(ReaderViewFeature.READER_VIEW_EXTENSION_URL),
-            eq(true),
-            eq(false),
             onSuccess.capture(),
             onError.capture()
         )
@@ -531,7 +525,7 @@ class ReaderViewFeatureTest {
         store.dispatch(TabListAction.SelectTabAction(tab.id)).joinBlocking()
 
         val ext: WebExtension = mock()
-        whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_EXTENSION_ID), any())).thenReturn(port)
+        whenever(ext.getConnectedPort(eq(ReaderViewFeature.READER_VIEW_MESSAGING_ID), any())).thenReturn(port)
         WebExtensionController.installedExtensions[ReaderViewFeature.READER_VIEW_EXTENSION_ID] = ext
 
         val feature = ReaderViewFeature(testContext, engine, store, mock())

--- a/components/feature/webcompat-reporter/src/main/java/mozilla/components/feature/webcompat/reporter/WebCompatReporterFeature.kt
+++ b/components/feature/webcompat-reporter/src/main/java/mozilla/components/feature/webcompat/reporter/WebCompatReporterFeature.kt
@@ -21,7 +21,6 @@ object WebCompatReporterFeature {
      */
     fun install(runtime: WebExtensionRuntime) {
         runtime.installWebExtension(WEBCOMPAT_REPORTER_EXTENSION_ID, WEBCOMPAT_REPORTER_EXTENSION_URL,
-            supportActions = true,
             onSuccess = {
                 logger.debug("Installed WebCompat Reporter webextension: ${it.id}")
             },

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -35,6 +35,11 @@ fun String.isUrl() = URLStringUtils.isURLLike(this)
  */
 fun String.isExtensionUrl() = this.startsWith("moz-extension://")
 
+/**
+ * Checks if this String is a URL of a resource.
+ */
+fun String.isResourceUrl() = this.startsWith("resource://")
+
 fun String.toNormalizedUrl() = URLStringUtils.toNormalizedURL(this)
 
 fun String.isPhone() = re.phoneish.matches(this)

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -157,8 +157,16 @@ class StringTest {
     }
 
     @Test
+
     fun sanitizeURL() {
         val expectedUrl = "http://mozilla.org"
         assertEquals(expectedUrl, "\nhttp://mozilla.org\n".sanitizeURL())
+    }
+
+    fun isResourceUrl() {
+        assertTrue("resource://1232-abcd".isResourceUrl())
+        assertFalse("mozilla.org".isResourceUrl())
+        assertFalse("https://mozilla.org".isResourceUrl())
+        assertFalse("http://mozilla.org".isResourceUrl())
     }
 }

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionController.kt
@@ -19,10 +19,13 @@ import java.util.concurrent.ConcurrentHashMap
  * @property extensionId the unique ID of the web extension e.g. mozacReaderview.
  * @property extensionUrl the url pointing to a resources path for locating the
  * extension within the APK file e.g. resource://android/assets/extensions/my_web_ext.
+ * @property messagingId the unique ID used to exchange messages between extension
+ * scripts and the application.
  */
 class WebExtensionController(
     private val extensionId: String,
-    private val extensionUrl: String
+    private val extensionUrl: String,
+    private val messagingId: String
 ) {
     private val logger = Logger("mozac-webextensions")
     private var registerContentMessageHandler: (WebExtension) -> Unit? = { }
@@ -70,12 +73,12 @@ class WebExtensionController(
      *
      * @param engineSession the session the content message handler should be registered with.
      * @param messageHandler the message handler to register.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided messagingId.
      */
     fun registerContentMessageHandler(
         engineSession: EngineSession,
         messageHandler: MessageHandler,
-        name: String = extensionId
+        name: String = messagingId
     ) {
         synchronized(this) {
             registerContentMessageHandler = {
@@ -91,11 +94,11 @@ class WebExtensionController(
      * will be replaced and there is no need to unregister.
      *
      * @param messageHandler the message handler to register.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided messagingId.
      * */
     fun registerBackgroundMessageHandler(
         messageHandler: MessageHandler,
-        name: String = extensionId
+        name: String = messagingId
     ) {
         synchronized(this) {
             registerBackgroundMessageHandler = {
@@ -111,9 +114,9 @@ class WebExtensionController(
      *
      * @param msg the message to send
      * @param engineSession the session to send the content message to.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
-    fun sendContentMessage(msg: JSONObject, engineSession: EngineSession?, name: String = extensionId) {
+    fun sendContentMessage(msg: JSONObject, engineSession: EngineSession?, name: String = messagingId) {
         engineSession?.let { session ->
             installedExtensions[extensionId]?.let { ext ->
                 val port = ext.getConnectedPort(name, session)
@@ -127,11 +130,11 @@ class WebExtensionController(
      * Sends a background message to the provided extension.
      *
      * @param msg the message to send
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
     fun sendBackgroundMessage(
         msg: JSONObject,
-        name: String = extensionId
+        name: String = messagingId
     ) {
         installedExtensions[extensionId]?.let { ext ->
             val port = ext.getConnectedPort(name)
@@ -144,9 +147,9 @@ class WebExtensionController(
      * Checks whether or not a port is connected for the provided session.
      *
      * @param engineSession the session the port should be connected to or null for a port to a background script.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
-    fun portConnected(engineSession: EngineSession?, name: String = extensionId): Boolean {
+    fun portConnected(engineSession: EngineSession?, name: String = messagingId): Boolean {
         return installedExtensions[extensionId]?.let { ext ->
             ext.getConnectedPort(name, engineSession) != null
         } ?: false
@@ -156,9 +159,9 @@ class WebExtensionController(
      * Disconnects the port of the provided session.
      *
      * @param engineSession the session the port is connected to or null for a port to a background script.
-     * @param name (optional) name of the port, defaults to the provided extensionId.
+     * @param name (optional) name of the port, defaults to the provided [messagingId].
      */
-    fun disconnectPort(engineSession: EngineSession?, name: String = extensionId) {
+    fun disconnectPort(engineSession: EngineSession?, name: String = messagingId) {
         installedExtensions[extensionId]?.disconnectPort(name, engineSession)
     }
 

--- a/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -158,6 +158,7 @@ object WebExtensionSupport {
      * the updated extension will not be installed, until the user grants the new permissions.
      * @param onExtensionsLoaded (optional) callback invoked when the extensions are loaded by the
      * engine. Note that the UI (browser/page actions etc.) may not be initialized at this point.
+     * System add-ons (built-in extensions) will not be passed along.
      */
     @Suppress("LongParameterList")
     fun initialize(
@@ -290,7 +291,7 @@ object WebExtensionSupport {
                 extensions -> extensions.forEach { registerInstalledExtension(store, it) }
                 emitWebExtensionsInitializedFact(extensions)
                 initializationResult.complete(Unit)
-                onExtensionsLoaded?.invoke(extensions)
+                onExtensionsLoaded?.invoke(extensions.filter { !it.isBuiltIn() })
             },
             onError = {
                 throwable -> logger.error("Failed to query installed extension", throwable)

--- a/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -622,18 +622,28 @@ class WebExtensionSupportTest {
     fun `invokes onExtensionsLoaded callback`() {
         var executed = false
         val engine: Engine = mock()
+
         val ext: WebExtension = mock()
         whenever(ext.id).thenReturn("test")
+        whenever(ext.isBuiltIn()).thenReturn(false)
+
+        val builtInExt: WebExtension = mock()
+        whenever(builtInExt.id).thenReturn("test2")
+        whenever(builtInExt.isBuiltIn()).thenReturn(true)
+
         val store = spy(BrowserStore(BrowserState(extensions = mapOf(ext.id to WebExtensionState(ext.id)))))
 
         val callbackCaptor = argumentCaptor<((List<WebExtension>) -> Unit)>()
         whenever(engine.listInstalledWebExtensions(callbackCaptor.capture(), any())).thenAnswer {
-            callbackCaptor.value.invoke(listOf())
+            callbackCaptor.value.invoke(listOf(ext, builtInExt))
         }
 
-        val onExtensionsLoaded: ((List<WebExtension>) -> Unit) = { executed = true }
+        val onExtensionsLoaded: ((List<WebExtension>) -> Unit) = {
+            assertEquals(1, it.size)
+            assertEquals(ext, it[0])
+            executed = true
+        }
         WebExtensionSupport.initialize(runtime = engine, store = store, onExtensionsLoaded = onExtensionsLoaded)
-
         assertTrue(executed)
     }
 

--- a/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
+++ b/samples/browser/src/geckoNightly/java/org/mozilla/samples/browser/Components.kt
@@ -27,10 +27,10 @@ class Components(private val applicationContext: Context) : DefaultComponents(ap
 
     override val engine: Engine by lazy {
         GeckoEngine(applicationContext, engineSettings, runtime).also {
-            it.installWebExtension("mozacBorderify", "resource://android/assets/extensions/borderify/") {
+            it.installWebExtension("borderify@mozac.org", "resource://android/assets/extensions/borderify/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }
-            it.installWebExtension("mozacTest", "resource://android/assets/extensions/test/", supportActions = true) {
+            it.installWebExtension("testext@mozac.org", "resource://android/assets/extensions/test/") {
                 ext, throwable -> Log.log(Log.Priority.ERROR, "SampleBrowser", throwable, "Failed to install $ext")
             }
             WebCompatFeature.install(it)

--- a/samples/browser/src/main/assets/extensions/borderify/manifest.json
+++ b/samples/browser/src/main/assets/extensions/borderify/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "borderify@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Borderify",
   "version": "1.0",
   "content_scripts": [

--- a/samples/browser/src/main/assets/extensions/test/manifest.json
+++ b/samples/browser/src/main/assets/extensions/test/manifest.json
@@ -1,5 +1,10 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "testext@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Test extension",
   "description": "This extension is used for testing web extension functionality in Android Components",
   "version": "1.0",


### PR DESCRIPTION
This is replacing the deprecated `runtime.registerWebExtension` with the new `webExtensionController.ensureBuiltIn` for installing built-in extensions. 

I've described the required steps here: https://github.com/mozilla-mobile/android-components/issues/6356#issuecomment-638387500

This is best reviewed by collapsing the tests. The actual changeset is pretty small and cleaned up the engine logic nicely (net negative lines of code). 🎉 

@Amejia481 @psymoon Now that we've branched for release we can land this:
- The GV API landed in beta as well in the meantime, which means we can also remove the `supportActions` and `allowContentMessaging` fields (this is controlled by the manifest now)
- I will apply the change to beta once reviewed to make this easier to read
- The new GV API only installs if a newer version is available, solving the concerns described here: https://github.com/mozilla-mobile/android-components/issues/6356#issuecomment-639822748
- To make sure the latest version is installed in development and in releases and to make sure we don't forget updating the version, we have: https://github.com/mozilla-mobile/android-components/pull/7541

Marking as "Do not land" so I can coordinate landing with the required Fenix change.

