### PR TITLE
Add Bundle.contentEquals method

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/os/Bundle.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/os/Bundle.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.os
+
+import android.os.Bundle
+
+/**
+ * Returns `true` if the two specified bundles are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ */
+@Suppress("ComplexMethod")
+infix fun Bundle.contentEquals(other: Bundle): Boolean {
+    if (size() != other.size()) return false
+
+    return keySet().all { key ->
+        val valueTwo = other.get(key)
+        when (val valueOne = get(key)) {
+            // Compare bundles deeply
+            is Bundle -> valueTwo is Bundle && valueOne contentEquals valueTwo
+
+            // Compare arrays using contentEquals
+            is BooleanArray -> valueTwo is BooleanArray && valueOne contentEquals valueTwo
+            is ByteArray -> valueTwo is ByteArray && valueOne contentEquals valueTwo
+            is CharArray -> valueTwo is CharArray && valueOne contentEquals valueTwo
+            is DoubleArray -> valueTwo is DoubleArray && valueOne contentEquals valueTwo
+            is FloatArray -> valueTwo is FloatArray && valueOne contentEquals valueTwo
+            is IntArray -> valueTwo is IntArray && valueOne contentEquals valueTwo
+            is LongArray -> valueTwo is LongArray && valueOne contentEquals valueTwo
+            is ShortArray -> valueTwo is ShortArray && valueOne contentEquals valueTwo
+            is Array<*> -> valueTwo is Array<*> && valueOne contentEquals valueTwo
+
+            else -> valueOne == valueTwo
+        }
+    }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/os/BundleTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/os/BundleTest.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.os
+
+import androidx.core.os.bundleOf
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.base.crash.Breadcrumb
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+class BundleTest {
+
+    @Test
+    fun `bundles with different sizes should not be equals`() {
+        val small = bundleOf(
+            "hello" to "world"
+        )
+        val big = bundleOf(
+            "hello" to "world",
+            "foo" to "bar"
+        )
+        assertFalse(small.contentEquals(big))
+    }
+
+    @Test
+    fun `bundles with arrays should be equal`() {
+        val (bundle1, bundle2) = (0..1).map {
+            bundleOf(
+                "str" to "world",
+                "int" to 0,
+                "boolArray" to booleanArrayOf(true, false),
+                "byteArray" to "test".toByteArray(),
+                "charArray" to "test".toCharArray(),
+                "doubleArray" to doubleArrayOf(0.0, 1.1),
+                "floatArray" to floatArrayOf(1f, 2f),
+                "intArray" to intArrayOf(0, 1, 2),
+                "longArray" to longArrayOf(0L, 1L),
+                "shortArray" to shortArrayOf(1, 2),
+                "typedArray" to arrayOf("foo", "bar"),
+                "nestedBundle" to bundleOf()
+            )
+        }
+        assertTrue(bundle1.contentEquals(bundle2))
+    }
+
+    @Test
+    fun `bundles with parcelables should be equal`() {
+        val date = Date()
+        val (bundle1, bundle2) = (0..1).map {
+            bundleOf(
+                "crumbs" to Breadcrumb(message = "msg", level = Breadcrumb.Level.DEBUG, date = date)
+            )
+        }
+        assertTrue(bundle1.contentEquals(bundle2))
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-ktx**
+  * Adds `Bundle.contentEquals` function to check if two bundles are equal.
+
 # 49.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v48.0.0...v49.0.0)


### PR DESCRIPTION
This function makes it easier to test bundles and nav directions in Fenix.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
