### PR TITLE
Issue #7712: SearchActionProvider: Pass in suspending function instead of a Deferred<SearchEngine>

### DIFF
--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/AwesomeBarFeature.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.view.View
-import kotlinx.coroutines.Deferred
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
@@ -149,13 +148,13 @@ class AwesomeBarFeature(
      * @param showDescription whether or not to add the search engine name as description.
      */
     fun addSearchActionProvider(
-        searchEngine: Deferred<SearchEngine>,
+        searchEngineGetter: suspend () -> SearchEngine,
         searchUseCase: SearchUseCases.SearchUseCase,
         icon: Bitmap? = null,
         showDescription: Boolean = false
     ): AwesomeBarFeature {
         awesomeBar.addProviders(SearchActionProvider(
-            searchEngine,
+            searchEngineGetter,
             searchUseCase,
             icon,
             showDescription

--- a/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchActionProvider.kt
+++ b/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchActionProvider.kt
@@ -5,7 +5,6 @@
 package mozilla.components.feature.awesomebar.provider
 
 import android.graphics.Bitmap
-import kotlinx.coroutines.Deferred
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.search.SearchUseCases
@@ -17,7 +16,7 @@ private const val FIXED_ID = "@@@search.action.provider.fixed.id@@"
  * entered text and invokes a search with the given [SearchEngine] if clicked.
  */
 class SearchActionProvider(
-    private val searchEngine: Deferred<SearchEngine>,
+    private val searchEngineGetter: suspend () -> SearchEngine,
     private val searchUseCase: SearchUseCases.SearchUseCase,
     private val icon: Bitmap? = null,
     private val showDescription: Boolean = true
@@ -29,13 +28,15 @@ class SearchActionProvider(
             return emptyList()
         }
 
+        val searchEngine = searchEngineGetter()
+
         return listOf(AwesomeBar.Suggestion(
             provider = this,
             // We always use the same ID for the entered text so that this suggestion gets replaced "in place".
             id = FIXED_ID,
             title = text,
-            description = if (showDescription) searchEngine.await().name else null,
-            icon = icon ?: searchEngine.await().icon,
+            description = if (showDescription) searchEngine.name else null,
+            icon = icon ?: searchEngine.icon,
             score = Int.MAX_VALUE,
             onSuggestionClicked = {
                 searchUseCase.invoke(text)

--- a/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
+++ b/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchActionProviderTest.kt
@@ -4,10 +4,7 @@
 
 package mozilla.components.feature.awesomebar.provider
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import mozilla.components.browser.search.SearchEngine
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -32,7 +29,7 @@ class SearchActionProviderTest {
     @Test
     fun `provider returns suggestion matching input`() {
         val provider = SearchActionProvider(
-            searchEngine = GlobalScope.async { mock<SearchEngine>() },
+            searchEngineGetter = { mock() },
             searchUseCase = mock()
         )
         val suggestions = runBlocking { provider.onInputChanged("firefox") }

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserFragment.kt
@@ -9,8 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_browser.view.*
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import mozilla.components.browser.thumbnails.BrowserThumbnails
 import mozilla.components.feature.awesomebar.AwesomeBarFeature
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
@@ -70,7 +68,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 components.tabsUseCases.selectTab
             )
             .addSearchActionProvider(
-                searchEngine = GlobalScope.async {
+                searchEngineGetter = suspend {
                     components.searchEngineManager.getDefaultSearchEngine(applicationContext)
                 },
                 searchUseCase = components.searchUseCases.defaultSearch


### PR DESCRIPTION
While integrating the provider into Fenix I came to the conclusion that it makes much more sense
to pass in a suspending function. With that the caller does not need to deal with scopes and
dispatchers themselves.

(Follow-up from #7713)
