### PR TITLE
Closes #7961 - Hide keyboard on menu button clicks

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/MenuButton.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/MenuButton.kt
@@ -27,6 +27,7 @@ import mozilla.components.concept.menu.ext.effects
 import mozilla.components.concept.menu.ext.max
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.ktx.android.view.hideKeyboard
 
 /**
  * A `three-dot` button used for expanding menus.
@@ -127,6 +128,8 @@ class MenuButton @JvmOverloads constructor(
      * Shows the menu, or dismisses it if already open.
      */
     override fun onClick(v: View) {
+        this.hideKeyboard()
+
         // If a legacy menu is open, dismiss it.
         if (menu != null) {
             menu?.dismiss()

--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/view/MenuButton2.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/view/MenuButton2.kt
@@ -22,6 +22,7 @@ import mozilla.components.concept.menu.ext.effects
 import mozilla.components.concept.menu.ext.max
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
+import mozilla.components.support.ktx.android.view.hideKeyboard
 
 /**
  * A `three-dot` button used for expanding menus.
@@ -81,6 +82,7 @@ class MenuButton2 @JvmOverloads constructor(
      * Shows the menu.
      */
     override fun onClick(v: View) {
+        this.hideKeyboard()
         val menuController = menuController ?: return
 
         menuController.show(anchor = this)


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

I really tried to add tests for this and couldn't figure out how to do it so if someone has an idea...
I tried using a spy on the button like we do in `FindInPageBarTest` but it kept failing 😭

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
