### PR TITLE
Closes #7731: Update application-services to 61.0.10

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.4"
 
-    const val mozilla_appservices = "61.0.7"
+    const val mozilla_appservices = "61.0.10"
 
     const val mozilla_glean = "31.2.3"
 


### PR DESCRIPTION
---

This is a minimal release of app-services designed to get the following changes in, given that 62 is stalled at the moment (#7694). It contains the following changes relative to the version currently in use in android-components.

- The logins and places metrics have been renewed until early 2021. ([#3290](https://github.com/mozilla/application-services/pull/3290)).
- Empty strings are now correctly handled in login validation. ([#3331](https://github.com/mozilla/application-services/pull/3331)).

The full change-log is https://github.com/mozilla/application-services/compare/v61.0.7...v61.0.10 (it mostly is bookkeeping commits like merges, "update changelog", "cut release", etc)

CC @grigoryk 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
