### PR TITLE
Closes issue #7939: Prevent SimpleDownloadDialogFragment to be added multiple times

### DIFF
--- a/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -178,7 +178,8 @@ class DownloadsFeature(
         ).show()
     }
 
-    private fun showDialog(tab: SessionState, download: DownloadState) {
+    @VisibleForTesting
+    internal fun showDialog(tab: SessionState, download: DownloadState) {
         dialog.setDownload(download)
 
         dialog.onStartDownload = {
@@ -191,12 +192,15 @@ class DownloadsFeature(
             useCases.consumeDownload.invoke(tab.id, download.id)
         }
 
-        if (!isAlreadyADialogCreated() && fragmentManager != null) {
-            dialog.show(fragmentManager, FRAGMENT_TAG)
+        if (!dialog.isAdded && !isAlreadyADialogCreated() && fragmentManager != null) {
+            // We want to explicitly show the dialog and commit the transaction now
+            // to avoid adding the fragment multiple times.
+            dialog.showNow(fragmentManager, FRAGMENT_TAG)
         }
     }
 
-    private fun isAlreadyADialogCreated(): Boolean {
+    @VisibleForTesting
+    internal fun isAlreadyADialogCreated(): Boolean {
         return findPreviousDialogFragment() != null
     }
 

--- a/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
+++ b/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt
@@ -45,6 +45,7 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.times
 import org.robolectric.shadows.ShadowToast
 
 @RunWith(AndroidJUnit4::class)
@@ -410,6 +411,31 @@ class DownloadsFeatureTest {
         val toast = ShadowToast.getTextOfLatestToast()
         assertNotNull(toast)
         assertTrue(toast.contains("can’t download this file type"))
+    }
+
+    @Test
+    fun `download dialog must be added once`() {
+        val fragmentManager = mockFragmentManager()
+        val dialog = mock<DownloadDialogFragment>()
+        val feature = spy(DownloadsFeature(
+            testContext,
+            store,
+            useCases = mock(),
+            downloadManager = mock(),
+            dialog = dialog,
+            fragmentManager = fragmentManager
+        ))
+
+        feature.showDialog(mock(), mock())
+
+        verify(dialog).showNow(fragmentManager, DownloadDialogFragment.FRAGMENT_TAG)
+
+        doReturn(true).`when`(dialog).isAdded
+        doReturn(true).`when`(feature).isAlreadyADialogCreated()
+
+        feature.showDialog(mock(), mock())
+
+        verify(dialog, times(1)).showNow(fragmentManager, DownloadDialogFragment.FRAGMENT_TAG)
     }
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@ permalink: /changelog/
   * ⚠️ **This is a breaking change**: Renamed the following data classes from `BrowserAction`: `QueuedDownloadAction` to `AddDownloadAction`, `RemoveQueuedDownloadAction` to `RemoveDownloadAction`, `RemoveAllQueuedDownloadsAction` to `RemoveAllDownloadsAction`, and `UpdateQueuedDownloadAction` to `UpdateDownloadAction`.
   * ⚠️ **This is a breaking change**: Renamed `queuedDownloads` from `BrowserState` to `downloads` .
   * Removed automatic deletion of `downloads` upon a completed download.
+  * Fixed [#7939](https://github.com/mozilla-mobile/android-components/issues/7939) prevent `SimpleDownloadDialogFragment` from being added multiple times.
 
 * **browser-menu**
   * ⚠️ **This is a breaking change**: `BrowserMenuItemToolbar.Button.longClickListener` is now nullable and defaults to null.


### PR DESCRIPTION


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
