### PR TITLE
Closes #7641: Add onBackLongPressed to UserInteractionHandler.

### DIFF
--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/UserInteractionHandler.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/UserInteractionHandler.kt
@@ -19,6 +19,14 @@ interface UserInteractionHandler {
     fun onBackPressed(): Boolean
 
     /**
+     * Called when this [UserInteractionHandler] gets the option to handle the user long pressing the back key.
+     * Note: This will never be called when system gesture navigation is enabled on Android 10+.
+     *
+     * Returns true if this [UserInteractionHandler] consumed the event and no other components need to be notified.
+     */
+    fun onBackLongPressed(): Boolean = false
+
+    /**
      * In most cases, when the home button is pressed, we invoke this callback to inform the app that the user
      * is going to leave the app.
      *

--- a/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
+++ b/components/support/base/src/main/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapper.kt
@@ -155,6 +155,24 @@ class ViewBoundFeatureWrapper<T : LifecycleAwareFeature>() {
         return feature.onBackPressed()
     }
 
+    /**
+     * Convenient method for invoking [UserInteractionHandler.onBackLongPressed] on a wrapped
+     * [LifecycleAwareFeature] that implements [UserInteractionHandler]. Returns false if
+     * the [LifecycleAwareFeature] was cleared already.
+     */
+    @Synchronized
+    fun onBackLongPressed(): Boolean {
+        val feature = feature ?: return false
+
+        if (feature !is UserInteractionHandler) {
+            throw IllegalAccessError(
+                "Feature does not implement ${UserInteractionHandler::class.java.simpleName} interface"
+            )
+        }
+
+        return feature.onBackLongPressed()
+    }
+
     @Synchronized
     internal fun start() {
         feature?.start()

--- a/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
+++ b/components/support/base/src/test/java/mozilla/components/support/base/feature/ViewBoundFeatureWrapperTest.kt
@@ -55,6 +55,26 @@ class ViewBoundFeatureWrapperTest {
     }
 
     @Test
+    fun `onBackLongPressed is forwarded to feature`() {
+        val feature = MockFeatureWithUserInteractionHandler(onBackLongPressed = true)
+
+        val wrapper = ViewBoundFeatureWrapper(
+            feature = feature,
+            owner = MockedLifecycleOwner(MockedLifecycle(Lifecycle.State.CREATED)),
+            view = mock()
+        )
+
+        assertTrue(wrapper.onBackLongPressed())
+        assertTrue(feature.onBackLongPressedInvoked)
+
+        assertFalse(ViewBoundFeatureWrapper(
+            feature = MockFeatureWithUserInteractionHandler(onBackLongPressed = false),
+            owner = MockedLifecycleOwner(MockedLifecycle(Lifecycle.State.CREATED)),
+            view = mock()
+        ).onBackLongPressed())
+    }
+
+    @Test
     fun `Setting feature registers lifecycle and view observers`() {
         val lifecycle = spy(MockedLifecycle(Lifecycle.State.CREATED))
         val owner = MockedLifecycleOwner(lifecycle)
@@ -380,14 +400,23 @@ private open class MockFeature : LifecycleAwareFeature {
 }
 
 private class MockFeatureWithUserInteractionHandler(
-    private val onBackPressed: Boolean = false
+    private val onBackPressed: Boolean = false,
+    private val onBackLongPressed: Boolean = false
 ) : MockFeature(), UserInteractionHandler {
     var onBackPressedInvoked = false
+        private set
+
+    var onBackLongPressedInvoked = false
         private set
 
     override fun onBackPressed(): Boolean {
         onBackPressedInvoked = true
         return onBackPressed
+    }
+
+    override fun onBackLongPressed(): Boolean {
+        onBackLongPressedInvoked = true
+        return onBackLongPressed
     }
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **support-base**
+  * Added `UserInteractionHandler.onBackLongPressed` for fragments, features, and other components that want to handle the user long pressing the system back button.
+  
 
 # 50.0.0
 

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -66,6 +67,17 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         }
 
         super.onBackPressed()
+    }
+
+    override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            supportFragmentManager.fragments.forEach {
+                if (it is UserInteractionHandler && it.onBackLongPressed()) {
+                    return true
+                }
+            }
+        }
+        return super.onKeyLongPress(keyCode, event)
     }
 
     override fun onCreateView(parent: View?, name: String, context: Context, attrs: AttributeSet): View? =


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Blocker 2/3 for mozilla-mobile/fenix#1048

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
