### PR TITLE
Closes #7869: Load a non-mobile url when desktop mode is toggled on

### DIFF
--- a/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-beta/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Build
 import android.view.WindowManager
 import androidx.annotation.VisibleForTesting
@@ -47,6 +48,7 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate
 import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.WebRequestError
+import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -262,6 +264,7 @@ class GeckoEngineSession(
     override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         val currentMode = geckoSession.settings.userAgentMode
         val currentViewPortMode = geckoSession.settings.viewportMode
+        var overrideUrl: String? = null
 
         val newMode = if (enable) {
             GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
@@ -270,6 +273,7 @@ class GeckoEngineSession(
         }
 
         val newViewportMode = if (enable) {
+            overrideUrl = currentUrl?.let { checkForMobileSite(it) }
             GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
         } else {
             GeckoSessionSettings.VIEWPORT_MODE_MOBILE
@@ -282,8 +286,38 @@ class GeckoEngineSession(
         }
 
         if (reload) {
-            this.reload()
+            if (overrideUrl == null) {
+                this.reload()
+            } else {
+                loadUrl(overrideUrl, flags = LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY))
+            }
         }
+    }
+
+    /**
+     * Checks and returns a non-mobile version of the url.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun checkForMobileSite(url: String): String? {
+        var overrideUrl: String? = null
+        val mPrefix = "m."
+        val mobilePrefix = "mobile."
+
+        val uri = Uri.parse(url)
+        val authority = uri.authority?.toLowerCase(Locale.ROOT) ?: return null
+
+        val foundPrefix = when {
+            authority.startsWith(mPrefix) -> mPrefix
+            authority.startsWith(mobilePrefix) -> mobilePrefix
+            else -> null
+        }
+
+        foundPrefix?.let {
+            val mobileUri = Uri.parse(url).buildUpon().authority(authority.substring(it.length))
+            overrideUrl = mobileUri.toString()
+        }
+
+        return overrideUrl
     }
 
     /**

--- a/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-beta/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -53,6 +53,7 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
@@ -1755,6 +1756,36 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `toggleDesktopMode should reload a non-mobile url when set to desktop mode`() {
+        val mobileUrl = "https://m.example.com"
+        val nonMobileUrl = "https://example.com"
+        val engineSession = Mockito.spy(GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider))
+        engineSession.currentUrl = mobileUrl
+
+        engineSession.toggleDesktopMode(true, reload = true)
+        verify(engineSession, Mockito.atLeastOnce()).loadUrl(nonMobileUrl, null, LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY), null)
+
+        engineSession.toggleDesktopMode(false, reload = true)
+        verify(engineSession, Mockito.atLeastOnce()).reload()
+    }
+
+    @Test
+    fun checkForMobileSite() {
+        val mUrl = "https://m.example.com"
+        val mobileUrl = "https://mobile.example.com"
+        val nonAuthorityUrl = "mobile.example.com"
+        val unrecognizedMobilePrefixUrl = "https://phone.example.com"
+        val nonMobileUrl = "https://example.com"
+
+        val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
+
+        assertNull(engineSession.checkForMobileSite(nonAuthorityUrl))
+        assertNull(engineSession.checkForMobileSite(unrecognizedMobilePrefixUrl))
+        assertEquals(nonMobileUrl, engineSession.checkForMobileSite(mUrl))
+        assertEquals(nonMobileUrl, engineSession.checkForMobileSite(mobileUrl))
+    }
+
+    @Test
     fun findAll() {
         val finderResult = mock<GeckoSession.FinderResult>()
         val sessionFinder = mock<SessionFinder>()
@@ -2632,6 +2663,8 @@ class GeckoEngineSessionTest {
         assertEquals(LoadUrlFlags.EXTERNAL, GeckoSession.LOAD_FLAGS_EXTERNAL)
         assertEquals(LoadUrlFlags.ALLOW_POPUPS, GeckoSession.LOAD_FLAGS_ALLOW_POPUPS)
         assertEquals(LoadUrlFlags.BYPASS_CLASSIFIER, GeckoSession.LOAD_FLAGS_BYPASS_CLASSIFIER)
+        assertEquals(LoadUrlFlags.LOAD_FLAGS_FORCE_ALLOW_DATA_URI, GeckoSession.LOAD_FLAGS_FORCE_ALLOW_DATA_URI)
+        assertEquals(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY, GeckoSession.LOAD_FLAGS_REPLACE_HISTORY)
     }
 
     @Test

--- a/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/components/browser/engine-gecko-nightly/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.engine.gecko
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Build
 import android.view.WindowManager
 import androidx.annotation.VisibleForTesting
@@ -47,6 +48,7 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSession.NavigationDelegate
 import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.WebRequestError
+import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -262,6 +264,7 @@ class GeckoEngineSession(
     override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
         val currentMode = geckoSession.settings.userAgentMode
         val currentViewPortMode = geckoSession.settings.viewportMode
+        var overrideUrl: String? = null
 
         val newMode = if (enable) {
             GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
@@ -270,6 +273,7 @@ class GeckoEngineSession(
         }
 
         val newViewportMode = if (enable) {
+            overrideUrl = currentUrl?.let { checkForMobileSite(it) }
             GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
         } else {
             GeckoSessionSettings.VIEWPORT_MODE_MOBILE
@@ -282,8 +286,38 @@ class GeckoEngineSession(
         }
 
         if (reload) {
-            this.reload()
+            if (overrideUrl == null) {
+                this.reload()
+            } else {
+                loadUrl(overrideUrl, flags = LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY))
+            }
         }
+    }
+
+    /**
+     * Checks and returns a non-mobile version of the url.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun checkForMobileSite(url: String): String? {
+        var overrideUrl: String? = null
+        val mPrefix = "m."
+        val mobilePrefix = "mobile."
+
+        val uri = Uri.parse(url)
+        val authority = uri.authority?.toLowerCase(Locale.ROOT) ?: return null
+
+        val foundPrefix = when {
+            authority.startsWith(mPrefix) -> mPrefix
+            authority.startsWith(mobilePrefix) -> mobilePrefix
+            else -> null
+        }
+
+        foundPrefix?.let {
+            val mobileUri = Uri.parse(url).buildUpon().authority(authority.substring(it.length))
+            overrideUrl = mobileUri.toString()
+        }
+
+        return overrideUrl
     }
 
     /**

--- a/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko-nightly/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -53,8 +53,10 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyZeroInteractions
@@ -1755,6 +1757,36 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `toggleDesktopMode should reload a non-mobile url when set to desktop mode`() {
+        val mobileUrl = "https://m.example.com"
+        val nonMobileUrl = "https://example.com"
+        val engineSession = spy(GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider))
+        engineSession.currentUrl = mobileUrl
+
+        engineSession.toggleDesktopMode(true, reload = true)
+        verify(engineSession, atLeastOnce()).loadUrl(nonMobileUrl, null, LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY), null)
+
+        engineSession.toggleDesktopMode(false, reload = true)
+        verify(engineSession, atLeastOnce()).reload()
+    }
+
+    @Test
+    fun checkForMobileSite() {
+        val mUrl = "https://m.example.com"
+        val mobileUrl = "https://mobile.example.com"
+        val nonAuthorityUrl = "mobile.example.com"
+        val unrecognizedMobilePrefixUrl = "https://phone.example.com"
+        val nonMobileUrl = "https://example.com"
+
+        val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
+
+        assertNull(engineSession.checkForMobileSite(nonAuthorityUrl))
+        assertNull(engineSession.checkForMobileSite(unrecognizedMobilePrefixUrl))
+        assertEquals(nonMobileUrl, engineSession.checkForMobileSite(mUrl))
+        assertEquals(nonMobileUrl, engineSession.checkForMobileSite(mobileUrl))
+    }
+
+    @Test
     fun findAll() {
         val finderResult = mock<GeckoSession.FinderResult>()
         val sessionFinder = mock<SessionFinder>()
@@ -2632,6 +2664,8 @@ class GeckoEngineSessionTest {
         assertEquals(LoadUrlFlags.EXTERNAL, GeckoSession.LOAD_FLAGS_EXTERNAL)
         assertEquals(LoadUrlFlags.ALLOW_POPUPS, GeckoSession.LOAD_FLAGS_ALLOW_POPUPS)
         assertEquals(LoadUrlFlags.BYPASS_CLASSIFIER, GeckoSession.LOAD_FLAGS_BYPASS_CLASSIFIER)
+        assertEquals(LoadUrlFlags.LOAD_FLAGS_FORCE_ALLOW_DATA_URI, GeckoSession.LOAD_FLAGS_FORCE_ALLOW_DATA_URI)
+        assertEquals(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY, GeckoSession.LOAD_FLAGS_REPLACE_HISTORY)
     }
 
     @Test

--- a/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -53,6 +53,7 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
@@ -1751,6 +1752,36 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `toggleDesktopMode should reload a non-mobile url when set to desktop mode`() {
+        val mobileUrl = "https://m.example.com"
+        val nonMobileUrl = "https://example.com"
+        val engineSession = Mockito.spy(GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider))
+        engineSession.currentUrl = mobileUrl
+
+        engineSession.toggleDesktopMode(true, reload = true)
+        verify(engineSession, Mockito.atLeastOnce()).loadUrl(nonMobileUrl, null, LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY), null)
+
+        engineSession.toggleDesktopMode(false, reload = true)
+        verify(engineSession, Mockito.atLeastOnce()).reload()
+    }
+
+    @Test
+    fun checkForMobileSite() {
+        val mUrl = "https://m.example.com"
+        val mobileUrl = "https://mobile.example.com"
+        val nonAuthorityUrl = "mobile.example.com"
+        val unrecognizedMobilePrefixUrl = "https://phone.example.com"
+        val nonMobileUrl = "https://example.com"
+
+        val engineSession = GeckoEngineSession(runtime, geckoSessionProvider = geckoSessionProvider)
+
+        assertNull(engineSession.checkForMobileSite(nonAuthorityUrl))
+        assertNull(engineSession.checkForMobileSite(unrecognizedMobilePrefixUrl))
+        assertEquals(nonMobileUrl, engineSession.checkForMobileSite(mUrl))
+        assertEquals(nonMobileUrl, engineSession.checkForMobileSite(mobileUrl))
+    }
+
+    @Test
     fun findAll() {
         val finderResult = mock<GeckoSession.FinderResult>()
         val sessionFinder = mock<SessionFinder>()
@@ -2440,6 +2471,8 @@ class GeckoEngineSessionTest {
         assertEquals(LoadUrlFlags.EXTERNAL, GeckoSession.LOAD_FLAGS_EXTERNAL)
         assertEquals(LoadUrlFlags.ALLOW_POPUPS, GeckoSession.LOAD_FLAGS_ALLOW_POPUPS)
         assertEquals(LoadUrlFlags.BYPASS_CLASSIFIER, GeckoSession.LOAD_FLAGS_BYPASS_CLASSIFIER)
+        assertEquals(LoadUrlFlags.LOAD_FLAGS_FORCE_ALLOW_DATA_URI, GeckoSession.LOAD_FLAGS_FORCE_ALLOW_DATA_URI)
+        assertEquals(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY, GeckoSession.LOAD_FLAGS_REPLACE_HISTORY)
     }
 
     @Test

--- a/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -390,7 +390,10 @@ abstract class EngineSession(
             const val EXTERNAL: Int = 1 shl 2
             const val ALLOW_POPUPS: Int = 1 shl 3
             const val BYPASS_CLASSIFIER: Int = 1 shl 4
-            internal const val ALL = BYPASS_CACHE + BYPASS_PROXY + EXTERNAL + ALLOW_POPUPS + BYPASS_CLASSIFIER
+            const val LOAD_FLAGS_FORCE_ALLOW_DATA_URI: Int = 1 shl 5
+            const val LOAD_FLAGS_REPLACE_HISTORY: Int = 1 shl 6
+            internal const val ALL = BYPASS_CACHE + BYPASS_PROXY + EXTERNAL + ALLOW_POPUPS +
+                BYPASS_CLASSIFIER + LOAD_FLAGS_FORCE_ALLOW_DATA_URI + LOAD_FLAGS_REPLACE_HISTORY
 
             fun all() = LoadUrlFlags(ALL)
             fun none() = LoadUrlFlags(NONE)

--- a/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -660,6 +660,8 @@ class EngineSessionTest {
         assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.EXTERNAL).value))
         assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.ALLOW_POPUPS).value))
         assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.BYPASS_CLASSIFIER).value))
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_FORCE_ALLOW_DATA_URI).value))
+        assertTrue(LoadUrlFlags.all().contains(LoadUrlFlags.select(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY).value))
 
         val flags = LoadUrlFlags.select(LoadUrlFlags.EXTERNAL)
         assertTrue(flags.contains(LoadUrlFlags.EXTERNAL))
@@ -667,6 +669,8 @@ class EngineSessionTest {
         assertFalse(flags.contains(LoadUrlFlags.BYPASS_CACHE))
         assertFalse(flags.contains(LoadUrlFlags.BYPASS_CLASSIFIER))
         assertFalse(flags.contains(LoadUrlFlags.BYPASS_PROXY))
+        assertFalse(flags.contains(LoadUrlFlags.LOAD_FLAGS_FORCE_ALLOW_DATA_URI))
+        assertFalse(flags.contains(LoadUrlFlags.LOAD_FLAGS_REPLACE_HISTORY))
     }
 
     @Test


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
