### PR TITLE
For #7700 - Use the website favicon in save login dialog

### DIFF
--- a/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -475,7 +475,8 @@ class PromptFeature private constructor(
                     sessionId = session.id,
                     hint = promptRequest.hint,
                     // For v1, we only handle a single login and drop all others on the floor
-                    login = promptRequest.logins[0]
+                    login = promptRequest.logins[0],
+                    icon = session.content.icon
                 )
             }
 

--- a/components/feature/prompts/src/main/res/layout/mozac_feature_prompt_save_login_prompt.xml
+++ b/components/feature/prompts/src/main/res/layout/mozac_feature_prompt_save_login_prompt.xml
@@ -15,19 +15,27 @@
     android:paddingBottom="16dp"
     tools:ignore="Overdraw">
 
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/host_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/mozac_ic_globe"
+        android:importantForAccessibility="no" />
+
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/host_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:drawablePadding="16dp"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:gravity="center_vertical"
         android:textColor="?android:textColorPrimary"
         android:textSize="16sp"
-        app:drawableStartCompat="@drawable/mozac_ic_globe"
-        app:drawableTint="?android:textColorPrimary"
-        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
+        app:layout_constraintStart_toEndOf="@+id/host_icon"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="host.com" />
 

--- a/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragmentTest.kt
+++ b/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragmentTest.kt
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.dialog
+
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.textfield.TextInputEditText
+import junit.framework.TestCase
+import mozilla.components.concept.storage.Login
+import mozilla.components.feature.prompts.R
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.ext.appCompatContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.robolectric.Shadows
+
+@RunWith(AndroidJUnit4::class)
+class SaveLoginDialogFragmentTest : TestCase() {
+    @Test
+    fun `dialog should always set the website icon if it is available`() {
+        val sessionId = "sessionId"
+        val hint = 42
+        val loginUsername = "username"
+        val loginPassword = "password"
+        val login: Login = mock() // valid image to be used as favicon
+        `when`(login.username).thenReturn(loginUsername)
+        `when`(login.password).thenReturn(loginPassword)
+        val icon: Bitmap = mock()
+        val fragment = spy(SaveLoginDialogFragment.newInstance(
+            sessionId, hint, login, icon
+        ))
+        doReturn(appCompatContext).`when`(fragment).requireContext()
+        doAnswer {
+            FrameLayout(appCompatContext).apply {
+                addView(TextInputEditText(appCompatContext).apply { id = R.id.username_field })
+                addView(TextInputEditText(appCompatContext).apply { id = R.id.password_field })
+                addView(ImageView(appCompatContext).apply { id = R.id.host_icon })
+            }
+        }.`when`(fragment).inflateRootView(any())
+
+        val fragmentView = fragment.onCreateView(mock(), mock(), mock())
+
+        verify(fragment).inflateRootView(any())
+        verify(fragment).setupRootView(any())
+        assertEquals(sessionId, fragment.sessionId)
+        // Using assertTrue since assertEquals / assertSame would fail here
+        assertTrue(loginUsername == fragmentView.findViewById<TextInputEditText>(R.id.username_field).text.toString())
+        assertTrue(loginPassword == fragmentView.findViewById<TextInputEditText>(R.id.password_field).text.toString())
+
+        // Actually verifying that the provided image is used
+        verify(fragment, times(0)).setImageViewTint(any())
+        assertSame(icon, (fragmentView.findViewById<ImageView>(R.id.host_icon).drawable as BitmapDrawable).bitmap)
+    }
+
+    @Test
+    fun `dialog should use a default tinted icon if favicon is not available`() {
+        val sessionId = "sessionId"
+        val hint = 42
+        val loginUsername = "username"
+        val loginPassword = "password"
+        val login: Login = mock()
+        `when`(login.username).thenReturn(loginUsername)
+        `when`(login.password).thenReturn(loginPassword)
+        val icon: Bitmap? = null // null favicon
+        val fragment = spy(SaveLoginDialogFragment.newInstance(
+            sessionId, hint, login, icon
+        ))
+        val defaultIconResource = R.drawable.mozac_ic_globe
+        doReturn(appCompatContext).`when`(fragment).requireContext()
+        doAnswer {
+            FrameLayout(appCompatContext).apply {
+                addView(TextInputEditText(appCompatContext).apply { id = R.id.username_field })
+                addView(TextInputEditText(appCompatContext).apply { id = R.id.password_field })
+                addView(ImageView(appCompatContext).apply {
+                    id = R.id.host_icon
+                    setImageResource(defaultIconResource)
+                })
+            }
+        }.`when`(fragment).inflateRootView(any())
+
+        val fragmentView = fragment.onCreateView(mock(), mock(), mock())
+
+        verify(fragment).inflateRootView(any())
+        verify(fragment).setupRootView(any())
+        assertEquals(sessionId, fragment.sessionId)
+        // Using assertTrue since assertEquals / assertSame would fail here
+        assertTrue(loginUsername == fragmentView.findViewById<TextInputEditText>(R.id.username_field).text.toString())
+        assertTrue(loginPassword == fragmentView.findViewById<TextInputEditText>(R.id.password_field).text.toString())
+
+        // Actually verifying that the tinted default image is used
+        val iconView = fragmentView.findViewById<ImageView>(R.id.host_icon)
+        verify(fragment).setImageViewTint(iconView)
+        assertNotNull(iconView.imageTintList)
+        // The icon sent was null, we want the default instead
+        assertNotNull(iconView.drawable)
+        assertEquals(defaultIconResource, Shadows.shadowOf(iconView.drawable).createdFromResId)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,9 @@ permalink: /changelog/
   * Added `ContainerToolbarFeature` to update the toolbar with the container page action whenever
     the selected tab changes.
 
+* **feature-prompts**
+  * Replaced generic icon in `LoginDialogFragment` with site icon (keep the generic one as fallback)
+
 # 56.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v55.0.0...v56.0.0)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

Showing the dialog using a generated favicon or downloaded one, depending on what the browser uses
![SaveLoginsFragmentIcons](https://user-images.githubusercontent.com/11428869/91267394-f4117580-e77b-11ea-8902-370d9b47f7d1.gif)
[video](https://drive.google.com/file/d/1hh38hp1OyZZHFW1Gl2YMiqmzQykqCW9E/view?usp=sharing)

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
