### PR TITLE
Issue #7876: Remove info logging for SearchEngineMigrationResult.

### DIFF
--- a/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
+++ b/components/support/migration/src/main/java/mozilla/components/support/migration/FennecMigrator.kt
@@ -1085,14 +1085,12 @@ class FennecMigrator private constructor(
                 return when (val failure = migrationFailureWrapper.failure) {
                     is SearchEngineMigrationResult.Failure.NoDefault -> {
                         logger.error("Missing search engine default: $failure")
-                        crashReporter.submitCaughtException(migrationFailureWrapper)
                         MigrationSearch.failureReason.add(FailureReasonTelemetryCodes.SEARCH_NO_DEFAULT.code)
                         result
                     }
 
                     is SearchEngineMigrationResult.Failure.NoMatch -> {
                         logger.error("Could not find matching search engine: $failure")
-                        crashReporter.submitCaughtException(migrationFailureWrapper)
                         MigrationSearch.failureReason.add(FailureReasonTelemetryCodes.SEARCH_NO_MATCH.code)
                         result
                     }


### PR DESCRIPTION
The log messages themselves are not actionable and just add nosie to Sentry. We collect the same
information via telemetry and that gives us a much better view of the success/failure distribution.