### PR TITLE
For #7992 - Don't show "Download link" for webpages links

### DIFF
--- a/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -290,7 +290,7 @@ data class ContextMenuCandidate(
         ) = ContextMenuCandidate(
             id = "mozac.feature.contextmenu.download_link",
             label = context.getString(R.string.mozac_feature_contextmenu_download_link),
-            showFor = { _, hitResult -> hitResult.isLink() },
+            showFor = { _, hitResult -> hitResult.isLinkForOtherThanWebpage() },
             action = { tab, hitResult ->
                 contextMenuUseCases.injectDownload(
                     tab.id,
@@ -430,6 +430,12 @@ private fun HitResult.isVideoAudio(): Boolean =
 private fun HitResult.isLink(): Boolean =
     ((this is HitResult.UNKNOWN && src.isNotEmpty()) || this is HitResult.IMAGE_SRC) &&
         getLink().startsWith("http")
+
+private fun HitResult.isLinkForOtherThanWebpage(): Boolean {
+    val link = getLink()
+    val isHtml = link.endsWith("html") || link.endsWith("htm")
+    return isLink() && !isHtml
+}
 
 private fun HitResult.isIntent(): Boolean =
     (this is HitResult.UNKNOWN && src.isNotEmpty() &&

--- a/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -540,6 +540,14 @@ class ContextMenuCandidateTest {
             createTab("https://www.mozilla.org"),
             HitResult.GEO("https://www.mozilla.org")))
 
+        assertFalse(downloadLink.showFor(
+            createTab("https://www.mozilla.org"),
+            HitResult.UNKNOWN("https://www.mozilla.org/firefox/products.html")))
+
+        assertFalse(downloadLink.showFor(
+            createTab("https://www.mozilla.org"),
+            HitResult.UNKNOWN("https://www.mozilla.org/firefox/products.htm")))
+
         // action
 
         assertNull(store.state.tabs.first().content.download)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,10 @@ permalink: /changelog/
 * **feature-webcompat-reporter**
   * Added a second parameter to the `install` method: `productName` allows to provide a unique product name per usage for automatic product-labelling on webcompat.com 
 
+* **feature-contextmenu**
+  * Do not show the "Download link" option for html URLs.
+  * Uses a speculative check, may not work in all cases.
+
 # 52.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v51.0.0...v52.0.0)


### PR DESCRIPTION
The "Download link" option in the contextual menu might not be a necessary
option if the link is for other webpages.
Speculate based on the url ending whether the link is for a webpage and prevent
showing the "Download link" in this case.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint check.
- [x] **Tests**:  No tests. Small change.
- [x] **Changelog**: This PR does not need a changelog entry, small change.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
