### PR TITLE
Bumps Application Services to v62.0.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "1.6.3"
 
-    const val mozilla_appservices = "61.0.7"
+    const val mozilla_appservices = "62.0.0"
 
     const val mozilla_glean = "31.2.3"
 

--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.plus
+import mozilla.appservices.fxaclient.AuthorizationParams
 import mozilla.appservices.fxaclient.FirefoxAccount as InternalFxAcct
 import mozilla.components.concept.sync.AccessType
 import mozilla.components.concept.sync.AuthFlowUrl
@@ -101,7 +102,7 @@ class FirefoxAccount internal constructor(
 
     override fun beginOAuthFlowAsync(scopes: Set<String>) = scope.async {
         handleFxaExceptions(logger, "begin oauth flow", { null }) {
-            val url = inner.beginOAuthFlow(scopes.toTypedArray())
+            val url = inner.beginOAuthFlow(scopes.toTypedArray(), "none")
             val state = Uri.parse(url).getQueryParameter("state")!!
             AuthFlowUrl(state, url)
         }
@@ -109,7 +110,7 @@ class FirefoxAccount internal constructor(
 
     override fun beginPairingFlowAsync(pairingUrl: String, scopes: Set<String>) = scope.async {
         handleFxaExceptions(logger, "begin oauth pairing flow", { null }) {
-            val url = inner.beginPairingFlow(pairingUrl, scopes.toTypedArray())
+            val url = inner.beginPairingFlow(pairingUrl, scopes.toTypedArray(), "none")
             val state = Uri.parse(url).getQueryParameter("state")!!
             AuthFlowUrl(state, url)
         }
@@ -140,7 +141,8 @@ class FirefoxAccount internal constructor(
         accessType: AccessType
     ) = scope.async {
         handleFxaExceptions(logger, "authorizeOAuthCode", { null }) {
-            inner.authorizeOAuthCode(clientId, scopes, state, accessType.msg)
+            val authParams = AuthorizationParams(clientId, scopes, state, accessType.msg)
+            inner.authorizeOAuthCode(authParams)
         }
     }
 


### PR DESCRIPTION
Connects to https://github.com/mozilla/application-services/issues/3337
Bumps Application Services to 62.0.0

# v62.0.0 (_2020-07-13_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...v62.0.0)

## FxA Client

### ⚠️ Breaking changes ⚠️

- Adds support for `entrypoint` in oauth flow APIs: consumers of `beginOAuthFlow` and `beginPairingFlow` (`beginAuthentication` and `beginPairingAuthentication` in ios) are now ***required*** to pass an `entrypoint` argument that would be used for metrics. This puts the `beginOAuthFlow` and `beginPairingFlow` APIs inline with other existing APIs, like `getManageAccountUrl`.  ([#3265](https://github.com/mozilla/application-services/pull/3265))
- Changes the `authorizeOAuthCode` API to now accept an `AuthorizationParams` object instead of the individual parameters. The `AuthorizationParams` also includes optional `AuthorizationPKCEParams` that contain the `codeChallenge`, `codeChallengeMethod`. `AuthorizationParams` also includes an optional `keysJwk` for requesting keys ([#3264](https://github.com/mozilla/application-services/pull/3264))

### What's new ###
- Consumers can now optionally include parameters for metrics in `beginOAuthFlow` and `beginPairingFlow` (`beginAuthentication` and `beginPairingAuthentication` in ios). Those parameters can be passed in using a `MetricsParams` struct/class. `MetricsParams` is defined in both the Kotlin and Swift bindings. The parameters are the following ([#3328](https://github.com/mozilla/application-services/pull/3328)):
  - flow_id
  - flow_begin_time
  - device_id
  - utm_source
  - utm_content
  - utm_medium
  - utm_term
  - utm_campaign
  - entrypoint_experiment
  - entrypoint_variation

## Logins

### What's fixed ###

- Fixed a bug where attempting to edit a login with an empty `form_submit_url` would incorrectly
  reject the entry as invalid ([#3331](https://github.com/mozilla/application-services/pull/3331)).

## Tabs

### What's new ###

- Tab records now have an explicit TTL set when storing on the server, to match the behaviour
  of Firefox Desktop clients ([#3322](https://github.com/mozilla/application-services/pull/3322)).

