### PR TITLE
Closes #8046: Remove unneeded unload handlers to make bfcache work

### DIFF
--- a/components/feature/accounts/src/main/assets/extensions/fxawebchannel/fxawebchannel.js
+++ b/components/feature/accounts/src/main/assets/extensions/fxawebchannel/fxawebchannel.js
@@ -16,10 +16,6 @@ port.onMessage.addListener((event) => {
   }));
 });
 
-// We should use pagehide/pageshow events instead, to better handle page navigation events.
-// See https://github.com/mozilla-mobile/android-components/issues/2984.
-window.addEventListener("unload", (event) => { port.disconnect() }, false);
-
 /*
 Handle messages from FxA. Messages are posted to the native application for processing.
 */

--- a/components/feature/p2p/src/main/assets/extensions/p2p/p2p.js
+++ b/components/feature/p2p/src/main/assets/extensions/p2p/p2p.js
@@ -110,6 +110,3 @@ port.onDisconnect.addListener((p) => {
         console.log("Wah! Disconnected due to an error: ${p.error.message}");
     }
 });
-
-window.addEventListener("unload", (event) => { port.disconnect() }, false);
-

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview-content.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview-content.js
@@ -58,7 +58,20 @@ function connectNativePort() {
      }
   });
 
-  window.addEventListener("unload", (event) => { port.disconnect() }, false);
+  return port;
 }
 
-connectNativePort();
+let port = connectNativePort();
+
+// When navigating to a cached page, this content script won't run again, but we
+// do want to connect a new native port to trigger a new readerable check and
+// apply the same logic (as on page load) in our feature class (e.g. updating the
+// toolbar etc.)
+window.addEventListener("pageshow", (event) => {
+  port = (port != null)? port : connectNativePort();
+});
+
+window.addEventListener("pagehide", (event) => {
+  port.disconnect();
+  port = null;
+});

--- a/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -376,6 +376,4 @@ function connectNativePort() {
         console.error(`Received invalid action ${message.action}`);
     }
   });
-
-   window.addEventListener("unload", (event) => { port.disconnect() }, false);
 }


### PR DESCRIPTION
Window unload handlers block the bfcache. The extension framework already automatically disconnects ports on unload so they aren't needed in the first place.

For the reader mode content script, we are now connecting and disconnecting on pageshow/pagehide to support readerable checks when navigating (back/forward) to cached pages. We don't need to do that for reader pages, as we opted out of the cache there.

For FxA there's no difference in behaviour. I've also tested navigating back and forth during the signup flow and it still works, as expected.

For p2p, I opted not to change behaviour, but I am not familiar enough how it would be affected not that the bfcache is active.


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
