### PR TITLE
Make sure device finalization succeeds before proceeding to postAuth

### DIFF
--- a/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -151,6 +151,7 @@ internal object FxaStateMatrix {
                 Event.FetchProfile -> AccountState.AuthenticatedNoProfile
                 Event.FetchedProfile -> AccountState.AuthenticatedWithProfile
                 Event.FailedToFetchProfile -> AccountState.AuthenticatedNoProfile
+                Event.FailedToAuthenticate -> AccountState.NotAuthenticated
                 Event.Logout -> AccountState.NotAuthenticated
                 else -> null
             }

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -1304,11 +1304,12 @@ class FxaAccountManagerTest {
 
         assertNull(manager.authenticatedAccount())
         assertNull(manager.accountProfile())
+        verify(accountStorage, times(1)).clear()
 
         assertTrue(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signin, "dummyCode", EXPECTED_AUTH_STATE)).await())
 
         verify(accountStorage, times(1)).read()
-        verify(accountStorage, never()).clear()
+        verify(accountStorage, times(1)).clear()
 
         verify(accountObserver, times(1)).onAuthenticated(mockAccount, AuthType.Signin)
         verify(accountObserver, times(1)).onProfileUpdated(profile)
@@ -1350,11 +1351,12 @@ class FxaAccountManagerTest {
 
         assertNull(manager.authenticatedAccount())
         assertNull(manager.accountProfile())
+        verify(accountStorage, times(1)).clear()
 
         assertTrue(manager.finishAuthenticationAsync(FxaAuthData(AuthType.Signin, "dummyCode", EXPECTED_AUTH_STATE)).await())
 
         verify(accountStorage, times(1)).read()
-        verify(accountStorage, never()).clear()
+        verify(accountStorage, times(1)).clear()
 
         verify(accountObserver, times(1)).onAuthenticated(mockAccount, AuthType.Signin)
         verify(accountObserver, times(1)).onProfileUpdated(profile)
@@ -1930,6 +1932,7 @@ class FxaAccountManagerTest {
     ): FxaAccountManager {
         `when`(mockAccount.getProfileAsync(ignoreCache = false)).thenReturn(CompletableDeferred(profile))
 
+        `when`(mockAccount.disconnectAsync()).thenReturn(CompletableDeferred(true))
         `when`(mockAccount.beginOAuthFlowAsync(any())).thenReturn(CompletableDeferred(value = null))
         `when`(mockAccount.beginPairingFlowAsync(anyString(), any())).thenReturn(CompletableDeferred(value = null))
         `when`(mockAccount.completeOAuthFlowAsync(anyString(), anyString())).thenReturn(CompletableDeferred(true))

--- a/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/FxaStateMatrixTest.kt
+++ b/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/FxaStateMatrixTest.kt
@@ -68,7 +68,7 @@ class FxaStateMatrixTest {
         assertEquals(AccountState.AuthenticatedNoProfile, FxaStateMatrix.nextState(state, Event.FetchProfile))
         assertEquals(AccountState.AuthenticatedWithProfile, FxaStateMatrix.nextState(state, Event.FetchedProfile))
         assertEquals(AccountState.AuthenticatedNoProfile, FxaStateMatrix.nextState(state, Event.FailedToFetchProfile))
-        assertNull(FxaStateMatrix.nextState(state, Event.FailedToAuthenticate))
+        assertEquals(AccountState.NotAuthenticated, FxaStateMatrix.nextState(state, Event.FailedToAuthenticate))
         assertEquals(AccountState.NotAuthenticated, FxaStateMatrix.nextState(state, Event.Logout))
         assertEquals(AccountState.AuthenticationProblem, FxaStateMatrix.nextState(state, Event.AuthenticationError("test")))
         assertNull(FxaStateMatrix.nextState(state, Event.SignInShareableAccount(mock(), false)))


### PR DESCRIPTION
Closes #7536 

Proper fix is coming in https://github.com/mozilla-mobile/android-components/pull/7856, but this gets the crashes to go away.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
