### PR TITLE
Add compat method for Vibrator

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/os/Vibrator.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/os/Vibrator.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.os
+
+import android.Manifest.permission.VIBRATE
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import android.os.VibrationEffect
+import android.os.VibrationEffect.DEFAULT_AMPLITUDE
+import android.os.Vibrator
+import androidx.annotation.RequiresPermission
+
+/**
+ * Vibrate constantly for the specified period of time.
+ *
+ * @param milliseconds The number of milliseconds to vibrate.
+ */
+@RequiresPermission(VIBRATE)
+fun Vibrator.vibrateOneShot(milliseconds: Long) {
+    if (SDK_INT >= Build.VERSION_CODES.O) {
+        vibrate(VibrationEffect.createOneShot(milliseconds, DEFAULT_AMPLITUDE))
+    } else {
+        @Suppress("Deprecation")
+        vibrate(milliseconds)
+    }
+}

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/os/VibratorTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/os/VibratorTest.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.os
+
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.VibrationEffect.DEFAULT_AMPLITUDE
+import android.os.Vibrator
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+class VibratorTest {
+
+    private lateinit var vibrator: Vibrator
+
+    @Before
+    fun setup() {
+        vibrator = mock()
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.O])
+    @Test
+    fun `vibrateOneShot uses VibrationEffect on new APIs`() {
+        vibrator.vibrateOneShot(50L)
+
+        verify(vibrator).vibrate(VibrationEffect.createOneShot(50L, DEFAULT_AMPLITUDE))
+    }
+
+    @Suppress("Deprecation")
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `vibrateOneShot uses vibrate on new APIs`() {
+        vibrator.vibrateOneShot(100L)
+
+        verify(vibrator).vibrate(100L)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ permalink: /changelog/
 
 * **support-images**
   * ⚠️ **This is a breaking change**: Removed `ImageLoader.loadIntoView(view: ImageView, id: String)` extension function.
+
 * **service-glean**
   * Glean was updated to v31.5.0
     * Implement ping tagging (i.e. the `X-Source-Tags` header) ([#1074](https://github.com/mozilla/glean/pull/1074)). Note that this is not yet implemented for iOS.
@@ -39,6 +40,9 @@ permalink: /changelog/
   * Added support for the new `MenuController` interface for menu2.
     When a menu controller is added to a toolbar, it will be used in place of the `BrowserMenuBuilder`.
     The builder will supply items to the `MenuController` in `invalidateMenu` if it is kept.
+
+* **support-ktx**
+  * Added `Vibrator.vibrateOneShot` compat method.
 
 # 51.0.0
 


### PR DESCRIPTION
This logic is currently used in Fenix's `PairFragment`. The compat method delegates to a different function depending on API level.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
