### PR TITLE
For mozilla-mobile/fenix#7310 - Adds bypassCache parameter to reload.

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -132,8 +132,8 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.reload]
      */
-    override fun reload() {
-        geckoSession.reload()
+    override fun reload(flags: LoadUrlFlags) {
+        geckoSession.reload(flags.value)
     }
 
     /**

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -467,7 +467,18 @@ class GeckoEngineSessionTest {
 
         engineSession.reload()
 
-        verify(geckoSession).reload()
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_NONE)
+    }
+
+    @Test
+    fun reloadBypassingCache() {
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+        engineSession.loadUrl("http://mozilla.org")
+
+        engineSession.reload(flags = LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE))
+
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE)
     }
 
     @Test
@@ -2319,7 +2330,7 @@ class GeckoEngineSessionTest {
 
         // reload()
         engineSession.reload()
-        verify(geckoSession).reload()
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         fakePageLoad(true)
@@ -2341,7 +2352,7 @@ class GeckoEngineSessionTest {
         // toggleDesktopMode()
         engineSession.toggleDesktopMode(false, reload = true)
         // This is the second time in this test, so we actually want two invocations.
-        verify(geckoSession, times(2)).reload()
+        verify(geckoSession, times(2)).reload(GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -132,8 +132,8 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.reload]
      */
-    override fun reload() {
-        geckoSession.reload()
+    override fun reload(flags: LoadUrlFlags) {
+        geckoSession.reload(flags.value)
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -467,7 +467,18 @@ class GeckoEngineSessionTest {
 
         engineSession.reload()
 
-        verify(geckoSession).reload()
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_NONE)
+    }
+
+    @Test
+    fun reloadBypassingCache() {
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+        engineSession.loadUrl("http://mozilla.org")
+
+        engineSession.reload(flags = LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE))
+
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE)
     }
 
     @Test
@@ -2500,7 +2511,7 @@ class GeckoEngineSessionTest {
 
         // reload()
         engineSession.reload()
-        verify(geckoSession).reload()
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         fakePageLoad(true)
@@ -2522,7 +2533,7 @@ class GeckoEngineSessionTest {
         // toggleDesktopMode()
         engineSession.toggleDesktopMode(false, reload = true)
         // This is the second time in this test, so we actually want two invocations.
-        verify(geckoSession, times(2)).reload()
+        verify(geckoSession, times(2)).reload(GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -132,8 +132,8 @@ class GeckoEngineSession(
     /**
      * See [EngineSession.reload]
      */
-    override fun reload() {
-        geckoSession.reload()
+    override fun reload(flags: LoadUrlFlags) {
+        geckoSession.reload(flags.value)
     }
 
     /**

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -467,7 +467,18 @@ class GeckoEngineSessionTest {
 
         engineSession.reload()
 
-        verify(geckoSession).reload()
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_NONE)
+    }
+
+    @Test
+    fun reloadBypassingCache() {
+        val engineSession = GeckoEngineSession(mock(),
+                geckoSessionProvider = geckoSessionProvider)
+        engineSession.loadUrl("http://mozilla.org")
+
+        engineSession.reload(flags = LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE))
+
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE)
     }
 
     @Test
@@ -2319,7 +2330,7 @@ class GeckoEngineSessionTest {
 
         // reload()
         engineSession.reload()
-        verify(geckoSession).reload()
+        verify(geckoSession).reload(GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         fakePageLoad(true)
@@ -2341,7 +2352,7 @@ class GeckoEngineSessionTest {
         // toggleDesktopMode()
         engineSession.toggleDesktopMode(false, reload = true)
         // This is the second time in this test, so we actually want two invocations.
-        verify(geckoSession, times(2)).reload()
+        verify(geckoSession, times(2)).reload(GeckoSession.LOAD_FLAGS_NONE)
         fakePageLoad(false)
 
         fakePageLoad(true)

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -103,8 +103,9 @@ class SystemEngineSession(
 
     /**
      * See [EngineSession.reload]
+     * @param flags currently not supported in `SystemEngineSession`.
      */
-    override fun reload() {
+    override fun reload(flags: LoadUrlFlags) {
         webView.reload()
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -55,7 +55,7 @@ class EngineObserverTest {
             override fun goBack() {}
             override fun goForward() {}
             override fun goToHistoryIndex(index: Int) {}
-            override fun reload() {}
+            override fun reload(flags: LoadUrlFlags) {}
             override fun stopLoading() {}
             override fun restoreState(state: EngineSessionState): Boolean { return false }
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
@@ -112,7 +112,7 @@ class EngineObserverTest {
             override fun goForward() {}
             override fun goToHistoryIndex(index: Int) {}
             override fun stopLoading() {}
-            override fun reload() {}
+            override fun reload(flags: LoadUrlFlags) {}
             override fun restoreState(state: EngineSessionState): Boolean { return false }
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun disableTrackingProtection() {}
@@ -157,7 +157,7 @@ class EngineObserverTest {
             override fun goForward() {}
             override fun goToHistoryIndex(index: Int) {}
             override fun stopLoading() {}
-            override fun reload() {}
+            override fun reload(flags: LoadUrlFlags) {}
             override fun restoreState(state: EngineSessionState): Boolean { return false }
             override fun enableTrackingProtection(policy: TrackingProtectionPolicy) {
                 notifyObservers { onTrackerBlockingEnabledChange(true) }

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -416,7 +416,7 @@ abstract class EngineSession(
      * @param url the url to load.
      * @param parent the parent (referring) [EngineSession] i.e. the session that
      * triggered creating this one.
-     * @param flags the [LoadUrlFlags] to use when loading the provider url.
+     * @param flags the [LoadUrlFlags] to use when loading the provided url.
      * @param additionalHeaders the extra headers to use when loading the provided url.
      */
     abstract fun loadUrl(
@@ -452,8 +452,10 @@ abstract class EngineSession(
 
     /**
      * Reloads the current URL.
+     *
+     * @param flags the [LoadUrlFlags] to use when reloading the current url.
      */
-    abstract fun reload()
+    abstract fun reload(flags: LoadUrlFlags = LoadUrlFlags.none())
 
     /**
      * Navigates back in the history of this session.

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -827,7 +827,7 @@ open class DummyEngineSession : EngineSession() {
 
     override fun stopLoading() {}
 
-    override fun reload() {}
+    override fun reload(flags: LoadUrlFlags) {}
 
     override fun goBack() {}
 

--- a/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -109,19 +109,26 @@ class SessionUseCases(
          * selected session if none is provided).
          *
          * @param session the session for which reload should be triggered.
+         * @param flags the [LoadUrlFlags] to use when reloading the given session.
          */
-        operator fun invoke(session: Session? = sessionManager.selectedSession) {
+        operator fun invoke(
+            session: Session? = sessionManager.selectedSession,
+            flags: LoadUrlFlags = LoadUrlFlags.none()
+        ) {
             if (session != null) {
-                sessionManager.getOrCreateEngineSession(session).reload()
+                sessionManager.getOrCreateEngineSession(session).reload(flags)
             }
         }
 
         /**
          * Reloads the current page of the tab with the given [tabId].
+         *
+         * @param tabId id of the tab that should be reloaded
+         * @param flags the [LoadUrlFlags] to use when reloading the given tabId.
          */
-        operator fun invoke(tabId: String) {
+        operator fun invoke(tabId: String, flags: LoadUrlFlags = LoadUrlFlags.none()) {
             sessionManager.findSessionById(tabId)?.let {
-                invoke(it)
+                invoke(it, flags)
             }
         }
     }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -82,6 +82,21 @@ class SessionUseCasesTest {
     }
 
     @Test
+    fun reloadBypassCache() {
+        val engineSession = mock<EngineSession>()
+        val session = mock<Session>()
+        val flags = LoadUrlFlags.select(LoadUrlFlags.BYPASS_CACHE)
+        whenever(sessionManager.getOrCreateEngineSession(session)).thenReturn(engineSession)
+
+        useCases.reload(session, flags = flags)
+        verify(engineSession).reload(flags = flags)
+
+        whenever(sessionManager.getOrCreateEngineSession(selectedSession)).thenReturn(selectedEngineSession)
+        useCases.reload(flags = flags)
+        verify(selectedEngineSession).reload(flags = flags)
+    }
+
+    @Test
     fun stopLoading() {
         val engineSession = mock<EngineSession>()
         val session = mock<Session>()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,12 +24,14 @@ permalink: /changelog/
 * **feature-session**
   * Added `SessionFeature.release()`: Calling this method stops the feature from rendering sessions on the `EngineView` (until explicitly started again) and releases an already rendering session from the `EngineView`.
   * Added `SessionUseCases.goToHistoryIndex` to allow consumers to jump to a specific index in a session's history.
+  * Added `flags` parameter to `ReloadUrlUseCase`.
 
 * **support-ktx**
   * Adds `Bundle.contentEquals` function to check if two bundles are equal.
 
 * **concept-engine**
   * Added `EngineSession.goToHistoryIndex` to jump to a specific index in a session's history.
+  * Adds `flags` parameter to `reload`.
 
 * **service-location**
   * `LocationService.hasRegionCached()` is introduced to query if the region is already cached and a long running operation to fetch the region is not needed.


### PR DESCRIPTION
For mozilla-mobile/fenix#7310 - Adds bypassCache parameter to reload. 
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
