### PR TITLE
For #7803: Visually indicate different types of suggestions in the search screen

### DIFF
--- a/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
+++ b/components/browser/awesomebar/src/main/java/mozilla/components/browser/awesomebar/layout/DefaultSuggestionViewHolder.kt
@@ -38,12 +38,22 @@ internal sealed class DefaultSuggestionViewHolder {
         private val descriptionView = view.findViewById<TextView>(R.id.mozac_browser_awesomebar_description).apply {
             setTextColor(awesomeBar.styling.descriptionTextColor)
         }
-        private val iconView = view.findViewById<ImageView>(R.id.mozac_browser_awesomebar_icon)
+        private val iconView: ImageView = view.findViewById(R.id.mozac_browser_awesomebar_icon)
+        private val iconIndicatorView: ImageView = view.findViewById(R.id.mozac_browser_awesomebar_icon_indicator)
 
         override fun bind(suggestion: AwesomeBar.Suggestion, selectionListener: () -> Unit) {
             val title = if (suggestion.title.isNullOrEmpty()) suggestion.description else suggestion.title
 
             iconView.setImageBitmap(suggestion.icon)
+
+            if (suggestion.indicatorIcon == null) {
+                iconIndicatorView.visibility = View.GONE
+            } else {
+                iconIndicatorView.apply {
+                    setImageDrawable(suggestion.indicatorIcon)
+                    visibility = View.VISIBLE
+                }
+            }
 
             titleView.text = title?.take(MAX_TEXT_LENGTH)
 

--- a/components/browser/awesomebar/src/main/res/layout/mozac_browser_awesomebar_item_generic.xml
+++ b/components/browser/awesomebar/src/main/res/layout/mozac_browser_awesomebar_item_generic.xml
@@ -23,6 +23,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageView
+        android:id="@+id/mozac_browser_awesomebar_icon_indicator"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:visibility="gone"
+        android:elevation="2dp"
+        android:importantForAccessibility="no"
+        android:layout_marginStart="14dp"
+        android:layout_marginTop="30dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_search_results_bookmarks" />
+
     <TextView
         android:id="@+id/mozac_browser_awesomebar_title"
         android:layout_width="0dp"

--- a/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.awesomebar
 
 import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import android.view.View
 import java.util.UUID
 
@@ -77,6 +78,7 @@ interface AwesomeBar {
      * @property description A user-readable description for the [Suggestion].
      * @property icon A lambda that can be invoked by the [AwesomeBar] implementation to receive an icon [Bitmap] for
      * this [Suggestion]. The [AwesomeBar] will pass in its desired width and height for the Bitmap.
+     * @property indicatorIcon A drawable for indicating different types of [Suggestion].
      * @property chips A list of [Chip] instances to be displayed.
      * @property flags A set of [Flag] values for this [Suggestion].
      * @property onSuggestionClicked A callback to be executed when the [Suggestion] was clicked by the user.
@@ -90,6 +92,7 @@ interface AwesomeBar {
         val title: String? = null,
         val description: String? = null,
         val icon: Bitmap? = null,
+        val indicatorIcon: Drawable? = null,
         val chips: List<Chip> = emptyList(),
         val flags: Set<Flag> = emptySet(),
         val onSuggestionClicked: (() -> Unit)? = null,

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.awesomebar
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import android.view.View
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.search.SearchEngine
@@ -31,11 +32,13 @@ import mozilla.components.feature.tabs.TabsUseCases
 /**
  * Connects an [AwesomeBar] with a [Toolbar] and allows adding multiple [AwesomeBar.SuggestionProvider] implementations.
  */
+@Suppress("LongParameterList")
 class AwesomeBarFeature(
     private val awesomeBar: AwesomeBar,
     private val toolbar: Toolbar,
     private val engineView: EngineView? = null,
     private val icons: BrowserIcons? = null,
+    private val indicatorIcon: Drawable? = null,
     onEditStart: (() -> Unit)? = null,
     onEditComplete: (() -> Unit)? = null
 ) {
@@ -59,7 +62,7 @@ class AwesomeBarFeature(
         store: BrowserStore,
         selectTabUseCase: TabsUseCases.SelectTabUseCase
     ): AwesomeBarFeature {
-        val provider = SessionSuggestionProvider(resources, store, selectTabUseCase, icons)
+        val provider = SessionSuggestionProvider(resources, store, selectTabUseCase, icons, indicatorIcon)
         awesomeBar.addProviders(provider)
         return this
     }

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProvider.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.awesomebar.provider
 
+import android.graphics.drawable.Drawable
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.concept.awesomebar.AwesomeBar
@@ -32,6 +33,7 @@ class BookmarksStorageSuggestionProvider(
     private val bookmarksStorage: BookmarksStorage,
     private val loadUrlUseCase: SessionUseCases.LoadUrlUseCase,
     private val icons: BrowserIcons? = null,
+    private val indicatorIcon: Drawable? = null,
     private val engine: Engine? = null
 ) : AwesomeBar.SuggestionProvider {
 
@@ -63,6 +65,8 @@ class BookmarksStorageSuggestionProvider(
                 provider = this@BookmarksStorageSuggestionProvider,
                 id = result.guid,
                 icon = icon?.await()?.bitmap,
+                indicatorIcon = indicatorIcon,
+                flags = setOf(AwesomeBar.Suggestion.Flag.BOOKMARK),
                 title = result.title,
                 description = result.url,
                 onSuggestionClicked = { loadUrlUseCase.invoke(result.url!!) }

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.awesomebar.provider
 
 import android.content.res.Resources
+import android.graphics.drawable.Drawable
 import kotlinx.coroutines.Deferred
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.Icon
@@ -21,11 +22,13 @@ import java.util.UUID
  * A [AwesomeBar.SuggestionProvider] implementation that provides suggestions based on the sessions in the
  * [SessionManager] (Open tabs).
  */
+@Suppress("LongParameterList")
 class SessionSuggestionProvider(
     private val resources: Resources,
     private val store: BrowserStore,
     private val selectTabUseCase: TabsUseCases.SelectTabUseCase,
     private val icons: BrowserIcons? = null,
+    private val indicatorIcon: Drawable? = null,
     private val excludeSelectedSession: Boolean = false
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
@@ -53,7 +56,9 @@ class SessionSuggestionProvider(
                             id = result.id,
                             title = result.content.title,
                             description = resources.getString(R.string.switch_to_tab_description),
+                            flags = setOf(AwesomeBar.Suggestion.Flag.OPEN_TAB),
                             icon = icon?.await()?.bitmap,
+                            indicatorIcon = indicatorIcon,
                             onSuggestionClicked = { selectTabUseCase(result.id) }
                         )
                 )


### PR DESCRIPTION
Fenix PR: https://github.com/mozilla-mobile/fenix/pull/12780

We don't have synced tabs suggestions in awesomebar. So there isn't here either. mozilla-mobile/fenix#11258

Looks like opens tab suggestions not shown in private mode?

Also looks like there is a problem. If we wrote fast, this indicator icons shown on unrelated suggestions. Idk why. Needs further investigation.

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
