### PR TITLE
Closes #7180, #7939: Create single download dialog and don't reuse once destroyed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ permalink: /changelog/
     * Limit ping request body size to 1MB. ([#1098](https://github.com/mozilla/glean/pull/1098))
     * BUGFIX: Require activities executed via `GleanDebugView` to be exported.
 
+* **feature-downloads**
+  * ⚠️ **This is a breaking change**: `DownloadsFeature` is no longer accepting a custom download dialog but supporting customizations via the `promptStyling` parameter. The `dialog` parameter was unused so far. If it's required in the future it will need to be replaced with a lambda or factory so that the feature can create instances of the dialog itself, as needed.
+
 # 52.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v51.0.0...v52.0.0)


### PR DESCRIPTION
Closes #7180 Closes #7939 

Co-authored-by: Arturo Mejia <arturomejiamarmol@gmail.com>

With this we're no longer holding a reference to the download dialog in the
feature, which caused a memory leak, as we tried to reuse the dialog
instance after it was destroyed. In addition, we now also make sure we only
ever create a single instance of the dialog by relying on `showNow` to
prevent a delayed `commit` of the fragment transaction.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
