### PR TITLE
Remove width parameter from BrowserMenuController

### DIFF
--- a/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/BrowserMenuController.kt
+++ b/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/BrowserMenuController.kt
@@ -7,7 +7,6 @@ package mozilla.components.browser.menu2
 import android.view.View
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.PopupWindow
-import androidx.annotation.Px
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.menu2.ext.displayPopup
 import mozilla.components.browser.menu2.view.MenuView
@@ -36,17 +35,13 @@ class BrowserMenuController(
         notifyObservers { onDismiss() }
     }
 
-    override fun show(anchor: View): PopupWindow = show(anchor, orientation = null)
-
     /**
      * @param anchor The view on which to pin the popup window.
      * @param orientation The preferred orientation to show the popup window.
-     * @param width The width of the popup menu. The height is always set to wrap content.
      */
-    fun show(
+    override fun show(
         anchor: View,
-        orientation: Orientation? = null,
-        @Px width: Int = anchor.resources.getDimensionPixelSize(R.dimen.mozac_browser_menu2_width)
+        orientation: Orientation?
     ): PopupWindow {
         val desiredOrientation = orientation ?: determineMenuOrientation(anchor.parent as? View?)
         val view = MenuView(anchor.context).apply {
@@ -55,7 +50,7 @@ class BrowserMenuController(
             setVisibleSide(visibleSide)
         }
 
-        return MenuPopupWindow(view, width).apply {
+        return MenuPopupWindow(view).apply {
             view.onDismiss = ::dismiss
             view.onReopenMenu = ::reopenMenu
             setOnDismissListener(menuDismissListener)
@@ -129,9 +124,8 @@ class BrowserMenuController(
     }
 
     private class MenuPopupWindow(
-        val view: MenuView,
-        @Px width: Int
-    ) : PopupWindow(view, width, WRAP_CONTENT, true)
+        val view: MenuView
+    ) : PopupWindow(view, WRAP_CONTENT, WRAP_CONTENT, true)
 
     private data class PopupMenuInfo(
         val window: MenuPopupWindow,

--- a/components/browser/menu2/src/main/res/layout/mozac_browser_menu2_view.xml
+++ b/components/browser/menu2/src/main/res/layout/mozac_browser_menu2_view.xml
@@ -6,12 +6,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:parentTag="FrameLayout"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
     <androidx.cardview.widget.CardView
         style="@style/Mozac.Browser.Menu2"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:cardCornerRadius="@dimen/mozac_browser_menu2_corner_radius"
         app:cardElevation="@dimen/mozac_browser_menu2_elevation"
@@ -21,7 +21,7 @@
             android:id="@+id/mozac_browser_menu_recyclerView"
             android:paddingTop="@dimen/mozac_browser_menu2_padding_vertical"
             android:paddingBottom="@dimen/mozac_browser_menu2_padding_vertical"
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/mozac_browser_menu2_width"
             android:layout_height="wrap_content"
             tools:listitem="@layout/mozac_browser_menu2_candidate_text" />
 

--- a/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/BrowserMenuControllerTest.kt
+++ b/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/BrowserMenuControllerTest.kt
@@ -36,16 +36,6 @@ class BrowserMenuControllerTest {
     }
 
     @Test
-    fun `can show with custom width`() {
-        val menu = BrowserMenuController()
-        val width = 500
-        val anchor = Button(testContext)
-        val popup = menu.show(anchor, Orientation.UP, width)
-
-        assertEquals(width, popup.width)
-    }
-
-    @Test
     fun `observer is notified when submitList is called`() {
         var submitted: List<MenuCandidate>? = null
         val menu: MenuController = BrowserMenuController()

--- a/components/concept/menu/src/main/java/mozilla/components/concept/menu/MenuController.kt
+++ b/components/concept/menu/src/main/java/mozilla/components/concept/menu/MenuController.kt
@@ -16,8 +16,9 @@ interface MenuController : Observable<MenuController.Observer> {
 
     /**
      * @param anchor The view on which to pin the popup window.
+     * @param orientation The preferred orientation to show the popup window.
      */
-    fun show(anchor: View): PopupWindow
+    fun show(anchor: View, orientation: Orientation? = null): PopupWindow
 
     /**
      * Dismiss the menu popup if the menu is visible.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Config.kt)
 
+* **concept-menu**
+  * Added `orientation` parameter to `MenuController.show`. Passing null (the default) tells the menu to determine the best orientation itself.
+
+* **browser-menu2**
+  * ⚠️ **This is a breaking change**: `BrowserMenuController.show` no longer supports the width parameter.
+
 # 53.0.0
 
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v52.0.0...v53.0.0)


### PR DESCRIPTION
Also added `orientation` to the interface.

Width will be replaced with dynamic width soon.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
