### PR TITLE
Closes #7893: Prevent crash in QrFragment on devices without camera

### DIFF
--- a/components/feature/qr/src/main/res/layout/fragment_layout.xml
+++ b/components/feature/qr/src/main/res/layout/fragment_layout.xml
@@ -11,6 +11,15 @@
     android:focusable="true"
     tools:ignore="Overdraw">
 
+    <TextView
+        android:id="@+id/camera_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/mozac_feature_qr_scanner_no_camera"
+        android:textColor="@android:color/white"
+        android:visibility="gone" />
+
     <mozilla.components.feature.qr.views.AutoFitTextureView
         android:id="@+id/texture"
         android:layout_width="match_parent"
@@ -22,4 +31,5 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_centerInParent="true" />
+
 </RelativeLayout>

--- a/components/feature/qr/src/main/res/values/strings.xml
+++ b/components/feature/qr/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
     <!-- Content description (not visible, for screen readers etc.): Description of an image view. -->
     <string name="mozac_feature_qr_scanner">QR scanner</string>
 
+    <!-- Text shown if no camera is available on the device and the QR scanner cannot be displayed. -->
+    <string name="mozac_feature_qr_scanner_no_camera">No camera available on device</string>
+
 </resources>


### PR DESCRIPTION
Let's add this as a fallback in case applications forget to check if the device has a camera e.g. https://github.com/mozilla-mobile/fenix/issues/13037

We really shouldn't be crashing in this case. So, this just displays an error message instead, screenshot below. Working on a unit test too :).

![Screenshot_20200729-132835](https://user-images.githubusercontent.com/472523/88832982-a0713380-d19f-11ea-832a-abd51d3b5d7c.png) ![Screenshot_20200729-131514](https://user-images.githubusercontent.com/472523/88833047-b0891300-d19f-11ea-84b2-21da82f48c72.png)


