### PR TITLE
Lower max run time for some tasks

### DIFF
--- a/taskcluster/ci/build-samples-browser/kind.yml
+++ b/taskcluster/ci/build-samples-browser/kind.yml
@@ -37,7 +37,7 @@ job-defaults:
     worker:
         chain-of-trust: true
         docker-image: {in-tree: base}
-        max-run-time: 7200
+        max-run-time: 1200
 
 jobs:
     nightly:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -104,7 +104,7 @@ job-defaults:
     worker:
         chain-of-trust: true
         docker-image: {in-tree: base}
-        max-run-time: 7200
+        max-run-time: 1200
 
 
 overriden-jobs:

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -30,7 +30,7 @@ job-defaults:
     worker-type: b-android
     worker:
         docker-image: {in-tree: base}
-        max-run-time: 7200
+        max-run-time: 600
 
 jobs:
     compare-locales:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -45,7 +45,7 @@ job-defaults:
         env:
             GOOGLE_APPLICATION_CREDENTIALS: '.firebase_token.json'
             GOOGLE_PROJECT: moz-android-components-230120
-        max-run-time: 7200
+        max-run-time: 2400
 
 
 jobs:

--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -29,7 +29,7 @@ linux64-android-sdk-linux-repack:
         symbol: TL(android-sdk-linux)
     worker:
         docker-image: {in-tree: base}
-        max-run-time: 1800
+        max-run-time: 600
 
 
 linux64-android-gradle-dependencies:
@@ -55,4 +55,4 @@ linux64-android-gradle-dependencies:
         env:
             # TODO do no hardcode
             ANDROID_SDK_ROOT: /builds/worker/fetches/android-sdk-linux
-        max-run-time: 14400
+        max-run-time: 9600


### PR DESCRIPTION
Last month we had a problem with some workers that caused a large number of jobs to hang. Because of the long max run time of some of the android components tasks, this meant they were running for much, much, much longer than they usually would. The new max runtimes included in this patch are based on looking at the 99th percentile runtime for successful tasks since April, and adding some leeway. Data is included below.

Notably, there's a huge disparity between the 99th percentile and the max for some tests. I haven't dug into it, but I suspect we occasionly end up in a situation where the worker is weirdly slow. If that's the case, timing out sooner and rerunning on a new worker is likely to be faster than letting the task take 2-3x as long as the 99th percentile.

On the other hand, I didn't get as aggressive with the `gradle-dependencies` toolchain job because the distribution of its runtimes is much wider, and a rerun is more mostly in terms of dollars and time other jobs spend waiting for it to complete.

```
+-----------------------+-------------------------+---------------------+------+------+------+------+
|         kind          |         symbol          |       average       | min  | max  | p50  | p99  |
+-----------------------+-------------------------+---------------------+------+------+------+------+
| build                 | B                       |  246.30458953885199 |   78 | 1812 |  238 |  490 |
| build                 | BN                      |  208.35178702623276 |   83 |  818 |  198 |  349 |
| build                 | BR                      |   221.7616940581542 |   82 |  640 |  200 |  581 |
| build                 | BSnap                   |   292.0241545893719 |  185 |  508 |  289 |  417 |
| build-samples-browser | B                       |   312.9228859705317 |  165 | 1293 |  305 |  490 |
| lint                  | compare-locale          |   36.67712177121771 |    7 |  518 |   35 |   74 |
| lint                  | detekt                  |  189.94123091161498 |   90 |  426 |  206 |  348 |
| lint                  | detektKtlint            |  111.40434332988625 |   95 |  707 |  108 |  158 |
| lint                  | ktlint                  |  183.80857009781099 |   81 |  489 |  200 |  349 |
| test                  | ui                      |  1008.3333333333333 |  889 | 1386 |  974 | 1386 |
| test                  | ui-components           |  1116.4599277978339 |  580 | 6819 |  955 | 1852 |
| test                  | ui-samples-browser      |  1013.7685525349013 |  622 | 6338 |  859 | 1523 |
| test                  | ui-samples-glean        |   914.4345509893453 |  579 | 6516 |  768 | 1423 |
| test                  | unit-feature-containers |   1309.921722113503 | 1182 | 2232 | 1279 | 1845 |
| test                  | unit-feature-prompts    |  1315.7419354838707 | 1228 | 1617 | 1308 | 1617 |
| test                  | unit-feature-pwa        |  1275.6638513513515 |  583 | 1953 | 1268 | 1839 |
| test                  | unit-feature-top-sites  |  1286.3042735042739 |  560 | 2535 | 1275 | 1821 |
| test                  | unit-logins             |    1327.36815920398 | 1197 | 2866 | 1309 | 1657 |
| test                  | unit-share              |  1316.7494199535963 | 1175 | 2089 | 1285 | 1849 |
| test                  | unit-sitepermissions    |  1284.2823129251701 |  596 | 2398 | 1277 | 1754 |
| test                  | unit-support-ktx        |   1324.904761904762 | 1234 | 1675 | 1308 | 1675 |
| toolchain             | android-sdk-linux       |    85.8679706601467 |   57 |  746 |   84 |  132 |
| toolchain             | gradle-dependencies     |  1658.2742857142855 |  477 | 7325 | 1350 | 7234 |
+-----------------------+-------------------------+---------------------+------+------+------+------+
```