### PR TITLE
Add orientation parameter to concept-menu show

### DIFF
--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/BrowserMenuController.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/BrowserMenuController.kt
@@ -36,7 +36,8 @@ class BrowserMenuController(
         notifyObservers { onDismiss() }
     }
 
-    override fun show(anchor: View): PopupWindow = show(anchor, orientation = null)
+    override fun show(anchor: View, orientation: Orientation?): PopupWindow =
+        show(anchor, orientation, defaultWidth(anchor.resources))
 
     /**
      * @param anchor The view on which to pin the popup window.
@@ -46,7 +47,7 @@ class BrowserMenuController(
     fun show(
         anchor: View,
         orientation: Orientation? = null,
-        @Px width: Int = anchor.resources.getDimensionPixelSize(R.dimen.mozac_browser_menu2_width)
+        @Px width: Int = defaultWidth(anchor.resources)
     ): PopupWindow {
         val desiredOrientation = orientation ?: determineMenuOrientation(anchor.parent as? View?)
         val view = MenuView(anchor.context).apply {
@@ -127,6 +128,10 @@ class BrowserMenuController(
 
         notifyObservers { onMenuListSubmit(list) }
     }
+
+    @Px
+    private fun defaultWidth(resources: Resources) =
+        resources.getDimensionPixelSize(R.dimen.mozac_browser_menu2_width)
 
     private class MenuPopupWindow(
         val view: MenuView,

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/MenuController.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/MenuController.kt
@@ -16,8 +16,9 @@ interface MenuController : Observable<MenuController.Observer> {
 
     /**
      * @param anchor The view on which to pin the popup window.
+     * @param orientation The preferred orientation to show the popup window.
      */
-    fun show(anchor: View): PopupWindow
+    fun show(anchor: View, orientation: Orientation? = null): PopupWindow
 
     /**
      * Dismiss the menu popup if the menu is visible.


### PR DESCRIPTION
Small change to concept-menu since many menus care about their orientation too. Currently the menus I'm testing with in Fenix need to use the BrowserMenuController class instead of the interface simply due to the lack of orientation.