### PR TITLE
Closes #8009: Catch exceptions in Context.hasCamera check

### DIFF
--- a/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -74,9 +74,14 @@ fun Context.isPermissionGranted(vararg permission: String): Boolean {
  *
  * @return true if a camera was found, otherwise false.
  */
+@Suppress("TooGenericExceptionCaught")
 fun Context.hasCamera(): Boolean {
-    val cameraManager: CameraManager? = getSystemService()
-    return cameraManager?.cameraIdList?.isNotEmpty() ?: false
+    return try {
+        val cameraManager: CameraManager? = getSystemService()
+        cameraManager?.cameraIdList?.isNotEmpty() ?: false
+    } catch (e: Exception) {
+        false
+    }
 }
 
 /**

--- a/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
+++ b/components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/ContextTest.kt
@@ -15,7 +15,9 @@ import android.hardware.camera2.CameraManager
 import androidx.core.content.getSystemService
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -29,6 +31,7 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowApplication
 import org.robolectric.shadows.ShadowCameraCharacteristics
 import org.robolectric.shadows.ShadowProcess
+import java.lang.IllegalStateException
 
 @RunWith(AndroidJUnit4::class)
 class ContextTest {
@@ -147,5 +150,14 @@ class ContextTest {
         val cameraManager: CameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
         shadowOf(cameraManager).addCamera("camera0", ShadowCameraCharacteristics.newCameraCharacteristics())
         assertTrue(context.hasCamera())
+    }
+
+    @Test
+    fun `hasCamera returns false if exception is thrown`() {
+        val context = spy(testContext)
+        val cameraManager: CameraManager = mock()
+        whenever(context.getSystemService(Context.CAMERA_SERVICE)).thenReturn(cameraManager)
+        whenever(cameraManager.cameraIdList).thenThrow(IllegalStateException("Test"))
+        assertFalse(context.hasCamera())
     }
 }


### PR DESCRIPTION
We're already handling this for the QR fragment, but this call is also invoked directly e.g. by the SearchFragment in Fenix, and apparently on some devices `getCameraIdList` can crash: https://sentry.prod.mozaws.net/operations/fenix-fennec/issues/9299666

With this we return false, as expected. Only very few users affected so far, but let's uplift to 48 and 52 @pocmo ?