### PR TITLE
Remove deprecated android gradle flag

### DIFF
--- a/components/service/glean/gradle.properties
+++ b/components/service/glean/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/components/support/locale/gradle.properties
+++ b/components/support/locale/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,6 @@ libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableUnitTestBinaryResources=true
 
 android.forceJacocoOutOfProcess=true
 

--- a/samples/firefox-accounts/gradle.properties
+++ b/samples/firefox-accounts/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/samples/sync-logins/gradle.properties
+++ b/samples/sync-logins/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false

--- a/samples/sync/gradle.properties
+++ b/samples/sync/gradle.properties
@@ -1,2 +1,0 @@
-# TODO remove
-android.enableUnitTestBinaryResources=false


### PR DESCRIPTION
This was likely added for Roboletric, [but isn't needed since Android Studio 3.3](http://robolectric.org/migrating/). It's blocking migration to AGP 4