### PR TITLE
Issue #7712: Add flag for filtering exact matches from SearchSuggestionProvider and add SearchActionProvider.

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchActionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchActionProvider.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.awesomebar.provider
+
+import android.graphics.Bitmap
+import kotlinx.coroutines.Deferred
+import mozilla.components.browser.search.SearchEngine
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.search.SearchUseCases
+
+private const val FIXED_ID = "@@@search.action.provider.fixed.id@@"
+
+/**
+ * An [AwesomeBar.SuggestionProvider] implementation that returns a suggestion that mirrors the
+ * entered text and invokes a search with the given [SearchEngine] if clicked.
+ */
+class SearchActionProvider(
+    private val searchEngine: Deferred<SearchEngine>,
+    private val searchUseCase: SearchUseCases.SearchUseCase,
+    private val icon: Bitmap? = null,
+    private val showDescription: Boolean = true
+) : AwesomeBar.SuggestionProvider {
+    override val id: String = java.util.UUID.randomUUID().toString()
+
+    override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
+        if (text.isBlank()) {
+            return emptyList()
+        }
+
+        return listOf(AwesomeBar.Suggestion(
+            provider = this,
+            // We always use the same ID for the entered text so that this suggestion gets replaced "in place".
+            id = FIXED_ID,
+            title = text,
+            description = if (showDescription) searchEngine.await().name else null,
+            icon = icon ?: searchEngine.await().icon,
+            score = Int.MAX_VALUE,
+            onSuggestionClicked = {
+                searchUseCase.invoke(text)
+            }
+        ))
+    }
+
+    override val shouldClearSuggestions: Boolean = false
+}

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/AwesomeBarFeatureTest.kt
@@ -204,6 +204,19 @@ class AwesomeBarFeatureTest {
     }
 
     @Test
+    fun `addSearchActionProvider adds provider`() {
+        val awesomeBar: AwesomeBar = mock()
+
+        val feature = AwesomeBarFeature(awesomeBar, mock())
+
+        verify(awesomeBar, never()).addProviders(any())
+
+        feature.addSearchActionProvider(mock(), mock())
+
+        verify(awesomeBar).addProviders(any())
+    }
+
+    @Test
     fun `Feature invokes custom start and complete hooks`() {
         val toolbar: Toolbar = mock()
         val awesomeBar: AwesomeBar = mock()

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.awesomebar.provider
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.search.SearchEngine
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchActionProviderTest {
+    @Test
+    fun `provider returns no suggestion for empty text`() {
+        val provider = SearchActionProvider(mock(), mock())
+        val suggestions = runBlocking { provider.onInputChanged("") }
+
+        assertEquals(0, suggestions.size)
+    }
+
+    @Test
+    fun `provider returns no suggestion for blank text`() {
+        val provider = SearchActionProvider(mock(), mock())
+        val suggestions = runBlocking { provider.onInputChanged("     ") }
+
+        assertEquals(0, suggestions.size)
+    }
+
+    @Test
+    fun `provider returns suggestion matching input`() {
+        val provider = SearchActionProvider(
+            searchEngine = GlobalScope.async { mock<SearchEngine>() },
+            searchUseCase = mock()
+        )
+        val suggestions = runBlocking { provider.onInputChanged("firefox") }
+
+        assertEquals(1, suggestions.size)
+
+        val suggestion = suggestions[0]
+
+        assertEquals("firefox", suggestion.title)
+    }
+}


### PR DESCRIPTION
This allows a consuming app to filter suggestions that match the entered text from `SearchSuggestionProvider`. Then they can add `SearchActionProvider` that provides a suggestion for the entered text. The benefit is that `SearchActionProvider` does not depend on querying a search engine first and therefore the suggestion will appear faster - especially on slow networks.