### PR TITLE
Closes #7644: Add long click listener to BrowserMenuItemToolbar items.

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -53,6 +53,11 @@ class BrowserMenuItemToolbar(
                 item.listener()
                 menu.dismiss()
             }
+            button.setOnLongClickListener {
+                item.longClickListener()
+                menu.dismiss()
+                true
+            }
 
             layout.addView(button, LinearLayout.LayoutParams(0, MATCH_PARENT, 1f))
         }
@@ -77,13 +82,16 @@ class BrowserMenuItemToolbar(
      * @param contentDescription The button's content description, used for accessibility support.
      * @param iconTintColorResource Optional ID of color resource to tint the icon.
      * @param isEnabled Lambda to return true/false to indicate if this button should be enabled or disabled.
+     * @param longClickListener Callback to be invoked when the button is long clicked.
      * @param listener Callback to be invoked when the button is pressed.
      */
+    @Suppress("LongParameterList")
     open class Button(
         @DrawableRes val imageResource: Int,
         val contentDescription: String,
         @ColorRes val iconTintColorResource: Int = NO_ID,
         val isEnabled: () -> Boolean = { true },
+        val longClickListener: () -> Unit = {},
         val listener: () -> Unit
     ) {
 
@@ -131,8 +139,10 @@ class BrowserMenuItemToolbar(
      * @param secondaryImageTintResource Optional ID of secondary color resource to tint the icon.
      * @param isInPrimaryState Lambda to return true/false to indicate if this button should be primary or secondary.
      * @param disableInSecondaryState Optional boolean to disable the button when in secondary state.
+     * @param longClickListener Callback to be invoked when the button is long clicked.
      * @param listener Callback to be invoked when the button is pressed.
      */
+    @Suppress("LongParameterList")
     open class TwoStateButton(
         @DrawableRes val primaryImageResource: Int,
         val primaryContentDescription: String,
@@ -142,12 +152,14 @@ class BrowserMenuItemToolbar(
         @ColorRes val secondaryImageTintResource: Int = primaryImageTintResource,
         val isInPrimaryState: () -> Boolean = { true },
         val disableInSecondaryState: Boolean = false,
+        longClickListener: () -> Unit = {},
         listener: () -> Unit
     ) : Button(
         primaryImageResource,
         primaryContentDescription,
         primaryImageTintResource,
         isInPrimaryState,
+        longClickListener = longClickListener,
         listener = listener
     ) {
 

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -298,6 +298,39 @@ class BrowserMenuItemToolbarTest {
     }
 
     @Test
+    fun `long clicking item view invokes callback and dismisses menu`() {
+        var callbackInvoked = false
+
+        val button = BrowserMenuItemToolbar.Button(
+            R.drawable.abc_ic_ab_back_material,
+            "Test",
+            longClickListener = {
+                callbackInvoked = true
+            }
+        ) {}
+
+        assertFalse(callbackInvoked)
+
+        val menu = mock(BrowserMenu::class.java)
+        val layout = LinearLayout(testContext)
+
+        val toolbar = BrowserMenuItemToolbar(listOf(button))
+        toolbar.bind(menu, layout)
+
+        assertEquals(1, layout.childCount)
+
+        val view = layout.getChildAt(0)
+
+        assertFalse(callbackInvoked)
+        verify(menu, never()).dismiss()
+
+        view.performLongClick()
+
+        assertTrue(callbackInvoked)
+        verify(menu).dismiss()
+    }
+
+    @Test
     fun `toolbar can be converted to candidate`() {
         val listener = {}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ permalink: /changelog/
 
 * **browser-state**
   * Added map of `SessionState.contextId` and their respective `ContainerState` in `BrowserState` to track the state of a container.
+  
+* **browser-menu**
+  * Added an optional `longClickListener` parameter to `BrowserMenuItemToolbar.Button` and `BrowserMenuItemToolbar.TwoStateButton` to handle long click events.
 
 # 49.0.0
 


### PR DESCRIPTION

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Needed for mozilla-mobile/fenix#1048 and mozilla-mobile/fenix#2681
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
