### PR TITLE
Closes #7896: Change failure messages to not rely on Kotlin reflection

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/AddonMigration.kt
@@ -72,7 +72,7 @@ sealed class AddonMigrationResult {
          */
         internal data class FailedToQueryInstalledAddons(val throwable: Throwable) : Failure() {
             override fun toString(): String {
-                return "Failed to query installed add-ons: ${throwable::class}"
+                return "Failed to query installed add-ons: $throwable"
             }
         }
 

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecFxaMigration.kt
@@ -95,7 +95,7 @@ sealed class FxaMigrationResult {
          */
         data class CorruptAccountState(val e: JSONException) : Failure() {
             override fun toString(): String {
-                return "Corrupt account state, exception type: ${e::class}"
+                return "Corrupt account state, exception: $e"
             }
         }
 

--- a/components/support/migration/src/main/java/mozilla/components/support/migration/GeckoMigration.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/GeckoMigration.kt
@@ -62,7 +62,7 @@ sealed class GeckoMigrationResult {
          */
         internal data class FailedToWriteBackup(val throwable: Throwable) : Failure() {
             override fun toString(): String {
-                return "Failed to write backup of prefs.js file: ${throwable::class}"
+                return "Failed to write backup of prefs.js file: $throwable"
             }
         }
 
@@ -71,7 +71,7 @@ sealed class GeckoMigrationResult {
          */
         internal data class FailedToWritePrefs(val throwable: Throwable) : Failure() {
             override fun toString(): String {
-                return "Failed to write transformed prefs.js file: ${throwable::class}"
+                return "Failed to write transformed prefs.js file: $throwable"
             }
         }
 
@@ -80,7 +80,7 @@ sealed class GeckoMigrationResult {
          */
         internal data class FailedToDeleteFile(val throwable: Throwable? = null) : Failure() {
             override fun toString(): String {
-                return "Failed to delete prefs.js file: ${throwable?.let { it::class }}"
+                return "Failed to delete prefs.js file: ${throwable ?: ""}"
             }
         }
     }

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecFxaMigrationTest.kt
@@ -259,7 +259,7 @@ class FennecFxaMigrationTest {
             val corruptAccountResult = fxaMigrationException.failure as FxaMigrationResult.Failure.CorruptAccountState
             assertEquals(JSONException::class, corruptAccountResult.e::class)
 
-            assertEquals("Corrupt account state, exception type: class org.json.JSONException", corruptAccountResult.toString())
+            assertTrue(corruptAccountResult.toString().startsWith("Corrupt account state, exception: org.json.JSONException"))
         }
 
         verifyZeroInteractions(accountManager)
@@ -281,7 +281,7 @@ class FennecFxaMigrationTest {
             val corruptAccountResult = fxaMigrationException.failure as FxaMigrationResult.Failure.CorruptAccountState
             assertEquals(JSONException::class, corruptAccountResult.e::class)
 
-            assertEquals("Corrupt account state, exception type: class org.json.JSONException", corruptAccountResult.toString())
+            assertEquals("Corrupt account state, exception: org.json.JSONException: No value for pickle_version", corruptAccountResult.toString())
         }
 
         verifyZeroInteractions(accountManager)
@@ -303,7 +303,7 @@ class FennecFxaMigrationTest {
             val corruptAccountResult = fxaMigrationException.failure as FxaMigrationResult.Failure.CorruptAccountState
             assertEquals(JSONException::class, corruptAccountResult.e::class)
 
-            assertEquals("Corrupt account state, exception type: class org.json.JSONException", corruptAccountResult.toString())
+            assertEquals("Corrupt account state, exception: org.json.JSONException: No value for version", corruptAccountResult.toString())
         }
 
         verifyZeroInteractions(accountManager)

--- a/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
+++ b/components/support/migration/src/test/java/mozilla/components/support/migration/FennecMigratorTest.kt
@@ -1011,7 +1011,7 @@ class FennecMigratorTest {
         verify(crashReporter).submitCaughtException(captor.capture())
 
         assertEquals(AddonMigrationException::class, captor.value::class)
-        assertEquals("Failed to query installed add-ons: ${IllegalArgumentException::class}", captor.value.message)
+        assertEquals("Failed to query installed add-ons: ${IllegalArgumentException::class.java.name}", captor.value.message)
     }
 
     @Test


### PR DESCRIPTION
Another option would be to use the entire `toString` of the exception, instead of just the class name, but sticking to what we had so we don't expose anything by mistake.

The `Exception.uniqueId` extension function should also be affected by this so changed it here as well.

@grigoryk @pocmo Relatively minor, but maybe we want land this / fix it and cherry-pick on the branch for next round?