### PR TITLE
Bug 1645844 - Allow the webcompat-reporter to provide a product name to the reporting backend.

### DIFF
--- a/components/feature/webcompat-reporter/README.md
+++ b/components/feature/webcompat-reporter/README.md
@@ -22,6 +22,16 @@ WebCompatReporterFeature.install(engine)
 
 Please make sure to only run this once, as the feature itself does not check if the extension is already installed.
 
+### Providing the browser-XXX label for reports
+
+The `install` function has an optional second parameter, `productName`. This allows reports to be labelled using the correct broswer-XXX label on webcompat.com. For example,
+
+```
+WebCompatReporterFeature.install(engine, "fenix")
+```
+
+would add the `browser-fenix` label to the report. Note that simply inventing new values here does not work, as each product name has to be whitelisted by the WebCompat team on webcompat.com, so [please get in touch](https://wiki.mozilla.org/Compatibility#Core_Team) when you need to add a new product name.
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/components/feature/webcompat-reporter/src/main/assets/extensions/webcompat-reporter/manifest.json
+++ b/components/feature/webcompat-reporter/src/main/assets/extensions/webcompat-reporter/manifest.json
@@ -3,7 +3,7 @@
   "name": "WebCompat Reporter",
   "description": "Report site compatibility issues on webcompat.com",
   "author": "Thomas Wisniewski <twisniewski@mozilla.com>",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage_url": "https://github.com/mozilla/webcompat-reporter",
   "applications": {
     "gecko": {
@@ -36,6 +36,8 @@
     "128": "icons/lightbulb.svg"
   },
   "permissions": [
+    "geckoViewAddons",
+    "nativeMessaging",
     "tabs",
     "<all_urls>"
   ],

--- a/components/feature/webcompat-reporter/src/main/java/mozilla/components/feature/webcompat/reporter/WebCompatReporterFeature.kt
+++ b/components/feature/webcompat-reporter/src/main/java/mozilla/components/feature/webcompat/reporter/WebCompatReporterFeature.kt
@@ -8,7 +8,8 @@ import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.support.base.log.logger.Logger
 
 /**
- * Feature to enable website-hotfixing via the Web Compatibility System-Addon.
+ * A feature that enables users to report site issues to Mozilla's Web Compatibility team for
+ * further diagnosis.
  */
 object WebCompatReporterFeature {
     private val logger = Logger("mozac-webcompat-reporter")

--- a/components/feature/webcompat-reporter/src/main/java/mozilla/components/feature/webcompat/reporter/WebCompatReporterFeature.kt
+++ b/components/feature/webcompat-reporter/src/main/java/mozilla/components/feature/webcompat/reporter/WebCompatReporterFeature.kt
@@ -4,8 +4,11 @@
 
 package mozilla.components.feature.webcompat.reporter
 
+import mozilla.components.concept.engine.webextension.MessageHandler
+import mozilla.components.concept.engine.webextension.Port
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.support.base.log.logger.Logger
+import org.json.JSONObject
 
 /**
  * A feature that enables users to report site issues to Mozilla's Web Compatibility team for
@@ -16,14 +19,33 @@ object WebCompatReporterFeature {
 
     internal const val WEBCOMPAT_REPORTER_EXTENSION_ID = "webcompat-reporter@mozilla.org"
     internal const val WEBCOMPAT_REPORTER_EXTENSION_URL = "resource://android/assets/extensions/webcompat-reporter/"
+    internal const val WEBCOMPAT_REPORTER_MESSAGING_ID = "mozacWebcompatReporter"
+
+    private class WebcompatReporterBackgroundMessageHandler(
+        // This information will be provided as a browser-XXX label to the reporting backend, allowing
+        // us to differentiate different android-components based products.
+        private val productName: String
+    ) : MessageHandler {
+        override fun onPortConnected(port: Port) {
+            port.postMessage(JSONObject().put("productName", productName))
+        }
+    }
 
     /**
      * Installs the web extension in the runtime through the WebExtensionRuntime install method
+     *
+     * @param runtime a WebExtensionRuntime.
+     * @param productName a custom product name used to automatically label reports. Defaults to
+     * "android-components".
      */
-    fun install(runtime: WebExtensionRuntime) {
+    fun install(runtime: WebExtensionRuntime, productName: String = "android-components") {
         runtime.installWebExtension(WEBCOMPAT_REPORTER_EXTENSION_ID, WEBCOMPAT_REPORTER_EXTENSION_URL,
             onSuccess = {
                 logger.debug("Installed WebCompat Reporter webextension: ${it.id}")
+                it.registerBackgroundMessageHandler(
+                    WEBCOMPAT_REPORTER_MESSAGING_ID,
+                    WebcompatReporterBackgroundMessageHandler(productName)
+                )
             },
             onError = { ext, throwable ->
                 logger.error("Failed to install WebCompat Reporter webextension: $ext", throwable)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ permalink: /changelog/
 * **feature-downloads**
   * ⚠️ **This is a breaking change**: `DownloadsFeature` is no longer accepting a custom download dialog but supporting customizations via the `promptStyling` parameter. The `dialog` parameter was unused so far. If it's required in the future it will need to be replaced with a lambda or factory so that the feature can create instances of the dialog itself, as needed.
 
+* **feature-webcompat-reporter**
+  * Added a second parameter to the `install` method: `productName` allows to provide a unique product name per usage for automatic product-labelling on webcompat.com 
+
 # 52.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v51.0.0...v52.0.0)


### PR DESCRIPTION
This adds the ability to automatically add `browser-XXX` labels to our reports. This is important, as all android-components-based products show up as the same thing on webcompat.com - which makes our work a bit harder.

r? @pocmo 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
This currently lacks test, because adding tests is a bit harder than I expected. I'm still working on this, but since correct labeling is blocking a teammate, I decided to ship this first. Feel free to shake your fist at me if you disagree. :)
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
