### PR TITLE
Turn on Gradle configure on demand

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,14 @@ org.gradle.jvmargs=-Xmx4096m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# https://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # XXX Deactivated because of broken releases?
 org.gradle.parallel=false
+
+# When configured, Gradle will only configure relevant projects instead of all of them.
+# This option should only be used with decoupled projects. More details, visit
+# https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand
+org.gradle.configureondemand=true
 
 # Build cache - further configured in settings.gradle
 org.gradle.caching=true


### PR DESCRIPTION
Gradle optimizations for CI. When this flag is turned on, only modules that are dependencies will be configured in a CI task. For example, build-support-base only needs to compile support-base and support-test. Sample Browser still depends on everything, so this just helps with individual tasks.