### PR TITLE
Closes #7710: Stop intercepting redirect with subframe load request without user action

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -377,7 +377,7 @@ class GeckoEngineSession(
                 initialLoad = true
             }
 
-            return if (maybeInterceptRequest(request) != null) {
+            return if (maybeInterceptRequest(request, false) != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
             } else {
                 notifyObservers {
@@ -400,7 +400,7 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(AllowOrDeny.ALLOW)
             }
 
-            return if (maybeInterceptRequest(request) != null) {
+            return if (maybeInterceptRequest(request, true) != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
             } else {
                 // Not notifying session observer because of performance concern and currently there
@@ -450,7 +450,8 @@ class GeckoEngineSession(
         }
 
         private fun maybeInterceptRequest(
-            request: NavigationDelegate.LoadRequest
+            request: NavigationDelegate.LoadRequest,
+            isSubframeRequest: Boolean
         ): InterceptionResponse? {
             val interceptor = settings.requestInterceptor
             return if (
@@ -464,7 +465,8 @@ class GeckoEngineSession(
                     request.hasUserGesture,
                     isSameDomain,
                     request.isRedirect,
-                    request.isDirectNavigation
+                    request.isDirectNavigation,
+                    isSubframeRequest
                 )?.apply {
                     when (this) {
                         is InterceptionResponse.Content -> loadData(data, mimeType, encoding)

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -639,7 +639,7 @@ class GeckoEngineSessionTest {
     fun `keeps track of current url via onLocationChange events`() {
         val mockedContentBlockingController = mock<ContentBlockingController>()
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
-        var geckoResult = GeckoResult<Boolean?>()
+        val geckoResult = GeckoResult<Boolean?>()
         whenever(runtime.contentBlockingController).thenReturn(mockedContentBlockingController)
         whenever(mockedContentBlockingController.checkException(any())).thenReturn(geckoResult)
 
@@ -660,7 +660,7 @@ class GeckoEngineSessionTest {
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider,
             context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
-        var geckoResult = GeckoResult<Boolean?>()
+        val geckoResult = GeckoResult<Boolean?>()
         whenever(runtime.contentBlockingController).thenReturn(mockedContentBlockingController)
         whenever(mockedContentBlockingController.checkException(any())).thenReturn(geckoResult)
 
@@ -1270,7 +1270,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
@@ -1300,7 +1301,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -1335,7 +1337,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalled = true
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -1380,7 +1383,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return null
@@ -2047,7 +2051,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
@@ -2088,6 +2093,7 @@ class GeckoEngineSessionTest {
 
         var observedUrl: String? = null
         var observedIntent: Intent? = null
+        var observedIsSubframe = false
 
         engineSession.settings.requestInterceptor = object : RequestInterceptor {
             override fun interceptsAppInitiatedRequests() = true
@@ -2098,8 +2104,10 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
+                observedIsSubframe = isSubframeRequest
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
                     else -> null
@@ -2122,12 +2130,14 @@ class GeckoEngineSessionTest {
 
         assertNotNull(observedIntent)
         assertEquals("result", observedUrl)
+        assertEquals(true, observedIsSubframe)
 
         navigationDelegate.value.onSubframeLoadRequest(
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
         assertNotNull(observedIntent)
         assertEquals("result", observedUrl)
+        assertEquals(true, observedIsSubframe)
     }
 
     @Test
@@ -2152,7 +2162,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.Url("result")
@@ -2275,7 +2286,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     fakeUrl -> null

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -374,7 +374,7 @@ class GeckoEngineSession(
             }
 
             return when {
-                maybeInterceptRequest(request) != null ->
+                maybeInterceptRequest(request, false) != null ->
                     GeckoResult.fromValue(AllowOrDeny.DENY)
                 request.target == NavigationDelegate.TARGET_WINDOW_NEW ->
                     GeckoResult.fromValue(AllowOrDeny.ALLOW)
@@ -400,7 +400,7 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(AllowOrDeny.ALLOW)
             }
 
-            return if (maybeInterceptRequest(request) != null) {
+            return if (maybeInterceptRequest(request, true) != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
             } else {
                 // Not notifying session observer because of performance concern and currently there
@@ -450,7 +450,8 @@ class GeckoEngineSession(
         }
 
         private fun maybeInterceptRequest(
-            request: NavigationDelegate.LoadRequest
+            request: NavigationDelegate.LoadRequest,
+            isSubframeRequest: Boolean
         ): InterceptionResponse? {
             val interceptor = settings.requestInterceptor
             return if (
@@ -464,7 +465,8 @@ class GeckoEngineSession(
                     request.hasUserGesture,
                     isSameDomain,
                     request.isRedirect,
-                    request.isDirectNavigation
+                    request.isDirectNavigation,
+                    isSubframeRequest
                 )?.apply {
                     when (this) {
                         is InterceptionResponse.Content -> loadData(data, mimeType, encoding)

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -1270,7 +1270,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
@@ -1300,7 +1301,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -1335,7 +1337,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalled = true
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -1380,7 +1383,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return null
@@ -1935,7 +1939,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
@@ -2008,7 +2013,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
@@ -2078,7 +2084,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
@@ -2228,7 +2235,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
@@ -2269,6 +2277,7 @@ class GeckoEngineSessionTest {
 
         var observedUrl: String? = null
         var observedIntent: Intent? = null
+        var observedIsSubframe = false
 
         engineSession.settings.requestInterceptor = object : RequestInterceptor {
             override fun interceptsAppInitiatedRequests() = true
@@ -2279,8 +2288,10 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
+                observedIsSubframe = isSubframeRequest
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
                     else -> null
@@ -2303,12 +2314,14 @@ class GeckoEngineSessionTest {
 
         assertNotNull(observedIntent)
         assertEquals("result", observedUrl)
+        assertEquals(true, observedIsSubframe)
 
         navigationDelegate.value.onSubframeLoadRequest(
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
         assertNotNull(observedIntent)
         assertEquals("result", observedUrl)
+        assertEquals(true, observedIsSubframe)
     }
 
     @Test
@@ -2333,7 +2346,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.Url("result")
@@ -2456,7 +2470,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     fakeUrl -> null

--- a/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -377,7 +377,7 @@ class GeckoEngineSession(
                 initialLoad = true
             }
 
-            return if (maybeInterceptRequest(request) != null) {
+            return if (maybeInterceptRequest(request, false) != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
             } else {
                 notifyObservers {
@@ -400,7 +400,7 @@ class GeckoEngineSession(
                 return GeckoResult.fromValue(AllowOrDeny.ALLOW)
             }
 
-            return if (maybeInterceptRequest(request) != null) {
+            return if (maybeInterceptRequest(request, true) != null) {
                 GeckoResult.fromValue(AllowOrDeny.DENY)
             } else {
                 // Not notifying session observer because of performance concern and currently there
@@ -450,7 +450,8 @@ class GeckoEngineSession(
         }
 
         private fun maybeInterceptRequest(
-            request: NavigationDelegate.LoadRequest
+            request: NavigationDelegate.LoadRequest,
+            isSubframeRequest: Boolean
         ): InterceptionResponse? {
             val interceptor = settings.requestInterceptor
             return if (
@@ -464,7 +465,8 @@ class GeckoEngineSession(
                     request.hasUserGesture,
                     isSameDomain,
                     request.isRedirect,
-                    request.isDirectNavigation
+                    request.isDirectNavigation,
+                    isSubframeRequest
                 )?.apply {
                     when (this) {
                         is InterceptionResponse.Content -> loadData(data, mimeType, encoding)

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -639,7 +639,7 @@ class GeckoEngineSessionTest {
     fun `keeps track of current url via onLocationChange events`() {
         val mockedContentBlockingController = mock<ContentBlockingController>()
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
-        var geckoResult = GeckoResult<Boolean?>()
+        val geckoResult = GeckoResult<Boolean?>()
         whenever(runtime.contentBlockingController).thenReturn(mockedContentBlockingController)
         whenever(mockedContentBlockingController.checkException(any())).thenReturn(geckoResult)
 
@@ -660,7 +660,7 @@ class GeckoEngineSessionTest {
         val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider,
             context = coroutineContext)
         val historyTrackingDelegate: HistoryTrackingDelegate = mock()
-        var geckoResult = GeckoResult<Boolean?>()
+        val geckoResult = GeckoResult<Boolean?>()
         whenever(runtime.contentBlockingController).thenReturn(mockedContentBlockingController)
         whenever(mockedContentBlockingController.checkException(any())).thenReturn(geckoResult)
 
@@ -1270,7 +1270,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
@@ -1300,7 +1301,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -1335,7 +1337,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalled = true
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -1380,7 +1383,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return null
@@ -2047,7 +2051,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
@@ -2088,6 +2093,7 @@ class GeckoEngineSessionTest {
 
         var observedUrl: String? = null
         var observedIntent: Intent? = null
+        var observedIsSubframe = false
 
         engineSession.settings.requestInterceptor = object : RequestInterceptor {
             override fun interceptsAppInitiatedRequests() = true
@@ -2098,8 +2104,10 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
+                observedIsSubframe = isSubframeRequest
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.AppIntent(mock(), "result")
                     else -> null
@@ -2122,12 +2130,14 @@ class GeckoEngineSessionTest {
 
         assertNotNull(observedIntent)
         assertEquals("result", observedUrl)
+        assertEquals(true, observedIsSubframe)
 
         navigationDelegate.value.onSubframeLoadRequest(
             mock(), mockLoadRequest("sample:about", triggeredByRedirect = false))
 
         assertNotNull(observedIntent)
         assertEquals("result", observedUrl)
+        assertEquals(true, observedIsSubframe)
     }
 
     @Test
@@ -2152,7 +2162,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     "sample:about" -> RequestInterceptor.InterceptionResponse.Url("result")
@@ -2275,7 +2286,8 @@ class GeckoEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return when (uri) {
                     fakeUrl -> null

--- a/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -251,7 +251,8 @@ class SystemEngineView @JvmOverloads constructor(
                         request.hasGesture(),
                         session.currentUrl.tryGetHostFromUrl() == request.url.host,
                         isRedirect,
-                        false
+                        false,
+                        request.isForMainFrame
                     )?.apply {
                         return when (this) {
                             is InterceptionResponse.Content ->

--- a/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
+++ b/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt
@@ -460,7 +460,8 @@ class SystemEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
@@ -534,7 +535,8 @@ class SystemEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 return RequestInterceptor.InterceptionResponse.Content("<h1>Hello World</h1>")
             }
@@ -568,7 +570,8 @@ class SystemEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return RequestInterceptor.InterceptionResponse.Url("https://mozilla.org")
@@ -624,7 +627,8 @@ class SystemEngineSessionTest {
                 hasUserGesture: Boolean,
                 isSameDomain: Boolean,
                 isRedirect: Boolean,
-                isDirectNavigation: Boolean
+                isDirectNavigation: Boolean,
+                isSubframeRequest: Boolean
             ): RequestInterceptor.InterceptionResponse? {
                 interceptorCalledWithUri = uri
                 return null

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/request/RequestInterceptor.kt
@@ -63,6 +63,7 @@ interface RequestInterceptor {
      * @param isSameDomain If the request is the same domain as the current URL then true, else false.
      * @param isRedirect If the request is due to redirect then true, else false.
      * @param isDirectNavigation If the request is due to a direct navigation then true, else false.
+     * @param isSubframeRequest If the request is coming from a subframe then true, else false.
      * @return An [InterceptionResponse] object containing alternative content
      * or an alternative URL. Null if the original request should continue to
      * be loaded.
@@ -74,7 +75,8 @@ interface RequestInterceptor {
         hasUserGesture: Boolean,
         isSameDomain: Boolean,
         isRedirect: Boolean,
-        isDirectNavigation: Boolean
+        isDirectNavigation: Boolean,
+        isSubframeRequest: Boolean
     ): InterceptionResponse? = null
 
     /**

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/request/RequestInterceptorTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/request/RequestInterceptorTest.kt
@@ -41,7 +41,7 @@ class RequestInterceptorTest {
     fun `interceptor has default methods`() {
         val engineSession = mock(EngineSession::class.java)
         val interceptor = object : RequestInterceptor { }
-        interceptor.onLoadRequest(engineSession, "url", false, false, false, false)
+        interceptor.onLoadRequest(engineSession, "url", false, false, false, false, false)
         interceptor.onErrorRequest(engineSession, ErrorType.ERROR_UNKNOWN_SOCKET_TYPE, null)
     }
 }

--- a/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeature.kt
+++ b/components/feature/accounts/src/main/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeature.kt
@@ -68,7 +68,8 @@ class FirefoxAccountsAuthFeature(
             hasUserGesture: Boolean,
             isSameDomain: Boolean,
             isRedirect: Boolean,
-            isDirectNavigation: Boolean
+            isDirectNavigation: Boolean,
+            isSubframeRequest: Boolean
         ): RequestInterceptor.InterceptionResponse? {
             if (uri.startsWith(redirectUrl)) {
                 val parsedUri = Uri.parse(uri)

--- a/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
+++ b/components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt
@@ -151,25 +151,25 @@ class FirefoxAccountsAuthFeatureTest {
         ) { _, _ -> }
 
         // Non-final FxA url.
-        assertNull(feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/not/the/right/url", false, false, false, false))
+        assertNull(feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/not/the/right/url", false, false, false, false, false))
         verify(manager, never()).finishAuthenticationAsync(any())
 
         // Non-FxA url.
-        assertNull(feature.interceptor.onLoadRequest(mock(), "https://www.wikipedia.org", false, false, false, false))
+        assertNull(feature.interceptor.onLoadRequest(mock(), "https://www.wikipedia.org", false, false, false, false, false))
         verify(manager, never()).finishAuthenticationAsync(any())
 
         // Redirect url, without code/state.
-        assertNull(feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/", false, false, false, false))
+        assertNull(feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/", false, false, false, false, false))
         verify(manager, never()).finishAuthenticationAsync(any())
 
         // Redirect url, without code/state.
-        assertNull(feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/test", false, false, false, false))
+        assertNull(feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/test", false, false, false, false, false))
         verify(manager, never()).finishAuthenticationAsync(any())
 
         // Code+state, no action.
         assertEquals(
             RequestInterceptor.InterceptionResponse.Url(redirectUrl),
-            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode1&state=testState1", false, false, false, false)
+            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode1&state=testState1", false, false, false, false, false)
         )
         verify(manager).finishAuthenticationAsync(
             FxaAuthData(authType = AuthType.OtherExternal(null), code = "testCode1", state = "testState1")
@@ -178,7 +178,7 @@ class FirefoxAccountsAuthFeatureTest {
         // Code+state, action=signin.
         assertEquals(
             RequestInterceptor.InterceptionResponse.Url(redirectUrl),
-            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode2&state=testState2&action=signin", false, false, false, false)
+            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode2&state=testState2&action=signin", false, false, false, false, false)
         )
         verify(manager).finishAuthenticationAsync(
             FxaAuthData(authType = AuthType.Signin, code = "testCode2", state = "testState2")
@@ -187,7 +187,7 @@ class FirefoxAccountsAuthFeatureTest {
         // Code+state, action=signup.
         assertEquals(
             RequestInterceptor.InterceptionResponse.Url(redirectUrl),
-            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode3&state=testState3&action=signup", false, false, false, false)
+            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode3&state=testState3&action=signup", false, false, false, false, false)
         )
         verify(manager).finishAuthenticationAsync(
             FxaAuthData(authType = AuthType.Signup, code = "testCode3", state = "testState3")
@@ -196,7 +196,7 @@ class FirefoxAccountsAuthFeatureTest {
         // Code+state, action=pairing.
         assertEquals(
             RequestInterceptor.InterceptionResponse.Url(redirectUrl),
-            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode4&state=testState4&action=pairing", false, false, false, false)
+            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode4&state=testState4&action=pairing", false, false, false, false, false)
         )
         verify(manager).finishAuthenticationAsync(
             FxaAuthData(authType = AuthType.Pairing, code = "testCode4", state = "testState4")
@@ -205,7 +205,7 @@ class FirefoxAccountsAuthFeatureTest {
         // Code+state, action is an unknown value.
         assertEquals(
             RequestInterceptor.InterceptionResponse.Url(redirectUrl),
-            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode5&state=testState5&action=someNewActionType", false, false, false, false)
+            feature.interceptor.onLoadRequest(mock(), "https://accounts.firefox.com/oauth/success/123/?code=testCode5&state=testState5&action=someNewActionType", false, false, false, false, false)
         )
         verify(manager).finishAuthenticationAsync(
             FxaAuthData(authType = AuthType.OtherExternal("someNewActionType"), code = "testCode5", state = "testState5")

--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
@@ -51,8 +51,7 @@ class AppLinksInterceptor(
     private val launchInApp: () -> Boolean = { false },
     private val useCases: AppLinksUseCases = AppLinksUseCases(context, launchInApp,
         alwaysDeniedSchemes = alwaysDeniedSchemes),
-    private val launchFromInterceptor: Boolean = false,
-    private val allowRedirectUrls: Set<String> = ALLOW_REDIRECT_HOSTS
+    private val launchFromInterceptor: Boolean = false
 ) : RequestInterceptor {
 
     override fun onLoadRequest(
@@ -61,12 +60,13 @@ class AppLinksInterceptor(
         hasUserGesture: Boolean,
         isSameDomain: Boolean,
         isRedirect: Boolean,
-        isDirectNavigation: Boolean
+        isDirectNavigation: Boolean,
+        isSubframeRequest: Boolean
     ): RequestInterceptor.InterceptionResponse? {
         val encodedUri = Uri.parse(uri)
         val uriScheme = encodedUri.scheme
         val engineSupportsScheme = engineSupportedSchemes.contains(uriScheme)
-        val isAllowedRedirect = (isRedirect && encodedUri.host in allowRedirectUrls)
+        val isAllowedRedirect = (isRedirect && !isSubframeRequest)
 
         val doNotIntercept = when {
             uriScheme == null -> true
@@ -130,11 +130,5 @@ class AppLinksInterceptor(
         }
 
         return null
-    }
-
-    companion object {
-        internal val ALLOW_REDIRECT_HOSTS: Set<String> = setOf(
-            "www.ubereats.com"
-        )
     }
 }

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
@@ -61,32 +61,31 @@ class AppLinksInterceptorTest {
             context = mockContext,
             interceptLinkClicks = true,
             launchInApp = { true },
-            useCases = mockUseCases,
-            allowRedirectUrls = setOf("soundcloud.com")
+            useCases = mockUseCases
         )
     }
 
     @Test
     fun `request is intercepted by user clicking on a link`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
     @Test
-    fun `request is intercepted by an allowed redirect`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, true, false)
+    fun `request is intercepted by redirect`() {
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, true, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
     @Test
-    fun `request is not intercepted by a not allowed redirect`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrl, false, false, true, false)
+    fun `request is not intercepted by a subframe redirect`() {
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrl, false, false, true, false, true)
         assertEquals(null, response)
     }
 
     @Test
     fun `request is intercepted by direct navigation`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, false, true)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, false, true, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
@@ -99,7 +98,7 @@ class AppLinksInterceptorTest {
             useCases = mockUseCases
         )
 
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -112,31 +111,31 @@ class AppLinksInterceptorTest {
             useCases = mockUseCases
         )
 
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false, false)
         assertEquals(null, response)
     }
 
     @Test
     fun `request is not intercepted when not user clicking on a link`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, false, false, false)
         assertEquals(null, response)
     }
 
     @Test
     fun `request is not intercepted if the current session is already on the same host`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, true, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, true, false, false, false)
         assertEquals(null, response)
     }
 
     @Test
     fun `request is not intercepted by a redirect on same domain`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, true, true, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, true, true, false, false)
         assertEquals(null, response)
     }
 
     @Test
     fun `request is not intercepted if not user gesture, not redirect and not direct navigation`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, false, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -155,7 +154,7 @@ class AppLinksInterceptorTest {
         val blackListedUrl = "$blacklistedScheme://example.com"
         val blacklistedRedirect = AppLinkRedirect(Intent.parseUri(blackListedUrl, 0), blackListedUrl, null)
         whenever(mockGetRedirect.invoke(blackListedUrl)).thenReturn(blacklistedRedirect)
-        var response = feature.onLoadRequest(engineSession, blackListedUrl, true, false, false, false)
+        var response = feature.onLoadRequest(engineSession, blackListedUrl, true, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -174,7 +173,7 @@ class AppLinksInterceptorTest {
         val supportedUrl = "$supportedScheme://example.com"
         val supportedRedirect = AppLinkRedirect(Intent.parseUri(supportedUrl, 0), null, null)
         whenever(mockGetRedirect.invoke(supportedUrl)).thenReturn(supportedRedirect)
-        val response = feature.onLoadRequest(engineSession, supportedUrl, true, false, false, false)
+        val response = feature.onLoadRequest(engineSession, supportedUrl, true, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -193,7 +192,7 @@ class AppLinksInterceptorTest {
         val supportedUrl = "$supportedScheme://example.com"
         val supportedRedirect = AppLinkRedirect(Intent.parseUri(supportedUrl, 0), null, null)
         whenever(mockGetRedirect.invoke(supportedUrl)).thenReturn(supportedRedirect)
-        val response = feature.onLoadRequest(engineSession, supportedUrl, true, false, false, false)
+        val response = feature.onLoadRequest(engineSession, supportedUrl, true, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -212,7 +211,7 @@ class AppLinksInterceptorTest {
         val supportedUrl = "$supportedScheme://example.com"
         val supportedRedirect = AppLinkRedirect(Intent.parseUri(supportedUrl, 0), null, null)
         whenever(mockGetRedirect.invoke(supportedUrl)).thenReturn(supportedRedirect)
-        val response = feature.onLoadRequest(engineSession, supportedUrl, false, false, false, false)
+        val response = feature.onLoadRequest(engineSession, supportedUrl, false, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -234,7 +233,7 @@ class AppLinksInterceptorTest {
         val notSupportedUrl = "$notSupportedScheme://example.com"
         val notSupportedRedirect = AppLinkRedirect(Intent.parseUri(notSupportedUrl, 0), null, null)
         whenever(mockGetRedirect.invoke(notSupportedUrl)).thenReturn(notSupportedRedirect)
-        val response = feature.onLoadRequest(engineSession, notSupportedUrl, false, false, false, false)
+        val response = feature.onLoadRequest(engineSession, notSupportedUrl, false, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
@@ -255,7 +254,7 @@ class AppLinksInterceptorTest {
         val notSupportedUrl = "$notSupportedScheme://example.com"
         val notSupportedRedirect = AppLinkRedirect(Intent.parseUri(notSupportedUrl, 0), null, null)
         whenever(mockGetRedirect.invoke(notSupportedUrl)).thenReturn(notSupportedRedirect)
-        val response = feature.onLoadRequest(engineSession, notSupportedUrl, false, false, false, false)
+        val response = feature.onLoadRequest(engineSession, notSupportedUrl, false, false, false, false, false)
         assertEquals(null, response)
     }
 
@@ -277,7 +276,7 @@ class AppLinksInterceptorTest {
         val notSupportedUrl = "$notSupportedScheme://example.com"
         val notSupportedRedirect = AppLinkRedirect(Intent.parseUri(notSupportedUrl, 0), fallbackUrl, null)
         whenever(mockGetRedirect.invoke(notSupportedUrl)).thenReturn(notSupportedRedirect)
-        val response = feature.onLoadRequest(engineSession, notSupportedUrl, false, false, false, false)
+        val response = feature.onLoadRequest(engineSession, notSupportedUrl, false, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
@@ -300,7 +299,7 @@ class AppLinksInterceptorTest {
         val fallbackUrl = "https://example.com"
         val notSupportedRedirect = AppLinkRedirect(Intent.parseUri(notSupportedUrl, 0), fallbackUrl, null)
         whenever(mockGetRedirect.invoke(notSupportedUrl)).thenReturn(notSupportedRedirect)
-        val response = feature.onLoadRequest(engineSession, notSupportedUrl, true, false, false, false)
+        val response = feature.onLoadRequest(engineSession, notSupportedUrl, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.Url)
     }
 
@@ -317,7 +316,7 @@ class AppLinksInterceptorTest {
         val intentUrl = "intent://example.com"
         val intentRedirect = AppLinkRedirect(Intent.parseUri(intentUrl, 0), null, null)
         whenever(mockGetRedirect.invoke(intentUrl)).thenReturn(intentRedirect)
-        val response = feature.onLoadRequest(engineSession, intentUrl, true, false, false, false)
+        val response = feature.onLoadRequest(engineSession, intentUrl, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
@@ -335,7 +334,7 @@ class AppLinksInterceptorTest {
         val fallbackUrl = "https://example.com"
         val intentRedirect = AppLinkRedirect(Intent.parseUri(intentUrl, 0), fallbackUrl, null)
         whenever(mockGetRedirect.invoke(intentUrl)).thenReturn(intentRedirect)
-        val response = feature.onLoadRequest(engineSession, intentUrl, true, false, false, false)
+        val response = feature.onLoadRequest(engineSession, intentUrl, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.Url)
     }
 
@@ -346,19 +345,19 @@ class AppLinksInterceptorTest {
         val appRedirect = AppLinkRedirect(Intent.parseUri(javascriptUri, 0), null, null)
         whenever(mockGetRedirect.invoke(javascriptUri)).thenReturn(appRedirect)
 
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, javascriptUri, true, true, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, javascriptUri, true, true, false, false, false)
         assertEquals(null, response)
     }
 
     @Test
     fun `Use the fallback URL when no non-browser app is installed`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, fallbackUrl, true, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, fallbackUrl, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.Url)
     }
 
     @Test
     fun `use the market intent if target app is not installed`() {
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, marketplaceUrl, true, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, marketplaceUrl, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
 
@@ -372,7 +371,7 @@ class AppLinksInterceptorTest {
             launchFromInterceptor = true
         )
 
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, true, false, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
         verify(mockOpenRedirect).invoke(any(), anyBoolean(), any())
     }
@@ -402,7 +401,7 @@ class AppLinksInterceptorTest {
             launchFromInterceptor = true
         )
 
-        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, intentUrl, false, true, false, false)
+        val response = appLinksInterceptor.onLoadRequest(mockEngineSession, intentUrl, false, true, false, false, false)
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
         verify(mockOpenRedirect).invoke(any(), anyBoolean(), any())
     }

--- a/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppInterceptor.kt
+++ b/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/WebAppInterceptor.kt
@@ -30,7 +30,8 @@ class WebAppInterceptor(
         hasUserGesture: Boolean,
         isSameDomain: Boolean,
         isRedirect: Boolean,
-        isDirectNavigation: Boolean
+        isDirectNavigation: Boolean,
+        isSubframeRequest: Boolean
     ): RequestInterceptor.InterceptionResponse? {
         val scope = manifestStorage.getInstalledScope(uri) ?: return null
         val startUrl = manifestStorage.getStartUrlForInstalledScope(scope) ?: return null

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppInterceptorTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppInterceptorTest.kt
@@ -44,7 +44,7 @@ class WebAppInterceptorTest {
         whenever(mockManifestStorage.getInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
         whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
 
-        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false)
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false, false)
 
         assert(response is RequestInterceptor.InterceptionResponse.Deny)
     }
@@ -54,7 +54,7 @@ class WebAppInterceptorTest {
         whenever(mockManifestStorage.getInstalledScope(webUrlOutOfScope)).thenReturn(null)
         whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlOutOfScope)).thenReturn(null)
 
-        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlOutOfScope, true, false, false, false)
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlOutOfScope, true, false, false, false, false)
 
         assertNull(response)
     }
@@ -64,7 +64,7 @@ class WebAppInterceptorTest {
         whenever(mockManifestStorage.getInstalledScope(webUrl)).thenReturn(null)
         whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrl)).thenReturn(null)
 
-        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrl, true, false, false, false)
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrl, true, false, false, false, false)
 
         assertNull(response)
     }
@@ -80,7 +80,7 @@ class WebAppInterceptorTest {
         whenever(mockManifestStorage.getInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
         whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
 
-        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false)
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false, false)
 
         assert(response is RequestInterceptor.InterceptionResponse.AppIntent)
     }
@@ -95,7 +95,7 @@ class WebAppInterceptorTest {
         whenever(mockManifestStorage.getInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
         whenever(mockManifestStorage.getStartUrlForInstalledScope(webUrlWithWebApp)).thenReturn(webUrlWithWebApp)
 
-        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false)
+        val response = webAppInterceptor.onLoadRequest(mockEngineSession, webUrlWithWebApp, true, false, false, false, false)
 
         assert(response is RequestInterceptor.InterceptionResponse.Deny)
     }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleRequestInterceptor.kt
@@ -15,25 +15,28 @@ import org.mozilla.samples.browser.ext.components
 
 class SampleRequestInterceptor(val context: Context) : RequestInterceptor {
 
-    override fun interceptsAppInitiatedRequests() = true
-
     override fun onLoadRequest(
         engineSession: EngineSession,
         uri: String,
         hasUserGesture: Boolean,
         isSameDomain: Boolean,
         isRedirect: Boolean,
-        isDirectNavigation: Boolean
+        isDirectNavigation: Boolean,
+        isSubframeRequest: Boolean
     ): InterceptionResponse? {
         return when (uri) {
             "sample:about" -> InterceptionResponse.Content("<h1>I am the sample browser</h1>")
             else -> {
                 var response = context.components.appLinksInterceptor.onLoadRequest(
-                        engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation)
+                        engineSession, uri, hasUserGesture, isSameDomain, isRedirect,
+                        isDirectNavigation, isSubframeRequest
+                )
 
                 if (response == null && !isDirectNavigation) {
                     response = context.components.webAppInterceptor.onLoadRequest(
-                        engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation)
+                        engineSession, uri, hasUserGesture, isSameDomain, isRedirect,
+                        isDirectNavigation, isSubframeRequest
+                    )
                 }
 
                 response

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleUrlEncodedRequestInterceptor.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/request/SampleUrlEncodedRequestInterceptor.kt
@@ -24,12 +24,13 @@ class SampleUrlEncodedRequestInterceptor(val context: Context) : RequestIntercep
         hasUserGesture: Boolean,
         isSameDomain: Boolean,
         isRedirect: Boolean,
-        isDirectNavigation: Boolean
+        isDirectNavigation: Boolean,
+        isSubframeRequest: Boolean
     ): InterceptionResponse? {
         return when (uri) {
             "sample:about" -> InterceptionResponse.Content("<h1>I am the sample browser</h1>")
             else -> context.components.appLinksInterceptor.onLoadRequest(
-                engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation)
+                engineSession, uri, hasUserGesture, isSameDomain, isRedirect, isDirectNavigation, isSubframeRequest)
         }
     }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
