### PR TITLE
For #7627 - Add hasRegionCached() to LocationService

### DIFF
--- a/components/service/location/src/main/java/mozilla/components/service/location/LocationService.kt
+++ b/components/service/location/src/main/java/mozilla/components/service/location/LocationService.kt
@@ -14,6 +14,11 @@ interface LocationService {
     suspend fun fetchRegion(readFromCache: Boolean = true): Region?
 
     /**
+     * Get if there is already a cached region.
+     */
+    fun hasRegionCached(): Boolean
+
+    /**
      * A [Region] returned by the location service.
      *
      * The [Region] use region codes and names from the GENC dataset, which is for the most part
@@ -34,6 +39,7 @@ interface LocationService {
          */
         fun dummy() = object : LocationService {
             override suspend fun fetchRegion(readFromCache: Boolean): Region? = null
+            override fun hasRegionCached(): Boolean = false
         }
     }
 }

--- a/components/service/location/src/main/java/mozilla/components/service/location/MozillaLocationService.kt
+++ b/components/service/location/src/main/java/mozilla/components/service/location/MozillaLocationService.kt
@@ -72,6 +72,15 @@ class MozillaLocationService(
 
         client.fetchRegion(regionServiceUrl)?.also { context.cacheRegion(it) }
     }
+
+    /**
+     * Get if there is already a cached region.
+     * This does not guarantee we have the current actual region but only the last value
+     * which may be obsolete at this time.
+     */
+    override fun hasRegionCached(): Boolean {
+        return context.hasCachedRegion()
+    }
 }
 
 private fun Context.loadCachedRegion(): LocationService.Region? {
@@ -85,6 +94,11 @@ private fun Context.loadCachedRegion(): LocationService.Region? {
     } else {
         null
     }
+}
+
+private fun Context.hasCachedRegion(): Boolean {
+    val cache = regionCache()
+    return cache.contains(KEY_COUNTRY_CODE) && cache.contains(KEY_COUNTRY_NAME)
 }
 
 private fun Context.cacheRegion(region: LocationService.Region) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@ permalink: /changelog/
 * **concept-engine**
   * Added `EngineSession.goToHistoryIndex` to jump to a specific index in a session's history.
   
+* **service-location**
+  * `LocationService.hasRegionCached()` is introduced to query if the region is already cached and a long running operation to fetch the region is not needed.
+  
 # 49.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v48.0.0...v49.0.0)


### PR DESCRIPTION
This method can be used by clients to better estimate if fetchRegion() is
expected to take very little time as the region is already cached or if it can
take a bit longer since there are multiple operations / longer running
operations needed to actually fetch the region.

In the case of MozillaLocationService if the region is not already cached the
process of fetching the region involves a REST call with a connect / read
timeout of 10 seconds.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended).
- [x] **Tests**: No tests. Small straightforward code.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
