### PR TITLE
For #7836: Refine add-ons badge design

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
@@ -54,7 +54,7 @@ class WebExtensionBrowserMenuItem(
         }
         badgeView.setBadgeText(action.badgeText)
         action.badgeTextColor?.let { badgeView.setTextColor(it) }
-        action.badgeBackgroundColor?.let { badgeView.setBackgroundColor(it) }
+        action.badgeBackgroundColor?.let { badgeView.background?.setTint(it) }
 
         MainScope().launch {
             loadIcon(view.context, imageView.measuredHeight)?.let {

--- a/components/browser/menu/src/main/res/drawable/rounded_corner.xml
+++ b/components/browser/menu/src/main/res/drawable/rounded_corner.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="4dp" />
+</shape>

--- a/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -2,7 +2,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -44,9 +43,13 @@
         android:id="@+id/badge_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minWidth="22dp"
+        android:gravity="center"
+        android:textStyle="bold"
+        android:textColor="@color/photonWhite"
+        android:background="@drawable/rounded_corner"
         android:visibility="invisible"
         android:padding="3dp"
         android:textSize="12sp"
         tools:text="18" />
-
 </LinearLayout>

--- a/components/browser/menu/src/main/res/values/dimens.xml
+++ b/components/browser/menu/src/main/res/values/dimens.xml
@@ -40,7 +40,7 @@
 
     <!--WebExtensionBrowserMenuItem -->
     <dimen name="mozac_browser_menu_item_web_extension_icon_width">24dp</dimen>
-    <dimen name="mozac_browser_menu_item_web_extension_icon_height">27dp</dimen>
+    <dimen name="mozac_browser_menu_item_web_extension_icon_height">24dp</dimen>
     <!--WebExtensionBrowserMenuItem -->
 
     <!--BrowserMenuImageText-->

--- a/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.menu.item
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
@@ -21,7 +22,6 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -94,10 +94,12 @@ class WebExtensionBrowserMenuItemTest {
         val icon: Bitmap = mock()
         val imageView: ImageView = mock()
         val badgeView: TextView = mock()
+        val background: Drawable = mock()
         val labelView: TextView = mock()
         val container = View(testContext)
         val view: View = mock()
 
+        whenever(badgeView.background).thenReturn(background)
         whenever(view.findViewById<ImageView>(R.id.action_image)).thenReturn(imageView)
         whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(badgeView)
         whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
@@ -119,13 +121,13 @@ class WebExtensionBrowserMenuItemTest {
 
         val iconCaptor = argumentCaptor<BitmapDrawable>()
         verify(imageView).setImageDrawable(iconCaptor.capture())
-        Assert.assertEquals(icon, iconCaptor.value.bitmap)
+        assertEquals(icon, iconCaptor.value.bitmap)
 
         verify(imageView).contentDescription = "title"
-        verify(labelView).setText("title")
-        verify(badgeView).setText("badgeText")
+        verify(labelView).text = "title"
+        verify(badgeView).text = "badgeText"
         verify(badgeView).setTextColor(Color.WHITE)
-        verify(badgeView).setBackgroundColor(Color.BLUE)
+        verify(background).setTint(Color.BLUE)
     }
 
     @Test
@@ -263,8 +265,8 @@ class WebExtensionBrowserMenuItemTest {
         item.bind(menu, view)
         testDispatcher.advanceUntilIdle()
 
-        verify(labelView).setText("title")
-        verify(badgeView).setText("badgeText")
+        verify(labelView).text = "title"
+        verify(badgeView).text = "badgeText"
 
         val browserActionOverride = Action(
                 title = "override",
@@ -278,8 +280,8 @@ class WebExtensionBrowserMenuItemTest {
         item.action = browserActionOverride
         item.invalidate(view)
 
-        verify(labelView).setText("override")
-        verify(badgeView).setText("overrideBadge")
+        verify(labelView).text = "override"
+        verify(badgeView).text = "overrideBadge"
         verify(labelView).invalidate()
         verify(badgeView).invalidate()
     }


### PR DESCRIPTION
cc @brampitoyo

https://github.com/mozilla-mobile/fenix/issues/12845#issuecomment-663272360

Colors are coming from extensions. They need to set more stylish colors.

<img src="https://user-images.githubusercontent.com/17825767/88461470-61e02e00-ceac-11ea-99a4-822e3bc05d8f.png" width="200"><img src="https://user-images.githubusercontent.com/17825767/88461472-63115b00-ceac-11ea-968e-3cee2eea8d7f.png" width="200"><img src="https://user-images.githubusercontent.com/17825767/88461474-63115b00-ceac-11ea-90a8-ba043509c1e6.png" width="200">
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
