### PR TITLE
No issue: Remove snapshot appending to version in glean plugin

### DIFF
--- a/components/tooling/glean-gradle-plugin/build.gradle
+++ b/components/tooling/glean-gradle-plugin/build.gradle
@@ -41,7 +41,7 @@ publishing {
                 groupId = config.componentsGroupId
                 artifactId = archivesBaseName
                 description = project.ext.description
-                version = config.componentsVersion + (project.hasProperty('snapshot') ? '-SNAPSHOT' : (project.hasProperty('local') ? '-local' + getLocalPublicationTimestamp() : ''))
+                version = config.componentsVersion + (project.hasProperty('local') ? '-local' + getLocalPublicationTimestamp() : '')
 
                 licenses {
                     license {


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Some small cleanup from when we removed snapshot builds that had a minor conflict with local publishing.
