### PR TITLE
Remove more properties from Session.

### DIFF
--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -13,7 +13,6 @@ import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.browser.session.ext.syncDispatch
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.session.ext.toTabSessionState
-import mozilla.components.browser.state.action.ContentAction.FullScreenChangedAction
 import mozilla.components.browser.state.action.ContentAction.RemoveThumbnailAction
 import mozilla.components.browser.state.action.ContentAction.RemoveWebAppManifestAction
 import mozilla.components.browser.state.action.ContentAction.UpdateBackNavigationStateAction
@@ -26,7 +25,6 @@ import mozilla.components.browser.state.action.ContentAction.UpdateThumbnailActi
 import mozilla.components.browser.state.action.ContentAction.UpdateTitleAction
 import mozilla.components.browser.state.action.ContentAction.UpdateUrlAction
 import mozilla.components.browser.state.action.ContentAction.UpdateWebAppManifestAction
-import mozilla.components.browser.state.action.ContentAction.ViewportFitChangedAction
 import mozilla.components.browser.state.action.CustomTabListAction.RemoveCustomTabAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction.AddTabAction
@@ -95,11 +93,6 @@ class Session(
         fun onTrackerBlocked(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onTrackerLoaded(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onDesktopModeChanged(session: Session, enabled: Boolean) = Unit
-        fun onFullScreenChanged(session: Session, enabled: Boolean) = Unit
-        /**
-         * @param layoutInDisplayCutoutMode value of defined in https://developer.android.com/reference/android/view/WindowManager.LayoutParams#layoutInDisplayCutoutMode
-         */
-        fun onMetaViewportFitChanged(session: Session, layoutInDisplayCutoutMode: Int) = Unit
         fun onThumbnailChanged(session: Session, bitmap: Bitmap?) = Unit
         fun onContentPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
         fun onAppPermissionRequested(session: Session, permissionRequest: PermissionRequest): Boolean = false
@@ -374,23 +367,6 @@ class Session(
      */
     var desktopMode: Boolean by Delegates.observable(false) { _, old, new ->
         notifyObservers(old, new) { onDesktopModeChanged(this@Session, new) }
-    }
-
-    /**
-     * Exits fullscreen mode if it's in that state.
-     */
-    var fullScreenMode: Boolean by Delegates.observable(false) { _, old, new ->
-        if (notifyObservers(old, new) { onFullScreenChanged(this@Session, new) }) {
-            store?.syncDispatch(FullScreenChangedAction(id, new))
-        }
-    }
-
-    /**
-     * Display cutout mode state.
-     */
-    var layoutInDisplayCutoutMode: Int by Delegates.observable(0) { _, _, new ->
-        notifyObservers { onMetaViewportFitChanged(this@Session, new) }
-        store?.syncDispatch(ViewportFitChangedAction(id, new))
     }
 
     /**

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/Session.kt
@@ -11,11 +11,8 @@ import mozilla.components.browser.session.engine.request.LaunchIntentMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
 import mozilla.components.browser.session.ext.syncDispatch
-import mozilla.components.browser.session.ext.toFindResultState
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.session.ext.toTabSessionState
-import mozilla.components.browser.state.action.ContentAction.AddFindResultAction
-import mozilla.components.browser.state.action.ContentAction.ClearFindResultsAction
 import mozilla.components.browser.state.action.ContentAction.ConsumeHitResultAction
 import mozilla.components.browser.state.action.ContentAction.FullScreenChangedAction
 import mozilla.components.browser.state.action.ContentAction.RemoveThumbnailAction
@@ -101,7 +98,6 @@ class Session(
         fun onTrackerBlocked(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onTrackerLoaded(session: Session, tracker: Tracker, all: List<Tracker>) = Unit
         fun onLongPress(session: Session, hitResult: HitResult): Boolean = false
-        fun onFindResult(session: Session, result: FindResult) = Unit
         fun onDesktopModeChanged(session: Session, enabled: Boolean) = Unit
         fun onFullScreenChanged(session: Session, enabled: Boolean) = Unit
         /**
@@ -185,15 +181,6 @@ class Session(
          */
         RESTORED
     }
-
-    /**
-     * A value type representing a result of a "find in page" operation.
-     *
-     * @property activeMatchOrdinal the zero-based ordinal of the currently selected match.
-     * @property numberOfMatches the match count
-     * @property isDoneCounting true if the find operation has completed, otherwise false.
-     */
-    data class FindResult(val activeMatchOrdinal: Int, val numberOfMatches: Int, val isDoneCounting: Boolean)
 
     /**
      * The currently loading or loaded URL.
@@ -373,23 +360,6 @@ class Session(
             // `EngineObserver` always adds new trackers to the end of the list. So we just dispatch
             // an action for the last item in the list.
             store?.syncDispatch(TrackingProtectionAction.TrackerLoadedAction(id, new.last()))
-        }
-    }
-
-    /**
-     * List of results of that latest "find in page" operation.
-     */
-    var findResults: List<FindResult> by Delegates.observable(emptyList()) { _, old, new ->
-        notifyObservers(old, new) {
-            if (new.isNotEmpty()) {
-                onFindResult(this@Session, new.last())
-            }
-        }
-
-        if (new.isNotEmpty()) {
-            store?.syncDispatch(AddFindResultAction(id, new.last().toFindResultState()))
-        } else {
-            store?.syncDispatch(ClearFindResultsAction(id))
         }
     }
 

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -167,7 +167,9 @@ internal class EngineObserver(
     }
 
     override fun onLongPress(hitResult: HitResult) {
-        session.hitResult = Consumable.from(hitResult)
+        store?.dispatch(
+            ContentAction.UpdateHitResultAction(session.id, hitResult)
+        )
     }
 
     override fun onFind(text: String) {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.MediaAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.state.content.FindResultState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.HitResult
@@ -132,7 +133,8 @@ internal class EngineObserver(
     override fun onLoadingStateChange(loading: Boolean) {
         session.loading = loading
         if (loading) {
-            session.findResults = emptyList()
+            store?.dispatch(ContentAction.ClearFindResultsAction(session.id))
+
             session.trackersBlocked = emptyList()
             session.trackersLoaded = emptyList()
         }
@@ -169,11 +171,18 @@ internal class EngineObserver(
     }
 
     override fun onFind(text: String) {
-        session.findResults = emptyList()
+        store?.dispatch(ContentAction.ClearFindResultsAction(session.id))
     }
 
     override fun onFindResult(activeMatchOrdinal: Int, numberOfMatches: Int, isDoneCounting: Boolean) {
-        session.findResults += Session.FindResult(activeMatchOrdinal, numberOfMatches, isDoneCounting)
+        store?.dispatch(ContentAction.AddFindResultAction(
+            session.id,
+            FindResultState(
+                activeMatchOrdinal,
+                numberOfMatches,
+                isDoneCounting
+            )
+        ))
     }
 
     override fun onExternalResource(

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/engine/EngineObserver.kt
@@ -218,11 +218,15 @@ internal class EngineObserver(
     }
 
     override fun onFullScreenChange(enabled: Boolean) {
-        session.fullScreenMode = enabled
+        store?.dispatch(ContentAction.FullScreenChangedAction(
+            session.id, enabled
+        ))
     }
 
     override fun onMetaViewportFitChanged(layoutInDisplayCutoutMode: Int) {
-        session.layoutInDisplayCutoutMode = layoutInDisplayCutoutMode
+        store?.dispatch(ContentAction.ViewportFitChangedAction(
+            session.id, layoutInDisplayCutoutMode
+        ))
     }
 
     override fun onThumbnailChange(bitmap: Bitmap?) {

--- a/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt
+++ b/components/browser/session/src/main/java/mozilla/components/browser/session/ext/SessionExtensions.kt
@@ -10,7 +10,6 @@ import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.TrackingProtectionState
-import mozilla.components.browser.state.state.content.FindResultState
 
 /**
  * Create a matching [TabSessionState] from a [Session].
@@ -58,13 +57,6 @@ private fun Session.toContentState(): ContentState {
  */
 fun Session.SecurityInfo.toSecurityInfoState(): SecurityInfoState {
     return SecurityInfoState(secure, host, issuer)
-}
-
-/**
- * Creates a matching [FindResultState] from a [Session.FindResult]
- */
-fun Session.FindResult.toFindResultState(): FindResultState {
-    return FindResultState(activeMatchOrdinal, numberOfMatches, isDoneCounting)
 }
 
 /**

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -148,7 +148,6 @@ class SelectionAwareSessionObserverTest {
         observer.onTrackerBlockingEnabledChanged(session, true)
         observer.onTrackerBlocked(session, Tracker(""), emptyList())
         observer.onDesktopModeChanged(session, true)
-        observer.onFullScreenChanged(session, true)
         observer.onThumbnailChanged(session, Mockito.spy(Bitmap::class.java))
         observer.onSessionRemoved(session)
         observer.onAllSessionsRemoved()

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -149,7 +149,6 @@ class SelectionAwareSessionObserverTest {
         observer.onTrackerBlockingEnabledChanged(session, true)
         observer.onTrackerBlocked(session, Tracker(""), emptyList())
         observer.onLongPress(session, Mockito.mock(HitResult::class.java))
-        observer.onFindResult(session, Mockito.mock(Session.FindResult::class.java))
         observer.onDesktopModeChanged(session, true)
         observer.onFullScreenChanged(session, true)
         observer.onThumbnailChanged(session, Mockito.spy(Bitmap::class.java))

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SelectionAwareSessionObserverTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.session
 
 import android.graphics.Bitmap
-import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -148,7 +147,6 @@ class SelectionAwareSessionObserverTest {
         observer.onCustomTabConfigChanged(session, null)
         observer.onTrackerBlockingEnabledChanged(session, true)
         observer.onTrackerBlocked(session, Tracker(""), emptyList())
-        observer.onLongPress(session, Mockito.mock(HitResult::class.java))
         observer.onDesktopModeChanged(session, true)
         observer.onFullScreenChanged(session, true)
         observer.onThumbnailChanged(session, Mockito.spy(Bitmap::class.java))

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -13,9 +13,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
-import mozilla.components.concept.engine.HitResult
 import mozilla.components.concept.engine.content.blocking.Tracker
-import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -797,32 +795,6 @@ class SessionManagerMigrationTest {
             assertFalse(tab.trackingProtection.enabled)
             assertEquals(0, tab.trackingProtection.blockedTrackers.size)
             assertEquals(0, tab.trackingProtection.loadedTrackers.size)
-        }
-    }
-
-    @Test
-    fun `Adding a hit result`() {
-        val store = BrowserStore()
-        val manager = SessionManager(engine = mock(), store = store)
-
-        val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
-        manager.add(session)
-
-        assertNull(session.hitResult.peek())
-        assertNull(store.state.findTab("session")!!.content.hitResult)
-
-        val hitResult: HitResult = HitResult.UNKNOWN("test")
-        session.hitResult = Consumable.from(hitResult)
-
-        assertEquals(hitResult, session.hitResult.peek())
-        store.state.findTab("session")!!.also { tab ->
-            assertNotNull(tab.content.hitResult)
-            assertSame(hitResult, tab.content.hitResult)
-        }
-
-        session.hitResult.consume { true }
-        store.state.findTab("session")!!.also { tab ->
-            assertNull(tab.content.hitResult)
         }
     }
 

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionManagerMigrationTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.session
 
 import android.content.ComponentCallbacks2
-import mozilla.components.browser.session.ext.toFindResultState
 import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.selectedTab
@@ -913,32 +912,6 @@ class SessionManagerMigrationTest {
         store.state.findTab("session2")!!.also { tab ->
             assertEquals(engineSession, tab.engineState.engineSession)
         }
-    }
-
-    @Test
-    fun `Adding a find result`() {
-        val store = BrowserStore()
-        val manager = SessionManager(engine = mock(), store = store)
-
-        val session = Session(id = "session", initialUrl = "https://www.mozilla.org")
-        manager.add(session)
-
-        assertTrue(session.findResults.isEmpty())
-        assertTrue(store.state.findTab("session")!!.content.findResults.isEmpty())
-
-        val result = Session.FindResult(0, 0, false)
-        session.findResults += result
-
-        assertEquals(1, session.findResults.size)
-        assertEquals(result, session.findResults.last())
-        store.state.findTab("session")!!.also { tab ->
-            assertEquals(1, tab.content.findResults.size)
-            assertEquals(result.toFindResultState(), tab.content.findResults.last())
-        }
-
-        session.findResults = emptyList()
-        assertTrue(session.findResults.isEmpty())
-        assertTrue(store.state.findTab("session")!!.content.findResults.isEmpty())
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -5,7 +5,6 @@
 package mozilla.components.browser.session
 
 import android.graphics.Bitmap
-import android.view.WindowManager
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
@@ -579,34 +578,6 @@ class SessionTest {
     }
 
     @Test
-    fun `observer is notified on fullscreen mode`() {
-        val observer = mock(Session.Observer::class.java)
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-        session.fullScreenMode = true
-        verify(observer).onFullScreenChanged(session, true)
-        reset(observer)
-        session.unregister(observer)
-        session.fullScreenMode = false
-        verify(observer, never()).onFullScreenChanged(session, false)
-    }
-
-    @Test
-    fun `observer is notified on meta viewport fit change`() {
-        val observer = mock(Session.Observer::class.java)
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-        session.layoutInDisplayCutoutMode =
-            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
-        verify(observer).onMetaViewportFitChanged(session,
-            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT)
-        reset(observer)
-        session.unregister(observer)
-        session.layoutInDisplayCutoutMode = 123
-        verify(observer, never()).onMetaViewportFitChanged(session, 123)
-    }
-
-    @Test
     fun `observer is notified on on thumbnail changed `() {
         val observer = mock(Session.Observer::class.java)
         val session = Session("https://www.mozilla.org")
@@ -658,7 +629,6 @@ class SessionTest {
         defaultObserver.onTrackerBlockingEnabledChanged(session, true)
         defaultObserver.onTrackerBlocked(session, mock(), emptyList())
         defaultObserver.onDesktopModeChanged(session, true)
-        defaultObserver.onFullScreenChanged(session, true)
         defaultObserver.onThumbnailChanged(session, spy(Bitmap::class.java))
         defaultObserver.onContentPermissionRequested(session, contentPermissionRequest)
         defaultObserver.onAppPermissionRequested(session, appPermissionRequest)

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/SessionTest.kt
@@ -14,7 +14,6 @@ import mozilla.components.browser.session.Session.Source
 import mozilla.components.browser.session.engine.request.LaunchIntentMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestMetadata
 import mozilla.components.browser.session.engine.request.LoadRequestOption
-import mozilla.components.browser.session.ext.toFindResultState
 import mozilla.components.browser.session.ext.toSecurityInfoState
 import mozilla.components.browser.session.ext.toTabSessionState
 import mozilla.components.browser.state.action.ContentAction
@@ -35,7 +34,6 @@ import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -628,59 +626,6 @@ class SessionTest {
     }
 
     @Test
-    fun `observer is notified on find result`() {
-        val observer = mock(Session.Observer::class.java)
-        val session = Session("https://www.mozilla.org")
-        session.register(observer)
-
-        val result1 = Session.FindResult(0, 1, false)
-        session.findResults += result1
-        verify(observer).onFindResult(
-                eq(session),
-                eq(result1)
-        )
-        assertEquals(listOf(result1), session.findResults)
-
-        result1.copy()
-        val result2 = result1.copy(1, 2)
-        session.findResults += result2
-        verify(observer).onFindResult(
-                eq(session),
-                eq(result2)
-        )
-        assertEquals(listOf(result1, result2), session.findResults)
-
-        assertEquals(session.findResults[0].activeMatchOrdinal, 0)
-        assertEquals(session.findResults[0].numberOfMatches, 1)
-        assertFalse(session.findResults[0].isDoneCounting)
-        assertEquals(session.findResults[1].activeMatchOrdinal, 1)
-        assertEquals(session.findResults[1].numberOfMatches, 2)
-        assertFalse(session.findResults[1].isDoneCounting)
-        assertNotEquals(result1, result2)
-
-        session.findResults = emptyList()
-        verifyNoMoreInteractions(observer)
-    }
-
-    @Test
-    fun `action is dispatched when find results are updated`() {
-        val store: BrowserStore = mock()
-        `when`(store.dispatch(any())).thenReturn(mock())
-
-        val session = Session("https://www.mozilla.org")
-        session.store = store
-
-        val result: Session.FindResult = Session.FindResult(0, 1, false)
-        session.findResults += result
-        verify(store).dispatch(ContentAction.AddFindResultAction(session.id, result.toFindResultState()))
-
-        session.findResults = emptyList()
-        verify(store).dispatch(ContentAction.ClearFindResultsAction(session.id))
-
-        verifyNoMoreInteractions(store)
-    }
-
-    @Test
     fun `observer is notified when desktop mode is set`() {
         val observer = mock(Session.Observer::class.java)
         val session = Session("https://www.mozilla.org")
@@ -772,7 +717,6 @@ class SessionTest {
         defaultObserver.onTrackerBlockingEnabledChanged(session, true)
         defaultObserver.onTrackerBlocked(session, mock(), emptyList())
         defaultObserver.onLongPress(session, mock(HitResult::class.java))
-        defaultObserver.onFindResult(session, mock(Session.FindResult::class.java))
         defaultObserver.onDesktopModeChanged(session, true)
         defaultObserver.onFullScreenChanged(session, true)
         defaultObserver.onThumbnailChanged(session, spy(Bitmap::class.java))

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -434,31 +434,53 @@ class EngineObserverTest {
 
     @Test
     fun engineObserverNotifiesFullscreenMode() {
-        val session = Session("https://www.mozilla.org")
-        val observer = EngineObserver(session)
+        val session = Session("https://www.mozilla.org", id = "test-id")
+        val store: BrowserStore = mock()
+        val observer = EngineObserver(session, store)
 
         observer.onFullScreenChange(true)
-        assertEquals(true, session.fullScreenMode)
+
+        verify(store).dispatch(ContentAction.FullScreenChangedAction(
+            "test-id", true
+        ))
+        reset(store)
+
         observer.onFullScreenChange(false)
-        assertEquals(false, session.fullScreenMode)
+
+        verify(store).dispatch(ContentAction.FullScreenChangedAction(
+            "test-id", false
+        ))
     }
 
     @Test
     fun engineObserverNotifiesMetaViewportFitChange() {
-        val session = Session("https://www.mozilla.org")
-        val observer = EngineObserver(session)
+        val store: BrowserStore = mock()
+        val session = Session("https://www.mozilla.org", id = "test-id")
+        val observer = EngineObserver(session, store)
 
         observer.onMetaViewportFitChanged(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT)
-        assertEquals(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT,
-            session.layoutInDisplayCutoutMode)
+        verify(store).dispatch(ContentAction.ViewportFitChangedAction(
+            "test-id", WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+        ))
+        reset(store)
+
         observer.onMetaViewportFitChanged(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES)
-        assertEquals(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES,
-            session.layoutInDisplayCutoutMode)
+        verify(store).dispatch(ContentAction.ViewportFitChangedAction(
+            "test-id", WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        ))
+        reset(store)
+
         observer.onMetaViewportFitChanged(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER)
-        assertEquals(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER,
-            session.layoutInDisplayCutoutMode)
+        verify(store).dispatch(ContentAction.ViewportFitChangedAction(
+            "test-id", WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+        ))
+        reset(store)
+
         observer.onMetaViewportFitChanged(123)
-        assertEquals(123, session.layoutInDisplayCutoutMode)
+        verify(store).dispatch(ContentAction.ViewportFitChangedAction(
+            "test-id", 123
+        ))
+        reset(store)
     }
 
     @Test

--- a/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
+++ b/components/browser/session/src/test/java/mozilla/components/browser/session/engine/EngineObserverTest.kt
@@ -375,17 +375,16 @@ class EngineObserverTest {
 
     @Test
     fun engineObserverPassingHitResult() {
-        val session = Session("https://www.mozilla.org")
-        val observer = EngineObserver(session)
+        val session = Session("https://www.mozilla.org", id = "test-id")
+        val store: BrowserStore = mock()
+        val observer = EngineObserver(session, store)
         val hitResult = HitResult.UNKNOWN("data://foobar")
 
         observer.onLongPress(hitResult)
 
-        session.hitResult.consume {
-            assertEquals("data://foobar", it.src)
-            assertTrue(it is HitResult.UNKNOWN)
-            true
-        }
+        verify(store).dispatch(
+            ContentAction.UpdateHitResultAction("test-id", hitResult)
+        )
     }
 
     @Test

--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuUseCases.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuUseCases.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.feature.contextmenu
 
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore
@@ -14,22 +12,19 @@ import mozilla.components.concept.engine.HitResult
 /**
  * Contains use cases related to the context menu feature.
  *
- * @param sessionManager the application's [SessionManager].
+ * @param store the application's [BrowserStore].
  */
 class ContextMenuUseCases(
-    sessionManager: SessionManager,
     store: BrowserStore
 ) {
     class ConsumeHitResultUseCase(
-        private val sessionManager: SessionManager
+        private val store: BrowserStore
     ) {
         /**
-         * Consumes the [HitResult] from the [Session] with the given [tabId].
+         * Consumes the [HitResult] from the [BrowserStore] with the given [tabId].
          */
         operator fun invoke(tabId: String) {
-            sessionManager.findSessionById(tabId)?.let {
-                it.hitResult.consume { true }
-            }
+            store.dispatch(ContentAction.ConsumeHitResultAction(tabId))
         }
     }
 
@@ -37,7 +32,7 @@ class ContextMenuUseCases(
         private val store: BrowserStore
     ) {
         /**
-         * Adds a [Download] to the [Session] with the given [tabId].
+         * Adds a [DownloadState] to the [BrowserStore] with the given [tabId].
          *
          * This is a hacky workaround. After we have migrated everything from browser-session to
          * browser-state we should revisits this and find a better solution.
@@ -49,6 +44,6 @@ class ContextMenuUseCases(
         }
     }
 
-    val consumeHitResult = ConsumeHitResultUseCase(sessionManager)
+    val consumeHitResult = ConsumeHitResultUseCase(store)
     val injectDownload = InjectDownloadUseCase(store)
 }

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -396,7 +396,7 @@ class ContextMenuCandidateTest {
 
         val saveImage = ContextMenuCandidate.createSaveImageCandidate(
             testContext,
-            ContextMenuUseCases(sessionManager, store))
+            ContextMenuUseCases(store))
 
         // showFor
 
@@ -448,7 +448,7 @@ class ContextMenuCandidateTest {
 
         val saveVideoAudio = ContextMenuCandidate.createSaveVideoAudioCandidate(
             testContext,
-            ContextMenuUseCases(sessionManager, store))
+            ContextMenuUseCases(store))
 
         // showFor
 
@@ -503,7 +503,8 @@ class ContextMenuCandidateTest {
 
         val downloadLink = ContextMenuCandidate.createDownloadLinkCandidate(
             testContext,
-            ContextMenuUseCases(sessionManager, store))
+            ContextMenuUseCases(store)
+        )
 
         // showFor
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **browser-session**
+  * ⚠️ **This is a breaking change**: Removed the following properties from `Session`: `findResults`, `hitResult`, `fullScreenMode` and `layoutInDisplayCutoutMode`. The values still exist in `BrowserState` and can be read from there.
+
 * **support-images**
   * ⚠️ **This is a breaking change**: Removed `ImageRequest` in favor of `ImageSaveRequest` and `ImageLoadRequest` to separate the information passed to methods that load and save images.
   * ⚠️ **This is a breaking change**: `ImageLoader.loadIntoView()` now takes an `ImageSaveRequest` instead of an `ImageRequest`.

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -377,5 +377,5 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store, sessionManager) }
     val downloadsUseCases: DownloadsUseCases by lazy { DownloadsUseCases(store) }
-    val contextMenuUseCases: ContextMenuUseCases by lazy { ContextMenuUseCases(sessionManager, store) }
+    val contextMenuUseCases: ContextMenuUseCases by lazy { ContextMenuUseCases(store) }
 }


### PR DESCRIPTION
Removing a bunch of properties where our code is already reading them exclusively from `BrowserState`. The only change needed in Fenix is to no longer pass `SessionManager` to `ContextMenuUseCases`.