### PR TITLE
[WIP] For mozilla-mobile/fenix#12226: Follow ux mock on download notifications

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadNotification.kt
@@ -94,14 +94,16 @@ internal object DownloadNotification {
                 }
 
         notificationLayout.setTextViewText(R.id.notification_title, "Firefox Preview · now")
-        notificationLayout.setTextViewText(R.id.title, downloadState.fileName)
+        notificationLayout.setTextViewText(R.id.download_filename, downloadState.fileName)
+        notificationLayout.setTextViewText(R.id.pause, "Pause")
+        notificationLayout.setTextViewText(R.id.cancel, "Cancel")
 
         val progress = if (isIndeterminate) {
             ""
         } else {
             "${convertToMB(bytesCopied)}MB / ${convertToMB(downloadState.contentLength!!)}MB"
         }
-        notificationLayout.setTextViewText(R.id.text, progress)
+        notificationLayout.setTextViewText(R.id.downloaded_file, progress)
 
         notificationLayout.setProgressBar(
                 R.id.progress,

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
@@ -2,35 +2,77 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout"
     android:layout_width="match_parent"
-    android:layout_height="96dp"
-    android:padding="8dp"
+    android:layout_height="wrap_content"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="16dp"
     android:background="@color/mozac_feature_downloads_notification_background_color_dark">
 
     <ImageView
         android:id="@+id/image"
-        android:layout_centerVertical="true"
-        android:layout_width="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:importantForAccessibility="no"
+        android:tint="@color/mozac_feature_downloads_notification_text_color_dark"
+        android:src="@drawable/mozac_feature_download_ic_download" />
+
+    <TextView
+        android:id="@+id/notification_title"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:src="@drawable/mozac_feature_download_ic_ongoing_download" />
+        android:layout_marginStart="8dp"
+        android:layout_toEndOf="@id/image"
+        android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
+        android:textSize="12sp"
+        tools:text="Firefox Preview · now" />
 
     <TextView
         android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_toEndOf="@id/image"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_toStartOf="@+id/text"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/notification_title"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
-        android:layout_marginTop="20dp"
-        tools:text="DOWNLOAD" />
+        tools:text="com.google.android.apps.ringer.apk" />
 
     <TextView
         android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="2dp"
-        android:layout_toEndOf="@id/image"
+        android:layout_marginTop="8dp"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@id/notification_title"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
-        android:layout_below="@id/title"
-        tools:text="DOWNLOADTEXT" />
+        tools:text="85 MB / 200 MB" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/text"
+        android:progressTint="@color/mozac_feature_downloads_notification_accent_color_dark"
+        style="?android:attr/progressBarStyleHorizontal" />
+
+    <Button
+        android:id="@+id/pause"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/mozac_feature_downloads_notification_accent_color_dark"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/progress"
+        tools:text="PAUSE" />
+
+    <Button
+        android:id="@+id/cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/mozac_feature_downloads_notification_accent_color_dark"
+        android:layout_toEndOf="@id/pause"
+        android:layout_below="@id/progress"
+        tools:text="CANCEL" />
 </RelativeLayout>

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
@@ -2,7 +2,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="16dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="16dp"
+    android:paddingBottom="4dp"
     android:background="@color/mozac_feature_downloads_notification_background_color_dark">
 
     <ImageView
@@ -50,6 +53,7 @@
         android:id="@+id/progress"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
         android:layout_alignParentStart="true"
         android:layout_below="@id/download_filename"
         android:progressTint="@color/mozac_feature_downloads_notification_accent_color_dark"

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
@@ -1,11 +1,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:paddingTop="16dp"
+    android:padding="16dp"
     android:background="@color/mozac_feature_downloads_notification_background_color_dark">
 
     <ImageView
@@ -28,24 +25,24 @@
         tools:text="Firefox Preview · now" />
 
     <TextView
-        android:id="@+id/title"
+        android:id="@+id/download_filename"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
-        android:layout_toStartOf="@+id/text"
+        android:layout_toStartOf="@+id/downloaded_file"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/notification_title"
+        android:layout_below="@id/image"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
         tools:text="com.google.android.apps.ringer.apk" />
 
     <TextView
-        android:id="@+id/text"
+        android:id="@+id/downloaded_file"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:layout_alignParentEnd="true"
-        android:layout_below="@id/notification_title"
+        android:layout_below="@id/image"
+        android:layout_marginTop="8dp"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
         tools:text="85 MB / 200 MB" />
 
@@ -54,7 +51,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/text"
+        android:layout_below="@id/download_filename"
         android:progressTint="@color/mozac_feature_downloads_notification_accent_color_dark"
         style="?android:attr/progressBarStyleHorizontal" />
 
@@ -64,8 +61,11 @@
         android:layout_height="wrap_content"
         android:textColor="@color/mozac_feature_downloads_notification_accent_color_dark"
         android:layout_alignParentStart="true"
+        android:minHeight="0dp"
+        android:minWidth="0dp"
         android:layout_below="@id/progress"
-        tools:text="PAUSE" />
+        style="@style/Widget.AppCompat.Button.Borderless"
+        tools:text="Pause" />
 
     <Button
         android:id="@+id/cancel"
@@ -73,6 +73,9 @@
         android:layout_height="wrap_content"
         android:textColor="@color/mozac_feature_downloads_notification_accent_color_dark"
         android:layout_toEndOf="@id/pause"
+        android:minHeight="0dp"
+        android:minWidth="0dp"
         android:layout_below="@id/progress"
-        tools:text="CANCEL" />
+        style="@style/Widget.AppCompat.Button.Borderless"
+        tools:text="Cancel" />
 </RelativeLayout>

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
@@ -1,0 +1,36 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout"
+    android:layout_width="match_parent"
+    android:layout_height="96dp"
+    android:padding="8dp"
+    android:background="@color/mozac_feature_downloads_notification_background_color_dark">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_centerVertical="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/mozac_feature_download_ic_ongoing_download" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_toEndOf="@id/image"
+        android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
+        android:layout_marginTop="20dp"
+        tools:text="DOWNLOAD" />
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="2dp"
+        android:layout_toEndOf="@id/image"
+        android:textColor="@color/mozac_feature_downloads_notification_text_color_dark"
+        android:layout_below="@id/title"
+        tools:text="DOWNLOADTEXT" />
+</RelativeLayout>

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_dark.xml
@@ -63,6 +63,7 @@
         android:layout_alignParentStart="true"
         android:minHeight="0dp"
         android:minWidth="0dp"
+        android:layout_marginStart="-12dp"
         android:layout_below="@id/progress"
         style="@style/Widget.AppCompat.Button.Borderless"
         tools:text="Pause" />

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
@@ -1,8 +1,14 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="16dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="16dp"
+    android:paddingBottom="4dp"
     android:background="@color/mozac_feature_downloads_notification_background_color_light">
 
     <ImageView
@@ -50,6 +56,7 @@
         android:id="@+id/progress"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
         android:layout_alignParentStart="true"
         android:layout_below="@id/download_filename"
         android:progressTint="@color/mozac_feature_downloads_notification_accent_color_light"

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
@@ -2,35 +2,77 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout"
     android:layout_width="match_parent"
-    android:layout_height="96dp"
-    android:padding="8dp"
+    android:layout_height="wrap_content"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="16dp"
     android:background="@color/mozac_feature_downloads_notification_background_color_light">
 
     <ImageView
         android:id="@+id/image"
-        android:layout_centerVertical="true"
-        android:layout_width="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:importantForAccessibility="no"
+        android:tint="@color/mozac_feature_downloads_notification_text_color_light"
+        android:src="@drawable/mozac_feature_download_ic_download" />
+
+    <TextView
+        android:id="@+id/notification_title"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:src="@drawable/mozac_feature_download_ic_ongoing_download" />
+        android:layout_marginStart="8dp"
+        android:layout_toEndOf="@id/image"
+        android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
+        android:textSize="12sp"
+        tools:text="Firefox Preview · now" />
 
     <TextView
         android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_toEndOf="@id/image"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_toStartOf="@+id/text"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/notification_title"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
-        android:layout_marginTop="20dp"
-        tools:text="DOWNLOAD" />
+        tools:text="com.google.android.apps.ringer.apk" />
 
     <TextView
         android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="2dp"
-        android:layout_toEndOf="@id/image"
+        android:layout_marginTop="8dp"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@id/notification_title"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
-        android:layout_below="@id/title"
-        tools:text="DOWNLOADTEXT" />
+        tools:text="85MB / 200 MB" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/text"
+        android:progressTint="@color/mozac_feature_downloads_notification_accent_color_light"
+        style="?android:attr/progressBarStyleHorizontal" />
+
+    <Button
+        android:id="@+id/pause"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/mozac_feature_downloads_notification_accent_color_light"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/progress"
+        tools:text="PAUSE" />
+
+    <Button
+        android:id="@+id/cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/mozac_feature_downloads_notification_accent_color_light"
+        android:layout_toEndOf="@id/pause"
+        android:layout_below="@id/progress"
+        tools:text="CANCEL" />
 </RelativeLayout>

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
@@ -1,0 +1,36 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout"
+    android:layout_width="match_parent"
+    android:layout_height="96dp"
+    android:padding="8dp"
+    android:background="@color/mozac_feature_downloads_notification_background_color_light">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_centerVertical="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/mozac_feature_download_ic_ongoing_download" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_toEndOf="@id/image"
+        android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
+        android:layout_marginTop="20dp"
+        tools:text="DOWNLOAD" />
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="2dp"
+        android:layout_toEndOf="@id/image"
+        android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
+        android:layout_below="@id/title"
+        tools:text="DOWNLOADTEXT" />
+</RelativeLayout>

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
@@ -1,11 +1,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:paddingTop="16dp"
+    android:padding="16dp"
     android:background="@color/mozac_feature_downloads_notification_background_color_light">
 
     <ImageView
@@ -28,33 +25,33 @@
         tools:text="Firefox Preview · now" />
 
     <TextView
-        android:id="@+id/title"
+        android:id="@+id/download_filename"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
-        android:layout_toStartOf="@+id/text"
+        android:layout_toStartOf="@+id/downloaded_file"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/notification_title"
+        android:layout_below="@id/image"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
         tools:text="com.google.android.apps.ringer.apk" />
 
     <TextView
-        android:id="@+id/text"
+        android:id="@+id/downloaded_file"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:layout_alignParentEnd="true"
-        android:layout_below="@id/notification_title"
+        android:layout_below="@id/image"
+        android:layout_marginTop="8dp"
         android:textColor="@color/mozac_feature_downloads_notification_text_color_light"
-        tools:text="85MB / 200 MB" />
+        tools:text="85 MB / 200 MB" />
 
     <ProgressBar
         android:id="@+id/progress"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/text"
+        android:layout_below="@id/download_filename"
         android:progressTint="@color/mozac_feature_downloads_notification_accent_color_light"
         style="?android:attr/progressBarStyleHorizontal" />
 
@@ -64,8 +61,11 @@
         android:layout_height="wrap_content"
         android:textColor="@color/mozac_feature_downloads_notification_accent_color_light"
         android:layout_alignParentStart="true"
+        android:minHeight="0dp"
+        android:minWidth="0dp"
         android:layout_below="@id/progress"
-        tools:text="PAUSE" />
+        style="@style/Widget.AppCompat.Button.Borderless"
+        tools:text="Pause" />
 
     <Button
         android:id="@+id/cancel"
@@ -73,6 +73,9 @@
         android:layout_height="wrap_content"
         android:textColor="@color/mozac_feature_downloads_notification_accent_color_light"
         android:layout_toEndOf="@id/pause"
+        android:minHeight="0dp"
+        android:minWidth="0dp"
         android:layout_below="@id/progress"
-        tools:text="CANCEL" />
+        style="@style/Widget.AppCompat.Button.Borderless"
+        tools:text="Cancel" />
 </RelativeLayout>

--- a/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
+++ b/components/feature/downloads/src/main/res/layout/download_notification_layout_light.xml
@@ -63,6 +63,7 @@
         android:layout_alignParentStart="true"
         android:minHeight="0dp"
         android:minWidth="0dp"
+        android:layout_marginStart="-12dp"
         android:layout_below="@id/progress"
         style="@style/Widget.AppCompat.Button.Borderless"
         tools:text="Pause" />

--- a/components/feature/downloads/src/main/res/values/colors.xml
+++ b/components/feature/downloads/src/main/res/values/colors.xml
@@ -6,8 +6,10 @@
     <color name="mozac_feature_downloads_notification">#607D8B</color>
     <color name="mozac_feature_downloads_notification_text_color_dark">#fbfbfe</color>
     <color name="mozac_feature_downloads_notification_background_color_dark">#32313c</color>
+    <color name="mozac_feature_downloads_notification_accent_color_dark">#592acb</color>
 
 
     <color name="mozac_feature_downloads_notification_background_color_light">#ffffff</color>
     <color name="mozac_feature_downloads_notification_text_color_light">#20123a</color>
+    <color name="mozac_feature_downloads_notification_accent_color_light">#ab71ff</color>
 </resources>

--- a/components/feature/downloads/src/main/res/values/colors.xml
+++ b/components/feature/downloads/src/main/res/values/colors.xml
@@ -4,4 +4,10 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <color name="mozac_feature_downloads_notification">#607D8B</color>
+    <color name="mozac_feature_downloads_notification_text_color_dark">#fbfbfe</color>
+    <color name="mozac_feature_downloads_notification_background_color_dark">#32313c</color>
+
+
+    <color name="mozac_feature_downloads_notification_background_color_light">#ffffff</color>
+    <color name="mozac_feature_downloads_notification_text_color_light">#20123a</color>
 </resources>


### PR DESCRIPTION
cc @Amejia481

To-do:

- [ ] Match ux mocks
- [ ] Manage other cases (paused, group, completed, failed)
- [ ] Import hardcoded strings
- [ ] "Firefox Preview  · now" is fixed text, fetch app name and startup time
- [x] ~~Set proper height based on Android's default notification height~~
- [x] ~~Add progress bar~~
- [x] ~~Change animated icon color based on theme~~ (converted to static)
- [x] ~~Add pause stop buttons~~

"Sessiz bildirimler" means silent notifications.
**Current looks**
<img src="https://user-images.githubusercontent.com/17825767/87861481-4d9dad80-c94f-11ea-8b84-14e35d3531d8.png" width="300"><img src="https://user-images.githubusercontent.com/17825767/87861482-4eceda80-c94f-11ea-9dd6-5dd397437e59.png" width="300">
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
