### PR TITLE
Issue #7753: EngineViewPresenter: Temporarily disable releasing of engine session.

### DIFF
--- a/components/feature/session/src/main/java/mozilla/components/feature/session/engine/EngineViewPresenter.kt
+++ b/components/feature/session/src/main/java/mozilla/components/feature/session/engine/EngineViewPresenter.kt
@@ -48,7 +48,12 @@ internal class EngineViewPresenter(
 
     private fun onEngineSession(engineSession: EngineSession?) {
         if (engineSession == null) {
-            engineView.release()
+            // With no EngineSession being available to render anymore we could call release here
+            // to make sure GeckoView also frees any references to the previous session. However
+            // we are seeing problems with that and are temporarily disabling this to investigate.
+            // https://github.com/mozilla-mobile/android-components/issues/7753
+            //
+            // engineView.release()
         } else {
             engineView.render(engineSession)
         }

--- a/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
+++ b/components/feature/session/src/test/java/mozilla/components/feature/session/SessionFeatureTest.kt
@@ -27,6 +27,7 @@ import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.anyString
@@ -245,6 +246,7 @@ class SessionFeatureTest {
     }
 
     @Test
+    @Ignore("https://github.com/mozilla-mobile/android-components/issues/7753")
     fun `Releases when last selected session gets removed`() {
         val store = BrowserStore(BrowserState(
             tabs = listOf(
@@ -329,6 +331,7 @@ class SessionFeatureTest {
     }
 
     @Test
+    @Ignore("https://github.com/mozilla-mobile/android-components/issues/7753")
     fun `Releases when custom tab gets removed`() {
         val store = BrowserStore(BrowserState(
             tabs = listOf(


### PR DESCRIPTION
That was a new behavior that was introduced with the migration to `BrowserStore/State` and, surprise!, it can cause a white page of death - even though the order of events look correct and make sense. Anyhow, more in #7753. I think we should temporarily disable this and continue to investigate the actual cause of the white page issue.