### PR TITLE
Fix broken decision task on PRs: treerherder name too long

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -124,7 +124,7 @@ def loader(kind, path, config, params, loaded_tasks):
     }
     # Filter away overridden jobs that we wouldn't build anyways to avoid ending up with
     # partial job entries.
-    overridden_jobs = {k: v for k, v in config.pop('overriden-jobs', {}).items() if affected_components is ALL_COMPONENTS or k in affected_components}
+    overridden_jobs = {k: v for k, v in config.pop('overriden-jobs', {}).items() if affected_components is ALL_COMPONENTS or k in jobs.keys()}
     jobs = merge(jobs, overridden_jobs)
 
     config['jobs'] = jobs


### PR DESCRIPTION
Follows #7907 up. Fixes #7922: https://firefox-ci-tc.services.mozilla.com/tasks/ZdIHy3lPSgeLzvBUl2K-Fw/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FZdIHy3lPSgeLzvBUl2K-Fw%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L2991

r? @mozbhearsum @pocmo 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
