### PR TITLE
Closes #8011: Single-threaded places dispatcher, exception handling

### DIFF
--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorage.kt
@@ -34,7 +34,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The populated root starting from the guid.
      */
     override suspend fun getTree(guid: String, recursive: Boolean): BookmarkNode? {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             reader.getBookmarksTree(guid, recursive)?.asBookmarkNode()
         }
     }
@@ -46,7 +46,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The bookmark node or null if it does not exist.
      */
     override suspend fun getBookmark(guid: String): BookmarkNode? {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             reader.getBookmark(guid)?.asBookmarkNode()
         }
     }
@@ -58,7 +58,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The list of bookmarks that match the URL
      */
     override suspend fun getBookmarksWithUrl(url: String): List<BookmarkNode> {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             reader.getBookmarksWithURL(url).map { it.asBookmarkNode() }
         }
     }
@@ -71,7 +71,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The list of matching bookmark nodes up to the limit number of items.
      */
     override suspend fun searchBookmarks(query: String, limit: Int): List<BookmarkNode> {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             reader.searchBookmarks(query, limit).map { it.asBookmarkNode() }
         }
     }
@@ -88,7 +88,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The guid of the newly inserted bookmark item.
      */
     override suspend fun addItem(parentGuid: String, url: String, title: String, position: Int?): String {
-        return withContext(scope.coroutineContext) {
+        return withContext(writeScope.coroutineContext) {
             writer.createBookmarkItem(parentGuid, url, title, position)
         }
     }
@@ -104,7 +104,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The guid of the newly inserted bookmark item.
      */
     override suspend fun addFolder(parentGuid: String, title: String, position: Int?): String {
-        return withContext(scope.coroutineContext) {
+        return withContext(writeScope.coroutineContext) {
             writer.createFolder(parentGuid, title, position)
         }
     }
@@ -119,7 +119,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return The guid of the newly inserted bookmark item.
      */
     override suspend fun addSeparator(parentGuid: String, position: Int?): String {
-        return withContext(scope.coroutineContext) {
+        return withContext(writeScope.coroutineContext) {
             writer.createSeparator(parentGuid, position)
         }
     }
@@ -133,7 +133,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @param info The info to change in the bookmark.
      */
     override suspend fun updateNode(guid: String, info: BookmarkInfo) {
-        return withContext(scope.coroutineContext) {
+        return withContext(writeScope.coroutineContext) {
             writer.updateBookmark(guid, BookmarkUpdateInfo(info.parentGuid, info.position, info.title, info.url))
         }
     }
@@ -145,7 +145,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      *
      * @return Whether the bookmark existed or not.
      */
-    override suspend fun deleteNode(guid: String): Boolean = withContext(scope.coroutineContext) {
+    override suspend fun deleteNode(guid: String): Boolean = withContext(writeScope.coroutineContext) {
         writer.deleteBookmarkNode(guid)
     }
 
@@ -156,7 +156,7 @@ open class PlacesBookmarksStorage(context: Context) : PlacesStorage(context), Bo
      * @return Sync status of OK or Error
      */
     suspend fun sync(authInfo: SyncAuthInfo): SyncStatus {
-        return withContext(scope.coroutineContext) {
+        return withContext(writeScope.coroutineContext) {
             syncAndHandleExceptions {
                 places.syncBookmarks(authInfo)
             }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -40,7 +40,7 @@ open class PlacesHistoryStorage(
     override val logger = Logger("PlacesHistoryStorage")
 
     override suspend fun recordVisit(uri: String, visit: PageVisit) {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             handlePlacesExceptions("recordVisit") {
                 places.writer().noteObservation(VisitObservation(uri,
                     visitType = visit.visitType.into(),
@@ -59,7 +59,7 @@ open class PlacesHistoryStorage(
 
     override suspend fun recordObservation(uri: String, observation: PageObservation) {
         // NB: visitType 'UPDATE_PLACE' means "record meta information about this URL".
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             // Ignore exceptions related to uris. This means we may drop some of the data on the floor
             // if the underlying storage layer refuses it.
             handlePlacesExceptions("recordObservation") {
@@ -75,11 +75,11 @@ open class PlacesHistoryStorage(
     }
 
     override suspend fun getVisited(uris: List<String>): List<Boolean> {
-        return withContext(scope.coroutineContext) { places.reader().getVisited(uris) }
+        return withContext(readScope.coroutineContext) { places.reader().getVisited(uris) }
     }
 
     override suspend fun getVisited(): List<String> {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             places.reader().getVisitedUrlsInRange(
                     start = 0,
                     end = System.currentTimeMillis(),
@@ -89,19 +89,19 @@ open class PlacesHistoryStorage(
     }
 
     override suspend fun getDetailedVisits(start: Long, end: Long, excludeTypes: List<VisitType>): List<VisitInfo> {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             places.reader().getVisitInfos(start, end, excludeTypes.map { it.into() }).map { it.into() }
         }
     }
 
     override suspend fun getVisitsPaginated(offset: Long, count: Long, excludeTypes: List<VisitType>): List<VisitInfo> {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             places.reader().getVisitPage(offset, count, excludeTypes.map { it.into() }).map { it.into() }
         }
     }
 
     override suspend fun getTopFrecentSites(numItems: Int): List<TopFrecentSiteInfo> {
-        return withContext(scope.coroutineContext) {
+        return withContext(readScope.coroutineContext) {
             places.reader().getTopFrecentSiteInfos(numItems).map { it.into() }
         }
     }
@@ -133,7 +133,7 @@ open class PlacesHistoryStorage(
      * history from returning.
      */
     override suspend fun deleteEverything() {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             places.writer().deleteEverything()
         }
     }
@@ -143,7 +143,7 @@ open class PlacesHistoryStorage(
      * ones for a URL.
      */
     override suspend fun deleteVisitsSince(since: Long) {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             places.writer().deleteVisitsSince(since)
         }
     }
@@ -153,7 +153,7 @@ open class PlacesHistoryStorage(
      * ones for a URL.
      */
     override suspend fun deleteVisitsBetween(startTime: Long, endTime: Long) {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             places.writer().deleteVisitsBetween(startTime, endTime)
         }
     }
@@ -162,7 +162,7 @@ open class PlacesHistoryStorage(
      * Sync behaviour: will remove history from remote devices.
      */
     override suspend fun deleteVisitsFor(url: String) {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             places.writer().deleteVisitsFor(url)
         }
     }
@@ -172,7 +172,7 @@ open class PlacesHistoryStorage(
      * Otherwise, remote devices are not affected.
      */
     override suspend fun deleteVisit(url: String, timestamp: Long) {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             places.writer().deleteVisit(url, timestamp)
         }
     }
@@ -183,7 +183,7 @@ open class PlacesHistoryStorage(
      * Sync behaviour: will not remove history from remote clients.
      */
     override suspend fun prune() {
-        withContext(scope.coroutineContext) {
+        withContext(writeScope.coroutineContext) {
             places.writer().pruneDestructively()
         }
     }
@@ -195,7 +195,7 @@ open class PlacesHistoryStorage(
      * @return Sync status of OK or Error
      */
     suspend fun sync(authInfo: SyncAuthInfo): SyncStatus {
-        return withContext(scope.coroutineContext) {
+        return withContext(writeScope.coroutineContext) {
             syncAndHandleExceptions {
                 places.syncHistory(authInfo)
             }

--- a/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
+++ b/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesStorage.kt
@@ -7,7 +7,7 @@ package mozilla.components.browser.storage.sync
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.withContext
 import mozilla.appservices.places.InternalPanic
@@ -20,6 +20,7 @@ import mozilla.components.concept.sync.SyncableStore
 import mozilla.components.support.base.crash.CrashReporting
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.logElapsedTime
+import java.util.concurrent.Executors
 
 /**
  * A base class for concrete implementations of PlacesStorages
@@ -28,8 +29,9 @@ abstract class PlacesStorage(
     context: Context,
     val crashReporter: CrashReporting? = null
 ) : Storage, SyncableStore {
-
-    internal val scope by lazy { CoroutineScope(Dispatchers.IO) }
+    internal val scope by lazy {
+        CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    }
     private val storageDir by lazy { context.filesDir }
 
     abstract val logger: Logger


### PR DESCRIPTION
This does two things to address the few places-related crashes we're seeing:
- switches `PlacesStorage` to a single-threaded executor. Before we were using Dispatchers.IO, which uses a thread pool underneath. This means we could have concurrent places write operations on the same connection, which isn't really supported by sqlite, resulting in a SQLITE BUSY signal.
- ignores non-panic exceptions which places can throw. That's a long tail of things like "disk full", etc. Not much we can do here, but no point in crashing either. Application can configure a crash reporter to keep track of these.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
