### PR TITLE
Closes #7930: Use fallback url over market intent if user preference is not to launch in external app

### DIFF
--- a/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
+++ b/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
@@ -111,6 +111,12 @@ class AppLinksInterceptor(
         redirect: AppLinkRedirect,
         uri: String
     ): RequestInterceptor.InterceptionResponse? {
+        if (!launchInApp()) {
+            redirect.fallbackUrl?.let {
+                return RequestInterceptor.InterceptionResponse.Url(it)
+            }
+        }
+
         if (!redirect.hasExternalApp()) {
             redirect.marketplaceIntent?.let {
                 return RequestInterceptor.InterceptionResponse.AppIntent(it, uri)
@@ -121,12 +127,6 @@ class AppLinksInterceptor(
             }
 
             return null
-        }
-
-        if (!launchInApp()) {
-            redirect.fallbackUrl?.let {
-                return RequestInterceptor.InterceptionResponse.Url(it)
-            }
         }
 
         redirect.appIntent?.let {

--- a/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
+++ b/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
@@ -322,6 +322,29 @@ class AppLinksInterceptorTest {
     }
 
     @Test
+    fun `not supported schemes request uses fallback URL not market intent if launchInApp is set to false`() {
+        val engineSession: EngineSession = mock()
+        val supportedScheme = "supported"
+        val notSupportedScheme = "not_supported"
+        val blacklistedScheme = "blacklisted"
+        val feature = AppLinksInterceptor(
+            context = mockContext,
+            interceptLinkClicks = true,
+            engineSupportedSchemes = setOf(supportedScheme),
+            alwaysDeniedSchemes = setOf(blacklistedScheme),
+            launchInApp = { false },
+            useCases = mockUseCases
+        )
+
+        val notSupportedUrl = "$notSupportedScheme://example.com"
+        val fallbackUrl = "https://example.com"
+        val notSupportedRedirect = AppLinkRedirect(null, fallbackUrl, Intent.parseUri(marketplaceUrl, 0))
+        whenever(mockGetRedirect.invoke(notSupportedUrl)).thenReturn(notSupportedRedirect)
+        val response = feature.onLoadRequest(engineSession, notSupportedUrl, null, true, false, false, false, false)
+        assert(response is RequestInterceptor.InterceptionResponse.Url)
+    }
+
+    @Test
     fun `intent scheme launch intent if fallback URL is unavailable and launchInApp is set to false`() {
         val engineSession: EngineSession = mock()
         val feature = AppLinksInterceptor(


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
