### PR TITLE
For #7964 - Don't set initial orientation in MediaFullscreenOrientationFeature

### DIFF
--- a/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaFullscreenOrientationFeature.kt
+++ b/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaFullscreenOrientationFeature.kt
@@ -7,10 +7,12 @@ package mozilla.components.feature.media.fullscreen
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
 import mozilla.components.browser.state.state.MediaState.FullscreenOrientation
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.ext.flowScoped
@@ -31,12 +33,17 @@ class MediaFullscreenOrientationFeature(
     override fun start() {
         scope = store.flowScoped { flow ->
             flow.ifChanged { it.media.aggregate.activeFullscreenOrientation }
+                // Ignore setting the orientation contained in the Store when this was initialized.
+                // It could be null for a fresh Store or could contain one from a previous session, already set.
+                // Only act for future changes in media orientation.
+                .drop(1)
                 .collect { onChanged(it.media.aggregate.activeFullscreenOrientation) }
         }
     }
 
     @SuppressLint("SourceLockedOrientationActivity")
-    private fun onChanged(activeFullscreenOrientation: FullscreenOrientation?) {
+    @VisibleForTesting
+    internal fun onChanged(activeFullscreenOrientation: FullscreenOrientation?) {
         when (activeFullscreenOrientation) {
             FullscreenOrientation.LANDSCAPE -> activity.requestedOrientation =
                 ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE


### PR DESCRIPTION
The Store that MediaFullscreenOrientationFeature is initialized with can either
have a null activeFullscreenOrientation if media wasn't playing before or,
because we use a global Store shared by all application's components it could
have an activeFullscreenOrientation already set by another component.

We'll ignore setting the initial orientation (which may be stall) for the new
component using MediaFullscreenOrientationFeature and only act upon subsequent
media orientation changes.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Changelog**: This PR does not need [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md).
- [x] **Accessibility**: The code in this PR follows or does not include any user facing features.

Showing fix on Fenix:
(the portrait/landscape visual artefacts are already happening, probably because of us forcing orientations, not in the scope of this PR)
![FixedMediaFullscreenOrientation](https://user-images.githubusercontent.com/11428869/89310363-424fbf00-d67d-11ea-9c76-8b8836b3c7f0.gif)
[Video](https://drive.google.com/file/d/1r9embT7mZxdcK7ecoagraw--zhYvpqix/view?usp=sharing)

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
