### PR TITLE
No issue: add Activity.reportFullyDrawnSafe.

### DIFF
--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
@@ -7,10 +7,14 @@ package mozilla.components.feature.pwa.ext
 import android.app.Activity
 import android.content.pm.ActivityInfo
 import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.view.reportFullyDrawnSafe
 import mozilla.components.support.test.mock
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.verify
@@ -22,10 +26,12 @@ class ActivityKtTest {
     )
 
     private lateinit var activity: Activity
+    private lateinit var logger: Logger
 
     @Before
     fun setUp() {
         activity = mock()
+        logger = mock()
     }
 
     @Test
@@ -66,13 +72,18 @@ class ActivityKtTest {
 
     @Test
     fun `WHEN reportFullyDrawnSafe is called THEN reportFullyDrawn is called`() {
-        activity.reportFullyDrawnSafe()
+        activity.reportFullyDrawnSafe(logger)
         verify(activity).reportFullyDrawn()
     }
 
     @Test
-    fun `GIVEN reportFullyDrawn throws a SecurityException wHEN reportFullyDrawnSafe is called THEN the exception is caught`() {
-        `when`(activity.reportFullyDrawn()).thenThrow(SecurityException())
-        activity.reportFullyDrawnSafe() // If an exception is thrown, this test will fail.
+    fun `GIVEN reportFullyDrawn throws a SecurityException WHEN reportFullyDrawnSafe is called THEN the exception is caught and a log statement with fully drawn is logged`() {
+        val expectedSecurityException = SecurityException()
+        `when`(activity.reportFullyDrawn()).thenThrow(expectedSecurityException)
+        activity.reportFullyDrawnSafe(logger) // If an exception is thrown, this test will fail.
+
+        val msgArg = ArgumentCaptor.forClass(String::class.java)
+        verify(logger).error(msgArg.capture(), eq(expectedSecurityException))
+        assertTrue(msgArg.value, msgArg.value.contains("Fully drawn"))
     }
 }

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
@@ -9,11 +9,11 @@ import android.content.pm.ActivityInfo
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.view.reportFullyDrawnSafe
+import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyInt
@@ -82,7 +82,7 @@ class ActivityKtTest {
         `when`(activity.reportFullyDrawn()).thenThrow(expectedSecurityException)
         activity.reportFullyDrawnSafe(logger) // If an exception is thrown, this test will fail.
 
-        val msgArg = ArgumentCaptor.forClass(String::class.java)
+        val msgArg = argumentCaptor<String>()
         verify(logger).error(msgArg.capture(), eq(expectedSecurityException))
         assertTrue(msgArg.value, msgArg.value.contains("Fully drawn"))
     }

--- a/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
+++ b/components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt
@@ -7,8 +7,11 @@ package mozilla.components.feature.pwa.ext
 import android.app.Activity
 import android.content.pm.ActivityInfo
 import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.support.ktx.android.view.reportFullyDrawnSafe
 import mozilla.components.support.test.mock
+import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.verify
 
@@ -17,6 +20,13 @@ class ActivityKtTest {
         name = "Test Manifest",
         startUrl = "/"
     )
+
+    private lateinit var activity: Activity
+
+    @Before
+    fun setUp() {
+        activity = mock()
+    }
 
     @Test
     fun `applyOrientation calls setRequestedOrientation for every value`() {
@@ -52,5 +62,17 @@ class ActivityKtTest {
             activity.applyOrientation(null)
             verify(activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
         }
+    }
+
+    @Test
+    fun `WHEN reportFullyDrawnSafe is called THEN reportFullyDrawn is called`() {
+        activity.reportFullyDrawnSafe()
+        verify(activity).reportFullyDrawn()
+    }
+
+    @Test
+    fun `GIVEN reportFullyDrawn throws a SecurityException wHEN reportFullyDrawnSafe is called THEN the exception is caught`() {
+        `when`(activity.reportFullyDrawn()).thenThrow(SecurityException())
+        activity.reportFullyDrawnSafe() // If an exception is thrown, this test will fail.
     }
 }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
@@ -7,7 +7,7 @@ package mozilla.components.support.ktx.android.view
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
-import mozilla.components.support.base.log.Log
+import mozilla.components.support.base.log.logger.Logger
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
@@ -38,15 +38,18 @@ fun Activity.exitImmersiveModeIfNeeded() {
 /**
  * Calls [Activity.reportFullyDrawn] while also preventing crashes under some circumstances.
  *
- * @param errorTag the logtag to be used if errors are logged.
+ * @param errorLogger the logger to be used if errors are logged.
  */
-fun Activity.reportFullyDrawnSafe(errorTag: String? = null) {
+fun Activity.reportFullyDrawnSafe(errorLogger: Logger) {
     try {
         reportFullyDrawn()
     } catch (e: SecurityException) {
         // This exception is throw on some Samsung devices. We were unable to identify the root
         // cause but suspect it's related to Samsung security features. See
         // https://github.com/mozilla-mobile/fenix/issues/12345#issuecomment-655058864 for details.
-        Log.log(Log.Priority.ERROR, errorTag, e, "Unable to call reportFullyDrawn")
+        //
+        // We include "Fully drawn" in the log statement so that this error appears when grepping
+        // for fully drawn time.
+        errorLogger.error("Fully drawn - unable to call reportFullyDrawn", e)
     }
 }

--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/view/Activity.kt
@@ -7,6 +7,7 @@ package mozilla.components.support.ktx.android.view
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
+import mozilla.components.support.base.log.Log
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
@@ -32,4 +33,20 @@ fun Activity.exitImmersiveModeIfNeeded() {
 
     window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+}
+
+/**
+ * Calls [Activity.reportFullyDrawn] while also preventing crashes under some circumstances.
+ *
+ * @param errorTag the logtag to be used if errors are logged.
+ */
+fun Activity.reportFullyDrawnSafe(errorTag: String? = null) {
+    try {
+        reportFullyDrawn()
+    } catch (e: SecurityException) {
+        // This exception is throw on some Samsung devices. We were unable to identify the root
+        // cause but suspect it's related to Samsung security features. See
+        // https://github.com/mozilla-mobile/fenix/issues/12345#issuecomment-655058864 for details.
+        Log.log(Log.Priority.ERROR, errorTag, e, "Unable to call reportFullyDrawn")
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ permalink: /changelog/
 * **feature-pwa**
   * Added `ManifestStorage.loadShareableManifests` to get manifest with a `WebAppManifest.ShareTarget`.
 
+* **support-ktx**
+  * Add `Activity.reportFullyDrawnSafe`, a function to call `Activity.reportFullyDrawn` while catching crashes under some circumstances.
+
 # 50.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v49.0.0...v50.0.0)


### PR DESCRIPTION
The production method is imported from Fenix:
    https://github.com/mozilla-mobile/fenix/blob/69020a1f269c57e86fb4eb1dfd25d3ea168b5a29/app/src/main/java/org/mozilla/fenix/ext/Activity.kt#L28

And was verified to address the issue it was added for.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
