### PR TITLE
Closes #7664: Add EngineSession.goToHistoryIndex to jump to a specifi…

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -153,6 +153,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.goToHistoryIndex]
+     */
+    override fun goToHistoryIndex(index: Int) {
+        geckoSession.gotoHistoryIndex(index)
+    }
+
+    /**
      * See [EngineSession.saveState]
      */
     override fun saveState(): EngineSessionState {

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -491,6 +491,16 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun goToHistoryIndex() {
+        val engineSession = GeckoEngineSession(mock(),
+            geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.goToHistoryIndex(0)
+
+        verify(geckoSession).gotoHistoryIndex(0)
+    }
+
+    @Test
     fun restoreState() {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
@@ -2332,6 +2342,13 @@ class GeckoEngineSessionTest {
         engineSession.toggleDesktopMode(false, reload = true)
         // This is the second time in this test, so we actually want two invocations.
         verify(geckoSession, times(2)).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goToHistoryIndex(index: Int)
+        engineSession.goToHistoryIndex(0)
+        verify(geckoSession).gotoHistoryIndex(0)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -153,6 +153,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.goToHistoryIndex]
+     */
+    override fun goToHistoryIndex(index: Int) {
+        geckoSession.gotoHistoryIndex(index)
+    }
+
+    /**
      * See [EngineSession.saveState]
      */
     override fun saveState(): EngineSessionState {

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -491,6 +491,16 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun goToHistoryIndex() {
+        val engineSession = GeckoEngineSession(mock(),
+            geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.goToHistoryIndex(0)
+
+        verify(geckoSession).gotoHistoryIndex(0)
+    }
+
+    @Test
     fun restoreState() {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
@@ -2332,6 +2342,13 @@ class GeckoEngineSessionTest {
         engineSession.toggleDesktopMode(false, reload = true)
         // This is the second time in this test, so we actually want two invocations.
         verify(geckoSession, times(2)).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goToHistoryIndex(index: Int)
+        engineSession.goToHistoryIndex(0)
+        verify(geckoSession).gotoHistoryIndex(0)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -153,6 +153,13 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.goToHistoryIndex]
+     */
+    override fun goToHistoryIndex(index: Int) {
+        geckoSession.gotoHistoryIndex(index)
+    }
+
+    /**
      * See [EngineSession.saveState]
      */
     override fun saveState(): EngineSessionState {

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -491,6 +491,16 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun goToHistoryIndex() {
+        val engineSession = GeckoEngineSession(mock(),
+            geckoSessionProvider = geckoSessionProvider)
+
+        engineSession.goToHistoryIndex(0)
+
+        verify(geckoSession).gotoHistoryIndex(0)
+    }
+
+    @Test
     fun restoreState() {
         val engineSession = GeckoEngineSession(mock(),
                 geckoSessionProvider = geckoSessionProvider)
@@ -2332,6 +2342,13 @@ class GeckoEngineSessionTest {
         engineSession.toggleDesktopMode(false, reload = true)
         // This is the second time in this test, so we actually want two invocations.
         verify(geckoSession, times(2)).reload()
+        fakePageLoad(false)
+
+        fakePageLoad(true)
+
+        // goToHistoryIndex(index: Int)
+        engineSession.goToHistoryIndex(0)
+        verify(geckoSession).gotoHistoryIndex(0)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -38,7 +38,7 @@ internal val xRequestHeader = mapOf(
 /**
  * WebView-based EngineSession implementation.
  */
-@Suppress("TooManyFunctions")
+@Suppress("LargeClass", "TooManyFunctions")
 class SystemEngineSession(
     context: Context,
     private val defaultSettings: Settings? = null
@@ -123,6 +123,14 @@ class SystemEngineSession(
      */
     override fun goForward() {
         webView.goForward()
+    }
+
+    /**
+     * See [EngineSession.goToHistoryIndex]
+     */
+    override fun goToHistoryIndex(index: Int) {
+        val historyList = webView.copyBackForwardList()
+        webView.goBackOrForward(index - historyList.currentIndex)
     }
 
     /**

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -179,6 +179,21 @@ class SystemEngineSessionTest {
     }
 
     @Test
+    fun goToHistoryIndex() {
+        val engineSession = spy(SystemEngineSession(testContext))
+        val webView = mock<WebView>()
+
+        whenever(webView.copyBackForwardList()).thenReturn(mock())
+        engineSession.goToHistoryIndex(0)
+        verify(webView, never()).goBackOrForward(0)
+
+        engineSession.webView = webView
+
+        engineSession.goToHistoryIndex(0)
+        verify(webView).goBackOrForward(0)
+    }
+
+    @Test
     fun saveState() {
         val engineSession = spy(SystemEngineSession(testContext))
         val webView = mock<WebView>()

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -54,6 +54,7 @@ class EngineObserverTest {
 
             override fun goBack() {}
             override fun goForward() {}
+            override fun goToHistoryIndex(index: Int) {}
             override fun reload() {}
             override fun stopLoading() {}
             override fun restoreState(state: EngineSessionState): Boolean { return false }
@@ -109,6 +110,7 @@ class EngineObserverTest {
 
             override fun goBack() {}
             override fun goForward() {}
+            override fun goToHistoryIndex(index: Int) {}
             override fun stopLoading() {}
             override fun reload() {}
             override fun restoreState(state: EngineSessionState): Boolean { return false }
@@ -153,6 +155,7 @@ class EngineObserverTest {
 
             override fun goBack() {}
             override fun goForward() {}
+            override fun goToHistoryIndex(index: Int) {}
             override fun stopLoading() {}
             override fun reload() {}
             override fun restoreState(state: EngineSessionState): Boolean { return false }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -466,6 +466,15 @@ abstract class EngineSession(
     abstract fun goForward()
 
     /**
+     * Navigates to the specified index in the [HistoryState] of this session. The current index of
+     * this session's [HistoryState] will be updated but the items within it will be unchanged.
+     * Invalid index values are ignored.
+     *
+     * @param index the index of the session's [HistoryState] to navigate to
+     */
+    abstract fun goToHistoryIndex(index: Int)
+
+    /**
      * Saves and returns the engine state. Engine implementations are not required
      * to persist the state anywhere else than in the returned map. Engines that
      * already provide a serialized state can use a single entry in this map to

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -833,6 +833,8 @@ open class DummyEngineSession : EngineSession() {
 
     override fun goForward() {}
 
+    override fun goToHistoryIndex(index: Int) {}
+
     override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
 
     override fun disableTrackingProtection() {}

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -176,6 +176,26 @@ class SessionUseCases(
         }
     }
 
+    /**
+     * Use case to jump to an arbitrary history index in a session's backstack.
+     */
+    class GoToHistoryIndexUseCase internal constructor(
+        private val sessionManager: SessionManager
+    ) {
+        /**
+         * Navigates to a specific index in the [HistoryState] of the given session.
+         * Invalid index values will be ignored.
+         *
+         * @param index the index in the session's [HistoryState] to navigate to
+         * @param session the session whose [HistoryState] is being accessed
+         */
+        operator fun invoke(index: Int, session: Session? = sessionManager.selectedSession) {
+            if (session != null) {
+                sessionManager.getOrCreateEngineSession(session).goToHistoryIndex(index)
+            }
+        }
+    }
+
     class RequestDesktopSiteUseCase internal constructor(
         private val sessionManager: SessionManager
     ) {
@@ -267,6 +287,7 @@ class SessionUseCases(
     val stopLoading: StopLoadingUseCase by lazy { StopLoadingUseCase(sessionManager) }
     val goBack: GoBackUseCase by lazy { GoBackUseCase(sessionManager) }
     val goForward: GoForwardUseCase by lazy { GoForwardUseCase(sessionManager) }
+    val goToHistoryIndex: GoToHistoryIndexUseCase by lazy { GoToHistoryIndexUseCase(sessionManager) }
     val requestDesktopSite: RequestDesktopSiteUseCase by lazy { RequestDesktopSiteUseCase(sessionManager) }
     val exitFullscreen: ExitFullScreenUseCase by lazy { ExitFullScreenUseCase(sessionManager) }
     val clearData: ClearDataUseCase by lazy { ClearDataUseCase(sessionManager) }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -134,6 +134,25 @@ class SessionUseCasesTest {
     }
 
     @Test
+    fun goToHistoryIndex() {
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+
+        useCases.goToHistoryIndex(session = null, index = 0)
+        verify(engineSession, never()).goToHistoryIndex(0)
+        verify(selectedEngineSession, never()).goToHistoryIndex(0)
+
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        useCases.goToHistoryIndex(session = session, index = 0)
+        verify(engineSession).goToHistoryIndex(0)
+
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        useCases.goToHistoryIndex(index = 0)
+        verify(selectedEngineSession).goToHistoryIndex(0)
+    }
+
+    @Test
     fun requestDesktopSite() {
         val engineSession = mock<EngineSession>()
         val session = mock<Session>()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,10 +14,14 @@ permalink: /changelog/
 
 * **feature-session**
   * Added `SessionFeature.release()`: Calling this method stops the feature from rendering sessions on the `EngineView` (until explicitly started again) and releases an already rendering session from the `EngineView`.
+  * Added `SessionUseCases.goToHistoryIndex` to allow consumers to jump to a specific index in a session's history.
 
 * **support-ktx**
   * Adds `Bundle.contentEquals` function to check if two bundles are equal.
 
+* **concept-engine**
+  * Added `EngineSession.goToHistoryIndex` to jump to a specific index in a session's history.
+  
 # 49.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v48.0.0...v49.0.0)


### PR DESCRIPTION
…c index in a sessions history.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
