### PR TITLE
L10N uplift script

### DIFF
--- a/l10n-uplift.py
+++ b/l10n-uplift.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Purpose: uplift (via cherry-picking) any missing commits from an l10n bot
+# from 'MAIN_BRANCH' to a specified release branch.
+#
+# Usage examples: (append --verbose to print out detailed information)
+# Dry-run (says what will happen, doesn't do any work): ./l10n-uplift.py releases/48.0
+# Uplift, actually perform the work: ./l10n-uplift.py releases/48.0 --uplift
+# Process multiple branches at once: ./l10n-uplift.py releases/48.0 releases/44.0 --uplift --verbose
+
+import subprocess
+import argparse
+
+# TODO don't forget to change this once we switch to 'main' or whatever other name.
+MAIN_BRANCH="master"
+L10N_AUTHOR="release+l10n-automation-bot@mozilla.com"
+
+def run_cmd_checked(*args, **kwargs):
+    """Run a command, throwing an exception if it exits with non-zero status."""
+    kwargs["check"] = True
+    kwargs["capture_output"] = True
+    # beware! only run this script with inputs from a trusted, non-external source
+    kwargs["shell"] = True
+    try:
+        return subprocess.run(*args, **kwargs).stdout.decode()
+    except subprocess.CalledProcessError as err:
+        print(err.stderr)
+        raise err
+
+def uplift_commits(branch, verbose, uplift):
+    print(f"\nProcessing l10n commits for '{branch}'...")
+    # if necessary, this will setup 'branch' to track its upstream equivalent
+    run_cmd_checked([f"git checkout {branch}"])
+    # get l10n commits which happened on MAIN_BRANCH since 'branch' split off
+    commits_since_split = run_cmd_checked([f"git rev-list {branch}..{MAIN_BRANCH} --author={L10N_AUTHOR}"]).split()
+    # order commits by oldest-first, e.g. how we'd cherry pick them
+    commits_since_split.reverse()
+    print(f"Since '{branch}' split off '{MAIN_BRANCH}', there were {len(commits_since_split)} commit(s) from {L10N_AUTHOR}.")
+
+    if verbose:
+        print(f"\nHashes of those commits on '{MAIN_BRANCH}' are: {commits_since_split}\n")
+
+    # look for 'cherry picked' commits, and get the original commit hash from the commit message (as left by 'cherry-pick -x')
+    commits_already_uplifted = run_cmd_checked([f"git rev-list {MAIN_BRANCH}..{branch} --author={L10N_AUTHOR} --grep=\"cherry picked\" --pretty=%b | grep cherry | cut -d' ' -f5 | cut -c 1-40"]).split()
+    commits_already_uplifted.reverse()
+
+    print(f"Of those, {len(commits_already_uplifted)} commit(s) already uplifted.")
+
+    if verbose:
+        print(f"Hashes of commits already uplifted to '{branch}': {commits_already_uplifted}\n")
+
+    commits_to_uplift = [commit for commit in commits_since_split if commit not in commits_already_uplifted]
+
+    print(f"Need to uplift {len(commits_to_uplift)} commit(s).")
+
+    if verbose:
+        print(f"Hashes of commits to uplift from '{MAIN_BRANCH}' to '{branch}': {commits_to_uplift}\n")
+
+    if len(commits_to_uplift) == 0:
+        print("Nothing to uplift.")
+        return
+
+    if uplift:
+        print(f"Uplifting (for real)...")
+    else:
+        print(f"Uplifting (dry-run)...")
+
+    run_cmd_checked([f"git checkout {branch}"])
+    for commit in commits_to_uplift:
+        if verbose:
+            print(f"Cherry picking {commit} from '{MAIN_BRANCH}' to '{branch}'")
+        if uplift:
+            run_cmd_checked([f"git cherry-pick {commit} -x"])
+    if uplift:
+        print(f"Uplifted {len(commits_to_uplift)} commits from '{MAIN_BRANCH}' to '{branch}'")
+
+parser = argparse.ArgumentParser(description=f"Uplift l10n commits from {MAIN_BRANCH} to specified branches")
+parser.add_argument(
+    'branches', nargs='+', type=str,
+    help='target branches, e.g. specific release branches')
+parser.add_argument(
+    '--verbose', default=False, action='store_true',
+    help='print out commit hashes and other detailed information'
+)
+parser.add_argument(
+    '--uplift', default=False, action='store_true',
+    help='uplift l10n commits missing from specified branches (if not specified, dry-run is performed)'
+)
+args = parser.parse_args()
+
+# remember the current branch, so that we can return to it once we're done.
+current_branch = run_cmd_checked(["git rev-parse --abbrev-ref HEAD"])
+
+try:
+    for branch in args.branches:
+        uplift_commits(branch, args.verbose, args.uplift)
+finally:
+    # go back to the branch we were on before 'uplift_for_branches' ran
+    run_cmd_checked([f"git checkout {current_branch}"])


### PR DESCRIPTION
A script to help us uplift l10n commits from the automation bot into release branches (or, whatever other branches we want).

You can use it with multiple branches, it defaults to a dry-run (no changes performed):
```
➜  android-components git:(l10nCherry) ✗ ./l10n-uplift.py releases/48.0 releases/44.0

Processing l10n commits for 'releases/48.0'...
Since 'releases/48.0' split off 'master', there were 8 commit(s) from release+l10n-automation-bot@mozilla.com.
Of those, 0 commit(s) already uplifted.
Need to uplift 8 commit(s).
Uplifting (dry-run)...

Processing l10n commits for 'releases/44.0'...
Since 'releases/44.0' split off 'master', there were 24 commit(s) from release+l10n-automation-bot@mozilla.com.
Of those, 24 commit(s) already uplifted.
Need to uplift 0 commit(s).
Nothing to uplift.
```

There's a "verbose" mode, as well. To actually perform the work, you have to pass in an "--uplift" parameter:
```
➜  android-components git:(l10nCherry) ✗ ./l10n-uplift.py releases/48.0 --verbose --uplift

Processing l10n commits for 'releases/48.0'...
Since 'releases/48.0' split off 'master', there were 8 commit(s) from release+l10n-automation-bot@mozilla.com.

Hashes of those commits on 'master' are: ['032ace1d1a831e3a0db6c9a46fa08e15f1b94bbe', '0e79017768b22d4d7f1cd37e9ae61ca9cb3533ae', '65d9aa6d058ac479577ea1be13611e0fd28e45e0', 'b86e1c04ac6a076cde80de70a233363246ddd1cc', '37110f383014ff4c15288cb6c314ae805f5f19b6', '79a81a7aa0e5433824c2b5e8b726f36de8f14662', '6359ec7b3532bc5368f06d930595b01a348dafbb', '743acf82cc51008414f40098ff5311a95b70f76c']

Of those, 2 commit(s) already uplifted.
Hashes of commits already uplifted to 'releases/48.0': ['032ace1d1a831e3a0db6c9a46fa08e15f1b94bbe', '0e79017768b22d4d7f1cd37e9ae61ca9cb3533ae']

Need to uplift 6 commit(s).
Hashes of commits to uplift from 'master' to 'releases/48.0': ['65d9aa6d058ac479577ea1be13611e0fd28e45e0', 'b86e1c04ac6a076cde80de70a233363246ddd1cc', '37110f383014ff4c15288cb6c314ae805f5f19b6', '79a81a7aa0e5433824c2b5e8b726f36de8f14662', '6359ec7b3532bc5368f06d930595b01a348dafbb', '743acf82cc51008414f40098ff5311a95b70f76c']

Uplifting (for real)...
Cherry picking 65d9aa6d058ac479577ea1be13611e0fd28e45e0 from 'master' to 'releases/48.0'
Cherry picking b86e1c04ac6a076cde80de70a233363246ddd1cc from 'master' to 'releases/48.0'
Cherry picking 37110f383014ff4c15288cb6c314ae805f5f19b6 from 'master' to 'releases/48.0'
Cherry picking 79a81a7aa0e5433824c2b5e8b726f36de8f14662 from 'master' to 'releases/48.0'
Cherry picking 6359ec7b3532bc5368f06d930595b01a348dafbb from 'master' to 'releases/48.0'
Cherry picking 743acf82cc51008414f40098ff5311a95b70f76c from 'master' to 'releases/48.0'
Uplifted 6 commits from 'master' to 'releases/48.0'
```

It also works on Fenix, as well:
```
➜  fenix git:(master) ✗ ../android-components/l10n-uplift.py releases/v79.0.0

Processing l10n commits for 'releases/v79.0.0'...
Since 'releases/v79.0.0' split off 'master', there were 11 commit(s) from release+l10n-automation-bot@mozilla.com.
Of those, 0 commit(s) already uplifted.
Need to uplift 11 commit(s).
Uplifting (dry-run)...
```

I've made the "master" branch name easily configurable so that we can switch it later on to `main` or whatever else we pick.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
