### PR TITLE
Fix Digital Asset Links API URL

### DIFF
--- a/components/service/digitalassetlinks/src/main/java/mozilla/components/service/digitalassetlinks/api/DigitalAssetLinksApi.kt
+++ b/components/service/digitalassetlinks/src/main/java/mozilla/components/service/digitalassetlinks/api/DigitalAssetLinksApi.kt
@@ -53,7 +53,7 @@ class DigitalAssetLinksApi(
     }
 
     private fun apiUrlBuilder(path: String) = BASE_URL.toUri().buildUpon()
-        .path(path)
+        .encodedPath(path)
         .appendQueryParameter("prettyPrint", false.toString())
         .appendQueryParameter("key", apiKey)
 

--- a/components/service/digitalassetlinks/src/test/java/mozilla/components/service/digitalassetlinks/api/DigitalAssetLinksApiTest.kt
+++ b/components/service/digitalassetlinks/src/test/java/mozilla/components/service/digitalassetlinks/api/DigitalAssetLinksApiTest.kt
@@ -176,7 +176,7 @@ class DigitalAssetLinksApiTest {
     fun `passes data in get check request URL for android target`() {
         api.checkRelationship(webAsset, USE_AS_ORIGIN, androidAsset)
         verify(client).fetch(baseRequest.copy(
-            url = "https://digitalassetlinks.googleapis.com/v1/assetlinks%3Acheck?" +
+            url = "https://digitalassetlinks.googleapis.com/v1/assetlinks:check?" +
                 "prettyPrint=false&key=X&relation=delegate_permission%2Fcommon.use_as_origin&" +
                 "source.web.site=${Uri.encode("https://mozilla.org")}&" +
                 "target.androidApp.packageName=com.mozilla.fenix&" +
@@ -188,7 +188,7 @@ class DigitalAssetLinksApiTest {
     fun `passes data in get check request URL for web target`() {
         api.checkRelationship(webAsset, HANDLE_ALL_URLS, webAsset)
         verify(client).fetch(baseRequest.copy(
-            url = "https://digitalassetlinks.googleapis.com/v1/assetlinks%3Acheck?" +
+            url = "https://digitalassetlinks.googleapis.com/v1/assetlinks:check?" +
                 "prettyPrint=false&key=X&relation=delegate_permission%2Fcommon.handle_all_urls&" +
                 "source.web.site=${Uri.encode("https://mozilla.org")}&" +
                 "target.web.site=${Uri.encode("https://mozilla.org")}"
@@ -199,7 +199,7 @@ class DigitalAssetLinksApiTest {
     fun `passes data in get list request URL`() {
         api.listStatements(webAsset)
         verify(client).fetch(baseRequest.copy(
-            url = "https://digitalassetlinks.googleapis.com/v1/statements%3Alist?" +
+            url = "https://digitalassetlinks.googleapis.com/v1/statements:list?" +
                 "prettyPrint=false&key=X&source.web.site=${Uri.encode("https://mozilla.org")}"
         ))
     }


### PR DESCRIPTION
The color character shouldn't be encoded. This causes the calls to 404 in Fenix.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
