### PR TITLE
For mozilla-mobile/fenix#12509: Align add ons view section titles

### DIFF
--- a/components/feature/addons/src/main/res/layout/mozac_feature_addons_section_item.xml
+++ b/components/feature/addons/src/main/res/layout/mozac_feature_addons_section_item.xml
@@ -11,7 +11,7 @@
         android:background="?android:attr/selectableItemBackground"
         android:orientation="horizontal"
         android:paddingTop="16dp"
-        android:paddingStart="16dp"
+        android:paddingStart="72dp"
         android:paddingEnd="16dp"
         tools:text="Recommended"
         android:textStyle="bold" />


### PR DESCRIPTION
This pr aligns section title items to top bar.

This pr already got ux approval in mozilla-mobile/fenix#12509
![resim](https://user-images.githubusercontent.com/17825767/87398499-9acff700-c5be-11ea-8f9a-79f2b08eed9d.png)

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
