### PR TITLE
Closes #7840: Menu is only long clickable if listener is set

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbar.kt
@@ -54,10 +54,11 @@ class BrowserMenuItemToolbar(
                 menu.dismiss()
             }
             button.setOnLongClickListener {
-                item.longClickListener()
+                item.longClickListener?.invoke()
                 menu.dismiss()
                 true
             }
+            button.isLongClickable = item.longClickListener != null
 
             layout.addView(button, LinearLayout.LayoutParams(0, MATCH_PARENT, 1f))
         }
@@ -91,7 +92,7 @@ class BrowserMenuItemToolbar(
         val contentDescription: String,
         @ColorRes val iconTintColorResource: Int = NO_ID,
         val isEnabled: () -> Boolean = { true },
-        val longClickListener: () -> Unit = {},
+        val longClickListener: (() -> Unit)? = null,
         val listener: () -> Unit
     ) {
 
@@ -152,7 +153,7 @@ class BrowserMenuItemToolbar(
         @ColorRes val secondaryImageTintResource: Int = primaryImageTintResource,
         val isInPrimaryState: () -> Boolean = { true },
         val disableInSecondaryState: Boolean = false,
-        longClickListener: () -> Unit = {},
+        longClickListener: (() -> Unit)? = null,
         listener: () -> Unit
     ) : Button(
         primaryImageResource,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,9 +21,12 @@ permalink: /changelog/
 * **feature-downloads**
   * ⚠️ **This is a breaking change**: Removed the following properties from `DownloadJobState` in `AbstractFetchDownloadService` and added to `DownloadState`: `DownloadJobStatus` (now renamed to `DownloadStatus`) and `currentBytesCopied`. These properties can now be read from `DownloadState`.
   * ⚠️ **This is a breaking change**: Removed the enum class `DownloadJobStatus` from `AbstractFetchDownloadService` and moved into `DownloadState`, and removed the `ACTIVE` state while introducing two new states called `INITIATED` and `DOWNLOADING`.
-  * ⚠️ **This is a breaking change**: Renamed the following data classes from `BrowserAction`: `QueuedDownloadAction` to `AddDownloadAction`, `RemoveQueuedDownloadAction` to `RemoveDownloadAction`, `RemoveAllQueuedDownloadsAction` to `RemoveAllDownloadsAction`, and `UpdateQueuedDownloadAction` to `UpdateDownloadAction`. 
+  * ⚠️ **This is a breaking change**: Renamed the following data classes from `BrowserAction`: `QueuedDownloadAction` to `AddDownloadAction`, `RemoveQueuedDownloadAction` to `RemoveDownloadAction`, `RemoveAllQueuedDownloadsAction` to `RemoveAllDownloadsAction`, and `UpdateQueuedDownloadAction` to `UpdateDownloadAction`.
   * ⚠️ **This is a breaking change**: Renamed `queuedDownloads` from `BrowserState` to `downloads` .
   * Removed automatic deletion of `downloads` upon a completed download.
+
+* **browser-menu**
+  * ⚠️ **This is a breaking change**: `BrowserMenuItemToolbar.Button.longClickListener` is now nullable and defaults to null.
 
 # 52.0.0
 
@@ -73,7 +76,7 @@ permalink: /changelog/
   * Added support for the new `MenuController` interface for menu2.
     When a menu controller is added to a toolbar, it will be used in place of the `BrowserMenuBuilder`.
     The builder will supply items to the `MenuController` in `invalidateMenu` if it is kept.
-      
+
 * **feature-containers**
   * Adds a `ContainerMiddleware` that connects container browser actions with the `ContainerStorage`.
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
