### PR TITLE
Prune unnecessary tasks from ci tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -68,6 +68,13 @@ tasks:
                           else:
                               $if: 'tasks_for in ["cron", "action"]'
                               then: '${push.branch}'
+              base_sha:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.before}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.base.sha}'
+                      else: 'UNDEFINED'
               head_sha:
                   $if: 'tasks_for == "github-push"'
                   then: '${event.after}'
@@ -213,6 +220,7 @@ tasks:
                                     # to `mach taskgraph decision` are all on the command line.
                                     $merge:
                                         - MOBILE_BASE_REPOSITORY: '${baseRepoUrl}'
+                                          MOBILE_BASE_REV: '${base_sha}'
                                           MOBILE_HEAD_REPOSITORY: '${repoUrl}'
                                           MOBILE_HEAD_REF: '${head_branch}'
                                           MOBILE_HEAD_REV: '${head_sha}'

--- a/taskcluster/ac_taskgraph/__init__.py
+++ b/taskcluster/ac_taskgraph/__init__.py
@@ -8,10 +8,15 @@ import os
 
 from importlib import import_module
 from taskgraph.parameters import extend_parameters_schema
-from voluptuous import Required
+from voluptuous import All, Any, Range, Required
 
 from .build_config import get_components, get_version
 
+
+extend_parameters_schema({
+    Required("pull_request_number"): Any(All(int, Range(min=1)), None),
+    Required("base_rev"): Any(basestring, None),
+})
 
 def register(graph_config):
     """
@@ -36,6 +41,10 @@ def _fill_treeherder_groups(graph_config):
 
 
 def get_decision_parameters(graph_config, parameters):
+    pr_number = os.environ.get("MOBILE_PULL_REQUEST_NUMBER", None)
+    parameters["pull_request_number"] = None if pr_number is None else int(pr_number)
+    parameters["base_rev"] = os.environ.get("MOBILE_BASE_REV")
+
     if parameters["tasks_for"] == "github-release":
         head_tag = parameters["head_tag"].decode("utf-8")
         if not head_tag:

--- a/taskcluster/ac_taskgraph/files_changes.py
+++ b/taskcluster/ac_taskgraph/files_changes.py
@@ -1,0 +1,22 @@
+from taskgraph.util.taskcluster import get_session
+
+
+def get_files_changed_pr(base_repository, pull_request_number):
+    url = base_repository.replace("github.com", "api.github.com/repos")
+    url += "/pulls/%s/files" % pull_request_number
+
+    r = get_session().get(url, timeout=60)
+    r.raise_for_status()
+    files = [f["filename"] for f in r.json()]
+    return files
+
+
+def get_files_changed_push(base_repository, base_rev, head_rev):
+    url = base_repository.replace("github.com", "api.github.com/repos")
+    url += "/compare/"
+    url += "%s...%s" % (base_rev, head_rev)
+
+    r = get_session().get(url, timeout=60)
+    r.raise_for_status()
+    files = [f["filename"] for f in r.json().get("files")]
+    return files

--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -4,16 +4,105 @@
 
 from __future__ import print_function, unicode_literals
 
+import logging
 import os
+import re
+import subprocess
 
 from copy import deepcopy
 from taskgraph.loader.transform import loader as base_loader
+from taskgraph.util.memoize import memoize
+from taskgraph.util.taskcluster import get_session
 from taskgraph.util.templates import merge
 
+from ..files_changes import get_files_changed_pr, get_files_changed_push
 from ..build_config import get_components
 
 
+logger = logging.getLogger(__name__)
+
+ALL_COMPONENTS = object()
+
+def get_components_changed(files_changed):
+    """Translate a list of files changed into a list of components. Eg:
+        [
+            "components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegate.kt",
+            "components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt",
+        ]
+        ->
+        {service-sync-logins}
+    """
+    return set(["-".join(f.split("/")[1:3]) for f in files_changed if f.startswith("components")])
+
+
+cached_deps = {}
+
+# Gradle is expensive to run. Cache the results for each component.
+@memoize
+def get_deps_for_component(component):
+    """Return the full list of local upstream dependencies of a component."""
+    deps = set()
+    # Parsing output like this is not ideal but bhearsum couldn't find a way
+    # to get the dependencies printed in a better format. If we could convince
+    # gradle to spit out JSON that would be much better.
+    # This is filed as https://github.com/mozilla-mobile/android-components/issues/7814
+    for line in subprocess.check_output(['./gradlew', '%s:dependencies' % component, '--configuration', 'implementation']).splitlines():
+        if line.startswith("+--- project"):
+            deps.add(line.split(" ")[2])
+
+    cached_deps[component] = deps
+    # So far, we only have the direct local upstream dependencies. We need to look at
+    # each of those to find _their_ upstreams as well.
+    for d in deps.copy():
+        deps.update(get_deps_for_component(d))
+
+    return deps
+
+def get_affected_components(files_changed, files_affecting_components):
+    affected_components = set()
+
+    # First, find the list of changed components
+    for c in get_components_changed(files_changed):
+        affected_components.add(c)
+
+    # Then, look for any other affected components based on the files changed.
+    for pattern, components in files_affecting_components.items():
+        if any([re.match(pattern, f) for f in files_changed]):
+            # Some file changes may necessitate rebuilding _all_ components.
+            # In this we can just return immediately.
+            if components == "all-components":
+                return ALL_COMPONENTS
+
+            affected_components.update(components)
+
+    # Finally, go through all of the affected components and recursively
+    # find their dependencies.
+    for c in affected_components.copy():
+        affected_components.update(get_deps_for_component(c))
+
+    return affected_components
+
+
 def loader(kind, path, config, params, loaded_tasks):
+    if params["tasks_for"] == "github-pull-request":
+        logger.info("Processing pull request %s" % params["pull_request_number"])
+        files_changed = get_files_changed_pr(params["base_repository"], params["pull_request_number"])
+        affected_components = get_affected_components(files_changed, config.get("files-affecting-components"))
+    elif params["tasks_for"] == "github-push":
+        logger.info("Processing push for commit range %s -> %s" % (params["base_rev"], params["head_rev"]))
+        files_changed = get_files_changed_push(params["base_repository"], params["base_rev"], params["head_rev"])
+        affected_components = get_affected_components(files_changed, config.get("files-affecting-components"))
+    # Unknown tasks_for, can't safely prune tasks
+    else:
+        files_changed = []
+        affected_components = ALL_COMPONENTS
+
+    logger.info("Files changed: %s" % " ".join(files_changed))
+    if affected_components is ALL_COMPONENTS:
+        logger.info("Affected components: ALL")
+    else:
+        logger.info("Affected components: %s" % " ".join(affected_components))
+
     not_for_components = config.get("not-for-components", [])
     jobs = {
         '{}{}'.format(
@@ -28,10 +117,14 @@ def loader(kind, path, config, params, loaded_tasks):
         for component in get_components()
         for build_type in ('regular', 'nightly', 'release')
         if (
-            component['name'] not in not_for_components
+            (affected_components is ALL_COMPONENTS or component['name'] in affected_components)
+            and component['name'] not in not_for_components
             and (component['shouldPublish'] or build_type == 'regular')
         )
     }
+    # Filter away overridden jobs that we wouldn't build anyways to avoid ending up with
+    # partial job entries.
+    overridden_jobs = {k: v for k, v in config.pop('overriden-jobs', {}).items() if affected_components is ALL_COMPONENTS or k in affected_components}
     jobs = merge(jobs, config.pop('overriden-jobs', {}))
 
     config['jobs'] = jobs

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -16,6 +16,16 @@ not-for-components:
 kind-dependencies:
     - toolchain
 
+# We always build components that have changed files or dependencies, but we also need
+# to rebuild some or all components when other files change. This structure
+# maintains the latter mapping. The value may either be a list of specific components,
+# or the special sentinel value `all-components`.
+files-affecting-components:
+    ^build.gradle$: all-components
+    ^settings.gradle$: all-components
+    ^buildSrc.*$: all-components
+    ^gradle.properties$: all-components
+    ^gradle/wrapper/gradle-wrapper.properties$: all-components
 
 job-defaults:
     artifact-template:


### PR DESCRIPTION
This is a proof of concept for #7598. There's a number of things that need be improved & addressed (see below), but with commands like:
`taskgraph decision --pushlog-id=0 --pushdate=0 --project=android-components --message= --owner=skaspari+mozlando@mozilla.com --level=3 --base-repository=https://github.com/mozilla-mobile/android-components --head-repository=https://github.com/mozilla-mobile/android-components --head-ref=refs/heads/master --head-rev=6131efe915b92ad10eec23620a71dc54510bd3e9 --head-tag= --repository-type=git --tasks-for=github-push`

...it produces a significantly smaller set of tasks, like:
```
[u'build-concept-storage',
 u'build-samples-browser-beta',
 u'build-samples-browser-nightly',
 u'build-samples-browser-release',
 u'build-samples-browser-system',
 u'build-service-glean',
 u'build-support-base',
 u'build-support-ktx',
 u'build-support-sync-telemetry',
 u'build-support-utils',
 u'complete-push',
 u'complete-push-1',
 u'complete-push-2',
 u'lint-compare-locales',
 u'lint-detektAndKtlint',
 u'test-android-feature-containers',
 u'test-android-feature-pwa',
 u'test-android-feature-share',
 u'test-android-feature-sitepermissions',
 u'test-android-feature-top-sites',
 u'test-ui-browser',
 u'test-ui-glean',
 u'test-unit-browser-engine-gecko-nightly',
 u'toolchain-linux64-android-gradle-dependencies',
 u'toolchain-linux64-android-sdk-linux-repack']
```

Known TODOs include:
* ~~Use a Github API token to avoid getting rate limited~~ - This probably isn't necessary in the end, because we can do 60 requests/hour/IP. Each decision task will make 2 requests, and most decision tasks won't run on the same workers, so the IPs will differ.
* ~~Figure out how to find all files changed for PRs (something like https://github.com/mozilla-mobile/fenix/blob/master/taskcluster/fenix_taskgraph/parameters.py probably)~~
* ~~Ensure we're using the right API endpoints for commits/pushes~~
* Figure out what actual entries we need in `FILE_PATTERNS_TO_AFFECTED_COMPONENTS`
* See if we can get dependencies dumped from gradle in JSON or another more parseable format
* Determine whether or not the `build-samples-browser` tasks should be considered here, too.