### PR TITLE
Remove SimpleBrowserMenuHighlightableItem.itemType

### DIFF
--- a/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItem.kt
+++ b/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/SimpleBrowserMenuHighlightableItem.kt
@@ -27,17 +27,15 @@ import mozilla.components.concept.menu.candidate.TextStyle
  * @param textColorResource Optional ID of color resource to tint the text.
  * @param textSize The size of the label.
  * @param backgroundTint Tint for the menu item background color
- * @param itemType The type of the item. Used in the client side to know for
- * which item to update the highlightable state
  * @param isHighlighted Whether or not to display the highlight
  * @param listener Callback to be invoked when this menu item is clicked.
  */
+@Suppress("LongParameterList")
 class SimpleBrowserMenuHighlightableItem(
     private val label: String,
     @ColorRes private val textColorResource: Int = NO_ID,
     private val textSize: Float = NO_ID.toFloat(),
     @ColorInt val backgroundTint: Int,
-    val itemType: Any? = null,
     var isHighlighted: () -> Boolean = { true },
     private val listener: () -> Unit = {}
 ) : BrowserMenuItem {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@ permalink: /changelog/
 
 * **browser-menu**
   * ⚠️ **This is a breaking change**: `BrowserMenuItemToolbar.Button.longClickListener` is now nullable and defaults to null.
+  * ⚠️ **This is a breaking change**: Removed `SimpleBrowserMenuHighlightableItem.itemType`. Use a WeakMap instead if you need to attach private data.
 
 * **concept-menu**
   * Added `SmallMenuCandidate.onLongClick` to handle long click of row menu buttons.


### PR DESCRIPTION
Closes #7823

This field is no longer used in Fenix and can be removed.