### PR TITLE
Close #7079: Decouple BrowserTabsTray from TabsAdapter

### DIFF
--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/BrowserTabsTray.kt
@@ -12,14 +12,11 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.concept.tabstray.TabsTray
 
-const val DEFAULT_ITEM_BACKGROUND_COLOR = 0xFFFFFFFF.toInt()
-const val DEFAULT_ITEM_BACKGROUND_SELECTED_COLOR = 0xFFFF45A1FF.toInt()
-const val DEFAULT_ITEM_TEXT_COLOR = 0xFF111111.toInt()
-const val DEFAULT_ITEM_TEXT_SELECTED_COLOR = 0xFFFFFFFF.toInt()
-
 /**
  * A customizable tabs tray for browsers.
  */
+@Deprecated("Use a RecyclerView directly instead; styling can be passed to the TabsAdapter. " +
+    "This class will be removed in a future release.")
 class BrowserTabsTray @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -30,17 +27,9 @@ class BrowserTabsTray @JvmOverloads constructor(
 ) : RecyclerView(context, attrs, defStyleAttr),
     TabsTray by tabsAdapter {
 
-    internal val styling: TabsTrayStyling
-
     init {
-        tabsAdapter.tabsTray = this
-
-        layoutManager = layout
-        adapter = tabsAdapter
-        itemDecoration?.let { addItemDecoration(it) }
-
         val attr = context.obtainStyledAttributes(attrs, R.styleable.BrowserTabsTray, defStyleAttr, 0)
-        styling = TabsTrayStyling(
+        val tabsTrayStyling = TabsTrayStyling(
             attr.getColor(R.styleable.BrowserTabsTray_tabsTrayItemBackgroundColor, DEFAULT_ITEM_BACKGROUND_COLOR),
             attr.getColor(R.styleable.BrowserTabsTray_tabsTraySelectedItemBackgroundColor,
                 DEFAULT_ITEM_BACKGROUND_SELECTED_COLOR),
@@ -48,10 +37,17 @@ class BrowserTabsTray @JvmOverloads constructor(
             attr.getColor(R.styleable.BrowserTabsTray_tabsTraySelectedItemTextColor, DEFAULT_ITEM_TEXT_SELECTED_COLOR),
             attr.getColor(R.styleable.BrowserTabsTray_tabsTrayItemUrlTextColor, DEFAULT_ITEM_TEXT_COLOR),
             attr.getColor(R.styleable.BrowserTabsTray_tabsTraySelectedItemUrlTextColor,
-                DEFAULT_ITEM_TEXT_SELECTED_COLOR),
-            attr.getDimensionPixelSize(R.styleable.BrowserTabsTray_tabsTrayItemElevation, 0).toFloat()
+                DEFAULT_ITEM_TEXT_SELECTED_COLOR)
         )
         attr.recycle()
+
+        itemDecoration?.let { addItemDecoration(it) }
+
+        adapter = tabsAdapter.apply {
+            styling = tabsTrayStyling
+        }
+
+        layoutManager = layout
     }
 
     /**
@@ -61,13 +57,3 @@ class BrowserTabsTray @JvmOverloads constructor(
         return this
     }
 }
-
-internal data class TabsTrayStyling(
-    val itemBackgroundColor: Int,
-    val selectedItemBackgroundColor: Int,
-    val itemTextColor: Int,
-    val selectedItemTextColor: Int,
-    val itemUrlTextColor: Int,
-    val selectedItemUrlTextColor: Int,
-    val itemElevation: Float
-)

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -33,7 +33,12 @@ abstract class TabViewHolder(view: View) : RecyclerView.ViewHolder(view) {
      * @param isSelected boolean to describe whether or not the `Tab` is selected.
      * @param observable message bus to pass events to Observers of the TabsTray.
      */
-    abstract fun bind(tab: Tab, isSelected: Boolean, observable: Observable<TabsTray.Observer>)
+    abstract fun bind(
+        tab: Tab,
+        isSelected: Boolean,
+        styling: TabsTrayStyling,
+        observable: Observable<TabsTray.Observer>
+    )
 }
 
 /**
@@ -41,7 +46,6 @@ abstract class TabViewHolder(view: View) : RecyclerView.ViewHolder(view) {
  */
 class DefaultTabViewHolder(
     itemView: View,
-    private val tabsTray: BrowserTabsTray,
     private val thumbnailLoader: ImageLoader? = null
 ) : TabViewHolder(itemView) {
     private val iconView: ImageView? = itemView.findViewById(R.id.mozac_browser_tabstray_icon)
@@ -55,7 +59,12 @@ class DefaultTabViewHolder(
     /**
      * Displays the data of the given session and notifies the given observable about events.
      */
-    override fun bind(tab: Tab, isSelected: Boolean, observable: Observable<TabsTray.Observer>) {
+    override fun bind(
+        tab: Tab,
+        isSelected: Boolean,
+        styling: TabsTrayStyling,
+        observable: Observable<TabsTray.Observer>
+    ) {
         this.tab = tab
 
         val title = if (tab.title.isNotEmpty()) {
@@ -76,13 +85,13 @@ class DefaultTabViewHolder(
         }
 
         if (isSelected) {
-            titleView.setTextColor(tabsTray.styling.selectedItemTextColor)
-            itemView.setBackgroundColor(tabsTray.styling.selectedItemBackgroundColor)
-            closeView.imageTintList = ColorStateList.valueOf(tabsTray.styling.selectedItemTextColor)
+            titleView.setTextColor(styling.selectedItemTextColor)
+            itemView.setBackgroundColor(styling.selectedItemBackgroundColor)
+            closeView.imageTintList = ColorStateList.valueOf(styling.selectedItemTextColor)
         } else {
-            titleView.setTextColor(tabsTray.styling.itemTextColor)
-            itemView.setBackgroundColor(tabsTray.styling.itemBackgroundColor)
-            closeView.imageTintList = ColorStateList.valueOf(tabsTray.styling.itemTextColor)
+            titleView.setTextColor(styling.itemTextColor)
+            itemView.setBackgroundColor(styling.itemBackgroundColor)
+            closeView.imageTintList = ColorStateList.valueOf(styling.itemTextColor)
         }
 
         // In the final else case, we have no cache or fresh screenshot; do nothing instead of clearing the image.

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsAdapter.kt
@@ -16,37 +16,32 @@ import mozilla.components.support.images.loader.ImageLoader
 /**
  * Function responsible for creating a `TabViewHolder` in the `TabsAdapter`.
  */
-typealias ViewHolderProvider = (ViewGroup, BrowserTabsTray) -> TabViewHolder
+typealias ViewHolderProvider = (ViewGroup) -> TabViewHolder
 
 /**
  * RecyclerView adapter implementation to display a list/grid of tabs.
- * @param delegate TabsTray.Observer registry to allow `TabsAdapter` to conform to `Observable<TabsTray.Observer>`.
+ *
+ * @param thumbnailLoader an implementation of an [ImageLoader] for loading thumbnail images in the tabs tray.
  * @param viewHolderProvider a function that creates a `TabViewHolder`.
+ * @param delegate TabsTray.Observer registry to allow `TabsAdapter` to conform to `Observable<TabsTray.Observer>`.
  */
 @Suppress("TooManyFunctions")
 open class TabsAdapter(
     thumbnailLoader: ImageLoader? = null,
-    private val viewHolderProvider: ViewHolderProvider = { parent, tabsTray ->
+    private val viewHolderProvider: ViewHolderProvider = { parent ->
         DefaultTabViewHolder(
-                LayoutInflater.from(parent.context).inflate(
-                        R.layout.mozac_browser_tabstray_item,
-                        parent,
-                        false),
-                tabsTray,
-                thumbnailLoader
+            LayoutInflater.from(parent.context).inflate(R.layout.mozac_browser_tabstray_item, parent, false),
+            thumbnailLoader
         )
     },
     delegate: Observable<TabsTray.Observer> = ObserverRegistry()
-) : RecyclerView.Adapter<TabViewHolder>(),
-    TabsTray,
-    Observable<TabsTray.Observer> by delegate {
-
-    internal lateinit var tabsTray: BrowserTabsTray
-
+) : RecyclerView.Adapter<TabViewHolder>(), TabsTray, Observable<TabsTray.Observer> by delegate {
     private var tabs: Tabs? = null
 
+    var styling: TabsTrayStyling = TabsTrayStyling()
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabViewHolder {
-        return viewHolderProvider.invoke(parent, tabsTray)
+        return viewHolderProvider.invoke(parent)
     }
 
     override fun getItemCount() = tabs?.list?.size ?: 0
@@ -54,7 +49,7 @@ open class TabsAdapter(
     override fun onBindViewHolder(holder: TabViewHolder, position: Int) {
         val tabs = tabs ?: return
 
-        holder.bind(tabs.list[position], position == tabs.selectedIndex, this)
+        holder.bind(tabs.list[position], position == tabs.selectedIndex, styling, this)
     }
 
     override fun updateTabs(tabs: Tabs) {

--- a/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsTrayStyling.kt
+++ b/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabsTrayStyling.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.tabstray
+
+const val DEFAULT_ITEM_BACKGROUND_COLOR = 0xFFFFFFFF.toInt()
+const val DEFAULT_ITEM_BACKGROUND_SELECTED_COLOR = 0xFFFF45A1FF.toInt()
+const val DEFAULT_ITEM_TEXT_COLOR = 0xFF111111.toInt()
+const val DEFAULT_ITEM_TEXT_SELECTED_COLOR = 0xFFFFFFFF.toInt()
+
+/**
+ * Tabs tray styling for items in the [TabsAdapter]. If a custom [TabViewHolder]
+ * is used with [TabsAdapter.viewHolderProvider], the styling can be applied
+ * when [TabViewHolder.bind] is invoked.
+ *
+ * @property itemBackgroundColor the background color for all non-selected tabs.
+ * @property selectedItemBackgroundColor the background color for the selected tab.
+ * @property itemTextColor the text color for all non-selected tabs.
+ * @property selectedItemTextColor the text color for the selected tabs.
+ * @property itemUrlTextColor the URL text color for all non-selected tabs.
+ * @property selectedItemUrlTextColor the URL text color for the selected tab.
+ */
+data class TabsTrayStyling(
+    val itemBackgroundColor: Int = DEFAULT_ITEM_BACKGROUND_COLOR,
+    val selectedItemBackgroundColor: Int = DEFAULT_ITEM_BACKGROUND_SELECTED_COLOR,
+    val itemTextColor: Int = DEFAULT_ITEM_TEXT_COLOR,
+    val selectedItemTextColor: Int = DEFAULT_ITEM_TEXT_SELECTED_COLOR,
+    val itemUrlTextColor: Int = DEFAULT_ITEM_TEXT_COLOR,
+    val selectedItemUrlTextColor: Int = DEFAULT_ITEM_TEXT_SELECTED_COLOR
+)

--- a/components/browser/tabstray/src/main/res/values/attrs.xml
+++ b/components/browser/tabstray/src/main/res/values/attrs.xml
@@ -10,6 +10,5 @@
         <attr name="tabsTraySelectedItemBackgroundColor" format="reference|color" />
         <attr name="tabsTraySelectedItemTextColor" format="reference|color" />
         <attr name="tabsTraySelectedItemUrlTextColor" format="reference|color" />
-        <attr name="tabsTrayItemElevation" format="reference|dimension" />
     </declare-styleable>
 </resources>

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/BrowserTabsTrayTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/BrowserTabsTrayTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
+@Suppress("Deprecation")
 class BrowserTabsTrayTest {
 
     @Test
@@ -45,7 +46,7 @@ class BrowserTabsTrayTest {
         val adapter = TabsAdapter()
         val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter)
 
-        assertEquals(tabsTray, adapter.tabsTray)
+        assertEquals(tabsTray.adapter, adapter)
     }
 
     @Test
@@ -58,6 +59,6 @@ class BrowserTabsTrayTest {
         val tabsTray = BrowserTabsTray(testContext, tabsAdapter = adapter, itemDecoration = decoration)
 
         assertEquals(decoration, tabsTray.getItemDecorationAt(0))
-        assertEquals(decoration, adapter.tabsTray.getItemDecorationAt(0))
+        assertEquals(decoration, tabsTray.getItemDecorationAt(0))
     }
 }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
@@ -24,7 +24,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
@@ -37,13 +36,13 @@ class DefaultTabViewHolderTest {
         val titleView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_title)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
 
         assertEquals("", titleView.text)
 
         val session = Tab("a", "https://www.mozilla.org")
 
-        holder.bind(session, isSelected = false, observable = mock())
+        holder.bind(session, isSelected = false, styling = mock(), observable = mock())
 
         assertEquals("https://www.mozilla.org", titleView.text)
         assertEquals("www.mozilla.org", urlView.text)
@@ -53,10 +52,10 @@ class DefaultTabViewHolderTest {
     fun `URL text is set to tab URL when exception is thrown`() {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
         val session = Tab("a", "about:home")
 
-        holder.bind(session, isSelected = false, observable = mock())
+        holder.bind(session, isSelected = false, styling = mock(), observable = mock())
 
         assertEquals("about:home", urlView.text)
     }
@@ -69,10 +68,10 @@ class DefaultTabViewHolderTest {
         }
 
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
 
         val session = Tab("a", "https://www.mozilla.org")
-        holder.bind(session, isSelected = false, observable = registry)
+        holder.bind(session, isSelected = false, styling = mock(), observable = registry)
 
         view.performClick()
 
@@ -87,10 +86,10 @@ class DefaultTabViewHolderTest {
         }
 
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
 
         val session = Tab("a", "https://www.mozilla.org")
-        holder.bind(session, isSelected = true, observable = registry)
+        holder.bind(session, isSelected = true, styling = mock(), observable = registry)
 
         view.findViewById<View>(R.id.mozac_browser_tabstray_close).performClick()
 
@@ -105,13 +104,13 @@ class DefaultTabViewHolderTest {
         }
 
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
 
         val session = Tab("a", "https://www.mozilla.org")
         val titleView = holder.itemView.findViewById<TextView>(R.id.mozac_browser_tabstray_title)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
-        holder.bind(session, isSelected = true, observable = registry)
+        holder.bind(session, isSelected = true, styling = mock(), observable = registry)
 
         assertEquals(session.url, titleView.text)
         assertEquals("www.mozilla.org", urlView.text)
@@ -125,13 +124,13 @@ class DefaultTabViewHolderTest {
         }
 
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
 
         val session = Tab("a", "https://www.mozilla.org", title = "Mozilla Firefox")
         val titleView = holder.itemView.findViewById<TextView>(R.id.mozac_browser_tabstray_title)
         val urlView = view.findViewById<TextView>(R.id.mozac_browser_tabstray_url)
 
-        holder.bind(session, isSelected = true, observable = registry)
+        holder.bind(session, isSelected = true, styling = mock(), observable = registry)
 
         assertEquals("Mozilla Firefox", titleView.text)
         assertEquals("www.mozilla.org", urlView.text)
@@ -142,13 +141,13 @@ class DefaultTabViewHolderTest {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val thumbnailView = view.findViewById<ImageView>(R.id.mozac_browser_tabstray_thumbnail)
 
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
         assertEquals(null, thumbnailView.drawable)
 
         val emptyBitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
         val session = Tab("a", "https://www.mozilla.org", thumbnail = emptyBitmap)
 
-        holder.bind(session, isSelected = false, observable = mock())
+        holder.bind(session, isSelected = false, styling = mock(), observable = mock())
         assertTrue(thumbnailView.drawable != null)
     }
 
@@ -156,15 +155,15 @@ class DefaultTabViewHolderTest {
     fun `thumbnail is set from loader`() {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val loader: ImageLoader = mock()
-        val viewHolder = DefaultTabViewHolder(view, mockTabsTrayWithStyles(), loader)
+        val viewHolder = DefaultTabViewHolder(view, loader)
         val tabWithThumbnail = Tab("123", "https://example.com", thumbnail = mock())
         val tab = Tab("123", "https://example.com")
 
-        viewHolder.bind(tabWithThumbnail, false, mock())
+        viewHolder.bind(tabWithThumbnail, false, mock(), mock())
 
         verify(loader, never()).loadIntoView(any(), eq(ImageLoadRequest("123", 100)), nullable(), nullable())
 
-        viewHolder.bind(tab, false, mock())
+        viewHolder.bind(tab, false, mock(), mock())
 
         verify(loader).loadIntoView(any(), eq(ImageLoadRequest("123", 100)), nullable(), nullable())
     }
@@ -172,26 +171,15 @@ class DefaultTabViewHolderTest {
     @Test
     fun `thumbnailView does not change when there is no cache or new thumbnail`() {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val viewHolder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val viewHolder = DefaultTabViewHolder(view)
         val tab = Tab("123", "https://example.com")
         val thumbnailView = view.findViewById<ImageView>(R.id.mozac_browser_tabstray_thumbnail)
 
         thumbnailView.setImageBitmap(mock())
         val drawable = thumbnailView.drawable
 
-        viewHolder.bind(tab, false, mock())
+        viewHolder.bind(tab, false, mock(), mock())
 
         assertEquals(drawable, thumbnailView.drawable)
-    }
-
-    companion object {
-        fun mockTabsTrayWithStyles(): BrowserTabsTray {
-            val styles: TabsTrayStyling = mock()
-
-            val tabsTray: BrowserTabsTray = mock()
-            doReturn(styles).`when`(tabsTray).styling
-
-            return tabsTray
-        }
     }
 }

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabTouchCallbackTest.kt
@@ -7,7 +7,6 @@ package mozilla.components.browser.tabstray
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.tabstray.DefaultTabViewHolderTest.Companion.mockTabsTrayWithStyles
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -49,7 +48,7 @@ class TabTouchCallbackTest {
     @Test
     fun `onChildDraw alters alpha of ViewHolder on swipe gesture`() {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
-        val holder = DefaultTabViewHolder(view, mockTabsTrayWithStyles())
+        val holder = DefaultTabViewHolder(view)
         val callback = TabTouchCallback(mock())
 
         holder.itemView.alpha = 0f

--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -22,7 +22,12 @@ import org.mockito.Mockito.verify
 
 private class TestTabViewHolder(view: View) : TabViewHolder(view) {
     override var tab: Tab? = null
-    override fun bind(tab: Tab, isSelected: Boolean, observable: Observable<TabsTray.Observer>) { /* noop */ }
+    override fun bind(
+        tab: Tab,
+        isSelected: Boolean,
+        styling: TabsTrayStyling,
+        observable: Observable<TabsTray.Observer>
+    ) { /* noop */ }
 }
 
 @RunWith(AndroidJUnit4::class)
@@ -31,7 +36,6 @@ class TabsAdapterTest {
     @Test
     fun `onCreateViewHolder will create a DefaultTabViewHolder`() {
         val adapter = TabsAdapter()
-        adapter.tabsTray = mock()
 
         val type = adapter.onCreateViewHolder(FrameLayout(testContext), 0)
 
@@ -40,8 +44,7 @@ class TabsAdapterTest {
 
     @Test
     fun `onCreateViewHolder will create whatever TabViewHolder is provided`() {
-        val adapter = TabsAdapter(viewHolderProvider = { _, _ -> TestTabViewHolder(View(testContext)) })
-        adapter.tabsTray = mock()
+        val adapter = TabsAdapter(viewHolderProvider = { _ -> TestTabViewHolder(View(testContext)) })
 
         val type = adapter.onCreateViewHolder(FrameLayout(testContext), 0)
 
@@ -79,7 +82,6 @@ class TabsAdapterTest {
     @Test
     fun `onBindViewHolder calls bind on matching holder`() {
         val adapter = TabsAdapter()
-        adapter.tabsTray = mock()
 
         val holder: TabViewHolder = mock()
 
@@ -93,13 +95,12 @@ class TabsAdapterTest {
 
         adapter.onBindViewHolder(holder, 0)
 
-        verify(holder).bind(tab, true, adapter)
+        verify(holder).bind(tab, true, adapter.styling, adapter)
     }
 
     @Test
     fun `underlying adapter is notified about data set changes`() {
         val adapter = spy(TabsAdapter())
-        adapter.tabsTray = mock()
 
         adapter.onTabsInserted(27, 101)
         verify(adapter).notifyItemRangeInserted(27, 101)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,11 @@ permalink: /changelog/
 * **support-images**
   * ⚠️ **This is a breaking change**: Removed `ImageLoader.loadIntoView(view: ImageView, id: String)` extension function.
 
+* **browser-tabstray**
+  * ⚠️ **This is a breaking change**: The `BrowserTabsTray` is now deprecated. Using a `RecyclerView` directly is now recommended.
+  * ⚠️ **This is a breaking change**: `ViewHolderProvider` no longer has a second param.
+  * ⚠️ **This is a breaking change**: `TabsAdapter` has a `styling` field `TabsTrayStyling`.
+
 # 51.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v50.0.0...v51.0.0)

--- a/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -9,18 +9,11 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import mozilla.components.browser.state.state.WebExtensionState
-import mozilla.components.browser.tabstray.BrowserTabsTray
-import mozilla.components.browser.tabstray.DefaultTabViewHolder
-import mozilla.components.browser.tabstray.TabsAdapter
-import mozilla.components.browser.tabstray.ViewHolderProvider
-import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.concept.engine.EngineView
-import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.intent.ext.getSessionId
 import mozilla.components.feature.contextmenu.ext.DefaultSelectionActionDelegate
 import mozilla.components.support.base.feature.UserInteractionHandler
@@ -76,7 +69,6 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
                     context = context
                 )
             }.asView()
-            TabsTray::class.java.name -> createTabsTray(context, attrs)
             else -> super.onCreateView(parent, name, context, attrs)
         }
 
@@ -86,24 +78,5 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         intent.putExtra("web_extension_name", webExtensionState.name)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
-    }
-
-    private fun createTabsTray(context: Context, attrs: AttributeSet): BrowserTabsTray {
-        val thumbnailLoader = ThumbnailLoader(components.thumbnailStorage)
-        val viewHolderProvider: ViewHolderProvider = { viewGroup, tabsTray ->
-            DefaultTabViewHolder(
-                LayoutInflater.from(viewGroup.context).inflate(
-                    R.layout.mozac_browser_tabstray_item,
-                    viewGroup,
-                    false
-                ),
-                tabsTray,
-                thumbnailLoader
-            )
-        }
-
-        val adapter = TabsAdapter(thumbnailLoader, viewHolderProvider)
-
-        return BrowserTabsTray(context, attrs, 0, adapter)
     }
 }

--- a/samples/browser/src/main/res/layout/fragment_tabstray.xml
+++ b/samples/browser/src/main/res/layout/fragment_tabstray.xml
@@ -17,15 +17,13 @@
         app:layout_constraintTop_toTopOf="parent"
         android:background="#aaaaaa"/>
 
-    <mozilla.components.concept.tabstray.TabsTray
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tabsTray"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar"
-        mozac:tabsTrayItemElevation="4dp">
+        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
-    </mozilla.components.concept.tabstray.TabsTray>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Deprecates the `BrowserTabsTray` as well, using a `RecyclerView`
directly is now recommended.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Close #7079
Fenix breaking API fixes: https://github.com/mozilla-mobile/fenix/pull/12771

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
