### PR TITLE
Closes #7665: Add support for converting TrackingProtectionPolicy to ContentBlocking.Setting

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
+import org.mozilla.geckoview.ContentBlocking
+import org.mozilla.geckoview.GeckoRuntimeSettings
+
+/**
+ * Converts a [TrackingProtectionPolicy] into a GeckoView setting that can be used with [GeckoRuntimeSettings.Builder].
+ */
+fun TrackingProtectionPolicy.toContentBlockingSetting(
+    safeBrowsingPolicy: Array<EngineSession.SafeBrowsingPolicy> = arrayOf(EngineSession.SafeBrowsingPolicy.RECOMMENDED)
+) = ContentBlocking.Settings.Builder().apply {
+    enhancedTrackingProtectionLevel(getEtpLevel())
+    antiTracking(getAntiTrackingPolicy())
+    cookieBehavior(cookiePolicy.id)
+    safeBrowsing(safeBrowsingPolicy.sumBy { it.id })
+    // This will be fixed on merge day when strictSocialTrackingProtection will be available on beta
+    // strictSocialTrackingProtection(getStrictSocialTrackingProtection())
+}.build()
+
+/**
+ * Returns the [TrackingProtectionPolicy] categories as an Enhanced Tracking Protection level for GeckoView.
+ */
+internal fun TrackingProtectionPolicy.getEtpLevel(): Int {
+    return when {
+        trackingCategories.contains(TrackingCategory.NONE) -> ContentBlocking.EtpLevel.NONE
+        else -> ContentBlocking.EtpLevel.STRICT
+    }
+}
+
+/**
+ * Returns the [TrackingProtectionPolicy] as a tracking policy for GeckoView.
+ */
+internal fun TrackingProtectionPolicy.getAntiTrackingPolicy(): Int {
+    /**
+     * The [TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES] is an
+     * artificial category, created with the sole purpose of going around this bug
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1579264, for this reason we have to
+     * remove its value from the valid anti tracking categories, when is present.
+     */
+    val total = trackingCategories.sumBy { it.id }
+    return if (contains(TrackingCategory.SCRIPTS_AND_SUB_RESOURCES)) {
+        total - TrackingCategory.SCRIPTS_AND_SUB_RESOURCES.id
+    } else {
+        total
+    }
+}

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.geckoview.ContentBlocking.EtpLevel
+
+class TrackingProtectionPolicyKtTest {
+
+    private val defaultSafeBrowsing = arrayOf(EngineSession.SafeBrowsingPolicy.RECOMMENDED)
+
+    @Test
+    fun `transform the policy to a GeckoView ContentBlockingSetting`() {
+        val policy = TrackingProtectionPolicy.recommended()
+        val setting = policy.toContentBlockingSetting()
+
+        assertEquals(policy.getEtpLevel(), setting.enhancedTrackingProtectionLevel)
+        assertEquals(policy.getAntiTrackingPolicy(), setting.antiTrackingCategories)
+        assertEquals(policy.cookiePolicy.id, setting.cookieBehavior)
+        assertEquals(defaultSafeBrowsing.sumBy { it.id }, setting.safeBrowsingCategories)
+        // TODO Add this when we have it from GV; https://bugzilla.mozilla.org/show_bug.cgi?id=1651454
+        // assertEquals(policy.getStrictSocialTrackingProtection(), setting.strictSocialTrackingProtection)
+
+        val policyWithSafeBrowsing = TrackingProtectionPolicy.recommended().toContentBlockingSetting(emptyArray())
+        assertEquals(0, policyWithSafeBrowsing.safeBrowsingCategories)
+    }
+
+    @Test
+    fun `getEtpLevel is always Strict unless None`() {
+        assertEquals(EtpLevel.STRICT, TrackingProtectionPolicy.recommended().getEtpLevel())
+        assertEquals(EtpLevel.STRICT, TrackingProtectionPolicy.strict().getEtpLevel())
+        assertEquals(EtpLevel.NONE, TrackingProtectionPolicy.none().getEtpLevel())
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -7,6 +7,9 @@ package mozilla.components.browser.engine.gecko
 import android.content.Context
 import android.util.AttributeSet
 import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.engine.gecko.ext.getAntiTrackingPolicy
+import mozilla.components.browser.engine.gecko.ext.getEtpLevel
+import mozilla.components.browser.engine.gecko.ext.getStrictSocialTrackingProtection
 import mozilla.components.browser.engine.gecko.integration.LocaleSettingUpdater
 import mozilla.components.browser.engine.gecko.mediaquery.from
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
@@ -519,41 +522,28 @@ class GeckoEngine(
         override var trackingProtectionPolicy: TrackingProtectionPolicy? = null
             set(value) {
                 value?.let { policy ->
-                    val activateStrictSocialTracking =
-                        policy.strictSocialTrackingProtection ?: policy.trackingCategories.contains(
-                            TrackingCategory.STRICT
-                        )
-                    val etpLevel =
-                        when {
-                            policy.trackingCategories.contains(TrackingCategory.NONE) ->
-                                ContentBlocking.EtpLevel.NONE
-                            else -> ContentBlocking.EtpLevel.STRICT
+                    with(runtime.settings.contentBlocking) {
+                        if (enhancedTrackingProtectionLevel != value.getEtpLevel()) {
+                            enhancedTrackingProtectionLevel = value.getEtpLevel()
                         }
-                    runtime.settings.contentBlocking.setEnhancedTrackingProtectionLevel(etpLevel)
-                    runtime.settings.contentBlocking.setStrictSocialTrackingProtection(
-                        activateStrictSocialTracking
-                    )
-                    runtime.settings.contentBlocking.setAntiTracking(policy.getAntiTrackingPolicy())
-                    runtime.settings.contentBlocking.setCookieBehavior(policy.cookiePolicy.id)
+
+                        if (strictSocialTrackingProtection != value.getStrictSocialTrackingProtection()) {
+                            strictSocialTrackingProtection = policy.getStrictSocialTrackingProtection()
+                        }
+
+                        if (antiTrackingCategories != value.getAntiTrackingPolicy()) {
+                            setAntiTracking(policy.getAntiTrackingPolicy())
+                        }
+
+                        if (cookieBehavior != value.cookiePolicy.id) {
+                            cookieBehavior = value.cookiePolicy.id
+                        }
+                    }
+
                     defaultSettings?.trackingProtectionPolicy = value
                     field = value
                 }
             }
-
-        private fun TrackingProtectionPolicy.getAntiTrackingPolicy(): Int {
-            /**
-             * The [TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES] is an
-             * artificial category, created with the sole purpose of going around this bug
-             * https://bugzilla.mozilla.org/show_bug.cgi?id=1579264, for this reason we have to
-             * remove its value from the valid anti tracking categories, when is present.
-             */
-            val total = trackingCategories.sumBy { it.id }
-            return if (contains(TrackingCategory.SCRIPTS_AND_SUB_RESOURCES)) {
-                total - TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES.id
-            } else {
-                total
-            }
-        }
 
         override var remoteDebuggingEnabled: Boolean
             get() = runtime.settings.remoteDebuggingEnabled

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory
+import org.mozilla.geckoview.ContentBlocking
+import org.mozilla.geckoview.GeckoRuntimeSettings
+
+/**
+ * Converts a [TrackingProtectionPolicy] into a GeckoView setting that can be used with [GeckoRuntimeSettings.Builder].
+ */
+fun TrackingProtectionPolicy.toContentBlockingSetting(
+    safeBrowsingPolicy: Array<EngineSession.SafeBrowsingPolicy> = arrayOf(EngineSession.SafeBrowsingPolicy.RECOMMENDED)
+) = ContentBlocking.Settings.Builder().apply {
+    enhancedTrackingProtectionLevel(getEtpLevel())
+    antiTracking(getAntiTrackingPolicy())
+    cookieBehavior(cookiePolicy.id)
+    safeBrowsing(safeBrowsingPolicy.sumBy { it.id })
+    strictSocialTrackingProtection(getStrictSocialTrackingProtection())
+}.build()
+
+/**
+ * Returns whether [TrackingCategory.STRICT] is enabled in the [TrackingProtectionPolicy].
+ */
+internal fun TrackingProtectionPolicy.getStrictSocialTrackingProtection(): Boolean {
+    return strictSocialTrackingProtection ?: trackingCategories.contains(TrackingCategory.STRICT)
+}
+
+/**
+ * Returns the [TrackingProtectionPolicy] categories as an Enhanced Tracking Protection level for GeckoView.
+ */
+internal fun TrackingProtectionPolicy.getEtpLevel(): Int {
+    return when {
+        trackingCategories.contains(TrackingCategory.NONE) -> ContentBlocking.EtpLevel.NONE
+        else -> ContentBlocking.EtpLevel.STRICT
+    }
+}
+
+/**
+ * Returns the [TrackingProtectionPolicy] as a tracking policy for GeckoView.
+ */
+internal fun TrackingProtectionPolicy.getAntiTrackingPolicy(): Int {
+    /**
+     * The [TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES] is an
+     * artificial category, created with the sole purpose of going around this bug
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1579264, for this reason we have to
+     * remove its value from the valid anti tracking categories, when is present.
+     */
+    val total = trackingCategories.sumBy { it.id }
+    return if (contains(TrackingCategory.SCRIPTS_AND_SUB_RESOURCES)) {
+        total - TrackingCategory.SCRIPTS_AND_SUB_RESOURCES.id
+    } else {
+        total
+    }
+}

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -1,0 +1,51 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.components.browser.engine.gecko.ext
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mozilla.geckoview.ContentBlocking.EtpLevel
+
+class TrackingProtectionPolicyKtTest {
+
+    private val defaultSafeBrowsing = arrayOf(EngineSession.SafeBrowsingPolicy.RECOMMENDED)
+
+    @Test
+    fun `transform the policy to a GeckoView ContentBlockingSetting`() {
+        val policy = TrackingProtectionPolicy.recommended()
+        val setting = policy.toContentBlockingSetting()
+
+        assertEquals(policy.getEtpLevel(), setting.enhancedTrackingProtectionLevel)
+        assertEquals(policy.getAntiTrackingPolicy(), setting.antiTrackingCategories)
+        assertEquals(policy.cookiePolicy.id, setting.cookieBehavior)
+        assertEquals(defaultSafeBrowsing.sumBy { it.id }, setting.safeBrowsingCategories)
+        assertEquals(setting.strictSocialTrackingProtection, setting.strictSocialTrackingProtection)
+
+        val policyWithSafeBrowsing = TrackingProtectionPolicy.recommended().toContentBlockingSetting(emptyArray())
+        assertEquals(0, policyWithSafeBrowsing.safeBrowsingCategories)
+    }
+
+    @Test
+    fun `getEtpLevel is always Strict unless None`() {
+        assertEquals(EtpLevel.STRICT, TrackingProtectionPolicy.recommended().getEtpLevel())
+        assertEquals(EtpLevel.STRICT, TrackingProtectionPolicy.strict().getEtpLevel())
+        assertEquals(EtpLevel.NONE, TrackingProtectionPolicy.none().getEtpLevel())
+    }
+
+    @Test
+    fun `getStrictSocialTrackingProtection is true if category is STRICT`() {
+        val recommendedPolicy = TrackingProtectionPolicy.recommended()
+        val strictPolicy = TrackingProtectionPolicy.strict()
+
+        assertFalse(recommendedPolicy.toContentBlockingSetting().strictSocialTrackingProtection)
+        assertTrue(strictPolicy.toContentBlockingSetting().strictSocialTrackingProtection)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,12 @@ permalink: /changelog/
 * **browser-session**
   * ⚠️ **This is a breaking change**: `Session.Source` was moved to browser-state and is now `SessionState.Source`. No change is required other than fixing imports.
 
+* **browser-engine-beta**
+  * Added `TrackingProtectionPolicy.toContentBlockingSetting` extension methods to convert a policy to GeckoView's `ContentBlocking.Setting`.
+
+* **browser-engine-nightly**
+  * Added `TrackingProtectionPolicy.toContentBlockingSetting` extension methods to convert a policy to GeckoView's `ContentBlocking.Setting`.
+  * Added checks to not apply the same policy twice if they are the same as already on the engine.
 
 # 50.0.0
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
We added the changes needed for Fenix to apply the policy settings they
need to the GeckoRuntime directly.

Since we require GeckoView changes to support the fix, we will let the
fix ride the train. However, to avoid breaking the build variants in
Fenix, we add the GeckoEngine extensions that are needed for the beta
variant. This would not give us the full benefits of the perf fixes,
but it will avoid regressing ETP changes should we upgrade the engine
and forget to apply changes we need for Fenix's GeckoProvider in beta.

Co-authored-by: Arturo Mejia <arturomejiamarmol@gmail.com>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
