### PR TITLE
Closes #8051: Make collection account configurable

### DIFF
--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -49,6 +49,7 @@ internal const val DEFAULT_READ_TIMEOUT_IN_SECONDS = 20L
  * should remain valid. Defaults to -1, meaning no cache is being used by default.
  * @property client A reference of [Client] for interacting with the AMO HTTP api.
  */
+@Suppress("LongParameterList")
 class AddonCollectionProvider(
     private val context: Context,
     private val client: Client,

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -29,8 +29,9 @@ import java.util.concurrent.TimeUnit
 
 internal const val API_VERSION = "api/v4"
 internal const val DEFAULT_SERVER_URL = "https://addons.mozilla.org"
+internal const val DEFAULT_COLLECTION_ACCOUNT = "mozilla"
 internal const val DEFAULT_COLLECTION_NAME = "7e8d6dc651b54ab385fb8791bf9dac"
-internal const val COLLECTION_FILE_NAME = "mozilla_components_addon_collection_%s.json"
+internal const val COLLECTION_FILE_NAME = "%s_components_addon_collection_%s.json"
 internal const val MINUTE_IN_MS = 60 * 1000
 internal const val DEFAULT_READ_TIMEOUT_IN_SECONDS = 20L
 
@@ -40,6 +41,8 @@ internal const val DEFAULT_READ_TIMEOUT_IN_SECONDS = 20L
  *
  * @property serverURL The url of the endpoint to interact with e.g production, staging
  * or testing. Defaults to [DEFAULT_SERVER_URL].
+ * @property collectionAccount The account owning the collection to access, defaults
+ * to [DEFAULT_COLLECTION_ACCOUNT].
  * @property collectionName The name of the collection to access, defaults
  * to [DEFAULT_COLLECTION_NAME].
  * @property maxCacheAgeInMinutes maximum time (in minutes) the collection cache
@@ -50,6 +53,7 @@ class AddonCollectionProvider(
     private val context: Context,
     private val client: Client,
     private val serverURL: String = DEFAULT_SERVER_URL,
+    private val collectionAccount: String = DEFAULT_COLLECTION_ACCOUNT,
     private val collectionName: String = DEFAULT_COLLECTION_NAME,
     private val maxCacheAgeInMinutes: Long = -1
 ) : AddonsProvider {
@@ -81,7 +85,7 @@ class AddonCollectionProvider(
 
         return cachedAddons ?: client.fetch(
                 Request(
-                    url = "$serverURL/$API_VERSION/accounts/account/mozilla/collections/$collectionName/addons",
+                    url = "$serverURL/$API_VERSION/accounts/account/$collectionAccount/collections/$collectionName/addons",
                     readTimeout = Pair(readTimeoutInSeconds ?: DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
                 )
             )
@@ -156,7 +160,7 @@ class AddonCollectionProvider(
     }
 
     private fun getBaseCacheFile(context: Context): File {
-        return File(context.filesDir, COLLECTION_FILE_NAME.format(collectionName))
+        return File(context.filesDir, COLLECTION_FILE_NAME.format(collectionAccount, collectionName))
     }
 }
 

--- a/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
+++ b/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AddonCollectionProvider.kt
@@ -86,7 +86,15 @@ class AddonCollectionProvider(
 
         return cachedAddons ?: client.fetch(
                 Request(
-                    url = "$serverURL/$API_VERSION/accounts/account/$collectionAccount/collections/$collectionName/addons",
+                    url = listOf(
+                        serverURL,
+                        API_VERSION,
+                        "accounts/account",
+                        collectionAccount,
+                        "collections",
+                        collectionName,
+                        "addons"
+                    ).joinToString("/"),
                     readTimeout = Pair(readTimeoutInSeconds ?: DEFAULT_READ_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)
                 )
             )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,9 @@ permalink: /changelog/
 
 * **browser-menu**
   * ⚠️ **This is a breaking change**: Removed `SimpleBrowserMenuHighlightableItem.itemType`. Use a WeakMap instead if you need to attach private data.
+  
+* **feature-addons**
+  * ⚠️ **This is a breaking change**: Added a `collectionAccount` constructor argument to `AddonCollectionProvider` to override the default of `mozilla`. It has been inserted into the middle of the argument list, before `collectionName`, so code that passed later arguments positionally will need to change.
 
 # 53.0.0
 


### PR DESCRIPTION
Allow using an account name other than `mozilla` with the `AddonCollectionProvider`.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


This will fix #8051.

It doesn't look like any of the URL override parameters are tested, just the functionality of the class, so I didn't add a new test for this one. 
