### PR TITLE
Issue #7647: Add SessionFeature.release() to allow app to stop rendering engine sessions and release the current one.

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionFeature.kt
@@ -56,4 +56,15 @@ class SessionFeature(
     override fun stop() {
         presenter.stop()
     }
+
+    /**
+     * Stops the feature from rendering sessions on the [EngineView] (until explicitly started again)
+     * and releases an already rendering session from the [EngineView].
+     */
+    fun release() {
+        // Once we fully migrated to BrowserStore we may be able to get rid of the need for cleanup().
+        // See https://github.com/mozilla-mobile/android-components/issues/7657
+        presenter.stop()
+        engineView.release()
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **feature-session**
+  * Added `SessionFeature.release()`: Calling this method stops the feature from rendering sessions on the `EngineView` (until explicitly started again) and releases an already rendering session from the `EngineView`.
+
 * **support-ktx**
   * Adds `Bundle.contentEquals` function to check if two bundles are equal.
 


### PR DESCRIPTION
Previously Fenix just called `engineView.release()`. However since `EnginePresenter` is now listening to `BrowserStore` it may re-render the session that we just released. This new methods stops the presenter from updating and releases the current session.